### PR TITLE
feat(receipts): add shield, full-field, and duplicate-key conformance fixtures

### DIFF
--- a/receipts/v0/conformance/README.md
+++ b/receipts/v0/conformance/README.md
@@ -53,7 +53,7 @@ receipts/v0/conformance/
 
 Each fixture is two files sharing a base name:
 
-- `<name>.json` for single-receipt fixtures or `<name>.jsonl` for chain fixtures (the input to the verifier). Chains are JSONL with one receipt per line; the generator writes the `.jsonl` extension whenever a fixture contains more than one linked receipt.
+- `<name>.json` for single-receipt fixtures and receipt-bundle wrappers, or `<name>.jsonl` for raw chain fixtures (the input to the verifier). Chains are JSONL with one receipt per line.
 - `<name>.expect.json` for the expected verifier output.
 
 ### `.expect.json` schema
@@ -62,7 +62,7 @@ Each fixture is two files sharing a base name:
 {
   "fixture_id": "string, immutable",
   "category": "golden | malicious | edge",
-  "input_format": "receipt | chain",
+  "input_format": "receipt | chain | receipt_bundle",
   "verdict": "accept | reject",
   "reject_reason": "machine-readable enum (omitted when accept)",
   "description": "human prose",
@@ -172,6 +172,17 @@ additions follow the rule above.
     Strict-JSON requirements. No honest receipt has duplicate keys, so this
     hardens against a parser-differential smuggling vector without changing any
     honest receipt's verdict — it does not warrant a `v1` fork.
+- **2026-06-01** — Added boundary fixtures that lock down cross-language
+  canonicalization assumptions:
+  - `e09-maximum-json-nesting-depth` accepts an ignored probe field that brings
+    the whole JSON document to exactly 128 levels deep, proving verifiers share
+    the same depth boundary.
+  - `e10-non-bmp-map-key-order` exercises Go-compatible map-key ordering for
+    non-BMP Unicode keys.
+  - `e11-html-escape-canonicalization` exercises Go's JSON HTMLEscape behavior
+    for `<`, `>`, `&`, U+2028, and U+2029.
+  - `m14-duplicate-key-nested-unicode` rejects duplicate keys hidden inside an
+    array using a unicode-escaped equivalent key.
 
 ## What a passing verifier looks like
 

--- a/receipts/v0/conformance/README.md
+++ b/receipts/v0/conformance/README.md
@@ -96,6 +96,7 @@ implement against the enum, and produce identical reject codes.
 | `header_injection`             | Disallowed control byte (NUL, etc.) embedded in a string field         |
 | `unsupported_version`          | `version` or `action_record.version` outside accepted range            |
 | `invalid_action_type`          | `action_type` not in the closed action-model enum                      |
+| `duplicate_key`                | A JSON object contains the same key twice at any nesting depth         |
 
 ### Verifier policy assumptions
 
@@ -107,7 +108,10 @@ Conformance assumes the verifier is configured as follows:
   `expired` until 2027-04-15.
 - **Replay window:** keep the last 10000 `action_id` values per session.
 - **Schema version:** accept `version: 1` and `action_record.version: 1` only.
-- **Strict JSON:** reject BOM, trailing data, embedded NUL bytes in strings.
+- **Strict JSON:** reject BOM, trailing data, embedded NUL bytes in strings,
+  and duplicate object keys at any nesting depth (see the `duplicate_key` reject
+  reason). Last-wins duplicate handling is a parser-differential smuggling
+  vector and MUST be rejected at parse time, before signature verification.
 
 ## Running the corpus
 
@@ -142,6 +146,32 @@ directory's fixtures and expect outputs are frozen. Adding new fixtures to
 `v0` is allowed only if they preserve the verifier-behaviour-already-specified
 property — i.e. an existing correct verifier must still pass without code
 changes.
+
+"Already-specified behaviour" is defined by the receipt schema and signing
+protocol in this directory, whose source of truth is the Go `ActionRecord`
+struct and signer (see *Source* below) — **not** by whatever a given verifier
+happened to accept before. A fixture that exercises a field or rule the schema
+always required, but that earlier fixtures did not cover, is a coverage-gap
+closure and is allowed in `v0`: a verifier that fails it was never conformant
+against production receipts. Frozen means existing fixtures are never edited;
+additions follow the rule above.
+
+### Spec revisions
+
+- **2026-05-31** — Coverage + one new requirement, both non-breaking (no honest
+  receipt changes verdict):
+  - Added golden fixtures `09-allow-shield-summary` and
+    `10-full-field-differential` exercising the full `ActionRecord` field set
+    (notably `parent_action_id` and the nested `shield` object). These are
+    coverage-gap closures: the Go signer has always emitted these fields, but no
+    earlier fixture carried them, so reference verifiers that dropped them
+    verified against a different byte string than Go and silently failed real
+    receipts.
+  - Added the `duplicate_key` reject reason and malicious fixture
+    `m13-duplicate-key-verdict`, and added duplicate-key rejection to the
+    Strict-JSON requirements. No honest receipt has duplicate keys, so this
+    hardens against a parser-differential smuggling vector without changing any
+    honest receipt's verdict — it does not warrant a `v1` fork.
 
 ## What a passing verifier looks like
 

--- a/receipts/v0/conformance/_generator/main.go
+++ b/receipts/v0/conformance/_generator/main.go
@@ -1140,7 +1140,7 @@ func buildMalicious() ([]fixture, error) {
 			Expect: Expect{
 				FixtureID:    "m10-receipt-count-mismatch",
 				Category:     "malicious",
-				InputFormat:  "chain",
+				InputFormat:  "receipt_bundle",
 				Verdict:      "reject",
 				RejectReason: "receipt_count_mismatch",
 				Description:  "Wrapper envelope claims declared_receipt_count=5 but only 4 receipts are present in the body.",
@@ -1256,6 +1256,41 @@ func buildMalicious() ([]fixture, error) {
 				RejectReason: "duplicate_key",
 				Description:  "action_record carries two verdict keys (\"allow\" then the signed \"block\"). Valid JSON, last-wins parsing makes the signature verify, so a verifier without duplicate-key rejection silently accepts while a first-occurrence display layer shows the opposite verdict.",
 				Notes:        "Verifier MUST reject duplicate object keys at parse time, at any nesting depth, before signature verification, with explicit duplicate-key detection during raw parsing — last-wins map insertion hides the duplicate. Examples: a Go json.Decoder token loop, a JS pair/key scan, a Rust serde Visitor that tracks map keys (serde_json has no built-in reject-duplicate option; struct fields error on repeats but map-like decoding is last-wins), and Python's object_pairs_hook.",
+			},
+		})
+	}
+
+	// M14. Nested duplicate object key with unicode-escaped equivalent key.
+	// The duplicate lives inside an otherwise-ignored top-level probe field so
+	// signature verification would succeed if the raw duplicate-key scan missed
+	// nested array/object values or failed to normalize \u escapes.
+	{
+		ar := baseRecord(0, genesisHash, freshTime, "write", "block",
+			"https://attacker.example.net/exfil", "https", "POST")
+		r, err := signReceipt(ar, priv)
+		if err != nil {
+			return nil, err
+		}
+		good, err := marshalPretty(r)
+		if err != nil {
+			return nil, err
+		}
+		bad, err := addTopLevelRawField(good, "dup_probe", `[{"a":1,"\u0061":2}]`)
+		if err != nil {
+			return nil, fmt.Errorf("m14: %w", err)
+		}
+		out = append(out, fixture{
+			Category: "malicious",
+			Name:     "m14-duplicate-key-nested-unicode",
+			Payload:  bad,
+			Expect: Expect{
+				FixtureID:    "m14-duplicate-key-nested-unicode",
+				Category:     "malicious",
+				InputFormat:  "receipt",
+				Verdict:      "reject",
+				RejectReason: "duplicate_key",
+				Description:  `Ignored top-level probe contains an array element with duplicate keys "a" and "\u0061".`,
+				Notes:        "Verifier MUST reject duplicate object keys at any nesting depth, including unicode-escaped key equivalents inside arrays and fields ignored by signature canonicalization.",
 			},
 		})
 	}
