### PR TITLE
fix(runner): replay multi-server MCP drift responses

### DIFF
--- a/runner/main.go
+++ b/runner/main.go
@@ -65,7 +65,11 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 			return mfErr
 		}
 		for _, mfc := range mfCases {
-			cases = append(cases, mfc.toCase())
+			converted, convertErr := mfc.toCase()
+			if convertErr != nil {
+				return fmt.Errorf("convert multi-file case %s: %w", mfc.ID, convertErr)
+			}
+			cases = append(cases, converted)
 		}
 	}
 

--- a/runner/multifile.go
+++ b/runner/multifile.go
@@ -283,11 +283,15 @@ func (c MultiFileCase) receiptScoringExpected() string {
 // ExpectedVerdict is normalized through receiptScoringExpected so the
 // downstream receipt-profile mapping does not need to know about the
 // "warn" verdict that mcp-drift benign cases declare.
-func (c MultiFileCase) toCase() Case {
+func (c MultiFileCase) toCase() (Case, error) {
 	messages := make([]interface{}, 0, 4)
 	nextID := float64(1)
-	appendSnapshotMessages := func(snapshot map[string]interface{}) {
-		for _, response := range multiFileSnapshotResponses(snapshot) {
+	appendSnapshotMessages := func(label string, snapshot map[string]interface{}) error {
+		responses, err := multiFileSnapshotResponses(snapshot)
+		if err != nil {
+			return fmt.Errorf("%s snapshot: %w", label, err)
+		}
+		for _, response := range responses {
 			messages = append(messages, map[string]interface{}{
 				"jsonrpc": "2.0",
 				"method":  "tools/list",
@@ -296,9 +300,14 @@ func (c MultiFileCase) toCase() Case {
 			messages = append(messages, withJSONRPCID(response, nextID))
 			nextID++
 		}
+		return nil
 	}
-	appendSnapshotMessages(c.BeforeJSON)
-	appendSnapshotMessages(c.AfterJSON)
+	if err := appendSnapshotMessages("before", c.BeforeJSON); err != nil {
+		return Case{}, err
+	}
+	if err := appendSnapshotMessages("after", c.AfterJSON); err != nil {
+		return Case{}, err
+	}
 
 	return Case{
 		SchemaVersion: c.SchemaVersion,
@@ -319,26 +328,38 @@ func (c MultiFileCase) toCase() Case {
 		WhyExpected:     c.WhyExpected,
 		Notes:           c.Notes,
 		Source:          c.Source,
-	}
+	}, nil
 }
 
-func multiFileSnapshotResponses(snapshot map[string]interface{}) []interface{} {
-	rawServers, ok := snapshot["servers"].([]interface{})
+func multiFileSnapshotResponses(snapshot map[string]interface{}) ([]interface{}, error) {
+	rawServers, hasServers := snapshot["servers"]
+	if !hasServers {
+		return []interface{}{snapshot}, nil
+	}
+	servers, ok := rawServers.([]interface{})
 	if !ok {
-		return []interface{}{snapshot}
+		return nil, fmt.Errorf("servers must be an array")
 	}
-	responses := make([]interface{}, 0, len(rawServers))
-	for _, rawServer := range rawServers {
-		server, _ := rawServer.(map[string]interface{})
-		resp, ok := server["tools_list_response"].(map[string]interface{})
-		if ok {
-			responses = append(responses, resp)
+	if len(servers) == 0 {
+		return nil, fmt.Errorf("servers must contain at least one entry")
+	}
+
+	responses := make([]interface{}, 0, len(servers))
+	for i, rawServer := range servers {
+		server, ok := rawServer.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("servers[%d] must be an object", i)
 		}
+		resp, ok := server["tools_list_response"]
+		if !ok {
+			return nil, fmt.Errorf("servers[%d] missing tools_list_response", i)
+		}
+		if _, ok := resp.(map[string]interface{}); !ok {
+			return nil, fmt.Errorf("servers[%d].tools_list_response must be an object", i)
+		}
+		responses = append(responses, resp)
 	}
-	if len(responses) == 0 {
-		return []interface{}{snapshot}
-	}
-	return responses
+	return responses, nil
 }
 
 func withJSONRPCID(msg interface{}, id float64) interface{} {

--- a/runner/multifile.go
+++ b/runner/multifile.go
@@ -273,28 +273,33 @@ func (c MultiFileCase) receiptScoringExpected() string {
 }
 
 // toCase converts a MultiFileCase into a regular Case the existing runner
-// pipeline can execute. The Payload contains the four-message JSON-RPC
-// sequence the mcp_stdio adapter expects for tool-poisoning scenarios:
-// two client tools/list requests interleaved with two server responses
-// (before.json on request 1, after.json on request 2). Pipelock observes
-// both responses through a single MCP session and the adapter captures the
-// verdict on whichever response triggers a policy block, normally the
-// second.
+// pipeline can execute. The Payload contains an ordered JSON-RPC sequence of
+// client tools/list requests interleaved with server responses. Single-server
+// fixtures become the usual four-message sequence (before request/response,
+// after request/response). Multi-server fixtures become one request/response
+// pair per server snapshot so stdio proxy adapters can replay each observed
+// tools/list response without relying on JSON-RPC batches.
 //
 // ExpectedVerdict is normalized through receiptScoringExpected so the
 // downstream receipt-profile mapping does not need to know about the
 // "warn" verdict that mcp-drift benign cases declare.
 func (c MultiFileCase) toCase() Case {
-	clientReq1 := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"method":  "tools/list",
-		"id":      float64(1),
+	messages := make([]interface{}, 0, 4)
+	nextID := float64(1)
+	appendSnapshotMessages := func(snapshot map[string]interface{}) {
+		for _, response := range multiFileSnapshotResponses(snapshot) {
+			messages = append(messages, map[string]interface{}{
+				"jsonrpc": "2.0",
+				"method":  "tools/list",
+				"id":      nextID,
+			})
+			messages = append(messages, withJSONRPCID(response, nextID))
+			nextID++
+		}
 	}
-	clientReq2 := map[string]interface{}{
-		"jsonrpc": "2.0",
-		"method":  "tools/list",
-		"id":      float64(2),
-	}
+	appendSnapshotMessages(c.BeforeJSON)
+	appendSnapshotMessages(c.AfterJSON)
+
 	return Case{
 		SchemaVersion: c.SchemaVersion,
 		ID:            c.ID,
@@ -304,12 +309,7 @@ func (c MultiFileCase) toCase() Case {
 		InputType:     c.InputType,
 		Transport:     c.Transport,
 		Payload: map[string]interface{}{
-			"jsonrpc_messages": []interface{}{
-				clientReq1,
-				c.BeforeJSON,
-				clientReq2,
-				c.AfterJSON,
-			},
+			"jsonrpc_messages": messages,
 		},
 		ExpectedVerdict: c.receiptScoringExpected(),
 		Severity:        c.Severity,
@@ -320,6 +320,38 @@ func (c MultiFileCase) toCase() Case {
 		Notes:           c.Notes,
 		Source:          c.Source,
 	}
+}
+
+func multiFileSnapshotResponses(snapshot map[string]interface{}) []interface{} {
+	rawServers, ok := snapshot["servers"].([]interface{})
+	if !ok {
+		return []interface{}{snapshot}
+	}
+	responses := make([]interface{}, 0, len(rawServers))
+	for _, rawServer := range rawServers {
+		server, _ := rawServer.(map[string]interface{})
+		resp, ok := server["tools_list_response"].(map[string]interface{})
+		if ok {
+			responses = append(responses, resp)
+		}
+	}
+	if len(responses) == 0 {
+		return []interface{}{snapshot}
+	}
+	return responses
+}
+
+func withJSONRPCID(msg interface{}, id float64) interface{} {
+	m, ok := msg.(map[string]interface{})
+	if !ok {
+		return msg
+	}
+	cp := make(map[string]interface{}, len(m)+1)
+	for k, v := range m {
+		cp[k] = v
+	}
+	cp["id"] = id
+	return cp
 }
 
 // computeMultiFileSHA256 hashes the multi-file corpus directory contents

--- a/runner/multifile_test.go
+++ b/runner/multifile_test.go
@@ -275,6 +275,59 @@ func TestMultiFileCase_ToCase_BlockExpected(t *testing.T) {
 	}
 }
 
+// TestMultiFileCase_ToCase_MultiServerResponses verifies that multi-server
+// snapshots are converted into one request/response pair per server rather
+// than leaving the fixture-only "servers" wrapper in the adapter payload.
+func TestMultiFileCase_ToCase_MultiServerResponses(t *testing.T) {
+	cases, err := loadMultiFileCases(filepath.Join("..", "cases", "mcp-drift"))
+	if err != nil {
+		t.Fatalf("loadMultiFileCases: %v", err)
+	}
+	var collusion MultiFileCase
+	for _, c := range cases {
+		if c.ID == "mcp-drift-collusion-004" {
+			collusion = c
+			break
+		}
+	}
+	if collusion.ID == "" {
+		t.Fatal("mcp-drift-collusion-004 not found in mcp-drift fixtures")
+	}
+
+	caseRecord := collusion.toCase()
+	msgs, ok := caseRecord.Payload["jsonrpc_messages"].([]interface{})
+	if !ok || len(msgs) != 8 {
+		t.Fatalf("payload.jsonrpc_messages = %v, want 8-element slice", caseRecord.Payload["jsonrpc_messages"])
+	}
+	for idx := 0; idx < len(msgs); idx += 2 {
+		wantID := float64(idx/2 + 1)
+		req, ok := msgs[idx].(map[string]interface{})
+		if !ok {
+			t.Fatalf("msgs[%d] = %T, want request object", idx, msgs[idx])
+		}
+		if req["method"] != "tools/list" {
+			t.Errorf("msgs[%d].method = %v, want tools/list", idx, req["method"])
+		}
+		if req["id"] != wantID {
+			t.Errorf("msgs[%d].id = %v, want %v", idx, req["id"], wantID)
+		}
+
+		resp, ok := msgs[idx+1].(map[string]interface{})
+		if !ok {
+			t.Fatalf("msgs[%d] = %T, want response object", idx+1, msgs[idx+1])
+		}
+		if resp["id"] != wantID {
+			t.Errorf("msgs[%d].id = %v, want matching request id %v", idx+1, resp["id"], wantID)
+		}
+		if _, hasResult := resp["result"]; !hasResult {
+			t.Errorf("msgs[%d] missing result field; not a server response", idx+1)
+		}
+		if _, hasServers := resp["servers"]; hasServers {
+			t.Errorf("msgs[%d] still has servers wrapper", idx+1)
+		}
+	}
+}
+
 // TestMultiFileCase_ToCase_WarnNormalizedToAllow verifies the receipt-
 // scoring rubric normalization: a case.yaml with expected_verdict: warn
 // (the mcp-drift-benign-001 FP-guardrail case) is converted to a Case

--- a/runner/multifile_test.go
+++ b/runner/multifile_test.go
@@ -240,7 +240,10 @@ func TestMultiFileCase_ToCase_BlockExpected(t *testing.T) {
 		t.Fatal("mcp-drift-rugpull-desc-002 not found in mcp-drift fixtures")
 	}
 
-	caseRecord := rugpull.toCase()
+	caseRecord, err := rugpull.toCase()
+	if err != nil {
+		t.Fatalf("toCase: %v", err)
+	}
 	if caseRecord.ExpectedVerdict != "block" {
 		t.Errorf("ExpectedVerdict = %q, want block", caseRecord.ExpectedVerdict)
 	}
@@ -294,7 +297,10 @@ func TestMultiFileCase_ToCase_MultiServerResponses(t *testing.T) {
 		t.Fatal("mcp-drift-collusion-004 not found in mcp-drift fixtures")
 	}
 
-	caseRecord := collusion.toCase()
+	caseRecord, err := collusion.toCase()
+	if err != nil {
+		t.Fatalf("toCase: %v", err)
+	}
 	msgs, ok := caseRecord.Payload["jsonrpc_messages"].([]interface{})
 	if !ok || len(msgs) != 8 {
 		t.Fatalf("payload.jsonrpc_messages = %v, want 8-element slice", caseRecord.Payload["jsonrpc_messages"])
@@ -328,6 +334,66 @@ func TestMultiFileCase_ToCase_MultiServerResponses(t *testing.T) {
 	}
 }
 
+func TestMultiFileSnapshotResponses_RejectsMalformedServers(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot map[string]interface{}
+		wantErr  string
+	}{
+		{
+			name: "servers not array",
+			snapshot: map[string]interface{}{
+				"servers": map[string]interface{}{},
+			},
+			wantErr: "servers must be an array",
+		},
+		{
+			name: "empty servers",
+			snapshot: map[string]interface{}{
+				"servers": []interface{}{},
+			},
+			wantErr: "servers must contain at least one entry",
+		},
+		{
+			name: "server not object",
+			snapshot: map[string]interface{}{
+				"servers": []interface{}{"bad"},
+			},
+			wantErr: "servers[0] must be an object",
+		},
+		{
+			name: "missing tools list response",
+			snapshot: map[string]interface{}{
+				"servers": []interface{}{
+					map[string]interface{}{"name": "alpha"},
+				},
+			},
+			wantErr: "servers[0] missing tools_list_response",
+		},
+		{
+			name: "tools list response not object",
+			snapshot: map[string]interface{}{
+				"servers": []interface{}{
+					map[string]interface{}{"tools_list_response": "bad"},
+				},
+			},
+			wantErr: "servers[0].tools_list_response must be an object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := multiFileSnapshotResponses(tt.snapshot)
+			if err == nil {
+				t.Fatal("expected malformed servers error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestMultiFileCase_ToCase_WarnNormalizedToAllow verifies the receipt-
 // scoring rubric normalization: a case.yaml with expected_verdict: warn
 // (the mcp-drift-benign-001 FP-guardrail case) is converted to a Case
@@ -352,7 +418,10 @@ func TestMultiFileCase_ToCase_WarnNormalizedToAllow(t *testing.T) {
 	if benign.ExpectedVerdict != "warn" {
 		t.Fatalf("fixture expected_verdict = %q, want warn (rubric mapping assumes this)", benign.ExpectedVerdict)
 	}
-	caseRecord := benign.toCase()
+	caseRecord, err := benign.toCase()
+	if err != nil {
+		t.Fatalf("toCase: %v", err)
+	}
 	if caseRecord.ExpectedVerdict != "allow" {
 		t.Errorf("converted ExpectedVerdict = %q, want allow (warn maps to allow for receipt-scoring)", caseRecord.ExpectedVerdict)
 	}


### PR DESCRIPTION
## Summary
- expand multi-server snapshots into separate tools/list request/response pairs
- rewrite replay IDs so mocked responses match their triggering requests
- add regression coverage for mcp-drift-collusion-004 payload conversion

## Testing
- go test -race -count=1 ./... in runner
- go test -race -count=1 ./... in validate
- validate cases
- validate captured Pipelock result JSONL artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced test fixture processing to dynamically generate message sequences for scenarios with multiple servers, replacing previously hardcoded message patterns and enabling greater flexibility in test case design

* **Tests**
  * Added comprehensive validation test for multi-server fixture handling, verifying correct message sequencing, ID assignment, and proper response formatting across multiple server snapshots

<!-- end of auto-generated comment: release notes by coderabbit.ai -->