### PR TITLE
test(receipts): generate run-nonce conformance fixtures

### DIFF
--- a/receipts/v0/conformance/_generator/main.go
+++ b/receipts/v0/conformance/_generator/main.go
@@ -105,6 +105,13 @@ type ActionRecord struct {
 	ChainPrevHash string `json:"chain_prev_hash"`
 	ChainSeq      uint64 `json:"chain_seq"`
 
+	// RunNonce mirrors receipt.ActionRecord.RunNonce: generated once per
+	// process run and bound into every signed receipt so an otherwise
+	// repeatable decision is tied to a single run. Declared immediately after
+	// chain_seq to match the Go source's struct-order slot; omitempty, so
+	// fixtures that do not set it canonicalize byte-for-byte unchanged.
+	RunNonce string `json:"run_nonce,omitempty"`
+
 	// Jurisdictional fields - present in schema for forward compatibility.
 	Venue              string   `json:"venue,omitempty"`
 	Jurisdiction       string   `json:"jurisdiction,omitempty"`
@@ -729,6 +736,28 @@ func buildGolden() ([]fixture, error) {
 		}
 	}
 
+	// 11. run-nonce bound — a standalone allow receipt whose action_record
+	// carries run_nonce. The nonce is part of the signed preimage, binding an
+	// otherwise repeatable decision to one process run. Cross-language drift
+	// sentinel: run_nonce must canonicalize in the same struct-order slot
+	// (immediately after chain_seq) in every verifier. action_id is set to
+	// conformance-00010 (the eleventh fixture) while chain_seq stays 0 because
+	// this is a standalone receipt, not a chain link.
+	{
+		ar := baseRecord(0, genesisHash, baseTime.Add(10*time.Minute), "read", "allow",
+			"https://api.example.com/v1/data?nonce=bound", "https", "GET")
+		ar.ActionID = "conformance-00010"
+		ar.RunNonce = "0123456789abcdef0123456789abcdef"
+		if f, err := makeSingle("11-run-nonce-bound", "golden", priv, pubHex, ar,
+			"Allow receipt carrying action_record.run_nonce. The nonce is part of the signed ActionRecord preimage, binding an otherwise repeatable decision to one process run.",
+			"Verifier MUST accept. This is the run-nonce cross-language drift sentinel: action_record.run_nonce must be canonicalized in the same Go struct-order slot by every verifier.",
+		); err != nil {
+			return nil, err
+		} else {
+			out = append(out, f)
+		}
+	}
+
 	return out, nil
 }
 
@@ -1291,6 +1320,41 @@ func buildMalicious() ([]fixture, error) {
 				RejectReason: "duplicate_key",
 				Description:  `Ignored top-level probe contains an array element with duplicate keys "a" and "\u0061".`,
 				Notes:        "Verifier MUST reject duplicate object keys at any nesting depth, including unicode-escaped key equivalents inside arrays and fields ignored by signature canonicalization.",
+			},
+		})
+	}
+
+	// M15. run-nonce tampered after signing — the signature was valid for the
+	// original run_nonce, but action_record.run_nonce was rewritten post-sign,
+	// so SHA-256(canonical(action_record)) no longer matches. Mirrors the
+	// m11 body-tamper shape, aimed at the run_nonce slot.
+	{
+		ar := baseRecord(0, genesisHash, baseTime.Add(10*time.Minute), "read", "allow",
+			"https://api.example.com/v1/data?nonce=bound", "https", "GET")
+		ar.ActionID = "conformance-00010"
+		ar.RunNonce = "0123456789abcdef0123456789abcdef"
+		r, err := signReceipt(ar, priv)
+		if err != nil {
+			return nil, err
+		}
+		// Tamper the run_nonce after signing.
+		r.ActionRecord.RunNonce = "1123456789abcdef0123456789abcdef"
+		payload, err := marshalPretty(r)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, fixture{
+			Category: "malicious",
+			Name:     "m15-run-nonce-tampered",
+			Payload:  payload,
+			Expect: Expect{
+				FixtureID:    "m15-run-nonce-tampered",
+				Category:     "malicious",
+				InputFormat:  "receipt",
+				Verdict:      "reject",
+				RejectReason: "run_nonce_tampered",
+				Description:  "Signature was valid for the original run_nonce, but action_record.run_nonce has been rewritten post-signing. SHA-256(canonical(action_record)) no longer matches.",
+				Notes:        "Verifier MUST recompute the canonical ActionRecord including run_nonce. Accepting this fixture means the nonce is being treated as an unsigned cosmetic sidecar.",
 			},
 		})
 	}