@@ -1403,6 +1438,64 @@ func buildEdge() ([]fixture, error) {
 		}
 	}
 
+	// E9. Exact maximum JSON nesting depth in an ignored top-level field.
+	{
+		ar := baseRecord(0, genesisHash, freshTime, "read", "allow",
+			"https://api.example.com/v1/data", "https", "GET")
+		f, err := makeSingle("e09-maximum-json-nesting-depth", "edge", priv, pubHex, ar,
+			"Receipt carries an ignored top-level probe field that brings the whole JSON document to exactly 128 nesting levels.",
+			"Verifier MUST accept. The shared raw-JSON scanner limit allows 128 nested arrays/objects including the receipt root object and rejects the 129th; this fixture catches off-by-one differences between language runtimes.",
+		)
+		if err != nil {
+			return nil, err
+		}
+		f.Payload, err = addTopLevelRawField(f.Payload, "depth_probe", nestedArrayJSON(127))
+		if err != nil {
+			return nil, fmt.Errorf("e09: %w", err)
+		}
+		out = append(out, f)
+	}
+
+	// E10. Non-BMP map keys in redaction.by_class.
+	{
+		ar := baseRecord(0, genesisHash, freshTime, "write", "allow",
+			"https://api.example.com/v1/data", "https", "POST")
+		ar.Redaction = &RedactionSummary{
+			Profile:         "strict",
+			Provider:        "provider.example",
+			Parser:          "json",
+			TotalRedactions: 3,
+			ByClass: map[string]int{
+				"api_key":    1,
+				"\uE000":     2,
+				"\U00010000": 3,
+			},
+		}
+		if f, err := makeSingle("e10-non-bmp-map-key-order", "edge", priv, pubHex, ar,
+			"Redaction by_class map contains a non-BMP key and a private-use BMP key.",
+			"Verifier MUST accept. Go orders map keys by UTF-8/code-point order; JavaScript's default UTF-16 sort orders this pair differently, so this fixture catches map-key canonicalization drift.",
+		); err != nil {
+			return nil, err
+		} else {
+			out = append(out, f)
+		}
+	}
+
+	// E11. Go JSON HTML escaping parity.
+	{
+		ar := baseRecord(0, genesisHash, freshTime, "read", "allow",
+			"https://api.example.com/v1/data", "https", "GET")
+		ar.Intent = "render <script>alert('x')</script> & preserve \u2028 and \u2029 separators"
+		if f, err := makeSingle("e11-html-escape-canonicalization", "edge", priv, pubHex, ar,
+			"Intent contains characters Go's encoding/json escapes in Marshal output: <, >, &, U+2028, and U+2029.",
+			"Verifier MUST accept. Non-Go verifiers must post-process canonical JSON to match Go's HTMLEscape behavior before hashing.",
+		); err != nil {
+			return nil, err
+		} else {
+			out = append(out, f)
+		}
+	}
+
 	return out, nil
 }
 
@@ -1419,6 +1512,19 @@ func marshalPretty(r Receipt) ([]byte, error) {
 		return nil, err
 	}
 	return append(buf, '\n'), nil
+}
+
+func addTopLevelRawField(payload []byte, name, rawValue string) ([]byte, error) {
+	marker := []byte("\n}\n")
+	if !bytes.HasSuffix(payload, marker) {
+		return nil, fmt.Errorf("payload does not end with top-level object marker")
+	}
+	insert := []byte(fmt.Sprintf(",\n  %q: %s\n}\n", name, rawValue))
+	return append(append([]byte{}, payload[:len(payload)-len(marker)]...), insert...), nil
+}
+
+func nestedArrayJSON(depth int) string {
+	return strings.Repeat("[", depth) + "0" + strings.Repeat("]", depth)
 }
 
 // marshalChainJSONL serializes a slice of receipts as one compact JSON object
