### PR TITLE
chore: post-v2.3.0 audit (bump pipelock version refs in README + tool-profile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ Each case is a self-contained JSON file. Here's what one looks like:
 A runner feeds each case to the security tool and records whether it blocked or allowed the traffic. Runner output is one JSONL line per case:
 
 ```json
-{"case_id":"url-dlp-aws-key-001","tool":"pipelock","tool_version":"2.0.0","expected_verdict":"block","actual_verdict":"block","score":"pass","evidence":{},"notes":""}
-{"case_id":"url-benign-api-call-001","tool":"pipelock","tool_version":"2.0.0","expected_verdict":"allow","actual_verdict":"allow","score":"pass","evidence":{},"notes":""}
-{"case_id":"a2a-msg-dlp-api-key-001","tool":"pipelock","tool_version":"2.0.0","expected_verdict":"block","actual_verdict":"not_applicable","score":"not_applicable","evidence":{},"notes":"not applicable: missing_capability"}
+{"case_id":"url-dlp-aws-key-001","tool":"pipelock","tool_version":"2.3.0","expected_verdict":"block","actual_verdict":"block","score":"pass","evidence":{},"notes":""}
+{"case_id":"url-benign-api-call-001","tool":"pipelock","tool_version":"2.3.0","expected_verdict":"allow","actual_verdict":"allow","score":"pass","evidence":{},"notes":""}
+{"case_id":"a2a-msg-dlp-api-key-001","tool":"pipelock","tool_version":"2.3.0","expected_verdict":"block","actual_verdict":"not_applicable","score":"not_applicable","evidence":{},"notes":"not applicable: missing_capability"}
 ```
 
 Cases the tool can't handle (missing capabilities) score `not_applicable`, not `fail`. Nobody gets penalized for features they don't claim to support. See [docs/SCORING.md](docs/SCORING.md).

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The Gauntlet is an optional scoring program that evaluates tools on four indepen
 | **Detection** | Whether the tool identified what it caught |
 | **Evidence** | Whether the tool emitted structured proof |
 
-Containment has a hard floor: below 80%, the run is marked insufficient. There is no composite score. Each metric is reported independently.
+Containment has a hard floor: below 80%, the run is marked insufficient. There is no composite score. Each metric is reported independently. Published results are available on the [Gauntlet leaderboard](https://pipelab.org/gauntlet/).
 
 **Run the Gauntlet:**
 
@@ -237,6 +237,13 @@ This corpus was created by the [Pipelock](https://github.com/luckyPipewrench/pip
 **Conflict of interest disclosure:** The author builds an agent egress security tool. This corpus was designed to be tool-neutral: cases test observable behavior (did the request get blocked?), not implementation details. The [Pipelock runner](examples/pipelock/) is a reference implementation, not a privileged position.
 
 Full governance policy: [docs/GOVERNANCE.md](docs/GOVERNANCE.md).
+
+## Learn more
+
+- [What is an Agent Firewall?](https://pipelab.org/agent-firewall/) — the security architecture this corpus tests
+- [AI Agent Security: Three Layers](https://pipelab.org/learn/ai-agent-security/) — hooks, guardrails, and egress inspection explained
+- [MCP Vulnerabilities](https://pipelab.org/learn/mcp-vulnerabilities/) — the MCP attack surface mapped
+- [Gauntlet Leaderboard](https://pipelab.org/gauntlet/) — published scoring results
 
 ## License
 

--- a/examples/pipelock/tool-profile.json
+++ b/examples/pipelock/tool-profile.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "tool": "pipelock",
-  "tool_version": "2.1.2",
+  "tool_version": "2.3.0",
   "runner_version": "v2",
   "claims": [
     "url_dlp",


### PR DESCRIPTION
## Summary

Three pipelock version strings updated:

- README JSONL output examples (3 lines): \`2.0.0\` to \`2.3.0\`.
- \`examples/pipelock/tool-profile.json\`: \`2.1.2\` to \`2.3.0\`.

All 151 cases still validate. Runner unit tests still pass.