### PR TITLE
chore: repo hardening (.gitignore, SECURITY.md, CI scans)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All paths owned by maintainer
+* @luckyPipewrench

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,30 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          queries: security-and-quality
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -36,3 +36,12 @@ jobs:
             echo "ERROR: no case files found"
             exit 1
           fi
+
+      - name: Scan for personal information
+        run: |
+          if grep -ri 'pipelab\|debserver\|clawdbot\|family-agent\|10\.10\.' \
+            cases/ docs/ examples/ README.md CONTRIBUTING.md CLAUDE.md 2>/dev/null; then
+            echo "ERROR: personal/infrastructure information found in repo content"
+            exit 1
+          fi
+          echo "Personal info scan: clean"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Local/private files
+CLAUDE.local.md
+*.local.md
+*.local.yaml
+
+# Environment and secrets
+.env
+.env.*
+*.key
+*.pem
+
+# Build artifacts
+/tmp/
+/validate/aeb-validate
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Test output
+*.jsonl
+
+# Playwright
+.playwright-mcp/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Scope
+
+This repository contains **intentionally fake test data** designed to evaluate AI agent egress security tools. All credentials, API keys, and secrets in the `cases/` directory are synthetic and non-functional.
+
+## Reporting Issues
+
+If you find a real security issue in this repository (e.g., an accidentally committed real credential, a vulnerability in the validator, or a case that could cause harm when used), please report it via [GitHub Security Advisories](https://github.com/luckyPipewrench/agent-egress-bench/security/advisories).
+
+Do not open a public issue for security vulnerabilities.
+
+## What Is NOT a Security Issue
+
+- Fake API keys, tokens, or credentials in `cases/` directory (these are intentional test data)
+- Attack patterns described in case files (these are the purpose of the project)
+- Prompt injection payloads in response content cases (these test detection capabilities)


### PR DESCRIPTION
## Summary

Bring repo security and hygiene up to pipelock standards.

- `.gitignore`: editor files, build artifacts, local configs, secrets, `.local.md`
- `SECURITY.md`: vulnerability reporting policy, fake-secret scope clarification
- `CODEOWNERS`: all paths owned by maintainer
- Dependency review CI (blocks high-severity deps on PRs)
- CodeQL security scanning (weekly + on PR)
- Personal info scan in validate CI (fails if infrastructure details leak into content)