@@ -1448,6 +1554,13 @@ func writeAll(outDir string, fixtures []fixture) error {
 		extJSON := ".json"
 		if f.Expect.InputFormat == "chain" {
 			extJSON = ".jsonl"
+		}
+		staleExt := ".jsonl"
+		if extJSON == ".jsonl" {
+			staleExt = ".json"
+		}
+		if err := os.Remove(filepath.Join(dir, f.Name+staleExt)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove stale payload %s%s: %w", f.Name, staleExt, err)
 		}
 		payloadPath := filepath.Join(dir, f.Name+extJSON)
 		if err := os.WriteFile(payloadPath, f.Payload, 0o600); err != nil {

--- a/receipts/v0/conformance/_generator/main.go
+++ b/receipts/v0/conformance/_generator/main.go
@@ -40,8 +40,14 @@ const (
 	conformanceSessionID = "conformance-session"
 )
 
-// ActionRecord covers every field a v0 verifier may consult. Optional fields
-// are emitted with omitempty so the canonical JSON shape is stable.
+// ActionRecord covers every field a v0 verifier may consult. The field set,
+// declaration order, and omitempty semantics MIRROR THE GO STRUCT EXACTLY at
+// github.com/luckyPipewrench/pipelock/internal/receipt/action.go. The v1
+// signing input is SHA-256(json.Marshal(ActionRecord)) in struct-declaration
+// order (NOT JCS), so any field a verifier omits or reorders recomputes a
+// different canonical byte string and fails signature verification. Keeping
+// this struct a faithful mirror lets the generator emit fixtures that exercise
+// every field, which is what locks the four reference verifiers against drift.
 type ActionRecord struct {
 	Version int `json:"version"`
 
@@ -66,14 +72,90 @@ type ActionRecord struct {
 	PolicyHash string `json:"policy_hash"`
 	Verdict    string `json:"verdict"`
 
-	Transport string `json:"transport"`
-	Method    string `json:"method,omitempty"`
-	Layer     string `json:"layer,omitempty"`
-	Pattern   string `json:"pattern,omitempty"`
-	Severity  string `json:"severity,omitempty"`
+	// Taint-aware policy escalation context.
+	SessionTaintLevel   string           `json:"session_taint_level,omitempty"`
+	SessionContaminated bool             `json:"session_contaminated,omitempty"`
+	RecentTaintSources  []TaintSourceRef `json:"recent_taint_sources,omitempty"`
+	SessionTaskID       string           `json:"session_task_id,omitempty"`
+	SessionTaskLabel    string           `json:"session_task_label,omitempty"`
+	AuthorityKind       string           `json:"authority_kind,omitempty"`
+	TaintDecision       string           `json:"taint_decision,omitempty"`
+	TaintDecisionReason string           `json:"taint_decision_reason,omitempty"`
+	TaskOverrideApplied bool             `json:"task_override_applied,omitempty"`
+
+	// Contract context, populated when live lock evaluates this action.
+	ContractWinningSource string   `json:"contract_winning_source,omitempty"`
+	ContractLiveVerdict   string   `json:"contract_live_verdict,omitempty"`
+	ContractPolicySources []string `json:"contract_policy_sources,omitempty"`
+	ContractRuleID        string   `json:"contract_rule_id,omitempty"`
+	ActiveManifestHash    string   `json:"active_manifest_hash,omitempty"`
+	ContractHash          string   `json:"contract_hash,omitempty"`
+	ContractSelectorID    string   `json:"contract_selector_id,omitempty"`
+	ContractGeneration    uint64   `json:"contract_generation,omitempty"`
+
+	Transport string            `json:"transport"`
+	Method    string            `json:"method,omitempty"`
+	Layer     string            `json:"layer,omitempty"`
+	Pattern   string            `json:"pattern,omitempty"`
+	Severity  string            `json:"severity,omitempty"`
+	Redaction *RedactionSummary `json:"redaction,omitempty"`
+	Shield    *ShieldSummary    `json:"shield,omitempty"`
+	RequestID string            `json:"request_id,omitempty"`
 
 	ChainPrevHash string `json:"chain_prev_hash"`
 	ChainSeq      uint64 `json:"chain_seq"`
+
+	// Jurisdictional fields - present in schema for forward compatibility.
+	Venue              string   `json:"venue,omitempty"`
+	Jurisdiction       string   `json:"jurisdiction,omitempty"`
+	RulebookID         string   `json:"rulebook_id,omitempty"`
+	RemedyClass        string   `json:"remedy_class,omitempty"`
+	ContestationWindow string   `json:"contestation_window,omitempty"`
+	PrecedentRefs      []string `json:"precedent_refs,omitempty"`
+}
+
+// TaintSourceRef mirrors session.TaintSourceRef. Field order and omitempty
+// match the Go source so recent_taint_sources entries canonicalize identically.
+// Level mirrors session.TaintLevel (a uint8 with no custom JSON marshaller), so
+// it serializes as a NUMBER, not a string. The top-level ActionRecord
+// session_taint_level is a separate string field — do not conflate the two.
+type TaintSourceRef struct {
+	URL         string    `json:"url"`
+	Kind        string    `json:"kind"`
+	Level       uint8     `json:"level"`
+	Timestamp   time.Time `json:"timestamp"`
+	ReceiptID   string    `json:"receipt_id,omitempty"`
+	MatchReason string    `json:"match_reason,omitempty"`
+}
+
+// RedactionSummary mirrors receipt.RedactionSummary.
+type RedactionSummary struct {
+	Profile           string         `json:"profile,omitempty"`
+	Provider          string         `json:"provider,omitempty"`
+	Parser            string         `json:"parser,omitempty"`
+	TotalRedactions   int            `json:"total_redactions,omitempty"`
+	ByClass           map[string]int `json:"by_class,omitempty"`
+	CacheBoundaryKept bool           `json:"cache_boundary_kept,omitempty"`
+}
+
+// ShieldSummary mirrors receipt.ShieldSummary.
+type ShieldSummary struct {
+	Pipeline                 string `json:"pipeline,omitempty"`
+	TotalRewrites            int    `json:"total_rewrites,omitempty"`
+	ExtensionProbes          int    `json:"extension_probes,omitempty"`
+	TrackingBeacons          int    `json:"tracking_beacons,omitempty"`
+	AgentTraps               int    `json:"agent_traps,omitempty"`
+	FingerprintShimInjected  bool   `json:"fingerprint_shim_injected,omitempty"`
+	SVGForeignObjects        int    `json:"svg_foreign_objects,omitempty"`
+	SVGEventHandlers         int    `json:"svg_event_handlers,omitempty"`
+	SVGExternalReferences    int    `json:"svg_external_references,omitempty"`
+	SVGHiddenText            int    `json:"svg_hidden_text,omitempty"`
+	SVGAnimationInjections   int    `json:"svg_animation_injections,omitempty"`
+	BodyBytes                int    `json:"body_bytes,omitempty"`
+	ScannedBytes             int    `json:"scanned_bytes,omitempty"`
+	Partial                  bool   `json:"partial,omitempty"`
+	AdaptiveSignalsRecorded  int    `json:"adaptive_signals_recorded,omitempty"`
+	AdaptiveSignalMaxPerBody int    `json:"adaptive_signal_max_per_body,omitempty"`
 }
 
 // Receipt is the v0 signed envelope around an ActionRecord.
@@ -518,6 +600,100 @@ func buildGolden() ([]fixture, error) {
 		if f, err := makeSingle("08-warn-observe-mode", "golden", priv, pubHex, ar,
 			"Warn verdict in observe-mode: action allowed but flagged for review.",
 			"Verifier MUST accept and MUST NOT degrade to allow — the warn signal is the whole point of observe mode.",
+		); err != nil {
+			return nil, err
+		} else {
+			out = append(out, f)
+		}
+	}
+
+	// 9. allow + Browser Shield summary — exercises the nested `shield` object.
+	// Historically the TS and Rust canonical field lists OMITTED `shield`
+	// entirely, so a shield-bearing receipt recomputed a DIFFERENT canonical
+	// byte string in those verifiers and the signature failed to verify. This
+	// fixture is the regression that locks `shield` into every verifier's
+	// canonical field list, in the correct position (after redaction, before
+	// request_id).
+	{
+		ar := baseRecord(0, genesisHash, freshTime, "read", "allow",
+			"https://news.example.com/article/42", "https", "GET")
+		ar.Layer = "browser_shield"
+		ar.Severity = "low"
+		ar.Shield = &ShieldSummary{
+			Pipeline:                "browser_shield_v1",
+			TotalRewrites:           7,
+			TrackingBeacons:         3,
+			AgentTraps:              1,
+			FingerprintShimInjected: true,
+			BodyBytes:               20480,
+			ScannedBytes:            20480,
+		}
+		if f, err := makeSingle("09-allow-shield-summary", "golden", priv, pubHex, ar,
+			"Allow on a fetched page where Browser Shield rewrote tracking beacons and an agent trap.",
+			"Verifier MUST accept. The nested shield object MUST be included in the canonical field list (after redaction, before request_id); a verifier that drops it recomputes a different signing hash and wrongly reports signature_invalid.",
+		); err != nil {
+			return nil, err
+		} else {
+			out = append(out, f)
+		}
+	}
+
+	// 10. full-field differential — populates one representative field from
+	// every block that the non-Go verifiers historically dropped:
+	// parent_action_id, the taint block (scalars + a nested recent_taint_sources
+	// entry), the contract block, redaction (nested), and shield (nested). A
+	// verifier whose canonical field list is missing ANY of these recomputes a
+	// different signing hash and fails. This is the four-language differential:
+	// the Go signer includes all of them, so only a verifier that mirrors the
+	// full Go struct verifies it.
+	{
+		ar := baseRecord(0, genesisHash, freshTime, "write", "allow",
+			"https://api.example.com/v1/agents/spawn", "https", "POST")
+		ar.ParentActionID = "conformance-parent-00000"
+		ar.Intent = "delegated-subagent-write"
+		ar.Layer = "tool_policy"
+		ar.Severity = "medium"
+		ar.SessionTaintLevel = "suspected"
+		ar.SessionContaminated = true
+		ar.RecentTaintSources = []TaintSourceRef{
+			{
+				URL:  "https://compromised-blog.example/post/9",
+				Kind: "response_injection",
+				// session.TaintExternalUntrusted (4); serializes as a number.
+				Level:       4,
+				Timestamp:   freshTime,
+				MatchReason: "ignore_previous_instructions",
+			},
+		}
+		ar.SessionTaskID = "task-abc123"
+		ar.SessionTaskLabel = "research-and-summarize"
+		ar.AuthorityKind = "delegated"
+		ar.TaintDecision = "allow_with_constraints"
+		ar.TaintDecisionReason = "task_scope_permits_write"
+		ar.ContractWinningSource = "operator_policy"
+		ar.ContractLiveVerdict = "allow"
+		ar.ContractPolicySources = []string{"operator_policy", "org_default"}
+		ar.ContractRuleID = "rule-write-allow-7"
+		ar.ActiveManifestHash = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		ar.ContractHash = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+		ar.ContractSelectorID = "selector-9"
+		ar.ContractGeneration = 4
+		ar.Redaction = &RedactionSummary{
+			Profile:         "strict",
+			Provider:        "provider.example",
+			Parser:          "json",
+			TotalRedactions: 2,
+			ByClass:         map[string]int{"api_key": 1, "email": 1},
+		}
+		ar.Shield = &ShieldSummary{
+			Pipeline:      "browser_shield_v1",
+			TotalRewrites: 1,
+			AgentTraps:    1,
+		}
+		ar.RequestID = "req-7f3a"
+		if f, err := makeSingle("10-full-field-differential", "golden", priv, pubHex, ar,
+			"Allow on a delegated sub-agent write carrying parent_action_id, taint context (scalars + a nested recent_taint_sources entry), contract context, redaction, and shield. Every block here was missing from at least one reference verifier's canonical field list.",
+			"Verifier MUST accept. This is the cross-language drift sentinel: a verifier MUST mirror the full Go ActionRecord field set, declaration order, and omitempty semantics — including nested object key order for recent_taint_sources, redaction, and shield. Any omitted or reordered field recomputes a different signing hash and wrongly reports signature_invalid.",
 		); err != nil {
 			return nil, err
 		} else {
@@ -1001,6 +1177,57 @@ func buildMalicious() ([]fixture, error) {
 				RejectReason: "header_injection",
 				Description:  "principal field contains a NUL byte followed by a second agent identifier. Downstream consumers that string-split on common delimiters could be tricked into trusting the second identifier.",
 				Notes:        "Verifier MUST reject control bytes (0x00-0x1F except whitespace) in identifier fields. This is a transport-level integrity check, not a signature check.",
+			},
+		})
+	}
+
+	// M13. Duplicate object key — verdict smuggling via parser differential.
+	// The receipt is signed normally with verdict="block". The raw bytes are
+	// then rewritten to carry a SECOND, EARLIER verdict key with value "allow":
+	//   "verdict":"allow", ... "verdict":"block"
+	// This is valid JSON (RFC 8259 permits duplicate names but says behaviour
+	// is unpredictable). Go/JS/Rust-serde/Python json all resolve last-wins, so
+	// a verifier WITHOUT duplicate-key rejection parses verdict="block",
+	// recomputes the canonical form, and the signature VERIFIES — it silently
+	// ACCEPTS the receipt while a naive display or log layer that reads the
+	// first occurrence shows "allow". That display-vs-reality divergence is the
+	// attack. A correct verifier MUST reject any duplicate object key (at any
+	// nesting depth) at parse time, before signature verification.
+	{
+		ar := baseRecord(0, genesisHash, freshTime, "write", "block",
+			"https://attacker.example.net/exfil", "https", "POST")
+		ar.Layer = "tool_policy"
+		ar.Severity = "high"
+		r, err := signReceipt(ar, priv)
+		if err != nil {
+			return nil, err
+		}
+		good, err := marshalPretty(r)
+		if err != nil {
+			return nil, err
+		}
+		// Inject a duplicate `verdict` key inside the action_record, before the
+		// real (signed) one. marshalPretty indents action_record fields by four
+		// spaces. There is exactly one `verdict` key in the document (the
+		// Receipt envelope has none), so a single targeted replacement is safe.
+		marker := []byte("\"verdict\": \"block\"")
+		dup := []byte("\"verdict\": \"allow\",\n    \"verdict\": \"block\"")
+		if !bytes.Contains(good, marker) {
+			return nil, fmt.Errorf("m13: verdict marker not found in payload")
+		}
+		bad := bytes.Replace(good, marker, dup, 1)
+		out = append(out, fixture{
+			Category: "malicious",
+			Name:     "m13-duplicate-key-verdict",
+			Payload:  bad,
+			Expect: Expect{
+				FixtureID:    "m13-duplicate-key-verdict",
+				Category:     "malicious",
+				InputFormat:  "receipt",
+				Verdict:      "reject",
+				RejectReason: "duplicate_key",
+				Description:  "action_record carries two verdict keys (\"allow\" then the signed \"block\"). Valid JSON, last-wins parsing makes the signature verify, so a verifier without duplicate-key rejection silently accepts while a first-occurrence display layer shows the opposite verdict.",
+				Notes:        "Verifier MUST reject duplicate object keys at parse time, at any nesting depth, before signature verification. Use a raw token/pair scan (Go json.Decoder token loop, JS reviver/pair check, serde_json with reject_duplicate, Python object_pairs_hook) — last-wins map insertion hides the duplicate.",
 			},
 		})
 	}

--- a/receipts/v0/conformance/_generator/main.go
+++ b/receipts/v0/conformance/_generator/main.go
@@ -638,20 +638,24 @@ func buildGolden() ([]fixture, error) {
 		}
 	}
 
-	// 10. full-field differential — populates one representative field from
-	// every block that the non-Go verifiers historically dropped:
-	// parent_action_id, the taint block (scalars + a nested recent_taint_sources
-	// entry), the contract block, redaction (nested), and shield (nested). A
-	// verifier whose canonical field list is missing ANY of these recomputes a
+	// 10. full-field differential — populates EVERY omitempty field in the
+	// ActionRecord (parent_action_id, data classes, the taint block incl. a
+	// nested recent_taint_sources entry, the contract block, the jurisdictional
+	// block, and fully-populated nested redaction and shield objects). A verifier
+	// whose canonical field list omits or reorders ANY field recomputes a
 	// different signing hash and fails. This is the four-language differential:
 	// the Go signer includes all of them, so only a verifier that mirrors the
-	// full Go struct verifies it.
+	// full Go struct — every field, in declaration order, with nested object key
+	// order — verifies it.
 	{
 		ar := baseRecord(0, genesisHash, freshTime, "write", "allow",
 			"https://api.example.com/v1/agents/spawn", "https", "POST")
 		ar.ParentActionID = "conformance-parent-00000"
 		ar.Intent = "delegated-subagent-write"
+		ar.DataClassesIn = []string{"prompt", "secret"}
+		ar.DataClassesOut = []string{"summary"}
 		ar.Layer = "tool_policy"
+		ar.Pattern = "spawn_subagent"
 		ar.Severity = "medium"
 		ar.SessionTaintLevel = "suspected"
 		ar.SessionContaminated = true
@@ -662,6 +666,7 @@ func buildGolden() ([]fixture, error) {
 				// session.TaintExternalUntrusted (4); serializes as a number.
 				Level:       4,
 				Timestamp:   freshTime,
+				ReceiptID:   "conformance-taint-00000",
 				MatchReason: "ignore_previous_instructions",
 			},
 		}
@@ -670,6 +675,7 @@ func buildGolden() ([]fixture, error) {
 		ar.AuthorityKind = "delegated"
 		ar.TaintDecision = "allow_with_constraints"
 		ar.TaintDecisionReason = "task_scope_permits_write"
+		ar.TaskOverrideApplied = true
 		ar.ContractWinningSource = "operator_policy"
 		ar.ContractLiveVerdict = "allow"
 		ar.ContractPolicySources = []string{"operator_policy", "org_default"}
@@ -679,20 +685,42 @@ func buildGolden() ([]fixture, error) {
 		ar.ContractSelectorID = "selector-9"
 		ar.ContractGeneration = 4
 		ar.Redaction = &RedactionSummary{
-			Profile:         "strict",
-			Provider:        "provider.example",
-			Parser:          "json",
-			TotalRedactions: 2,
-			ByClass:         map[string]int{"api_key": 1, "email": 1},
+			Profile:           "strict",
+			Provider:          "provider.example",
+			Parser:            "json",
+			TotalRedactions:   2,
+			ByClass:           map[string]int{"api_key": 1, "email": 1},
+			CacheBoundaryKept: true,
 		}
 		ar.Shield = &ShieldSummary{
-			Pipeline:      "browser_shield_v1",
-			TotalRewrites: 1,
-			AgentTraps:    1,
+			Pipeline:                 "browser_shield_v1",
+			TotalRewrites:            5,
+			ExtensionProbes:          1,
+			TrackingBeacons:          2,
+			AgentTraps:               1,
+			FingerprintShimInjected:  true,
+			SVGForeignObjects:        1,
+			SVGEventHandlers:         1,
+			SVGExternalReferences:    1,
+			SVGHiddenText:            1,
+			SVGAnimationInjections:   1,
+			BodyBytes:                4096,
+			ScannedBytes:             4096,
+			Partial:                  true,
+			AdaptiveSignalsRecorded:  3,
+			AdaptiveSignalMaxPerBody: 8,
 		}
 		ar.RequestID = "req-7f3a"
+		// Jurisdictional block — present for forward compatibility; populated
+		// here so the full ActionRecord field set is genuinely exercised.
+		ar.Venue = "us-east"
+		ar.Jurisdiction = "operator-default"
+		ar.RulebookID = "rulebook-v1"
+		ar.RemedyClass = "compensate"
+		ar.ContestationWindow = "24h"
+		ar.PrecedentRefs = []string{"conformance-precedent-1"}
 		if f, err := makeSingle("10-full-field-differential", "golden", priv, pubHex, ar,
-			"Allow on a delegated sub-agent write carrying parent_action_id, taint context (scalars + a nested recent_taint_sources entry), contract context, redaction, and shield. Every block here was missing from at least one reference verifier's canonical field list.",
+			"Allow on a delegated sub-agent write that populates EVERY omitempty field in the ActionRecord — parent_action_id, data classes, the full taint block (scalars + a nested recent_taint_sources entry with receipt_id), the contract block, the jurisdictional block, and fully-populated nested redaction and shield objects. At least one reference verifier historically dropped each of these from its canonical field list.",
 			"Verifier MUST accept. This is the cross-language drift sentinel: a verifier MUST mirror the full Go ActionRecord field set, declaration order, and omitempty semantics — including nested object key order for recent_taint_sources, redaction, and shield. Any omitted or reordered field recomputes a different signing hash and wrongly reports signature_invalid.",
 		); err != nil {
 			return nil, err
@@ -1227,7 +1255,7 @@ func buildMalicious() ([]fixture, error) {
 				Verdict:      "reject",
 				RejectReason: "duplicate_key",
 				Description:  "action_record carries two verdict keys (\"allow\" then the signed \"block\"). Valid JSON, last-wins parsing makes the signature verify, so a verifier without duplicate-key rejection silently accepts while a first-occurrence display layer shows the opposite verdict.",
-				Notes:        "Verifier MUST reject duplicate object keys at parse time, at any nesting depth, before signature verification. Use a raw token/pair scan (Go json.Decoder token loop, JS reviver/pair check, serde_json with reject_duplicate, Python object_pairs_hook) — last-wins map insertion hides the duplicate.",
+				Notes:        "Verifier MUST reject duplicate object keys at parse time, at any nesting depth, before signature verification, with explicit duplicate-key detection during raw parsing — last-wins map insertion hides the duplicate. Examples: a Go json.Decoder token loop, a JS pair/key scan, a Rust serde Visitor that tracks map keys (serde_json has no built-in reject-duplicate option; struct fields error on repeats but map-like decoding is last-wins), and Python's object_pairs_hook.",
 			},
 		})
 	}

--- a/receipts/v0/conformance/edge/e09-maximum-json-nesting-depth.expect.json
+++ b/receipts/v0/conformance/edge/e09-maximum-json-nesting-depth.expect.json
@@ -1,0 +1,11 @@
+{
+  "fixture_id": "e09-maximum-json-nesting-depth",
+  "category": "edge",
+  "input_format": "receipt",
+  "verdict": "accept",
+  "description": "Receipt carries an ignored top-level probe field that brings the whole JSON document to exactly 128 nesting levels.",
+  "expected_chain_length": 1,
+  "expected_signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa",
+  "expected_root_hash": "34f2780dcb510c03f55fc31387c993066fad23e328a2bf5f64b630b8d58a0dfb",
+  "notes": "Verifier MUST accept. The shared raw-JSON scanner limit allows 128 nested arrays/objects including the receipt root object and rejects the 129th; this fixture catches off-by-one differences between language runtimes."
+}

--- a/receipts/v0/conformance/edge/e09-maximum-json-nesting-depth.json
+++ b/receipts/v0/conformance/edge/e09-maximum-json-nesting-depth.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "action_record": {
+    "version": 1,
+    "action_id": "conformance-00000",
+    "action_type": "read",
+    "timestamp": "2026-04-15T12:00:00Z",
+    "principal": "org:conformance-test",
+    "actor": "agent:conformance-runner",
+    "delegation_chain": [
+      "test-policy-v1",
+      "test-grant"
+    ],
+    "target": "https://api.example.com/v1/data",
+    "side_effect_class": "external_read",
+    "reversibility": "full",
+    "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "verdict": "allow",
+    "transport": "https",
+    "method": "GET",
+    "chain_prev_hash": "genesis",
+    "chain_seq": 0
+  },
+  "signature": "ed25519:1f2afffae9147815ff4cff126f144766b5e3964c95451b0cab940e7f6be27a48fef13075520f8b59d9355fba5232613a97ece81ce691c1366a0f7e2d77f5de0b",
+  "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa",
+  "depth_probe": [[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[0]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]
+}

--- a/receipts/v0/conformance/edge/e10-non-bmp-map-key-order.expect.json
+++ b/receipts/v0/conformance/edge/e10-non-bmp-map-key-order.expect.json
@@ -1,0 +1,11 @@
+{
+  "fixture_id": "e10-non-bmp-map-key-order",
+  "category": "edge",
+  "input_format": "receipt",
+  "verdict": "accept",
+  "description": "Redaction by_class map contains a non-BMP key and a private-use BMP key.",
+  "expected_chain_length": 1,
+  "expected_signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa",
+  "expected_root_hash": "ba0b358c94acd3dcd7c6b3388f50913124f63a9e45d4d5afbefbef62fa9d6b07",
+  "notes": "Verifier MUST accept. Go orders map keys by UTF-8/code-point order; JavaScript's default UTF-16 sort orders this pair differently, so this fixture catches map-key canonicalization drift."
+}

--- a/receipts/v0/conformance/edge/e10-non-bmp-map-key-order.json
+++ b/receipts/v0/conformance/edge/e10-non-bmp-map-key-order.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "action_record": {
+    "version": 1,
+    "action_id": "conformance-00000",
+    "action_type": "write",
+    "timestamp": "2026-04-15T12:00:00Z",
+    "principal": "org:conformance-test",
+    "actor": "agent:conformance-runner",
+    "delegation_chain": [
+      "test-policy-v1",
+      "test-grant"
+    ],
+    "target": "https://api.example.com/v1/data",
+    "side_effect_class": "external_write",
+    "reversibility": "compensatable",
+    "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "verdict": "allow",
+    "transport": "https",
+    "method": "POST",
+    "redaction": {
+      "profile": "strict",
+      "provider": "provider.example",
+      "parser": "json",
+      "total_redactions": 3,
+      "by_class": {
+        "api_key": 1,
+        "": 2,
+        "𐀀": 3
+      }
+    },
+    "chain_prev_hash": "genesis",
+    "chain_seq": 0
+  },
+  "signature": "ed25519:5d7f424c66074f1d5b5424b87879a042afd66d0569870a07d39290fc256c3d3d8bc6fe5f7753a9d272b8c2258bbc5aa0e78db4408a2b665503816f0465def909",
+  "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+}

--- a/receipts/v0/conformance/edge/e11-html-escape-canonicalization.expect.json
+++ b/receipts/v0/conformance/edge/e11-html-escape-canonicalization.expect.json
@@ -1,0 +1,11 @@
+{
+  "fixture_id": "e11-html-escape-canonicalization",
+  "category": "edge",
+  "input_format": "receipt",
+  "verdict": "accept",
+  "description": "Intent contains characters Go's encoding/json escapes in Marshal output: \u003c, \u003e, \u0026, U+2028, and U+2029.",
+  "expected_chain_length": 1,
+  "expected_signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa",
+  "expected_root_hash": "279042de97a54af2c73e00b2b7a239e435b552ac2a3afddbfcaaccf6cdc004aa",
+  "notes": "Verifier MUST accept. Non-Go verifiers must post-process canonical JSON to match Go's HTMLEscape behavior before hashing."
+}

--- a/receipts/v0/conformance/edge/e11-html-escape-canonicalization.json
+++ b/receipts/v0/conformance/edge/e11-html-escape-canonicalization.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "action_record": {
+    "version": 1,
+    "action_id": "conformance-00000",
+    "action_type": "read",
+    "timestamp": "2026-04-15T12:00:00Z",
+    "principal": "org:conformance-test",
+    "actor": "agent:conformance-runner",
+    "delegation_chain": [
+      "test-policy-v1",
+      "test-grant"
+    ],
+    "target": "https://api.example.com/v1/data",
+    "intent": "render \u003cscript\u003ealert('x')\u003c/script\u003e \u0026 preserve \u2028 and \u2029 separators",
+    "side_effect_class": "external_read",
+    "reversibility": "full",
+    "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "verdict": "allow",
+    "transport": "https",
+    "method": "GET",
+    "chain_prev_hash": "genesis",
+    "chain_seq": 0
+  },
+  "signature": "ed25519:776b0105e31f9b3e560ff059dbcb5d8e93ac5fedfbe27930b8f21069a53711a661948abc96ec45d49634346f9eacbdfe8b763579c7e2ed0b4d2b67f861caad07",
+  "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+}

--- a/receipts/v0/conformance/golden/09-allow-shield-summary.expect.json
+++ b/receipts/v0/conformance/golden/09-allow-shield-summary.expect.json
@@ -1,0 +1,11 @@
+{
+  "fixture_id": "09-allow-shield-summary",
+  "category": "golden",
+  "input_format": "receipt",
+  "verdict": "accept",
+  "description": "Allow on a fetched page where Browser Shield rewrote tracking beacons and an agent trap.",
+  "expected_chain_length": 1,
+  "expected_signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa",
+  "expected_root_hash": "6c609bd30d6a169a733bae50a65204523973c70244dc0cd3eb305c06166705f4",
+  "notes": "Verifier MUST accept. The nested shield object MUST be included in the canonical field list (after redaction, before request_id); a verifier that drops it recomputes a different signing hash and wrongly reports signature_invalid."
+}

--- a/receipts/v0/conformance/golden/09-allow-shield-summary.json
+++ b/receipts/v0/conformance/golden/09-allow-shield-summary.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "action_record": {
+    "version": 1,
+    "action_id": "conformance-00000",
+    "action_type": "read",
+    "timestamp": "2026-04-15T12:00:00Z",
+    "principal": "org:conformance-test",
+    "actor": "agent:conformance-runner",
+    "delegation_chain": [
+      "test-policy-v1",
+      "test-grant"
+    ],
+    "target": "https://news.example.com/article/42",
+    "side_effect_class": "external_read",
+    "reversibility": "full",
+    "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "verdict": "allow",
+    "transport": "https",
+    "method": "GET",
+    "layer": "browser_shield",
+    "severity": "low",
+    "shield": {
+      "pipeline": "browser_shield_v1",
+      "total_rewrites": 7,
+      "tracking_beacons": 3,
+      "agent_traps": 1,
+      "fingerprint_shim_injected": true,
+      "body_bytes": 20480,
+      "scanned_bytes": 20480
+    },
+    "chain_prev_hash": "genesis",
+    "chain_seq": 0
+  },
+  "signature": "ed25519:7cc04bc0018bb95f2655dcdaaa144e281b6d0fcd2f733af56c277c9ffb68e3de3fdf9056cb6787c4577a2fe8c3559da1a399a279a02c0a00d285810923754f06",
+  "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+}

--- a/receipts/v0/conformance/golden/10-full-field-differential.expect.json
+++ b/receipts/v0/conformance/golden/10-full-field-differential.expect.json
@@ -1,0 +1,11 @@
+{
+  "fixture_id": "10-full-field-differential",
+  "category": "golden",
+  "input_format": "receipt",
+  "verdict": "accept",
+  "description": "Allow on a delegated sub-agent write carrying parent_action_id, taint context (scalars + a nested recent_taint_sources entry), contract context, redaction, and shield. Every block here was missing from at least one reference verifier's canonical field list.",
+  "expected_chain_length": 1,
+  "expected_signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa",
+  "expected_root_hash": "2af9e2cfe675e5e42e528de0cd77a31719c10b12edef3a4595f260285dcc6aa8",
+  "notes": "Verifier MUST accept. This is the cross-language drift sentinel: a verifier MUST mirror the full Go ActionRecord field set, declaration order, and omitempty semantics — including nested object key order for recent_taint_sources, redaction, and shield. Any omitted or reordered field recomputes a different signing hash and wrongly reports signature_invalid."
+}

--- a/receipts/v0/conformance/golden/10-full-field-differential.expect.json
+++ b/receipts/v0/conformance/golden/10-full-field-differential.expect.json
@@ -3,9 +3,9 @@
   "category": "golden",
   "input_format": "receipt",
   "verdict": "accept",
-  "description": "Allow on a delegated sub-agent write carrying parent_action_id, taint context (scalars + a nested recent_taint_sources entry), contract context, redaction, and shield. Every block here was missing from at least one reference verifier's canonical field list.",
+  "description": "Allow on a delegated sub-agent write that populates EVERY omitempty field in the ActionRecord — parent_action_id, data classes, the full taint block (scalars + a nested recent_taint_sources entry with receipt_id), the contract block, the jurisdictional block, and fully-populated nested redaction and shield objects. At least one reference verifier historically dropped each of these from its canonical field list.",
   "expected_chain_length": 1,
   "expected_signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa",
-  "expected_root_hash": "2af9e2cfe675e5e42e528de0cd77a31719c10b12edef3a4595f260285dcc6aa8",
+  "expected_root_hash": "7d9996d79ab566731a858fab35a533e39252e032537b75740326365d707fb8dc",
   "notes": "Verifier MUST accept. This is the cross-language drift sentinel: a verifier MUST mirror the full Go ActionRecord field set, declaration order, and omitempty semantics — including nested object key order for recent_taint_sources, redaction, and shield. Any omitted or reordered field recomputes a different signing hash and wrongly reports signature_invalid."
 }

