### PR TITLE
feat: detection + evidence scoring, body DLP routing, config refresh

### DIFF
--- a/examples/pipelock/pipelock-benchmark.yaml
+++ b/examples/pipelock/pipelock-benchmark.yaml
@@ -1,26 +1,23 @@
-# Pipelock benchmark config: all scanners enabled, enforcement on.
-# This tests capability, not default UX tradeoffs.
+mode: balanced
 
-version: 1
-mode: strict
-
-api_allowlist:
-  - "*.anthropic.com"
-  - "*.openai.com"
-  - "github.com"
-  - "*.github.com"
-  - "*.githubusercontent.com"
-  - "api.example.com"
-  - "httpbin.org"
+scan_api:
+  listen: "127.0.0.1:9990"
+  auth:
+    bearer_tokens: ["bench-test-token"]
+  max_body_bytes: 1048576
+  kinds:
+    url: true
+    dlp: true
+    prompt_injection: true
+    tool_call: true
 
 fetch_proxy:
-  listen: 127.0.0.1:18899
+  listen: "127.0.0.1:9991"
   timeout_seconds: 30
   max_response_mb: 10
-  user_agent: Pipelock Fetch/1.0
   monitoring:
     max_url_length: 2000
-    entropy_threshold: 3.5
+    entropy_threshold: 4.0
     max_requests_per_minute: 0
     max_data_per_minute: 0
     blocklist:
@@ -36,48 +33,12 @@ forward_proxy:
   enabled: true
   sni_verification: true
 
-dlp:
-  scan_env: false
-  patterns:
-    - name: Anthropic API Key
-      regex: sk-ant-[a-zA-Z0-9\-_]{10,}
-      severity: critical
-    - name: OpenAI API Key
-      regex: sk-proj-[a-zA-Z0-9\-_]{10,}
-      severity: critical
-    - name: GitHub Token
-      regex: gh[pousr]_[A-Za-z0-9_]{36,}
-      severity: critical
-    - name: GitHub Fine-Grained PAT
-      regex: github_pat_[a-zA-Z0-9_]{36,}
-      severity: critical
-    - name: AWS Access ID
-      regex: (AKIA|A3T|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16,}
-      severity: critical
-    - name: Slack Token
-      regex: xox[bpras]-[0-9a-zA-Z-]{15,}
-      severity: critical
-    - name: Discord Bot Token
-      regex: '[MN][A-Za-z0-9]{23,}\.[A-Za-z0-9\-_]{6}\.[A-Za-z0-9\-_]{27,}'
-      severity: critical
-    - name: SendGrid API Key
-      regex: SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}
-      severity: critical
-    - name: Stripe Key
-      regex: '[sr]k_(live|test)_[a-zA-Z0-9]{20,}'
-      severity: critical
-    - name: Private Key Header
-      regex: '-----BEGIN\s+(RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----'
-      severity: critical
-    - name: JWT Token
-      regex: (ey[a-zA-Z0-9_\-=]{10,}\.){2}[a-zA-Z0-9_\-=]{10,}
-      severity: high
-    - name: Social Security Number
-      regex: \b\d{3}-\d{2}-\d{4}\b
-      severity: low
-    - name: Credential in URL
-      regex: \b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}
-      severity: high
+websocket_proxy:
+  enabled: true
+  max_message_bytes: 1048576
+  max_concurrent_connections: 128
+  max_connection_seconds: 60
+  idle_timeout_seconds: 15
 
 response_scanning:
   enabled: true
@@ -89,6 +50,26 @@ request_body_scanning:
   max_body_bytes: 1048576
   scan_headers: true
   header_mode: all
+
+internal: []
+
+dlp:
+  patterns:
+    - name: "Ethereum Address"
+      regex: '0x[0-9a-fA-F]{40}\b'
+      severity: high
+    - name: "Credit Card Number"
+      regex: '\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13}|6(?:011|5[0-9]{2})[0-9]{12})\b'
+      severity: high
+    - name: "Social Security Number"
+      regex: '\b\d{3}-\d{2}-\d{4}\b'
+      severity: low
+    - name: "IBAN"
+      regex: '\b(?:AL|AD|AT|AZ|BH|BY|BE|BA|BR|BG|CR|HR|CY|CZ|DK|DO|TL|EE|FO|FI|FR|GE|DE|GI|GR|GL|GT|HU|IS|IQ|IE|IL|IT|JO|KZ|XK|KW|LV|LB|LI|LT|LU|MK|MT|MR|MU|MC|MD|ME|NL|NO|PK|PS|PL|PT|QA|RO|LC|SM|ST|SA|RS|SC|SK|SI|ES|SE|CH|TN|TR|UA|AE|GB|VA|VG)\d{2}[A-Z0-9]{4}\d{7}([A-Z0-9]?){0,16}\b'
+      severity: high
+    - name: "Credential in URL"
+      regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
+      severity: high
 
 mcp_input_scanning:
   enabled: true
