### PR TITLE
docs: reconcile stale case counts to 165 logical cases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md: agent-egress-bench Development Guide
 
-agent-egress-bench is a tool-neutral attack corpus for evaluating AI agent egress security tools. 151 cases across 17 categories. JSON case files, a Go validator, a Gauntlet scoring runner, spec docs, and reference runners. This is NOT an application. The validator and runner are build tools, not the product.
+agent-egress-bench is a tool-neutral attack corpus for evaluating AI agent egress security tools. 165 logical cases across 18 categories. JSON case files, multi-file MCP drift fixtures, a Go validator, a Gauntlet scoring runner, spec docs, and reference runners. This is NOT an application. The validator and runner are build tools, not the product.
 
 ## Hard Rules
 

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ stats:
 	@echo "categories: $$(find cases -mindepth 1 -maxdepth 1 -type d | wc -l)"
 	@jblk=$$(find cases -name '*.json' -not -path 'cases/mcp-drift/*' -exec grep -l '"expected_verdict"[[:space:]]*:[[:space:]]*"block"' {} \; | wc -l); \
 	dblk=$$(grep -lE 'expected_verdict:[[:space:]]*block' cases/mcp-drift/*/case.yaml 2>/dev/null | wc -l); \
-	echo "malicious: $$((jblk + dblk))"
+	echo "block: $$((jblk + dblk))"
 	@jaln=$$(find cases -name '*.json' -not -path 'cases/mcp-drift/*' -exec grep -l '"expected_verdict"[[:space:]]*:[[:space:]]*"allow"' {} \; | wc -l); \
 	daln=$$(grep -lE 'expected_verdict:[[:space:]]*allow' cases/mcp-drift/*/case.yaml 2>/dev/null | wc -l); \
-	echo "benign: $$((jaln + daln))"
+	echo "allow: $$((jaln + daln))"
 	@echo "warn: $$(grep -lE 'expected_verdict:[[:space:]]*warn' cases/mcp-drift/*/case.yaml 2>/dev/null | wc -l)"
 	@set -- cases/*/; \
 	if [ "$$1" = 'cases/*/' ]; then exit 0; fi; \

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,29 @@
 .PHONY: stats
 
-# Print canonical stats from test cases
+# Print canonical stats from test cases.
+# Counts are LOGICAL cases: single-file JSON cases plus each multi-file
+# mcp-drift directory as one case. Verdicts include the mcp-drift case.yaml.
 stats:
 	@echo "# agent-egress-bench stats"
-	@echo "cases_total: $$(find cases -name '*.json' | wc -l)"
+	@single=$$(find cases -name '*.json' -not -path 'cases/mcp-drift/*' | wc -l); \
+	drift=$$(find cases/mcp-drift -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l); \
+	echo "cases_total: $$((single + drift))"
 	@echo "categories: $$(find cases -mindepth 1 -maxdepth 1 -type d | wc -l)"
-	@echo "malicious: $$(find cases -name '*.json' -exec grep -l '"expected_verdict"[[:space:]]*:[[:space:]]*"block"' {} \; | wc -l)"
-	@echo "benign: $$(find cases -name '*.json' -exec grep -l '"expected_verdict"[[:space:]]*:[[:space:]]*"allow"' {} \; | wc -l)"
+	@jblk=$$(find cases -name '*.json' -not -path 'cases/mcp-drift/*' -exec grep -l '"expected_verdict"[[:space:]]*:[[:space:]]*"block"' {} \; | wc -l); \
+	dblk=$$(grep -lE 'expected_verdict:[[:space:]]*block' cases/mcp-drift/*/case.yaml 2>/dev/null | wc -l); \
+	echo "malicious: $$((jblk + dblk))"
+	@jaln=$$(find cases -name '*.json' -not -path 'cases/mcp-drift/*' -exec grep -l '"expected_verdict"[[:space:]]*:[[:space:]]*"allow"' {} \; | wc -l); \
+	daln=$$(grep -lE 'expected_verdict:[[:space:]]*allow' cases/mcp-drift/*/case.yaml 2>/dev/null | wc -l); \
+	echo "benign: $$((jaln + daln))"
+	@echo "warn: $$(grep -lE 'expected_verdict:[[:space:]]*warn' cases/mcp-drift/*/case.yaml 2>/dev/null | wc -l)"
 	@set -- cases/*/; \
 	if [ "$$1" = 'cases/*/' ]; then exit 0; fi; \
 	for dir in "$$@"; do \
 		name=$$(basename "$$dir"); \
-		count=$$(find "$$dir" -name '*.json' | wc -l); \
+		if [ "$$name" = "mcp-drift" ]; then \
+			count=$$(find "$$dir" -mindepth 1 -maxdepth 1 -type d | wc -l); \
+		else \
+			count=$$(find "$$dir" -name '*.json' | wc -l); \
+		fi; \
 		echo "  $$name: $$count"; \
 	done

--- a/README.md
+++ b/README.md
@@ -227,8 +227,6 @@ Most AI agent security benchmarks test whether the **model** behaves safely. Thi
 
 The model-testing benchmarks assume the LLM is the last line of defense. This corpus assumes models will sometimes fail, and tests the defense-in-depth layer that sits between the agent and the network.
 