--- a/receipts/v0/conformance/golden/10-full-field-differential.json
+++ b/receipts/v0/conformance/golden/10-full-field-differential.json
@@ -14,6 +14,13 @@
     ],
     "target": "https://api.example.com/v1/agents/spawn",
     "intent": "delegated-subagent-write",
+    "data_classes_in": [
+      "prompt",
+      "secret"
+    ],
+    "data_classes_out": [
+      "summary"
+    ],
     "side_effect_class": "external_write",
     "reversibility": "compensatable",
     "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -26,6 +33,7 @@
         "kind": "response_injection",
         "level": 4,
         "timestamp": "2026-04-15T12:00:00Z",
+        "receipt_id": "conformance-taint-00000",
         "match_reason": "ignore_previous_instructions"
       }
     ],
@@ -34,6 +42,7 @@
     "authority_kind": "delegated",
     "taint_decision": "allow_with_constraints",
     "taint_decision_reason": "task_scope_permits_write",
+    "task_override_applied": true,
     "contract_winning_source": "operator_policy",
     "contract_live_verdict": "allow",
     "contract_policy_sources": [
@@ -48,6 +57,7 @@
     "transport": "https",
     "method": "POST",
     "layer": "tool_policy",
+    "pattern": "spawn_subagent",
     "severity": "medium",
     "redaction": {
       "profile": "strict",
@@ -57,17 +67,39 @@
       "by_class": {
         "api_key": 1,
         "email": 1
-      }
+      },
+      "cache_boundary_kept": true
     },
     "shield": {
       "pipeline": "browser_shield_v1",
-      "total_rewrites": 1,
-      "agent_traps": 1
+      "total_rewrites": 5,
+      "extension_probes": 1,
+      "tracking_beacons": 2,
+      "agent_traps": 1,
+      "fingerprint_shim_injected": true,
+      "svg_foreign_objects": 1,
+      "svg_event_handlers": 1,
+      "svg_external_references": 1,
+      "svg_hidden_text": 1,
+      "svg_animation_injections": 1,
+      "body_bytes": 4096,
+      "scanned_bytes": 4096,
+      "partial": true,
+      "adaptive_signals_recorded": 3,
+      "adaptive_signal_max_per_body": 8
     },
     "request_id": "req-7f3a",
     "chain_prev_hash": "genesis",