@@ -109,6 +90,28 @@ mcp_session_binding:
 tool_chain_detection:
   enabled: true
   action: block
+  pattern_overrides:
+    env-then-network: block
+    read-then-exec: block
+    read-write-send: block
+  custom_patterns:
+    - name: write-then-exec
+      sequence: ["write", "exec"]
+      severity: critical
+      action: block
+
+seed_phrase_detection:
+  enabled: true
+  action: block
+
+address_protection:
+  enabled: true
+  action: block
+
+reverse_proxy:
+  enabled: true
+  listen: "127.0.0.1:9992"
+  upstream: "http://127.0.0.1:9993"
 
 logging:
   level: warn

--- a/examples/pipelock/tool-profile.json
+++ b/examples/pipelock/tool-profile.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "tool": "pipelock",
-  "tool_version": "2.1.0",
+  "tool_version": "2.1.2",
   "runner_version": "v2",
   "claims": [
     "url_dlp",

--- a/gauntlet-site/index.html
+++ b/gauntlet-site/index.html
@@ -185,16 +185,19 @@ go build -o aeb-gauntlet .
     var full = scores.full || scores;
     var applicable = scores.applicable;
 
-    card.appendChild(txt('div', 'Full Corpus Scores (primary)', 'section-label'));
-    card.appendChild(makeScoresGrid(full));
-
     if (applicable) {
-      var aToggle = txt('div', 'Show applicable scores (diagnostic) \u25BE', 'toggle');
-      var aWrap = el('div', 'hidden');
-      aWrap.appendChild(makeScoresGrid(applicable));
-      aToggle.addEventListener('click', function() { aWrap.classList.toggle('hidden'); });
-      card.appendChild(aToggle);
-      card.appendChild(aWrap);
+      card.appendChild(txt('div', 'Applicable Scores (' + (cc.applicable || 0) + ' cases)', 'section-label'));
+      card.appendChild(makeScoresGrid(applicable));
+
+      var fToggle = txt('div', 'Show full corpus scores \u25BE', 'toggle');
+      var fWrap = el('div', 'hidden');
+      fWrap.appendChild(makeScoresGrid(full));
+      fToggle.addEventListener('click', function() { fWrap.classList.toggle('hidden'); });
+      card.appendChild(fToggle);
+      card.appendChild(fWrap);
+    } else {
+      card.appendChild(txt('div', 'Scores', 'section-label'));
+      card.appendChild(makeScoresGrid(full));
     }
 
     var cats = makeCategories(r.per_category);

--- a/runner/adapter/adapter.go
+++ b/runner/adapter/adapter.go
@@ -8,6 +8,7 @@ type Case struct {
 	ID              string
 	ExpectedVerdict string
 	Transport       string
+	InputType       string
 	Payload         map[string]interface{}
 }
 

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -68,6 +68,11 @@ func (p *ProxyAdapter) SetWSFixture(addr string) { p.wsAddr = addr }
 func (p *ProxyAdapter) Run(c Case, timeout time.Duration) Result {
 	switch c.Transport {
 	case "fetch_proxy":
+		// Body and header DLP cases route through scan API since
+		// the fetch endpoint only scans URLs, not request bodies.
+		if c.InputType == "request_body" || (c.InputType == "header" && p.scanURL != "") {
+			return p.runBodyViaScanAPI(c, timeout)
+		}
 		return p.runFetchProxy(c, timeout)
 	case "http_proxy":
 		return p.runHTTPProxy(c, timeout)
@@ -95,26 +100,32 @@ func (p *ProxyAdapter) Run(c Case, timeout time.Duration) Result {
 }
 
 // runFetchProxy sends a request to the proxy's /fetch endpoint.
-// The fetch endpoint only supports GET — cases declaring other methods are skipped.
+// Supports GET (URL scanning) and POST (request body scanning).
 func (p *ProxyAdapter) runFetchProxy(c Case, timeout time.Duration) Result {
 	targetURL, _ := payloadString(c.Payload, "url")
 	if targetURL == "" {
 		return Result{Err: fmt.Errorf("case %s: payload missing 'url'", c.ID)}
 	}
 
-	// The /fetch endpoint only accepts GET. Skip cases that require other methods.
-	if m, ok := payloadString(c.Payload, "method"); ok && m != "" && m != http.MethodGet {
-		return Result{
-			Verdict:  "skip",
-			Evidence: map[string]interface{}{"reason": fmt.Sprintf("fetch endpoint does not support %s", m)},
-		}
-	}
-
 	fetchURL := fmt.Sprintf("%s/fetch?url=%s", p.proxyURL.String(), url.QueryEscape(targetURL))
 
-	req, err := http.NewRequest(http.MethodGet, fetchURL, nil)
+	method := http.MethodGet
+	if m, ok := payloadString(c.Payload, "method"); ok && m != "" {
+		method = m
+	}
+
+	var bodyReader io.Reader
+	if bodyStr, ok := payloadString(c.Payload, "body"); ok && bodyStr != "" {
+		bodyReader = strings.NewReader(bodyStr)
+	}
+
+	req, err := http.NewRequest(method, fetchURL, bodyReader)
 	if err != nil {
 		return Result{Err: fmt.Errorf("case %s: building request: %w", c.ID, err)}
+	}
+
+	if ct, ok := payloadString(c.Payload, "content_type"); ok && ct != "" {
+		req.Header.Set("Content-Type", ct)
 	}
 
 	if hdrs, ok := c.Payload["headers"].(map[string]interface{}); ok {
@@ -141,12 +152,21 @@ func (p *ProxyAdapter) runFetchProxy(c Case, timeout time.Duration) Result {
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 
-	// The fetch endpoint returns JSON with a "blocked" field.
+	// The fetch endpoint returns JSON with blocked, block_reason, and scanner fields.
 	var fetchResp struct {
-		Blocked bool `json:"blocked"`
+		Blocked     bool   `json:"blocked"`
+		BlockReason string `json:"block_reason"`
+		Scanner     string `json:"scanner"`
 	}
 	if jsonErr := json.Unmarshal(body, &fetchResp); jsonErr == nil && fetchResp.Blocked {
-		return Result{Verdict: "block", Evidence: map[string]interface{}{"reason": "fetch_blocked"}}
+		ev := map[string]interface{}{"reason": "fetch_blocked"}
+		if fetchResp.BlockReason != "" {
+			ev["block_reason"] = fetchResp.BlockReason
+		}
+		if fetchResp.Scanner != "" {
+			ev["scanner"] = fetchResp.Scanner
+		}
+		return Result{Verdict: "block", Evidence: ev}
 	}
 
 	return classifyResponse(resp.StatusCode, string(body))
@@ -217,11 +237,15 @@ func (p *ProxyAdapter) runHTTPProxy(c Case, timeout time.Duration) Result {
 		errStr := err.Error()
 		// Proxy actively rejected the CONNECT (policy decision).
 		if strings.Contains(errStr, "Forbidden") || strings.Contains(errStr, "blocked") || strings.Contains(errStr, "403") || strings.Contains(errStr, "Method Not Allowed") || strings.Contains(errStr, "405") {
-			return Result{Verdict: "block", Evidence: map[string]interface{}{"reason": "proxy_rejected"}}
+			ev := map[string]interface{}{"reason": "proxy_rejected"}
+			extractBlockEvidence(errStr, ev)
+			return Result{Verdict: "block", Evidence: ev}
 		}
 		// Proxy or upstream connection reset — may be an active block.
 		if strings.Contains(errStr, "reset by peer") {
-			return Result{Verdict: "block", Evidence: map[string]interface{}{"reason": "connection_reset"}}
+			ev := map[string]interface{}{"reason": "connection_reset"}
+			extractBlockEvidence(errStr, ev)
+			return Result{Verdict: "block", Evidence: ev}
 		}
 		// Proxy unreachable — adapter infrastructure problem.
 		if strings.Contains(errStr, "connection refused") {
@@ -555,6 +579,56 @@ func (p *ProxyAdapter) runScanAPIWithKind(c Case, timeout time.Duration, kind st
 	return Result{Err: fmt.Errorf("case %s: scan API (%s) returned unparseable response: %s", c.ID, kind, truncate(string(respBody), 120))}
 }
 
+// runBodyViaScanAPI routes request_body and header cases through the scan
+// API for DLP checking. Falls back to the scan API text path since the fetch
+// endpoint only scans URLs, not request bodies.
+func (p *ProxyAdapter) runBodyViaScanAPI(c Case, timeout time.Duration) Result {
+	if p.scanURL == "" {
+		return Result{
+			Verdict:  "skip",
+			Evidence: map[string]interface{}{"reason": "scan API not configured for body/header DLP"},
+		}
+	}
+
+	var texts []string
+
+	// Extract body text.
+	if bodyStr, ok := payloadString(c.Payload, "body"); ok && bodyStr != "" {
+		texts = append(texts, bodyStr)
+	}
+
+	// Extract header values.
+	if hdrs, ok := c.Payload["headers"].(map[string]interface{}); ok {
+		for k, v := range hdrs {
+			if s, ok := v.(string); ok {
+				texts = append(texts, k+": "+s)
+			}
+		}
+	}
+
+	if len(texts) == 0 {
+		return Result{Verdict: "allow", Evidence: map[string]interface{}{"reason": "no_body_or_headers"}}
+	}
+
+	// Also scan the URL if present (catch URL DLP + body DLP together).
+	if u, ok := payloadString(c.Payload, "url"); ok && u != "" {
+		urlResult := p.runFetchProxy(c, timeout)
+		if urlResult.Verdict == "block" {
+			return urlResult
+		}
+	}
+
+	// Dual-pass scan: DLP first, then prompt_injection for body content
+	// that may contain injection patterns.
+	text := strings.Join(texts, "\n")
+	scanC := Case{ID: c.ID, ExpectedVerdict: c.ExpectedVerdict, Payload: map[string]interface{}{"body": text}}
+	result := p.runScanAPIWithKind(scanC, timeout, "dlp")
+	if result.Verdict == "block" || result.Err != nil {
+		return result
+	}
+	return p.runScanAPIWithKind(scanC, timeout, "prompt_injection")
+}
+
 // runA2AViaMCP wraps A2A content in a fake tools/call message and sends
 // it through the MCP proxy. The MCP input scanner runs full DLP including
 // encoding decode, which catches secrets that the scan API DLP misses.
@@ -641,22 +715,66 @@ func extractTextFromPayload(payload map[string]interface{}) string {
 	return string(b)
 }
 
+// extractBlockEvidence parses a block response body for scanner and reason fields.
+// Pipelock returns these in multiple formats depending on transport:
+//   - Fetch JSON: {"blocked":true,"block_reason":"DLP match: AWS","scanner":"dlp"}
+//   - Forward proxy text: "blocked by DLP: AWS Access ID" or "SSRF: private IP"
+//   - Kill switch: "kill switch active"
+func extractBlockEvidence(body string, ev map[string]interface{}) {
+	// Try JSON first (fetch endpoint responses).
+	var jsonResp struct {
+		BlockReason string `json:"block_reason"`
+		Scanner     string `json:"scanner"`
+	}
+	if json.Unmarshal([]byte(body), &jsonResp) == nil {
+		if jsonResp.BlockReason != "" {
+			ev["block_reason"] = jsonResp.BlockReason
+		}
+		if jsonResp.Scanner != "" {
+			ev["scanner"] = jsonResp.Scanner
+		}
+		return
+	}
+
+	// Text body classification by keyword matching.
+	lower := strings.ToLower(body)
+	switch {
+	case strings.Contains(lower, "dlp") || strings.Contains(lower, "secret") || strings.Contains(lower, "credential"):
+		ev["block_reason"] = truncate(body, 120)
+		ev["scanner"] = "dlp"
+	case strings.Contains(lower, "ssrf") || strings.Contains(lower, "private ip") || strings.Contains(lower, "metadata"):
+		ev["block_reason"] = truncate(body, 120)
+		ev["scanner"] = "ssrf"
+	case strings.Contains(lower, "injection") || strings.Contains(lower, "prompt"):
+		ev["block_reason"] = truncate(body, 120)
+		ev["scanner"] = "response_injection"
+	case strings.Contains(lower, "entropy"):
+		ev["block_reason"] = truncate(body, 120)
+		ev["scanner"] = "entropy"
+	case strings.Contains(lower, "blocklist") || strings.Contains(lower, "blocked domain"):
+		ev["block_reason"] = truncate(body, 120)
+		ev["scanner"] = "blocklist"
+	case strings.Contains(lower, "kill switch"):
+		ev["block_reason"] = truncate(body, 120)
+		ev["scanner"] = "kill_switch"
+	case strings.Contains(lower, "airlock"):
+		ev["block_reason"] = truncate(body, 120)
+		ev["scanner"] = "airlock"
+	case len(body) > 0:
+		ev["block_reason"] = truncate(body, 120)
+	}
+}
+
 // classifyResponse determines block vs allow from the HTTP response.
 func classifyResponse(statusCode int, body string) Result {
 	evidence := map[string]interface{}{
 		"status_code": statusCode,
 	}
 
-	if statusCode == http.StatusForbidden {
-		evidence["reason"] = "http_403"
-		if strings.Contains(body, "block_reason") || strings.Contains(body, "blocked") {
-			evidence["body_snippet"] = truncate(body, 200)
-		}
-		return Result{Verdict: "block", Evidence: evidence}
-	}
-
-	if statusCode == http.StatusBadRequest || statusCode == http.StatusBadGateway {
+	if statusCode == http.StatusForbidden || statusCode == http.StatusBadRequest || statusCode == http.StatusBadGateway {
 		evidence["reason"] = fmt.Sprintf("http_%d", statusCode)
+		// Extract structured block details from response body.
+		extractBlockEvidence(body, evidence)
 		return Result{Verdict: "block", Evidence: evidence}
 	}
 

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -80,19 +80,29 @@ func TestNewProxyAdapter_ScanAddrFallback(t *testing.T) {
 	}
 }
 
-func TestRunFetchProxy_SkipsNonGET(t *testing.T) {
-	a := &ProxyAdapter{}
+func TestRunFetchProxy_AcceptsPOST(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"blocked":false}`)
+	}))
+	defer srv.Close()
+	a, _ := NewProxyAdapter(srv.Listener.Addr().String(), "", "", "")
 	c := Case{
 		ID:        "test-post",
 		Transport: "fetch_proxy",
 		Payload: map[string]interface{}{
-			"url":    "https://example.com/upload",
-			"method": "POST",
+			"url":          "https://example.com/upload",
+			"method":       "POST",
+			"content_type": "application/json",
+			"body":         `{"key": "value"}`,
 		},
 	}
 	result := a.runFetchProxy(c, 5*time.Second)
-	if result.Verdict != "skip" {
-		t.Errorf("expected skip for POST fetch_proxy, got %q", result.Verdict)
+	if result.Verdict == "skip" {
+		t.Errorf("POST fetch_proxy should not be skipped, got skip")
 	}
 }
 

--- a/runner/main.go
+++ b/runner/main.go
@@ -117,6 +117,7 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 			ID:              c.ID,
 			ExpectedVerdict: c.ExpectedVerdict,
 			Transport:       c.Transport,
+			InputType:       c.InputType,
 			Payload:         c.Payload,
 		}
 		adapterResult := adapt.Run(adapterCase, timeout)

--- a/runner/score.go
+++ b/runner/score.go
@@ -44,15 +44,44 @@ func scoreCase(expected, actual string) string {
 	}
 }
 
+// hasClassification checks if the evidence contains scanner/kind information
+// that demonstrates the tool identified what KIND of attack it blocked.
+func hasClassification(ev map[string]interface{}) bool {
+	// Scan API results include "kind" (dlp, prompt_injection, tool_call).
+	if _, ok := ev["kind"]; ok {
+		return true
+	}
+	// Fetch proxy results include "scanner" or "block_reason".
+	if _, ok := ev["scanner"]; ok {
+		return true
+	}
+	if _, ok := ev["block_reason"]; ok {
+		return true
+	}
+	// MCP proxy results include "error_message" with scanner context.
+	if msg, ok := ev["error_message"].(string); ok && msg != "" {
+		return true
+	}
+	return false
+}
+
+// hasStructuredEvidence checks if the evidence contains structured proof
+// fields beyond a bare pass/fail signal.
+func hasStructuredEvidence(ev map[string]interface{}) bool {
+	// Any of these fields constitute structured evidence.
+	for _, key := range []string{"kind", "scanner", "block_reason", "error_message", "decision", "findings"} {
+		if v, ok := ev[key]; ok && v != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // computeScores calculates the four scoring dimensions from applicable case results.
 func computeScores(results []CaseResult) Scores {
 	var totalMalicious, blockedMalicious int
 	var totalBenign, blockedBenign int
-	// In v1 dry-run mode, detection and evidence are 0.0 because there's
-	// no real tool output to inspect.
-	// correctly_blocked_malicious = malicious cases where actual == block
-	// classified_correctly = 0 (no detection info in dry run)
-	// evidence_emitted = 0 (no evidence in dry run)
+	var classifiedCorrectly, evidenceEmitted int
 
 	for _, r := range results {
 		switch r.ExpectedVerdict {
@@ -60,6 +89,12 @@ func computeScores(results []CaseResult) Scores {
 			totalMalicious++
 			if r.ActualVerdict == "block" {
 				blockedMalicious++
+				if hasClassification(r.Evidence) {
+					classifiedCorrectly++
+				}
+				if hasStructuredEvidence(r.Evidence) {
+					evidenceEmitted++
+				}
 			}
 		case "allow":
 			totalBenign++
@@ -82,13 +117,10 @@ func computeScores(results []CaseResult) Scores {
 	}
 
 	if blockedMalicious > 0 {
-		// Detection: classified_correctly / correctly_blocked_malicious
-		// In dry-run mode, no classification info, so 0.0
-		zero := 0.0
-		s.Detection = &zero
-		// Evidence: evidence_emitted / correctly_blocked_malicious
-		// In dry-run mode, no evidence emitted, so 0.0
-		s.Evidence = &zero
+		det := float64(classifiedCorrectly) / float64(blockedMalicious)
+		s.Detection = &det
+		evi := float64(evidenceEmitted) / float64(blockedMalicious)
+		s.Evidence = &evi
 	}
 
 	return s
@@ -99,6 +131,7 @@ func computeScores(results []CaseResult) Scores {
 func computeFullCorpusScores(applicableResults []CaseResult, allCases []Case) Scores {
 	var totalMalicious, blockedMalicious int
 	var totalBenign, blockedBenign int
+	var classifiedCorrectly, evidenceEmitted int
 
 	for _, c := range allCases {
 		switch c.ExpectedVerdict {
@@ -114,6 +147,12 @@ func computeFullCorpusScores(applicableResults []CaseResult, allCases []Case) Sc
 		case "block":
 			if r.ActualVerdict == "block" {
 				blockedMalicious++
+				if hasClassification(r.Evidence) {
+					classifiedCorrectly++
+				}
+				if hasStructuredEvidence(r.Evidence) {
+					evidenceEmitted++
+				}
 			}
 		case "allow":
 			if r.ActualVerdict == "block" {
@@ -132,9 +171,10 @@ func computeFullCorpusScores(applicableResults []CaseResult, allCases []Case) Sc
 		s.FalsePositiveRate = &v
 	}
 	if blockedMalicious > 0 {
-		zero := 0.0
-		s.Detection = &zero
-		s.Evidence = &zero
+		det := float64(classifiedCorrectly) / float64(blockedMalicious)
+		s.Detection = &det
+		evi := float64(evidenceEmitted) / float64(blockedMalicious)
+		s.Evidence = &evi
 	}
 	return s
 }


### PR DESCRIPTION
## Summary
- Score Detection and Evidence dimensions from tool response metadata instead of hardcoding 0.0
- Route request_body/header cases through scan API for DLP (fetch endpoint only scans URLs)
- Extract block evidence from HTTP 403/502 response bodies
- Refresh pipelock benchmark config with all current scanner capabilities
- Show applicable scores as primary in leaderboard site

Replaces #22 (had conflicts from stale fixture branch).

## Test plan
- `cd runner && go test -race -count=1 ./...` — all pass
- Full gauntlet run: 142 applicable, 96.2% containment, 0% FP, 79.2% detection/evidence