--- a/receipts/v0/conformance/golden/11-run-nonce-bound.expect.json
+++ b/receipts/v0/conformance/golden/11-run-nonce-bound.expect.json
@@ -1,0 +1,11 @@
+{
+  "fixture_id": "11-run-nonce-bound",
+  "category": "golden",
+  "input_format": "receipt",
+  "verdict": "accept",
+  "description": "Allow receipt carrying action_record.run_nonce. The nonce is part of the signed ActionRecord preimage, binding an otherwise repeatable decision to one process run.",
+  "expected_chain_length": 1,
+  "expected_signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa",
+  "expected_root_hash": "568ea8684a698aea99462fbd035e96f55d360ac4c7afc7ac000fadb11147c5ce",
+  "notes": "Verifier MUST accept. This is the run-nonce cross-language drift sentinel: action_record.run_nonce must be canonicalized in the same Go struct-order slot by every verifier."
+}

--- a/receipts/v0/conformance/golden/11-run-nonce-bound.json
+++ b/receipts/v0/conformance/golden/11-run-nonce-bound.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "action_record": {
+    "version": 1,
+    "action_id": "conformance-00010",
+    "action_type": "read",
+    "timestamp": "2026-04-15T12:10:00Z",
+    "principal": "org:conformance-test",
+    "actor": "agent:conformance-runner",
+    "delegation_chain": [
+      "test-policy-v1",
+      "test-grant"
+    ],
+    "target": "https://api.example.com/v1/data?nonce=bound",
+    "side_effect_class": "external_read",
+    "reversibility": "full",
+    "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "verdict": "allow",
+    "transport": "https",
+    "method": "GET",
+    "chain_prev_hash": "genesis",
+    "chain_seq": 0,
+    "run_nonce": "0123456789abcdef0123456789abcdef"
+  },
+  "signature": "ed25519:c33030e67ac6f01b2707cbe64c1b6111e8ba3cd366e733ac2913677528e0af7f89bfa2a209542d7ad32d38ab7285a3673d047907334d707de39f57ae5d54740f",
+  "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+}

--- a/receipts/v0/conformance/malicious/m15-run-nonce-tampered.expect.json
+++ b/receipts/v0/conformance/malicious/m15-run-nonce-tampered.expect.json
@@ -1,0 +1,9 @@
+{
+  "fixture_id": "m15-run-nonce-tampered",
+  "category": "malicious",
+  "input_format": "receipt",
+  "verdict": "reject",
+  "reject_reason": "run_nonce_tampered",
+  "description": "Signature was valid for the original run_nonce, but action_record.run_nonce has been rewritten post-signing. SHA-256(canonical(action_record)) no longer matches.",
+  "notes": "Verifier MUST recompute the canonical ActionRecord including run_nonce. Accepting this fixture means the nonce is being treated as an unsigned cosmetic sidecar."
+}

--- a/receipts/v0/conformance/malicious/m15-run-nonce-tampered.json
+++ b/receipts/v0/conformance/malicious/m15-run-nonce-tampered.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "action_record": {
+    "version": 1,
+    "action_id": "conformance-00010",
+    "action_type": "read",
+    "timestamp": "2026-04-15T12:10:00Z",
+    "principal": "org:conformance-test",
+    "actor": "agent:conformance-runner",
+    "delegation_chain": [
+      "test-policy-v1",
+      "test-grant"
+    ],
+    "target": "https://api.example.com/v1/data?nonce=bound",
+    "side_effect_class": "external_read",
+    "reversibility": "full",
+    "policy_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "verdict": "allow",
+    "transport": "https",
+    "method": "GET",
+    "chain_prev_hash": "genesis",
+    "chain_seq": 0,
+    "run_nonce": "1123456789abcdef0123456789abcdef"
+  },
+  "signature": "ed25519:c33030e67ac6f01b2707cbe64c1b6111e8ba3cd366e733ac2913677528e0af7f89bfa2a209542d7ad32d38ab7285a3673d047907334d707de39f57ae5d54740f",
+  "signer_key": "890726e93f89e773fb3b4298271245a69c1884fd1003846c3358b8b65a2288fa"
+}


### PR DESCRIPTION
## What changed

Adds two receipt conformance fixtures and teaches the generator about the `run_nonce` field so both are produced from the canonical `ActionRecord` struct instead of being hand-authored.

- `golden/11-run-nonce-bound`: a signed allow receipt whose `action_record.run_nonce` is part of the signed preimage. This is the cross-language drift sentinel for the nonce; every reference verifier must canonicalize `run_nonce` in the same struct-order slot (immediately after `chain_seq`).
- `malicious/m15-run-nonce-tampered`: the same receipt with `run_nonce` rewritten after signing, so a correct verifier recomputes the canonical hash and rejects it.

## Generator

`run_nonce` is declared on the generator's `ActionRecord` immediately after `chain_seq`, matching the receipt struct slot. It is `omitempty`, so every existing fixture canonicalizes byte-for-byte unchanged: `go run . --write` regenerates the corpus with no diff outside the two new fixtures, and `go run . --verify` now treats both new fixtures as generator-managed.

## Why

These fixtures already exist in the downstream pipelock vendored copy of this corpus but were missing from the master here, so the vendored copy could not be pinned to a bench-main commit without reporting drift. Landing them keeps the master and the vendored copy consistent.
