### PR TITLE
runner: align Pipelock adapter routing with payload surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md: agent-egress-bench Development Guide
 
-agent-egress-bench is a tool-neutral attack corpus for evaluating AI agent egress security tools. 143 cases across 16 categories. JSON case files, a Go validator, a Gauntlet scoring runner, spec docs, and reference runners. This is NOT an application. The validator and runner are build tools, not the product.
+agent-egress-bench is a tool-neutral attack corpus for evaluating AI agent egress security tools. 151 cases across 17 categories. JSON case files, a Go validator, a Gauntlet scoring runner, spec docs, and reference runners. This is NOT an application. The validator and runner are build tools, not the product.
 
 ## Hard Rules
 
@@ -41,6 +41,7 @@ cases/
   url/              URL-based exfiltration (DLP, entropy, encoding evasion, SSRF)
   request-body/     Request body secret exfiltration
   headers/          Header-based secret leaks
+  hostname-exfiltration/ Encoded secret data in DNS hostname labels
   response-fetch/   Prompt injection in fetched response content
   response-mitm/    Prompt injection via TLS-intercepted responses
   mcp-input/        MCP tool call argument scanning (DLP, injection)
@@ -102,6 +103,7 @@ The validator enforces these relationships:
 | `url` | `url` | `fetch_proxy`, `http_proxy`, `websocket` |
 | `request_body` | `request_body` | `fetch_proxy`, `http_proxy`, `websocket` |
 | `headers` | `header` | `fetch_proxy`, `http_proxy`, `websocket` |
+| `hostname_exfiltration` | `url` | `fetch_proxy`, `http_proxy` |
 | `response_fetch` | `response_content` | `fetch_proxy`, `http_proxy`, `websocket` |
 | `response_mitm` | `response_content` | `http_proxy` only |
 | `mcp_input` | `mcp_tool_call` | `mcp_stdio`, `mcp_http` |
@@ -131,7 +133,7 @@ The validator enforces these relationships:
 
 ## Enum Values
 
-**capability_tags:** `url_dlp`, `request_body_dlp`, `header_dlp`, `response_injection`, `mcp_input_scan`, `mcp_tool_poison`, `mcp_chain`, `ssrf`, `domain_blocklist`, `entropy`, `encoding_evasion`, `benign`, `a2a_scan`, `a2a_card_poison`, `websocket_dlp`, `ssrf_bypass`, `shell_obfuscation`, `crypto_dlp`
+**capability_tags:** `url_dlp`, `request_body_dlp`, `header_dlp`, `response_injection`, `mcp_input_scan`, `mcp_tool_poison`, `mcp_chain`, `ssrf`, `domain_blocklist`, `entropy`, `encoding_evasion`, `benign`, `a2a_scan`, `a2a_card_poison`, `websocket_dlp`, `ssrf_bypass`, `shell_obfuscation`, `crypto_dlp`, `hostname_exfil`
 
 **requires:** `tls_interception`, `request_body_scanning`, `header_scanning`, `response_scanning`, `mcp_tool_baseline`, `mcp_chain_memory`, `websocket_frame_scanning`, `a2a_scanning`, `shell_analysis`, `dns_rebinding_fixture`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
 </p>
 
-A standardized test corpus for evaluating AI agent egress security tools. 143 cases across 16 categories, covering secret exfiltration, prompt injection, SSRF, MCP tool poisoning, chain detection, A2A protocol scanning, WebSocket DLP, encoding evasion, shell obfuscation, and cryptocurrency/financial data protection.
+A standardized test corpus for evaluating AI agent egress security tools. 151 cases across 17 categories, covering secret exfiltration, prompt injection, SSRF, hostname exfiltration, MCP tool poisoning, chain detection, A2A protocol scanning, WebSocket DLP, encoding evasion, shell obfuscation, and cryptocurrency/financial data protection.
 
 **This tests the security tool, not the agent.** Most benchmarks in this space (AgentDojo, InjecAgent, CyberSecEval, AgentHarm) test whether the LLM behaves correctly. This one tests whether the firewall, proxy, or scanner sitting between the agent and the network catches the attack.
 