-AgentDojo-style benchmarks run realistic multi-step sessions to see whether the agent gets fooled. agent-egress-bench feeds attacks to the proxy, firewall, scanner, or MCP wrapper and scores whether that security layer catches them. The two approaches are complementary: one tests agent behavior, the other tests the tool that should contain the agent's mistakes.
-
 AgentShield-benchmark is the closest comparable, but operates at the application/API layer (is this prompt an injection?). agent-egress-bench operates at the wire level (did this HTTP request contain an exfiltrated secret in the query string? did this MCP tool response contain prompt injection?).
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
 </p>
 
-A standardized test corpus for evaluating AI agent egress security tools. 155 cases across 18 categories, covering secret exfiltration, prompt injection, SSRF, hostname exfiltration, MCP tool poisoning, chain detection, MCP drift, A2A protocol scanning, WebSocket DLP, encoding evasion, shell obfuscation, and cryptocurrency/financial data protection.
+A standardized test corpus for evaluating AI agent egress security tools. 165 logical cases across 18 categories, covering secret exfiltration, prompt injection, SSRF, hostname exfiltration, MCP tool poisoning, chain detection, MCP drift, A2A protocol scanning, WebSocket DLP, encoding evasion, shell obfuscation, and cryptocurrency/financial data protection.
 
 **This tests the security tool, not the agent.** Most benchmarks in this space (AgentDojo, InjecAgent, CyberSecEval, AgentHarm) test whether the LLM behaves correctly. This one tests whether the firewall, proxy, or scanner sitting between the agent and the network catches the attack.
 
