### PR TITLE
chore: add Makefile with stats target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: stats
+
+# Print canonical stats from test cases
+stats:
+	@echo "# agent-egress-bench stats"
+	@echo "cases_total: $$(find cases -name '*.json' | wc -l)"
+	@echo "categories: $$(find cases -mindepth 1 -maxdepth 1 -type d | wc -l)"
+	@echo "malicious: $$(find cases -name '*.json' -exec grep -l '"expect": "block"' {} \; | wc -l)"
+	@echo "benign: $$(find cases -name '*.json' -exec grep -l '"expect": "allow"' {} \; | wc -l)"
+	@for dir in cases/*/; do \
+		name=$$(basename "$$dir"); \
+		count=$$(find "$$dir" -name '*.json' | wc -l); \
+		echo "  $$name: $$count"; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ stats:
 	@echo "# agent-egress-bench stats"
 	@echo "cases_total: $$(find cases -name '*.json' | wc -l)"
 	@echo "categories: $$(find cases -mindepth 1 -maxdepth 1 -type d | wc -l)"
-	@echo "malicious: $$(find cases -name '*.json' -exec grep -l '"expect": "block"' {} \; | wc -l)"
-	@echo "benign: $$(find cases -name '*.json' -exec grep -l '"expect": "allow"' {} \; | wc -l)"
-	@for dir in cases/*/; do \
+	@echo "malicious: $$(find cases -name '*.json' -exec grep -l '"expected_verdict"[[:space:]]*:[[:space:]]*"block"' {} \; | wc -l)"
+	@echo "benign: $$(find cases -name '*.json' -exec grep -l '"expected_verdict"[[:space:]]*:[[:space:]]*"allow"' {} \; | wc -l)"
+	@set -- cases/*/; \
+	if [ "$$1" = 'cases/*/' ]; then exit 0; fi; \
+	for dir in "$$@"; do \
 		name=$$(basename "$$dir"); \
 		count=$$(find "$$dir" -name '*.json' | wc -l); \
 		echo "  $$name: $$count"; \


### PR DESCRIPTION
Adds a Makefile with `make stats` target that prints canonical test case counts and per-category breakdown.

Part of the stats automation across the pipelock ecosystem repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new build task that outputs repository statistics: totals for JSON files, counts of immediate categories, per-category file counts, and counts of items labeled "block" or "allow". It handles missing categories gracefully and is accessible via the project’s build tooling for quick inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->