-    "chain_seq": 0
+    "chain_seq": 0,
+    "venue": "us-east",
+    "jurisdiction": "operator-default",
+    "rulebook_id": "rulebook-v1",
+    "remedy_class": "compensate",
+    "contestation_window": "24h",
+    "precedent_refs": [
+      "conformance-precedent-1"
+    ]
   },
-  "signature": "ed25519:4da6b80f86871bc2729b10b7a9859c57e2569464185d55ce9dfa4488a7d25d11fb785ee2929233c61e2fd3fc36c5c5ca3c40cab8c357fd7e88c1190b4323ed01",
+  "signature": "ed25519:e49c4513f8ae214d5f4ee14d6b6a2e90dfc1ecfa2532dd6801f18191022585325aaa8503f07361abad8756d1a96d7984fcea601e5ea237276ca3e90353b41a05",
   "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
 }

--- a/receipts/v0/conformance/golden/10-full-field-differential.json
+++ b/receipts/v0/conformance/golden/10-full-field-differential.json
@@ -1,0 +1,73 @@
+{
+  "version": 1,
+  "action_record": {
+    "version": 1,
+    "action_id": "conformance-00000",
+    "parent_action_id": "conformance-parent-00000",
+    "action_type": "write",
+    "timestamp": "2026-04-15T12:00:00Z",
+    "principal": "org:conformance-test",
+    "actor": "agent:conformance-runner",
+    "delegation_chain": [
+      "test-policy-v1",
+      "test-grant"
+    ],
+    "target": "https://api.example.com/v1/agents/spawn",
+    "intent": "delegated-subagent-write",
+    "side_effect_class": "external_write",
+    "reversibility": "compensatable",
+    "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "verdict": "allow",
+    "session_taint_level": "suspected",
+    "session_contaminated": true,
+    "recent_taint_sources": [
+      {
+        "url": "https://compromised-blog.example/post/9",
+        "kind": "response_injection",
+        "level": 4,
+        "timestamp": "2026-04-15T12:00:00Z",
+        "match_reason": "ignore_previous_instructions"
+      }
+    ],
+    "session_task_id": "task-abc123",
+    "session_task_label": "research-and-summarize",
+    "authority_kind": "delegated",
+    "taint_decision": "allow_with_constraints",
+    "taint_decision_reason": "task_scope_permits_write",
+    "contract_winning_source": "operator_policy",
+    "contract_live_verdict": "allow",
+    "contract_policy_sources": [
+      "operator_policy",
+      "org_default"
+    ],
+    "contract_rule_id": "rule-write-allow-7",
+    "active_manifest_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "contract_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "contract_selector_id": "selector-9",
+    "contract_generation": 4,
+    "transport": "https",
+    "method": "POST",
+    "layer": "tool_policy",
+    "severity": "medium",
+    "redaction": {
+      "profile": "strict",
+      "provider": "provider.example",
+      "parser": "json",
+      "total_redactions": 2,
+      "by_class": {
+        "api_key": 1,
+        "email": 1
+      }
+    },
+    "shield": {
+      "pipeline": "browser_shield_v1",
+      "total_rewrites": 1,
+      "agent_traps": 1
+    },
+    "request_id": "req-7f3a",
+    "chain_prev_hash": "genesis",
+    "chain_seq": 0
+  },
+  "signature": "ed25519:4da6b80f86871bc2729b10b7a9859c57e2569464185d55ce9dfa4488a7d25d11fb785ee2929233c61e2fd3fc36c5c5ca3c40cab8c357fd7e88c1190b4323ed01",
+  "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+}

--- a/receipts/v0/conformance/malicious/m10-receipt-count-mismatch.expect.json
+++ b/receipts/v0/conformance/malicious/m10-receipt-count-mismatch.expect.json
@@ -1,7 +1,7 @@
 {
   "fixture_id": "m10-receipt-count-mismatch",
   "category": "malicious",
-  "input_format": "chain",
+  "input_format": "receipt_bundle",
   "verdict": "reject",
   "reject_reason": "receipt_count_mismatch",
   "description": "Wrapper envelope claims declared_receipt_count=5 but only 4 receipts are present in the body.",

--- a/receipts/v0/conformance/malicious/m10-receipt-count-mismatch.json
+++ b/receipts/v0/conformance/malicious/m10-receipt-count-mismatch.json
@@ -1,0 +1,109 @@
+{
+  "declared_receipt_count": 5,
+  "receipts": [
+    {
+      "version": 1,
+      "action_record": {
+        "version": 1,
+        "action_id": "conformance-00000",
+        "action_type": "read",
+        "timestamp": "2026-04-15T12:00:00Z",
+        "principal": "org:conformance-test",
+        "actor": "agent:conformance-runner",
+        "delegation_chain": [
+          "test-policy-v1",
+          "test-grant"
+        ],
+        "target": "https://api.example.com/v1/data",
+        "side_effect_class": "external_read",
+        "reversibility": "full",
+        "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "verdict": "allow",
+        "transport": "https",
+        "method": "GET",
+        "chain_prev_hash": "genesis",
+        "chain_seq": 0
+      },
+      "signature": "ed25519:1f2afffae9147815ff4cff126f144766b5e3964c95451b0cab940e7f6be27a48fef13075520f8b59d9355fba5232613a97ece81ce691c1366a0f7e2d77f5de0b",
+      "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+    },
+    {
+      "version": 1,
+      "action_record": {
+        "version": 1,
+        "action_id": "conformance-00001",
+        "action_type": "read",
+        "timestamp": "2026-04-15T12:00:01Z",
+        "principal": "org:conformance-test",
+        "actor": "agent:conformance-runner",
+        "delegation_chain": [
+          "test-policy-v1",
+          "test-grant"
+        ],
+        "target": "https://api.example.com/v1/data",
+        "side_effect_class": "external_read",
+        "reversibility": "full",
+        "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "verdict": "allow",
+        "transport": "https",
+        "method": "GET",
+        "chain_prev_hash": "34f2780dcb510c03f55fc31387c993066fad23e328a2bf5f64b630b8d58a0dfb",
+        "chain_seq": 1
+      },
+      "signature": "ed25519:a74fb2658de0f899befa9673f06b725fff34575491bf00d8b24c6d6fcdd37fa24614f4723994e1369f91be41b3ea266a8ef6d57f73424b79cc1a7706015ac30c",
+      "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+    },
+    {
+      "version": 1,
+      "action_record": {
+        "version": 1,
+        "action_id": "conformance-00002",
+        "action_type": "read",
+        "timestamp": "2026-04-15T12:00:02Z",
+        "principal": "org:conformance-test",
+        "actor": "agent:conformance-runner",
+        "delegation_chain": [
+          "test-policy-v1",
+          "test-grant"
+        ],
+        "target": "https://api.example.com/v1/data",
+        "side_effect_class": "external_read",
+        "reversibility": "full",
+        "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "verdict": "allow",
+        "transport": "https",
+        "method": "GET",
+        "chain_prev_hash": "066037ef5bf14ea2c7135d091ca5fb9a5e743d75f8300d2073c427665aec4536",
+        "chain_seq": 2
+      },
+      "signature": "ed25519:0b8bd6868eecf2d934a3e7e804caa2b7787bd2ef866142f2b8dd1a376385bfa74189496bed9c14bece659fc5602e5e523d47d6253145538938edfc617a19bc0a",
+      "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+    },
+    {
+      "version": 1,
+      "action_record": {
+        "version": 1,
+        "action_id": "conformance-00003",
+        "action_type": "read",
+        "timestamp": "2026-04-15T12:00:03Z",
+        "principal": "org:conformance-test",
+        "actor": "agent:conformance-runner",
+        "delegation_chain": [
+          "test-policy-v1",
+          "test-grant"
+        ],
+        "target": "https://api.example.com/v1/data",
+        "side_effect_class": "external_read",
+        "reversibility": "full",
+        "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "verdict": "allow",
+        "transport": "https",
+        "method": "GET",
+        "chain_prev_hash": "cdf5642821ab773e65f7014cd90827c7c725aec1c0cf94c7121afffa26c5fee5",
+        "chain_seq": 3
+      },
+      "signature": "ed25519:b8e98441b2bf9a5afd57c8959fa084a8dfe3544e2e7e648564a37b4e6e12837c50eb3d4cf474cacce207738c6bbaa39a89870a5d70c4b03d98394e5b68a5d20c",
+      "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+    }
+  ]
+}

--- a/receipts/v0/conformance/malicious/m13-duplicate-key-verdict.expect.json
+++ b/receipts/v0/conformance/malicious/m13-duplicate-key-verdict.expect.json
@@ -5,5 +5,5 @@
   "verdict": "reject",
   "reject_reason": "duplicate_key",
   "description": "action_record carries two verdict keys (\"allow\" then the signed \"block\"). Valid JSON, last-wins parsing makes the signature verify, so a verifier without duplicate-key rejection silently accepts while a first-occurrence display layer shows the opposite verdict.",
-  "notes": "Verifier MUST reject duplicate object keys at parse time, at any nesting depth, before signature verification. Use a raw token/pair scan (Go json.Decoder token loop, JS reviver/pair check, serde_json with reject_duplicate, Python object_pairs_hook) — last-wins map insertion hides the duplicate."
+  "notes": "Verifier MUST reject duplicate object keys at parse time, at any nesting depth, before signature verification, with explicit duplicate-key detection during raw parsing — last-wins map insertion hides the duplicate. Examples: a Go json.Decoder token loop, a JS pair/key scan, a Rust serde Visitor that tracks map keys (serde_json has no built-in reject-duplicate option; struct fields error on repeats but map-like decoding is last-wins), and Python's object_pairs_hook."
 }

--- a/receipts/v0/conformance/malicious/m13-duplicate-key-verdict.expect.json
+++ b/receipts/v0/conformance/malicious/m13-duplicate-key-verdict.expect.json
@@ -1,0 +1,9 @@
+{
+  "fixture_id": "m13-duplicate-key-verdict",
+  "category": "malicious",
+  "input_format": "receipt",
+  "verdict": "reject",
+  "reject_reason": "duplicate_key",
+  "description": "action_record carries two verdict keys (\"allow\" then the signed \"block\"). Valid JSON, last-wins parsing makes the signature verify, so a verifier without duplicate-key rejection silently accepts while a first-occurrence display layer shows the opposite verdict.",
+  "notes": "Verifier MUST reject duplicate object keys at parse time, at any nesting depth, before signature verification. Use a raw token/pair scan (Go json.Decoder token loop, JS reviver/pair check, serde_json with reject_duplicate, Python object_pairs_hook) — last-wins map insertion hides the duplicate."
+}

--- a/receipts/v0/conformance/malicious/m13-duplicate-key-verdict.json
+++ b/receipts/v0/conformance/malicious/m13-duplicate-key-verdict.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "action_record": {
+    "version": 1,
+    "action_id": "conformance-00000",
+    "action_type": "write",
+    "timestamp": "2026-04-15T12:00:00Z",
+    "principal": "org:conformance-test",
+    "actor": "agent:conformance-runner",
+    "delegation_chain": [
+      "test-policy-v1",
+      "test-grant"
+    ],
+    "target": "https://attacker.example.net/exfil",
+    "side_effect_class": "external_write",
+    "reversibility": "compensatable",
+    "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "verdict": "allow",
+    "verdict": "block",
+    "transport": "https",
+    "method": "POST",
+    "layer": "tool_policy",
+    "severity": "high",
+    "chain_prev_hash": "genesis",
+    "chain_seq": 0
+  },
+  "signature": "ed25519:a6e43c84510f4735b1eb88167fb6e012fa2a83ecefce6d9051bccc091d0b33fcc9aad20112bc7a2f0f9db345743c2b2e5013e69168348adfd5c0e5693e9b9803",
+  "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+}

--- a/receipts/v0/conformance/malicious/m14-duplicate-key-nested-unicode.expect.json
+++ b/receipts/v0/conformance/malicious/m14-duplicate-key-nested-unicode.expect.json
@@ -1,0 +1,9 @@
+{
+  "fixture_id": "m14-duplicate-key-nested-unicode",
+  "category": "malicious",
+  "input_format": "receipt",
+  "verdict": "reject",
+  "reject_reason": "duplicate_key",
+  "description": "Ignored top-level probe contains an array element with duplicate keys \"a\" and \"\\u0061\".",
+  "notes": "Verifier MUST reject duplicate object keys at any nesting depth, including unicode-escaped key equivalents inside arrays and fields ignored by signature canonicalization."
+}

--- a/receipts/v0/conformance/malicious/m14-duplicate-key-nested-unicode.json
+++ b/receipts/v0/conformance/malicious/m14-duplicate-key-nested-unicode.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "action_record": {
+    "version": 1,
+    "action_id": "conformance-00000",
+    "action_type": "write",
+    "timestamp": "2026-04-15T12:00:00Z",
+    "principal": "org:conformance-test",
+    "actor": "agent:conformance-runner",
+    "delegation_chain": [
+      "test-policy-v1",
+      "test-grant"
+    ],
+    "target": "https://attacker.example.net/exfil",
+    "side_effect_class": "external_write",
+    "reversibility": "compensatable",
+    "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "verdict": "block",
+    "transport": "https",
+    "method": "POST",
+    "chain_prev_hash": "genesis",
+    "chain_seq": 0
+  },
+  "signature": "ed25519:5b78fafc57c7f8d085278f30d6c1226f8eb5b7d93a39afcc1d688045415deec10df6eccd1bdbdafcd22fb29b624e478f173a5e23ea8b2bcef23e28ad6141ca08",
+  "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa",
+  "dup_probe": [{"a":1,"\u0061":2}]
+}


### PR DESCRIPTION
Closes a coverage gap in the receipt-verifier conformance corpus and adds one new hardening requirement.

- Mirror the full action-record struct in the generator (`parent_action_id` + taint, contract, redaction, shield blocks) so fixtures can exercise every signed field.
- Add golden fixtures `09-allow-shield-summary` and `10-full-field-differential`, plus malicious `m13-duplicate-key-verdict` with a new `duplicate_key` reject reason.
- README: dated spec revision; clarify "already-specified behaviour" is the full struct field set; add duplicate-key rejection to the strict-JSON requirements.

Non-breaking: no existing fixture changed, no honest receipt changes verdict. `go run . --verify` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced JSON validation to reject duplicate object keys at parse time, before signature verification.

* **Documentation**
  * Updated conformance spec with duplicate-key rejection policy, expanded fixture input-format guidance (including receipt_bundle), and clarified versioning/spec revision notes.

* **Tests**
  * Added golden fixtures for shield summary and full-field coverage.
  * Added malicious fixtures for duplicate-key detection and receipt-count mismatch.
  * Added edge fixtures for nesting-depth, non-BMP key ordering, and HTML-escape canonicalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->