@@ -36,8 +36,8 @@ Tools exist to sit between agents and the network (proxies, firewalls, MCP wrapp
 
 | Category | Directory | Cases | What it tests |
 |----------|-----------|-------|---------------|
-| URL DLP | `cases/url/` | 15 | Secrets leaked via query strings, encoded paths, high-entropy subdomains, SSRF, domain blocklist |
-| Request body DLP | `cases/request-body/` | 10 | Secrets in POST bodies (JSON, YAML, CSV, multipart, base64, hex, env dumps) |
+| URL DLP | `cases/url/` | 18 | Secrets leaked via query strings, encoded paths, high-entropy subdomains, SSRF, domain blocklist |
+| Request body DLP | `cases/request-body/` | 12 | Secrets in POST bodies (JSON, YAML, CSV, multipart, base64, hex, env dumps) |
 | Header DLP | `cases/headers/` | 9 | API keys and tokens in HTTP headers (Bearer, JWT, AWS, multi-header) |
 | Hostname exfiltration | `cases/hostname-exfiltration/` | 8 | Encoded secrets in DNS hostname labels before resolution |
 | Response injection (fetch) | `cases/response-fetch/` | 8 | Prompt injection in fetched web content |
@@ -53,9 +53,11 @@ Tools exist to sit between agents and the network (proxies, firewalls, MCP wrapp
 | Encoding evasion | `cases/encoding-evasion/` | 9 | Multi-layer encoding chains, Unicode tricks, zero-width insertion |
 | Shell obfuscation | `cases/shell-obfuscation/` | 7 | Backtick substitution, brace expansion, IFS manipulation |
 | Crypto/financial DLP | `cases/crypto-financial/` | 8 | Wallet addresses, seed phrases, credit cards, IBANs |
-| False positive suite | `cases/false-positive/` | 12 | Benign traffic that must not be blocked |
+| False positive suite | `cases/false-positive/` | 17 | Benign traffic that must not be blocked |
 
-116 malicious cases (expected: block) and 39 non-blocking baselines (38 expected: allow, 1 expected: warn) to test false positive rates.
+Counts are logical cases, not fixture files. Most cases are single JSON files; MCP drift cases are multi-file before/after snapshots, and each drift directory counts as one case.
+
+121 block-expected cases, 43 allow-expected baselines, and 1 warn-class MCP drift guardrail test containment and false positive behavior.
 
 Most cases are self-contained JSON files with the attack payload, expected verdict (`block` or `allow`), severity, capability tags, and a machine-readable reason for the expected outcome. The 4 MCP drift cases under `cases/mcp-drift/` are multi-file before/after fixtures with `case.yaml` metadata.
 
@@ -215,15 +217,17 @@ Most AI agent security benchmarks test whether the **model** behaves safely. Thi
 
 | Benchmark | Tests what? | Focus |
 |-----------|------------|-------|
-| [AgentDojo](https://github.com/ethz-spylab/agentdojo) (ETH Zurich) | The LLM agent | Robustness to prompt injection (629 cases) |
-| [InjecAgent](https://github.com/uiuc-kang-lab/InjecAgent) (UIUC) | The LLM agent | Indirect prompt injection success rate (1,054 cases) |
-| [AgentHarm](https://huggingface.co/datasets/ai-safety-institute/AgentHarm) (UK AISI) | The LLM | Refusal of harmful multi-step tasks (440 cases) |
+| [AgentDojo](https://github.com/ethz-spylab/agentdojo) (ETH Zurich) | The LLM agent | Robustness to prompt injection in realistic tasks |
+| [InjecAgent](https://github.com/uiuc-kang-lab/InjecAgent) (UIUC) | The LLM agent | Indirect prompt injection success rate |
+| [AgentHarm](https://huggingface.co/datasets/ai-safety-institute/AgentHarm) (UK AISI) | The LLM | Refusal of harmful multi-step tasks |
 | [CyberSecEval](https://github.com/meta-llama/PurpleLlama) (Meta) | The LLM | Insecure code generation, cyberattack assistance |
-| [ASB](https://github.com/agiresearch/ASB) (ICLR 2025) | The LLM agent | Defense prompts reducing attack success (90K cases) |
-| [AgentShield-bench](https://github.com/doronp/agentshield-benchmark) (Agent Guard) | Security middleware | Prompt injection and jailbreak detection at API layer (537 cases) |
-| **agent-egress-bench** | **Security tools** | **Secret exfiltration, SSRF, MCP poisoning, A2A, hostname exfiltration, encoding evasion at the network layer (151 cases)** |
+| [ASB](https://github.com/agiresearch/ASB) (ICLR 2025) | The LLM agent | Defense prompts reducing attack success |
+| [AgentShield-bench](https://github.com/doronp/agentshield-benchmark) (Agent Guard) | Security middleware | Prompt injection and jailbreak detection at API layer |
+| **agent-egress-bench** | **Security tools** | **Secret exfiltration, SSRF, MCP poisoning, A2A, hostname exfiltration, encoding evasion at the network layer (165 logical cases)** |
 
 The model-testing benchmarks assume the LLM is the last line of defense. This corpus assumes models will sometimes fail, and tests the defense-in-depth layer that sits between the agent and the network.
+
+AgentDojo-style benchmarks run realistic multi-step sessions to see whether the agent gets fooled. agent-egress-bench feeds attacks to the proxy, firewall, scanner, or MCP wrapper and scores whether that security layer catches them. The two approaches are complementary: one tests agent behavior, the other tests the tool that should contain the agent's mistakes.
 
 AgentShield-benchmark is the closest comparable, but operates at the application/API layer (is this prompt an injection?). agent-egress-bench operates at the wire level (did this HTTP request contain an exfiltrated secret in the query string? did this MCP tool response contain prompt injection?).
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -63,7 +63,10 @@ Each case is a single JSON file in the `cases/` directory tree. Files are named 
 
 `block`, `allow`
 
-v1 is binary. No `warn` in case expectations.
+Single-file JSON v1 cases are binary. No `warn` appears in single-file JSON case expectations.
+The multi-file MCP drift fixtures use a separate `case.yaml` contract documented in
+[`cases/mcp-drift/README.md`](../cases/mcp-drift/README.md), where `warn` is allowed for
+benign drift that should be surfaced for operator review without being blocked.
 
 ### severity
 

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -75,7 +75,7 @@ nothing to pass. The profile is the published evidence.
 
 ## Coverage scope
 
-The reference runner exercises the 151 single-file cases under
+The reference runner exercises the 161 single-file cases under
 [`../cases/`](../cases/) plus the 4 multi-file cases in
 [`../cases/mcp-drift/`](../cases/mcp-drift/) (12 JSON fixture files
 total: `before.json`, `after.json`, `expected.json` per case). Multi-file


### PR DESCRIPTION
The README, CLAUDE.md, SPEC, and profiles doc carried stale case counts (155 and 151), and the comparison table cited volatile external benchmark counts. This reconciles every count to the corpus as it stands, and updates `make stats` so the tooling matches the docs.

Canonical count: 165 logical cases across 18 categories. That is 161 single-file JSON cases plus 4 multi-file mcp-drift cases. By expected verdict: 121 block, 43 allow, 1 warn (the mcp-drift benign-drift guardrail). The old 173 raw-file figure over-counted the 4 multi-file drift cases as 12 fixture files.

Changes:

- README headline and category table corrected (url 15 to 18, request-body 10 to 12, false-positive 12 to 17), with a note that counts are logical cases.
- Comparison table: dropped the external benchmark case counts (they drift and cannot be verified here) and set this corpus to 165 logical cases. Added a line on how this differs from AgentDojo-style session benchmarks.
- CLAUDE.md corrected to 165 / 18 and notes the multi-file drift fixtures.
- SPEC clarifies single-file JSON cases are binary, while the multi-file mcp-drift contract allows a warn verdict.
- profiles README corrected to 161 single-file cases.
- `make stats` now reports logical cases (drift directories counted as one case each, drift case.yaml verdicts included): 165 / 121 / 43 / 1.

No case content changed. The validator passes against all 161 single-file cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark and corpus descriptions across the docs to reflect the latest case totals and category counts.
  * Clarified how single-file cases and multi-file drift fixtures are classified, including when non-blocking review outcomes can appear.

* **Chores**
  * Refreshed the benchmark statistics output to report case totals and verdict counts more accurately, including the new review-only category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->