### PR TITLE
docs: bump pipelock tool_version examples to 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ Each case is a self-contained JSON file. Here's what one looks like:
 A runner feeds each case to the security tool and records whether it blocked or allowed the traffic. Runner output is one JSONL line per case:
 
 ```json
-{"case_id":"url-dlp-aws-key-001","tool":"pipelock","tool_version":"2.3.0","expected_verdict":"block","actual_verdict":"block","score":"pass","evidence":{},"notes":""}
-{"case_id":"url-benign-api-call-001","tool":"pipelock","tool_version":"2.3.0","expected_verdict":"allow","actual_verdict":"allow","score":"pass","evidence":{},"notes":""}
-{"case_id":"a2a-msg-dlp-api-key-001","tool":"pipelock","tool_version":"2.3.0","expected_verdict":"block","actual_verdict":"not_applicable","score":"not_applicable","evidence":{},"notes":"not applicable: missing_capability"}
+{"case_id":"url-dlp-aws-key-001","tool":"pipelock","tool_version":"2.4.0","expected_verdict":"block","actual_verdict":"block","score":"pass","evidence":{},"notes":""}
+{"case_id":"url-benign-api-call-001","tool":"pipelock","tool_version":"2.4.0","expected_verdict":"allow","actual_verdict":"allow","score":"pass","evidence":{},"notes":""}
+{"case_id":"a2a-msg-dlp-api-key-001","tool":"pipelock","tool_version":"2.4.0","expected_verdict":"block","actual_verdict":"not_applicable","score":"not_applicable","evidence":{},"notes":"not applicable: missing_capability"}
 ```
 
 Cases the tool can't handle (missing capabilities) score `not_applicable`, not `fail`. Nobody gets penalized for features they don't claim to support. See [docs/SCORING.md](docs/SCORING.md).

--- a/examples/pipelock/tool-profile.json
+++ b/examples/pipelock/tool-profile.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "tool": "pipelock",
-  "tool_version": "2.3.0",
+  "tool_version": "2.4.0",
   "runner_version": "v2",
   "claims": [
     "url_dlp",


### PR DESCRIPTION
Pipelock v2.4.0 tagged 2026-05-09. Refresh the example JSONL output in the README and the canonical examples/pipelock/tool-profile.json so readers and runner authors see the current release as the reference.

## Changes

- `README.md`: 3 example JSONL lines bumped from `tool_version: 2.3.0` to `2.4.0`
- `examples/pipelock/tool-profile.json`: `tool_version` field bumped from `2.3.0` to `2.4.0`

## Not changed

- Tool capabilities (`claims`, `supports`)
- Runner contract (`schema_version: 1`, `runner_version: v2`)
- Case format
- Scoring spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example runner output to reflect tool version 2.4.0.

* **Chores**
  * Updated tool profile version to 2.4.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/agent-egress-bench/pull/31)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->