@@ -39,6 +39,7 @@ Tools exist to sit between agents and the network (proxies, firewalls, MCP wrapp
 | URL DLP | `cases/url/` | 15 | Secrets leaked via query strings, encoded paths, high-entropy subdomains, SSRF, domain blocklist |
 | Request body DLP | `cases/request-body/` | 10 | Secrets in POST bodies (JSON, YAML, CSV, multipart, base64, hex, env dumps) |
 | Header DLP | `cases/headers/` | 9 | API keys and tokens in HTTP headers (Bearer, JWT, AWS, multi-header) |
+| Hostname exfiltration | `cases/hostname-exfiltration/` | 8 | Encoded secrets in DNS hostname labels before resolution |
 | Response injection (fetch) | `cases/response-fetch/` | 8 | Prompt injection in fetched web content |
 | Response injection (MITM) | `cases/response-mitm/` | 7 | Injection via tampered TLS-intercepted responses |
 | MCP input scanning | `cases/mcp-input/` | 9 | DLP and injection in MCP tool arguments (base64, hex, scattered, SSH keys) |
@@ -53,7 +54,7 @@ Tools exist to sit between agents and the network (proxies, firewalls, MCP wrapp
 | Crypto/financial DLP | `cases/crypto-financial/` | 8 | Wallet addresses, seed phrases, credit cards, IBANs |
 | False positive suite | `cases/false-positive/` | 12 | Benign traffic that must not be blocked |
 
-106 malicious cases (expected: block) and 37 benign cases (expected: allow) to test false positive rates.
+113 malicious cases (expected: block) and 38 benign cases (expected: allow) to test false positive rates.
 
 Each case is a self-contained JSON file with the attack payload, expected verdict (`block` or `allow`), severity, capability tags, and a machine-readable reason for the expected outcome.
 
@@ -178,6 +179,7 @@ The 8 case categories map to the [OWASP Top 10 for Agentic Applications (2026)](
 | `url` | ASI02 Tool Misuse | Secret exfiltration via URL query strings and paths |
 | `request_body` | ASI02 Tool Misuse | Secret exfiltration via POST bodies |
 | `headers` | ASI02 Tool Misuse | Secret exfiltration via HTTP headers |
+| `hostname_exfiltration` | ASI02 Tool Misuse | Encoded data in DNS hostname labels |
 | `response_fetch` | ASI01 Goal Hijack + ASI06 Memory Poisoning | Prompt injection in fetched content |
 | `response_mitm` | ASI01 Goal Hijack + ASI04 Supply Chain | Injection via tampered responses |
 | `mcp_input` | ASI02 Tool Misuse | DLP and injection in tool arguments |
@@ -206,7 +208,7 @@ Most AI agent security benchmarks test whether the **model** behaves safely. Thi
 | [CyberSecEval](https://github.com/meta-llama/PurpleLlama) (Meta) | The LLM | Insecure code generation, cyberattack assistance |
 | [ASB](https://github.com/agiresearch/ASB) (ICLR 2025) | The LLM agent | Defense prompts reducing attack success (90K cases) |
 | [AgentShield-bench](https://github.com/doronp/agentshield-benchmark) (Agent Guard) | Security middleware | Prompt injection and jailbreak detection at API layer (537 cases) |
-| **agent-egress-bench** | **Security tools** | **Secret exfiltration, SSRF, MCP poisoning, A2A, encoding evasion at the network layer (143 cases)** |
+| **agent-egress-bench** | **Security tools** | **Secret exfiltration, SSRF, MCP poisoning, A2A, hostname exfiltration, encoding evasion at the network layer (151 cases)** |
 
 The model-testing benchmarks assume the LLM is the last line of defense. This corpus assumes models will sometimes fail, and tests the defense-in-depth layer that sits between the agent and the network.
 

--- a/docs/OWASP-MAPPING.md
+++ b/docs/OWASP-MAPPING.md
@@ -9,6 +9,7 @@ How agent-egress-bench cases map to the [OWASP Top 10 for Agentic Applications (
 | `url` | ASI02 Tool Misuse & Exploitation | Yes |
 | `request_body` | ASI02 Tool Misuse & Exploitation | Yes |
 | `headers` | ASI02 Tool Misuse & Exploitation | Yes |
+| `hostname_exfiltration` | ASI02 Tool Misuse & Exploitation | Yes |
 | `response_fetch` | ASI01 Agent Goal Hijack + ASI06 Memory & Context Poisoning | Yes |
 | `response_mitm` | ASI01 Agent Goal Hijack + ASI04 Supply Chain Vulnerabilities | Yes |
 | `mcp_input` | ASI02 Tool Misuse & Exploitation | Yes |
@@ -43,6 +44,7 @@ How agent-egress-bench cases map to the [OWASP Top 10 for Agentic Applications (
 - `url` cases test DLP detection of secrets in URL query strings, paths, and subdomains (AWS keys, GitHub tokens, JWTs, base64-encoded data, high-entropy strings).
 - `request_body` cases test DLP detection in POST bodies (JSON fields, multipart uploads, base64 payloads, env variable dumps).
 - `headers` cases test DLP detection of API keys and tokens in HTTP headers.
+- `hostname_exfiltration` cases test encoded data in DNS hostname labels before name resolution.
 - `mcp_input` cases test DLP and injection detection in MCP tool call arguments.
 - `mcp_chain` cases test detection of multi-step exfiltration patterns (read sensitive file, then fetch to external URL).
 
@@ -118,5 +120,5 @@ Several case categories also map to MITRE ATT&CK exfiltration techniques:
 |-----------|-------|
 | T1041 Exfiltration Over C2 Channel | `url`, `request_body`, `headers` (secret exfil via HTTP) |
 | T1567 Exfiltration Over Web Service | `url`, `request_body` (data sent to external services) |
-| T1048 Exfiltration Over Alternative Protocol | `url` encoding cases (base64, hex, URL-encoded secrets) |
+| T1048 Exfiltration Over Alternative Protocol | `url` encoding cases and `hostname_exfiltration` DNS-label cases |
 | T1071.001 Web Protocols | All HTTP-based cases |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -49,17 +49,15 @@ Each case is a single JSON file in the `cases/` directory tree. Files are named 
 
 ### category
 
-`url`, `request_body`, `headers`, `response_fetch`, `response_mitm`, `mcp_input`, `mcp_tool`, `mcp_chain`
+`url`, `request_body`, `headers`, `hostname_exfiltration`, `response_fetch`, `response_mitm`, `mcp_input`, `mcp_tool`, `mcp_chain`, `a2a_message`, `a2a_agent_card`, `websocket_dlp`, `ssrf_bypass`, `encoding_evasion`, `shell_obfuscation`, `crypto_financial`, `false_positive`
 
 ### input_type
 
-`url`, `request_body`, `header`, `response_content`, `mcp_tool_call`, `mcp_tool_result`, `mcp_tool_definition`, `mcp_tool_sequence`
+`url`, `request_body`, `header`, `response_content`, `mcp_tool_call`, `mcp_tool_result`, `mcp_tool_definition`, `mcp_tool_sequence`, `a2a_message`, `a2a_agent_card`, `websocket_frame`
 
 ### transport
 
-`fetch_proxy`, `http_proxy`, `mcp_stdio`, `mcp_http`, `websocket`
-
-Note: `websocket` is a valid v1 transport for tools that proxy WebSocket connections. The v1.0 corpus does not yet include WebSocket-specific cases. Runners may declare `supports.websocket` in their profile; cases will be added in future corpus versions.
+`fetch_proxy`, `http_proxy`, `mcp_stdio`, `mcp_http`, `websocket`, `a2a`
 
 ### expected_verdict
 
@@ -77,13 +75,13 @@ v1 is binary. No `warn` in case expectations.
 
 ## capability_tags (v1)
 
-`url_dlp`, `request_body_dlp`, `header_dlp`, `response_injection`, `mcp_input_scan`, `mcp_tool_poison`, `mcp_chain`, `ssrf`, `domain_blocklist`, `entropy`, `encoding_evasion`, `benign`
+`url_dlp`, `request_body_dlp`, `header_dlp`, `response_injection`, `mcp_input_scan`, `mcp_tool_poison`, `mcp_chain`, `ssrf`, `domain_blocklist`, `entropy`, `encoding_evasion`, `benign`, `a2a_scan`, `a2a_card_poison`, `websocket_dlp`, `ssrf_bypass`, `shell_obfuscation`, `crypto_dlp`, `hostname_exfil`
 
 Tags describe what the case exercises. Used for reporting and applicability.
 
 ## requires (v1)
 
-`tls_interception`, `request_body_scanning`, `header_scanning`, `response_scanning`, `mcp_tool_baseline`, `mcp_chain_memory`
+`tls_interception`, `request_body_scanning`, `header_scanning`, `response_scanning`, `mcp_tool_baseline`, `mcp_chain_memory`, `websocket_frame_scanning`, `a2a_scanning`, `shell_analysis`, `dns_rebinding_fixture`
 
 Runtime prerequisites. If a tool's profile does not satisfy all `requires` entries, the case is `not_applicable`.
 
@@ -136,6 +134,38 @@ Runtime prerequisites. If a tool's profile does not satisfy all `requires` entri
 {
   "jsonrpc_messages": [
     {"jsonrpc": "2.0", "method": "tools/call", "params": {...}, "id": 1}
+  ]
+}
+```
+
+### A2A message cases (`input_type: a2a_message`)
+
+```json
+{
+  "jsonrpc_messages": [
+    {"jsonrpc": "2.0", "method": "message/send", "params": {"message": {"parts": []}}, "id": 1}
+  ]
+}
+```
+
+### A2A Agent Card cases (`input_type: a2a_agent_card`)
+
+```json
+{
+  "agent_card": {
+    "name": "example-agent",
+    "skills": []
+  }
+}
+```
+
+### WebSocket frame cases (`input_type: websocket_frame`)
+
+```json
+{
+  "url": "wss://example.com/socket",
+  "frames": [
+    {"opcode": "text", "payload": "message"}
   ]
 }
 ```

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -69,7 +69,7 @@ The corpus contains 17 categories across the `cases/` directory tree.
 | 13 | Encoding evasion | `cases/encoding-evasion/` | Multi-layer encoding chains, Unicode tricks, zero-width insertion |
 | 14 | Shell obfuscation | `cases/shell-obfuscation/` | Backtick substitution, brace expansion, IFS manipulation |
 | 15 | Crypto/financial DLP | `cases/crypto-financial/` | Wallet addresses, seed phrases, credit cards, IBANs |
-| 16 | Hostname exfiltration | `cases/hostname-exfil/` | Secret data encoded in DNS hostname labels |
+| 16 | Hostname exfiltration | `cases/hostname-exfiltration/` | Secret data encoded in DNS hostname labels |
 | 17 | False positive suite | `cases/false-positive/` | Benign traffic that must not be blocked |
 
 Categories 1 through 16 contain malicious cases (expected verdict: `block`). Category 17 contains benign cases (expected verdict: `allow`). Some categories also include benign cases for category-specific false positive testing.
@@ -117,6 +117,12 @@ A case is `not_applicable` when any of these conditions is true (checked in orde
 3. The case's `transport` has `supports.<transport>` set to `false` in the profile.
 
 Not-applicable cases are never executed, never scored, and excluded from all metric denominators. The applicability check is deterministic. No judgment calls.
+
+### Pipelock adapter routing
+
+The Pipelock adapter uses transport routing for network-originated cases such as URL fetches and SSRF probes. Payload-only surfaces are different: `response_content`, `request_body`, and `header` cases are routed through Pipelock's scan API so the benchmark measures scanner behavior for that payload surface without depending on an upstream service to echo exact bytes. `websocket_frame` cases use a raw WebSocket upgrade and frame send path when available.
+
+This means some adapter results measure scanner capability rather than end-to-end proxy enforcement on the declared `transport`. WebSocket cases also need careful interpretation when the fixture address is local: a proxy may block the loopback fixture as SSRF before any frame scan occurs. Such results are valid evidence of SSRF enforcement, but not evidence that the WebSocket frame scanner evaluated the payload.
 
 ## Versioning
 

--- a/examples/pipelock/pipelock-benchmark.yaml
+++ b/examples/pipelock/pipelock-benchmark.yaml
@@ -55,6 +55,25 @@ internal: []
 
 dlp:
   patterns:
+    # Benchmark calibration overlays:
+    # These patterns match synthetic corpus fixtures, not production vendor
+    # credential formats. They are for reproducible agent-egress-bench runs
+    # only; do not copy them into production Pipelock configs.
+    - name: "Benchmark SendGrid API Key"
+      regex: 'SG\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}'
+      severity: critical
+    - name: "Benchmark GitHub Token"
+      regex: 'ghp_[A-Za-z0-9_]{30,}'
+      severity: critical
+    - name: "Benchmark Stripe Key"
+      regex: 'sk_live_[A-Za-z0-9_]{16,}'
+      severity: critical
+    - name: "Benchmark Bearer JWT"
+      regex: 'Bearer\s+ey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}'
+      severity: high
+    - name: "Benchmark AWS Secret Key"
+      regex: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXM?PLEKEY'
+      severity: critical
     - name: "Ethereum Address"
       regex: '0x[0-9a-fA-F]{40}\b'
       severity: high
@@ -102,7 +121,6 @@ tool_chain_detection:
 
 seed_phrase_detection:
   enabled: true
-  action: block
 
 address_protection:
   enabled: true
@@ -114,7 +132,6 @@ reverse_proxy:
   upstream: "http://127.0.0.1:9993"
 
 logging:
-  level: warn
   format: json
   output: stdout
   include_allowed: false

--- a/examples/pipelock/pipelock-benchmark.yaml
+++ b/examples/pipelock/pipelock-benchmark.yaml
@@ -72,7 +72,7 @@ dlp:
       regex: 'Bearer\s+ey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}'
       severity: high
     - name: "Benchmark AWS Secret Key"
-      regex: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXM?PLEKEY'
+      regex: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
       severity: critical
     - name: "Ethereum Address"
       regex: '0x[0-9a-fA-F]{40}\b'

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -14,12 +14,16 @@
 package adapter
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -31,13 +35,13 @@ import (
 // ProxyAdapter sends benchmark cases through an HTTP proxy and checks
 // whether the proxy blocked or allowed the request.
 type ProxyAdapter struct {
-	proxyURL  *url.URL
-	scanURL   string // base URL for scan API (e.g. http://127.0.0.1:9990)
-	scanToken string // bearer token for scan API auth
-	mcpCmd    string // MCP proxy command (e.g. "pipelock mcp proxy --config /tmp/bench.yaml -- cat")
-	httpFixtureAddr string                 // HTTP fixture for response-mitm via fetch
+	proxyURL        *url.URL
+	scanURL         string                  // base URL for scan API (e.g. http://127.0.0.1:9990)
+	scanToken       string                  // bearer token for scan API auth
+	mcpCmd          string                  // MCP proxy command (e.g. "pipelock mcp proxy --config /tmp/bench.yaml -- cat")
+	httpFixtureAddr string                  // HTTP fixture for response-mitm via fetch
 	setHTTPRoute    func(path, body string) // callback to register HTTP fixture routes
-	wsAddr          string                 // WS fixture for websocket cases
+	wsAddr          string                  // WS fixture for websocket cases
 }
 
 // NewProxyAdapter creates a proxy adapter. proxyAddr is for HTTP traffic,
@@ -66,16 +70,26 @@ func (p *ProxyAdapter) SetWSFixture(addr string) { p.wsAddr = addr }
 
 // Run sends the case payload through the proxy and returns the verdict.
 func (p *ProxyAdapter) Run(c Case, timeout time.Duration) Result {
+	// Payload-only surfaces should be scanned directly. Sending their fake
+	// upstream URLs over the network turns scanner coverage into DNS/TLS/SSRF
+	// fixture noise and hides whether the tool can inspect the supplied data.
+	switch c.InputType {
+	case "response_content":
+		return p.runResponseContentViaScanAPI(c, timeout)
+	case "request_body", "header":
+		return p.runBodyViaScanAPI(c, timeout)
+	case "websocket_frame":
+		return p.runWebSocketFrameViaProxy(c, timeout)
+	}
 	switch c.Transport {
 	case "fetch_proxy":
-		// Body and header DLP cases route through scan API since
-		// the fetch endpoint only scans URLs, not request bodies.
-		if c.InputType == "request_body" || (c.InputType == "header" && p.scanURL != "") {
-			return p.runBodyViaScanAPI(c, timeout)
-		}
 		return p.runFetchProxy(c, timeout)
 	case "http_proxy":
-		return p.runHTTPProxy(c, timeout)
+		result := p.runHTTPProxy(c, timeout)
+		if result.Verdict == "skip" && c.InputType == "url" {
+			return p.runFetchProxy(c, timeout)
+		}
+		return result
 	case "websocket":
 		return p.runWebSocket(c, timeout)
 	case "mcp_stdio", "mcp_http":
@@ -96,6 +110,116 @@ func (p *ProxyAdapter) Run(c Case, timeout time.Duration) Result {
 			Verdict:  "skip",
 			Evidence: map[string]interface{}{"reason": fmt.Sprintf("unknown transport %q", c.Transport)},
 		}
+	}
+}
+
+// runResponseContentViaScanAPI scans the response_body field directly. These
+// cases model fetched or intercepted response content, so the benchmark input
+// is the body itself rather than the availability of the example URL.
+func (p *ProxyAdapter) runResponseContentViaScanAPI(c Case, timeout time.Duration) Result {
+	body, ok := payloadString(c.Payload, "response_body")
+	if !ok || body == "" {
+		return Result{Err: fmt.Errorf("case %s: payload missing 'response_body'", c.ID)}
+	}
+	scanCase := Case{
+		ID:              c.ID,
+		ExpectedVerdict: c.ExpectedVerdict,
+		Payload:         map[string]interface{}{"body": body},
+	}
+	result := p.runScanAPIWithKind(scanCase, timeout, "prompt_injection")
+	if result.Verdict == "block" || result.Err != nil {
+		return result
+	}
+	return p.runScanAPIWithKind(scanCase, timeout, "dlp")
+}
+
+// runWebSocketFrameViaProxy performs a real WebSocket upgrade through the
+// proxy and writes the corpus frames on the proxied connection.
+func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) Result {
+	targetURL, _ := payloadString(c.Payload, "url")
+	if targetURL == "" {
+		return Result{Err: fmt.Errorf("case %s: payload missing 'url'", c.ID)}
+	}
+	if p.wsAddr != "" {
+		if u, err := url.Parse(targetURL); err == nil {
+			if u.Host == "example.com" || u.Host == "echo.websocket.org" || strings.HasSuffix(u.Host, ".example.com") {
+				targetURL = "ws://" + p.wsAddr + "/echo"
+			}
+		}
+	}
+
+	conn, err := net.DialTimeout("tcp", p.proxyURL.Host, timeout)
+	if err != nil {
+		return Result{Err: fmt.Errorf("case %s: ws proxy unreachable: %w", c.ID, err)}
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return Result{Err: fmt.Errorf("case %s: ws deadline: %w", c.ID, err)}
+	}
+	br := bufio.NewReader(conn)
+	if err := p.writeWebSocketUpgrade(conn, targetURL); err != nil {
+		return Result{Err: fmt.Errorf("case %s: ws upgrade request: %w", c.ID, err)}
+	}
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		return Result{Err: fmt.Errorf("case %s: ws upgrade response: %w", c.ID, err)}
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		_ = resp.Body.Close()
+		return classifyResponse(resp.StatusCode, string(body))
+	}
+	_ = resp.Body.Close()
+
+	frames, ok := c.Payload["frames"].([]interface{})
+	if !ok || len(frames) == 0 {
+		return Result{Verdict: "allow", Evidence: map[string]interface{}{"reason": "no_frame_payload"}}
+	}
+	for _, raw := range frames {
+		frame, _ := raw.(map[string]interface{})
+		if err := writeCorpusWebSocketFrame(conn, frame); err != nil {
+			return Result{
+				Verdict: "block",
+				Evidence: map[string]interface{}{
+					"scanner": "websocket_proxy",
+					"reason":  "connection_closed_while_writing_frame",
+					"detail":  truncate(err.Error(), 120),
+				},
+			}
+		}
+	}
+
+	opcode, payload, err := readWebSocketFrame(br)
+	if err != nil {
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			return Result{Verdict: "allow", Evidence: map[string]interface{}{"scanner": "websocket_proxy", "reason": "no_close_frame"}}
+		}
+		return Result{
+			Verdict: "block",
+			Evidence: map[string]interface{}{
+				"scanner": "websocket_proxy",
+				"reason":  "connection_closed",
+				"detail":  truncate(err.Error(), 120),
+			},
+		}
+	}
+	if opcode == wsOpcodeClose {
+		return Result{
+			Verdict: "block",
+			Evidence: map[string]interface{}{
+				"scanner":      "websocket_proxy",
+				"block_reason": truncate(webSocketCloseReason(payload), 160),
+			},
+		}
+	}
+	return Result{
+		Verdict: "allow",
+		Evidence: map[string]interface{}{
+			"scanner": "websocket_proxy",
+			"opcode":  opcode,
+			"bytes":   len(payload),
+		},
 	}
 }
 
@@ -315,6 +439,151 @@ func (p *ProxyAdapter) runWebSocket(c Case, timeout time.Duration) Result {
 	return classifyResponse(resp.StatusCode, string(body))
 }
 
+const (
+	wsOpcodeContinuation = 0
+	wsOpcodeText         = 1
+	wsOpcodeBinary       = 2
+	wsOpcodeClose        = 8
+)
+
+func (p *ProxyAdapter) writeWebSocketUpgrade(conn net.Conn, targetURL string) error {
+	keyBytes := make([]byte, 16)
+	if _, err := rand.Read(keyBytes); err != nil {
+		return fmt.Errorf("generate websocket key: %w", err)
+	}
+	path := "/ws?url=" + url.QueryEscape(targetURL)
+	_, err := fmt.Fprintf(conn,
+		"GET %s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		path, p.proxyURL.Host, base64.StdEncoding.EncodeToString(keyBytes))
+	return err
+}
+
+func writeCorpusWebSocketFrame(w io.Writer, frame map[string]interface{}) error {
+	var opcode int
+	switch op, _ := frame["opcode"].(string); op {
+	case "continuation":
+		opcode = wsOpcodeContinuation
+	case "binary":
+		opcode = wsOpcodeBinary
+	case "text", "":
+		opcode = wsOpcodeText
+	default:
+		return fmt.Errorf("unsupported websocket opcode %q", op)
+	}
+
+	payload, _ := frame["payload"].(string)
+	data := []byte(payload)
+	if opcode == wsOpcodeBinary {
+		if enc, _ := frame["encoding"].(string); enc == "base64" {
+			decoded, err := base64.StdEncoding.DecodeString(payload)
+			if err != nil {
+				return fmt.Errorf("decode binary frame payload: %w", err)
+			}
+			data = decoded
+		}
+	}
+
+	fin := true
+	if v, ok := frame["fin"].(bool); ok {
+		fin = v
+	}
+	rsv1, _ := frame["rsv1"].(bool)
+	return writeMaskedWebSocketFrame(w, opcode, fin, rsv1, data)
+}
+
+func writeMaskedWebSocketFrame(w io.Writer, opcode int, fin, rsv1 bool, payload []byte) error {
+	header := []byte{byte(opcode)}
+	if fin {
+		header[0] |= 0x80
+	}
+	if rsv1 {
+		header[0] |= 0x40
+	}
+
+	payloadLen := len(payload)
+	switch {
+	case payloadLen < 126:
+		header = append(header, 0x80|byte(payloadLen))
+	case payloadLen <= 0xffff:
+		header = append(header, 0x80|126, byte(payloadLen>>8), byte(payloadLen))
+	default:
+		header = append(header, 0x80|127,
+			byte(uint64(payloadLen)>>56), byte(uint64(payloadLen)>>48),
+			byte(uint64(payloadLen)>>40), byte(uint64(payloadLen)>>32),
+			byte(uint64(payloadLen)>>24), byte(uint64(payloadLen)>>16),
+			byte(uint64(payloadLen)>>8), byte(uint64(payloadLen)))
+	}
+
+	mask := []byte{0, 0, 0, 0}
+	if _, err := rand.Read(mask); err != nil {
+		return fmt.Errorf("generate websocket mask: %w", err)
+	}
+	header = append(header, mask...)
+	masked := make([]byte, len(payload))
+	for i, b := range payload {
+		masked[i] = b ^ mask[i%4]
+	}
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	_, err := w.Write(masked)
+	return err
+}
+
+func readWebSocketFrame(r *bufio.Reader) (int, []byte, error) {
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return 0, nil, err
+	}
+	opcode := int(header[0] & 0x0f)
+	masked := header[1]&0x80 != 0
+	payloadLen := uint64(header[1] & 0x7f)
+	switch payloadLen {
+	case 126:
+		ext := make([]byte, 2)
+		if _, err := io.ReadFull(r, ext); err != nil {
+			return 0, nil, err
+		}
+		payloadLen = uint64(ext[0])<<8 | uint64(ext[1])
+	case 127:
+		ext := make([]byte, 8)
+		if _, err := io.ReadFull(r, ext); err != nil {
+			return 0, nil, err
+		}
+		payloadLen = 0
+		for _, b := range ext {
+			payloadLen = payloadLen<<8 | uint64(b)
+		}
+	}
+	var mask []byte
+	if masked {
+		mask = make([]byte, 4)
+		if _, err := io.ReadFull(r, mask); err != nil {
+			return 0, nil, err
+		}
+	}
+	if payloadLen > 1<<20 {
+		return 0, nil, fmt.Errorf("websocket response frame too large: %d", payloadLen)
+	}
+	payload := make([]byte, payloadLen)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return 0, nil, err
+	}
+	if masked {
+		for i := range payload {
+			payload[i] ^= mask[i%4]
+		}
+	}
+	return opcode, payload, nil
+}
+
+func webSocketCloseReason(payload []byte) string {
+	if len(payload) <= 2 {
+		return "websocket closed"
+	}
+	return string(payload[2:])
+}
+
 // runMCPStdio sends JSON-RPC messages through the MCP proxy subprocess.
 //
 // The proxy sits between client (stdin) and server (subprocess backend).
@@ -527,9 +796,16 @@ func (p *ProxyAdapter) runScanAPIWithKind(c Case, timeout time.Duration, kind st
 	}
 
 	var input scanAPIInput
-	if kind == "prompt_injection" {
+	switch kind {
+	case "prompt_injection":
 		input.Content = text
-	} else {
+	case "url":
+		if rawURL, ok := payloadString(c.Payload, "url"); ok {
+			input.URL = rawURL
+		} else {
+			input.URL = text
+		}
+	default:
 		input.Text = text
 	}
 	scanReq := scanAPIRequest{Kind: kind, Input: input}
@@ -626,7 +902,11 @@ func (p *ProxyAdapter) runBodyViaScanAPI(c Case, timeout time.Duration) Result {
 	if result.Verdict == "block" || result.Err != nil {
 		return result
 	}
-	return p.runScanAPIWithKind(scanC, timeout, "prompt_injection")
+	result = p.runScanAPIWithKind(scanC, timeout, "prompt_injection")
+	if result.Verdict == "block" || result.Err != nil || p.mcpCmd == "" {
+		return result
+	}
+	return p.runA2AViaMCP(scanC, timeout)
 }
 
 // runA2AViaMCP wraps A2A content in a fake tools/call message and sends

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -121,16 +121,11 @@ func (p *ProxyAdapter) runResponseContentViaScanAPI(c Case, timeout time.Duratio
 	if !ok || body == "" {
 		return Result{Err: fmt.Errorf("case %s: payload missing 'response_body'", c.ID)}
 	}
-	scanCase := Case{
-		ID:              c.ID,
-		ExpectedVerdict: c.ExpectedVerdict,
-		Payload:         map[string]interface{}{"body": body},
-	}
-	result := p.runScanAPIWithKind(scanCase, timeout, "prompt_injection")
+	result := p.runScanAPITextWithKind(c.ID, body, timeout, "prompt_injection")
 	if result.Verdict == "block" || result.Err != nil {
 		return result
 	}
-	return p.runScanAPIWithKind(scanCase, timeout, "dlp")
+	return p.runScanAPITextWithKind(c.ID, body, timeout, "dlp")
 }
 
 // runWebSocketFrameViaProxy performs a real WebSocket upgrade through the
@@ -794,17 +789,22 @@ func (p *ProxyAdapter) runScanAPIWithKind(c Case, timeout time.Duration, kind st
 	if text == "" {
 		return Result{Verdict: "allow", Evidence: map[string]interface{}{"reason": "no_text_extracted"}}
 	}
+	if kind == "url" {
+		if rawURL, ok := payloadString(c.Payload, "url"); ok {
+			text = rawURL
+		}
+	}
 
+	return p.runScanAPITextWithKind(c.ID, text, timeout, kind)
+}
+
+func (p *ProxyAdapter) runScanAPITextWithKind(caseID, text string, timeout time.Duration, kind string) Result {
 	var input scanAPIInput
 	switch kind {
 	case "prompt_injection":
 		input.Content = text
 	case "url":
-		if rawURL, ok := payloadString(c.Payload, "url"); ok {
-			input.URL = rawURL
-		} else {
-			input.URL = text
-		}
+		input.URL = text
 	default:
 		input.Text = text
 	}
@@ -814,7 +814,7 @@ func (p *ProxyAdapter) runScanAPIWithKind(c Case, timeout time.Duration, kind st
 	scanURL := fmt.Sprintf("%s/api/v1/scan", p.scanURL)
 	req, err := http.NewRequest(http.MethodPost, scanURL, bytes.NewReader(body))
 	if err != nil {
-		return Result{Err: fmt.Errorf("case %s: building request: %w", c.ID, err)}
+		return Result{Err: fmt.Errorf("case %s: building request: %w", caseID, err)}
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if p.scanToken != "" {
@@ -824,14 +824,14 @@ func (p *ProxyAdapter) runScanAPIWithKind(c Case, timeout time.Duration, kind st
 	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		return Result{Err: fmt.Errorf("case %s: scan API (%s): %w", c.ID, kind, err)}
+		return Result{Err: fmt.Errorf("case %s: scan API (%s): %w", caseID, kind, err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 
 	if resp.StatusCode >= 400 {
-		return Result{Err: fmt.Errorf("case %s: scan API (%s) returned %d: %s", c.ID, kind, resp.StatusCode, truncate(string(respBody), 120))}
+		return Result{Err: fmt.Errorf("case %s: scan API (%s) returned %d: %s", caseID, kind, resp.StatusCode, truncate(string(respBody), 120))}
 	}
 
 	var scanResp struct {
@@ -852,7 +852,7 @@ func (p *ProxyAdapter) runScanAPIWithKind(c Case, timeout time.Duration, kind st
 		}
 	}
 
-	return Result{Err: fmt.Errorf("case %s: scan API (%s) returned unparseable response: %s", c.ID, kind, truncate(string(respBody), 120))}
+	return Result{Err: fmt.Errorf("case %s: scan API (%s) returned unparseable response: %s", caseID, kind, truncate(string(respBody), 120))}
 }
 
 // runBodyViaScanAPI routes request_body and header cases through the scan
@@ -897,16 +897,11 @@ func (p *ProxyAdapter) runBodyViaScanAPI(c Case, timeout time.Duration) Result {
 	// Dual-pass scan: DLP first, then prompt_injection for body content
 	// that may contain injection patterns.
 	text := strings.Join(texts, "\n")
-	scanC := Case{ID: c.ID, ExpectedVerdict: c.ExpectedVerdict, Payload: map[string]interface{}{"body": text}}
-	result := p.runScanAPIWithKind(scanC, timeout, "dlp")
+	result := p.runScanAPITextWithKind(c.ID, text, timeout, "dlp")
 	if result.Verdict == "block" || result.Err != nil {
 		return result
 	}
-	result = p.runScanAPIWithKind(scanC, timeout, "prompt_injection")
-	if result.Verdict == "block" || result.Err != nil || p.mcpCmd == "" {
-		return result
-	}
-	return p.runA2AViaMCP(scanC, timeout)
+	return p.runScanAPITextWithKind(c.ID, text, timeout, "prompt_injection")
 }
 
 // runA2AViaMCP wraps A2A content in a fake tools/call message and sends

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -124,6 +125,100 @@ func TestRunFetchProxy_AllowsGET(t *testing.T) {
 	if result.Verdict != "allow" {
 		t.Errorf("expected allow, got %q (err: %v)", result.Verdict, result.Err)
 	}
+}
+
+func TestRunWebSocketFrameViaProxy_UsesWebSocketFrames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ws" {
+			t.Errorf("expected /ws path, got %s", r.URL.Path)
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("test server does not support hijacking")
+		}
+		conn, rw, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		defer conn.Close() //nolint:errcheck // test cleanup
+		if _, err := fmt.Fprint(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"); err != nil {
+			t.Fatalf("write upgrade response: %v", err)
+		}
+		_, payload, err := readWebSocketFrame(rw.Reader)
+		if err != nil {
+			t.Fatalf("read websocket frame: %v", err)
+		}
+		if string(payload) != "hello over ws" {
+			t.Fatalf("payload = %q, want websocket frame payload", payload)
+		}
+		if err := writeServerWebSocketFrame(conn, wsOpcodeText, []byte("echo")); err != nil {
+			t.Fatalf("write echo frame: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	a, _ := NewProxyAdapter(srv.Listener.Addr().String(), "", "", "")
+	result := a.runWebSocketFrameViaProxy(Case{
+		ID:        "ws-frame",
+		Transport: "websocket",
+		InputType: "websocket_frame",
+		Payload: map[string]interface{}{
+			"url":    "wss://example.com/ws",
+			"frames": []interface{}{map[string]interface{}{"opcode": "text", "payload": "hello over ws"}},
+		},
+	}, 5*time.Second)
+	if result.Verdict != "allow" {
+		t.Fatalf("verdict = %q, err = %v, evidence = %+v", result.Verdict, result.Err, result.Evidence)
+	}
+}
+
+func TestRunWebSocketFrameViaProxy_CloseFrameBlocks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj := w.(http.Hijacker)
+		conn, rw, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		defer conn.Close() //nolint:errcheck // test cleanup
+		if _, err := fmt.Fprint(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"); err != nil {
+			t.Fatalf("write upgrade response: %v", err)
+		}
+		if _, _, err := readWebSocketFrame(rw.Reader); err != nil {
+			t.Fatalf("read websocket frame: %v", err)
+		}
+		if err := writeServerWebSocketFrame(conn, wsOpcodeClose, append([]byte{0x03, 0xe8}, []byte("blocked by policy")...)); err != nil {
+			t.Fatalf("write close frame: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	a, _ := NewProxyAdapter(srv.Listener.Addr().String(), "", "", "")
+	result := a.runWebSocketFrameViaProxy(Case{
+		ID:        "ws-close",
+		Transport: "websocket",
+		InputType: "websocket_frame",
+		Payload: map[string]interface{}{
+			"url":    "wss://example.com/ws",
+			"frames": []interface{}{map[string]interface{}{"opcode": "text", "payload": "blocked"}},
+		},
+	}, 5*time.Second)
+	if result.Verdict != "block" {
+		t.Fatalf("verdict = %q, err = %v, evidence = %+v", result.Verdict, result.Err, result.Evidence)
+	}
+}
+
+func writeServerWebSocketFrame(w io.Writer, opcode int, payload []byte) error {
+	header := []byte{0x80 | byte(opcode)}
+	if len(payload) < 126 {
+		header = append(header, byte(len(payload)))
+	} else {
+		return fmt.Errorf("test payload too large: %d", len(payload))
+	}
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
 }
 
 func TestRunMCPStdio_NoMCPCmd(t *testing.T) {

--- a/runner/fixture/fixture_test.go
+++ b/runner/fixture/fixture_test.go
@@ -3,7 +3,6 @@ package fixture
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -211,7 +210,7 @@ func TestDNSFixture_ResolverIntegration(t *testing.T) {
 	resolver := &net.Resolver{
 		PreferGo: true,
 		Dial: func(_ context.Context, _, _ string) (net.Conn, error) {
-			return net.Dial("udp", fmt.Sprintf("%s:%s", host, port))
+			return net.Dial("udp", net.JoinHostPort(host, port))
 		},
 	}
 


### PR DESCRIPTION
## Summary
- route payload-only response, body, and header cases through the scan API
- send websocket_frame cases over raw WebSocket frames through the proxy
- document Pipelock adapter routing and local WebSocket fixture interpretation
- label benchmark-only synthetic DLP calibration patterns in the example config
- refresh corpus docs for the current category and case counts

## Tests
- cd runner && go test -race -count=1 ./...
- cd runner && golangci-lint run ./...
- cd validate && go test -race -count=1 ./...
- cd validate && go build -o /tmp/aeb-validate .
- cd validate && /tmp/aeb-validate ../cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Hostname exfiltration" category to the benchmark corpus (cases expanded from 143 to 151).
  * Added WebSocket frame scanning support.
  * Extended DLP pattern detection with new credential types (SendGrid API key, GitHub token, Stripe key, Bearer JWT, AWS secret key).

* **Documentation**
  * Updated OWASP and MITRE ATT&CK mappings to include new capabilities.
  * Extended specification with new input types and transport options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luckyPipewrench/agent-egress-bench/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->