### PR TITLE
runner: fail loud on harness errors, add --debug, refresh profile

### DIFF
--- a/examples/pipelock/tool-profile.json
+++ b/examples/pipelock/tool-profile.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "tool": "pipelock",
-  "tool_version": "2.5.0",
+  "tool_version": "3.1.0",
   "runner_version": "v2",
   "claims": [
     "url_dlp",

--- a/profiles/pipelock.json
+++ b/profiles/pipelock.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
   "tool": "pipelock",
-  "tool_version": "2.5.0",
+  "tool_version": "3.1.0",
   "corpus_version": "v2.0.0",
-  "corpus_sha256": "be61d7ee67a59e72d7964351ee6dd5b6c11da6d73e7fea3e4ff8aa4d1d76d914",
-  "tool_profile_sha256": "825a0394ca325e2a7076c8f46bb4c938a03176f1a61a498bbb24982962cf7a9a",
+  "corpus_sha256": "cb0c11b1ba74f75b891b9706ae3e87116bfb2ef05b1920959011035ac62ed778",
+  "tool_profile_sha256": "dc5b702f76de05a38dc209344febd1081e2c9a16aa282b92668503dad8cdc7cd",
   "verifier": {
     "shipped": true,
     "open_source": true,
@@ -13,9 +13,9 @@
     "exit_code_contract": "0 valid, 1 invalid, 2 error, 64 usage"
   },
   "summary": {
-    "blocked_yes_count": 115,
-    "blocked_no_count": 1,
-    "explained_yes_count": 107,
+    "blocked_yes_count": 148,
+    "blocked_no_count": 0,
+    "explained_yes_count": 143,
     "receipt_produced_yes_count": 0,
     "receipt_independently_verifiable_yes_count": 0,
     "false_positive_yes_count": 0
@@ -71,6 +71,22 @@
     },
     {
       "case_id": "a2a-card-poison-skill-injection-003",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "a2a-card-url-ssrf-008",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "a2a-msg-base64-secret-011",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",
@@ -134,6 +150,14 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "a2a-msg-file-part-ssrf-012",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "a2a-msg-injection-hijack-004",
       "blocked": "yes",
       "explained": "yes",
@@ -182,6 +206,14 @@
       "false_positive": "no"
     },
     {
+      "case_id": "body-dlp-azure-storage-key-001",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "body-dlp-base64-payload-003",
       "blocked": "yes",
       "explained": "yes",
@@ -214,6 +246,14 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "body-dlp-html-entity-008",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "body-dlp-json-key-001",
       "blocked": "yes",
       "explained": "yes",
@@ -222,7 +262,39 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "body-dlp-keyname-secret-011",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "body-dlp-multipart-002",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "body-dlp-pem-private-key-009",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "body-dlp-postgres-conn-001",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "body-dlp-ssn-routing-010",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",
@@ -278,7 +350,23 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "crypto-eth-raw-privkey-009",
+      "blocked": "yes",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "crypto-iban-007",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "crypto-seed-24word-011",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",
@@ -295,6 +383,14 @@
     },
     {
       "case_id": "crypto-wif-private-key-005",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "crypto-xpub-extended-key-010",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",
@@ -352,7 +448,7 @@
     {
       "case_id": "enc-triple-url-009",
       "blocked": "yes",
-      "explained": "no",
+      "explained": "yes",
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "n/a"
@@ -374,7 +470,39 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "fp-a2a-data-uuid-017",
+      "blocked": "n/a",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "no"
+    },
+    {
       "case_id": "fp-base64-image-data-uri-010",
+      "blocked": "n/a",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "no"
+    },
+    {
+      "case_id": "fp-camouflage-finance-authority-013",
+      "blocked": "n/a",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "no"
+    },
+    {
+      "case_id": "fp-camouflage-legal-control-014",
+      "blocked": "n/a",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "no"
+    },
+    {
+      "case_id": "fp-camouflage-runbook-step-015",
       "blocked": "n/a",
       "explained": "no",
       "receipt_produced": "no",
@@ -406,6 +534,14 @@
       "false_positive": "no"
     },
     {
+      "case_id": "fp-db-conn-no-credentials-013",
+      "blocked": "n/a",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "no"
+    },
+    {
       "case_id": "fp-error-message-token-expired-009",
       "blocked": "n/a",
       "explained": "no",
@@ -430,7 +566,23 @@
       "false_positive": "no"
     },
     {
+      "case_id": "fp-gitlab-lookalike-word-014",
+      "blocked": "n/a",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "no"
+    },
+    {
       "case_id": "fp-multilingual-security-terms-001",
+      "blocked": "n/a",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "no"
+    },
+    {
+      "case_id": "fp-nested-config-lookalike-018",
       "blocked": "n/a",
       "explained": "no",
       "receipt_produced": "no",
@@ -470,6 +622,14 @@
       "false_positive": "no"
     },
     {
+      "case_id": "fp-ws-clean-multiframe-016",
+      "blocked": "n/a",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "no"
+    },
+    {
       "case_id": "header-benign-auth-001",
       "blocked": "n/a",
       "explained": "no",
@@ -497,6 +657,14 @@
       "case_id": "header-dlp-aws-headers-005",
       "blocked": "yes",
       "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "header-dlp-basic-auth-007",
+      "blocked": "yes",
+      "explained": "no",
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "n/a"
@@ -542,9 +710,17 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "header-dlp-referer-token-008",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "hostname-exfil-base32-subdomain-002",
       "blocked": "yes",
-      "explained": "no",
+      "explained": "yes",
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "n/a"
@@ -568,7 +744,7 @@
     {
       "case_id": "hostname-exfil-chunked-labels-004",
       "blocked": "yes",
-      "explained": "no",
+      "explained": "yes",
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "n/a"
@@ -576,7 +752,7 @@
     {
       "case_id": "hostname-exfil-env-var-007",
       "blocked": "yes",
-      "explained": "no",
+      "explained": "yes",
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "n/a"
@@ -584,7 +760,7 @@
     {
       "case_id": "hostname-exfil-hex-subdomain-001",
       "blocked": "yes",
-      "explained": "no",
+      "explained": "yes",
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "n/a"
@@ -592,13 +768,29 @@
     {
       "case_id": "hostname-exfil-long-chain-005",
       "blocked": "yes",
-      "explained": "no",
+      "explained": "yes",
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "n/a"
     },
     {
       "case_id": "hostname-exfil-mixed-encoding-006",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "hostname-exfil-numeric-label-010",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "hostname-exfil-punycode-009",
       "blocked": "yes",
       "explained": "no",
       "receipt_produced": "no",
@@ -620,6 +812,22 @@
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "no"
+    },
+    {
+      "case_id": "mcp-chain-decoy-interleave-008",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "mcp-chain-dns-exfil-009",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
     },
     {
       "case_id": "mcp-chain-env-network-002",
@@ -686,14 +894,6 @@
       "false_positive": "no"
     },
     {
-      "case_id": "mcp-drift-collusion-004",
-      "blocked": "no",
-      "explained": "no",
-      "receipt_produced": "no",
-      "receipt_independently_verifiable": "no",
-      "false_positive": "n/a"
-    },
-    {
       "case_id": "mcp-drift-rugpull-desc-002",
       "blocked": "yes",
       "explained": "yes",
@@ -719,6 +919,14 @@
     },
     {
       "case_id": "mcp-input-dlp-001",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "mcp-input-double-encode-009",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",
@@ -758,6 +966,14 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "mcp-input-nested-deep-011",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "mcp-input-scattered-secret-005",
       "blocked": "yes",
       "explained": "yes",
@@ -783,6 +999,14 @@
     },
     {
       "case_id": "mcp-tool-exfil-description-005",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "mcp-tool-homoglyph-name-013",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",
@@ -934,6 +1158,22 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "response-mitm-markdown-link-008",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "response-mitm-split-boundary-007",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "response-mitm-tool-instruction-002",
       "blocked": "yes",
       "explained": "yes",
@@ -966,6 +1206,14 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "shell-base64-pipe-009",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "shell-benign-ls-007",
       "blocked": "n/a",
       "explained": "no",
@@ -974,7 +1222,23 @@
       "false_positive": "no"
     },
     {
+      "case_id": "shell-benign-tar-010",
+      "blocked": "n/a",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "no"
+    },
+    {
       "case_id": "shell-brace-expansion-004",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "shell-dollar-paren-008",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",
@@ -1015,6 +1279,14 @@
     },
     {
       "case_id": "ssrf-cloud-metadata-007",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "ssrf-connect-parity-013",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",
@@ -1070,6 +1342,14 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "ssrf-short-octet-011",
+      "blocked": "yes",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "ssrf-zero-ip-008",
       "blocked": "yes",
       "explained": "yes",
@@ -1118,7 +1398,23 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "url-dlp-gcp-service-account-001",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "url-dlp-github-token-002",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "url-dlp-gitlab-deploy-token-001",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",
@@ -1142,9 +1438,33 @@
       "false_positive": "n/a"
     },
     {
+      "case_id": "url-dlp-jwt-base64-013",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "url-dlp-postgres-conn-001",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
       "case_id": "url-dlp-urlencoded-008",
       "blocked": "yes",
       "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "url-dlp-userinfo-cred-012",
+      "blocked": "yes",
+      "explained": "no",
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "n/a"
@@ -1168,7 +1488,7 @@
     {
       "case_id": "url-entropy-subdomain-007",
       "blocked": "yes",
-      "explained": "no",
+      "explained": "yes",
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "n/a"
@@ -1255,6 +1575,14 @@
     },
     {
       "case_id": "ws-dlp-text-frame-secret-001",
+      "blocked": "yes",
+      "explained": "yes",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
+    },
+    {
+      "case_id": "ws-injection-frame-009",
       "blocked": "yes",
       "explained": "yes",
       "receipt_produced": "no",

--- a/profiles/pipelock.json
+++ b/profiles/pipelock.json
@@ -14,7 +14,7 @@
   },
   "summary": {
     "blocked_yes_count": 148,
-    "blocked_no_count": 0,
+    "blocked_no_count": 1,
     "explained_yes_count": 143,
     "receipt_produced_yes_count": 0,
     "receipt_independently_verifiable_yes_count": 0,
@@ -892,6 +892,14 @@
       "receipt_produced": "no",
       "receipt_independently_verifiable": "no",
       "false_positive": "no"
+    },
+    {
+      "case_id": "mcp-drift-collusion-004",
+      "blocked": "no",
+      "explained": "no",
+      "receipt_produced": "no",
+      "receipt_independently_verifiable": "no",
+      "false_positive": "n/a"
     },
     {
       "case_id": "mcp-drift-rugpull-desc-002",

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -684,22 +684,18 @@ func webSocketCloseReason(payload []byte) string {
 	return string(payload[2:])
 }
 
-// PreflightMockScriptExec verifies that the current environment can create
-// and execute a shell script from the OS temp directory (os.TempDir()) the
-// same way runMCPStdio does when it injects a mock MCP backend for
-// tool-poisoning cases (see the mockScript handling below): write a
-// "#!/bin/bash" script to a fresh os.CreateTemp file, chmod it 0750, and
-// execute it directly.
+// PreflightMockScriptExec verifies that the current environment can create a
+// temp script and run it with bash from PATH, matching runMCPStdio's mock MCP
+// backend injection for tool-poisoning cases.
 //
-// If the temp directory is mounted noexec, the current user lacks execute
-// permission on files it creates there, or bash is missing, that exact
-// mechanism silently breaks for every MCP tool-poisoning case in the corpus:
-// with stderr discarded (the bug this preflight exists to catch — see the
-// stderr capture in runMCPStdio) the failure surfaces, if at all, as a bare
-// unexplained exit code, or the case simply times out and gets scored as a
-// "block" with no indication that nothing was ever actually run. Call this
-// once, before the corpus runs, so that failure is loud, specific, and
-// actionable instead of silently corrupting dozens of case results.
+// If bash is missing or the temp script cannot be created/read, that mechanism
+// silently breaks every in-scope MCP tool-poisoning case: with stderr discarded
+// (the bug this preflight exists to catch; see the stderr capture in
+// runMCPStdio) the failure surfaces, if at all, as a bare unexplained exit
+// code, or the case simply times out and gets scored as a "block" with no
+// indication that nothing was ever actually run. Call this once, before those
+// cases run, so that failure is loud, specific, and actionable instead of
+// silently corrupting case results.
 //
 // Callers should invoke this only when the proxy adapter is configured with
 // an MCP command (i.e. tool-poisoning cases will actually exercise this
@@ -707,12 +703,13 @@ func webSocketCloseReason(payload []byte) string {
 func PreflightMockScriptExec() error {
 	tmpDir := os.TempDir()
 
-	if _, lookErr := exec.LookPath("bash"); lookErr != nil {
+	bashPath, lookErr := exec.LookPath("bash")
+	if lookErr != nil {
 		return fmt.Errorf(
 			"preflight failed: bash not found in PATH (%w).\n"+
 				"the proxy adapter's MCP mock-backend script (used for tool-poisoning\n"+
-				"cases) is a \"#!/bin/bash\" script; install bash or ensure it is on PATH\n"+
-				"and retry",
+				"cases) is run as \"bash <temp-script>\"; install bash or ensure it is\n"+
+				"on PATH and retry",
 			lookErr)
 	}
 
@@ -723,19 +720,16 @@ func PreflightMockScriptExec() error {
 	scriptPath := f.Name()
 	defer func() { _ = os.Remove(scriptPath) }()
 
-	if _, writeErr := f.WriteString("#!/bin/bash\nexit 0\n"); writeErr != nil {
+	if _, writeErr := f.WriteString("exit 0\n"); writeErr != nil {
 		_ = f.Close()
 		return fmt.Errorf("preflight failed: cannot write temp script %s: %w", scriptPath, writeErr)
 	}
 	if closeErr := f.Close(); closeErr != nil {
 		return fmt.Errorf("preflight failed: cannot close temp script %s: %w", scriptPath, closeErr)
 	}
-	if chmodErr := os.Chmod(scriptPath, 0o750); chmodErr != nil {
-		return fmt.Errorf("preflight failed: cannot chmod temp script %s executable: %w", scriptPath, chmodErr)
-	}
 
 	var stderrBuf bytes.Buffer
-	cmd := exec.Command(scriptPath) //nolint:gosec // fixed path to a script this function just created
+	cmd := exec.Command(bashPath, scriptPath) //nolint:gosec // fixed bash path and a script this function just created
 	cmd.Stderr = &stderrBuf
 	runErr := cmd.Run()
 	if runErr == nil {
@@ -746,41 +740,39 @@ func PreflightMockScriptExec() error {
 
 // classifyPreflightExecErr turns a failed exec of the preflight script into
 // a specific, actionable error message, keyed off the wrapped OS error so
-// the message names the likely root cause (noexec/permission vs a missing
-// interpreter) instead of a bare exit code. Split out from
-// PreflightMockScriptExec so the classification can be unit-tested with
-// synthetic errors, since reliably reproducing an actual noexec mount or a
-// missing /bin/bash in a portable test is impractical.
+// the message names the likely root cause instead of a bare exit code. Split
+// out from PreflightMockScriptExec so the classification can be unit-tested
+// with synthetic errors, since reliably reproducing permission and path races
+// in a portable test is impractical.
 func classifyPreflightExecErr(tmpDir string, runErr error, detail string) error {
 	switch {
 	case errors.Is(runErr, fs.ErrPermission):
 		return fmt.Errorf(
-			"preflight failed: cannot execute a script written to the temp directory\n"+
+			"preflight failed: bash cannot read a script written to the temp directory\n"+
 				"%s (%w).\n"+
-				"this directory is most likely mounted noexec, or the current user lacks\n"+
-				"execute permission on files it creates there. The proxy adapter spawns a\n"+
-				"mock MCP backend script from a freshly created temp file for tool-poisoning\n"+
-				"cases; if it cannot be executed here, those cases will silently misclassify\n"+
-				"or hang until timeout instead of producing a real verdict, with no\n"+
-				"indication why.\n"+
-				"Fix: point TMPDIR at a writable, executable directory and retry, e.g.:\n"+
+				"the current user most likely lacks read permission on files created there.\n"+
+				"The proxy adapter runs a mock MCP backend script from a freshly created\n"+
+				"temp file for tool-poisoning cases; if bash cannot read it, those cases\n"+
+				"will silently misclassify or hang until timeout instead of producing a\n"+
+				"real verdict, with no indication why.\n"+
+				"Fix: point TMPDIR at a writable directory and retry, e.g.:\n"+
 				"  mkdir -p \"$HOME/.cache/aeb-tmp\" && TMPDIR=\"$HOME/.cache/aeb-tmp\" <run command>\n"+
 				"stderr from the failed script: %s",
 			tmpDir, runErr, orNoneIfEmpty(detail))
 	case errors.Is(runErr, fs.ErrNotExist):
 		return fmt.Errorf(
-			"preflight failed: cannot execute a \"#!/bin/bash\" script in %s (%w).\n"+
-				"bash was found on PATH but the script's interpreter (/bin/bash) could not\n"+
-				"be loaded — bash is likely missing at that exact path. Install bash at\n"+
-				"/bin/bash (or symlink it there) and retry.\n"+
+			"preflight failed: cannot run bash with a temp script in %s (%w).\n"+
+				"bash was found on PATH, but either that executable or the temp script was\n"+
+				"not available when preflight tried to run it; check PATH, TMPDIR, and\n"+
+				"filesystem cleanup policy, then retry.\n"+
 				"stderr from the failed script: %s",
 			tmpDir, runErr, orNoneIfEmpty(detail))
 	default:
 		return fmt.Errorf(
-			"preflight failed: could not execute a test script in the temp directory\n"+
+			"preflight failed: could not run a test script from the temp directory\n"+
 				"%s (%w).\n"+
-				"the proxy adapter's MCP mock-backend mechanism needs to create and execute\n"+
-				"shell scripts in this directory for tool-poisoning cases; fix the\n"+
+				"the proxy adapter's MCP mock-backend mechanism needs to create temp\n"+
+				"scripts and run them with bash for tool-poisoning cases; fix the\n"+
 				"underlying environment issue and retry.\n"+
 				"stderr from the failed script: %s",
 			tmpDir, runErr, orNoneIfEmpty(detail))
@@ -794,6 +786,10 @@ func orNoneIfEmpty(s string) string {
 		return "(none)"
 	}
 	return s
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 // runMCPStdio sends JSON-RPC messages through the MCP proxy subprocess.
@@ -868,14 +864,14 @@ func (p *ProxyAdapter) runMCPStdio(c Case, timeout time.Duration) Result {
 			return Result{Err: fmt.Errorf("case %s: create temp script: %w", c.ID, scriptErr)}
 		}
 		tempFiles = append(tempFiles, mockScript.Name())
-		_, _ = fmt.Fprintf(mockScript, "#!/bin/bash\n_n=0\nwhile IFS= read -r _input; do\n  _n=$((_n+1))\n  sed -n \"${_n}p\" '%s'\ndone\n",
+		_, _ = fmt.Fprintf(mockScript, "_n=0\nwhile IFS= read -r _input; do\n  _n=$((_n+1))\n  sed -n \"${_n}p\" '%s'\ndone\n",
 			respFile.Name())
 		_ = mockScript.Close()
-		_ = os.Chmod(mockScript.Name(), 0o750)
 
-		// Replace the backend command with our custom mock script.
+		// Replace the backend command with our custom mock script. Invoke it
+		// through bash from PATH instead of relying on a hardcoded shebang path.
 		if idx := strings.Index(mcpCmd, " -- "); idx >= 0 {
-			mcpCmd = mcpCmd[:idx] + " -- " + mockScript.Name()
+			mcpCmd = mcpCmd[:idx] + " -- bash " + shellQuote(mockScript.Name())
 		} else {
 			return Result{Err: fmt.Errorf("case %s: --mcp-cmd missing ' -- ' separator, cannot inject mock backend", c.ID)}
 		}
@@ -896,11 +892,11 @@ func (p *ProxyAdapter) runMCPStdio(c Case, timeout time.Duration) Result {
 	cmd := exec.CommandContext(ctx, "sh", "-c", mcpCmd) //nolint:gosec // command from trusted CLI flag
 	// Capture stderr instead of discarding it. Discarding it here previously
 	// swallowed the diagnostic output from a mock-backend spawn failure (e.g.
-	// the temp directory being mounted noexec, or bash missing), leaving
-	// nothing but a bare, unexplained exit code or a silent timeout — see
-	// PreflightMockScriptExec for the guard that catches this class of
-	// failure loudly before the corpus runs, and the two branches below that
-	// now surface this buffer's contents when a case comes back empty.
+	// bash missing), leaving nothing but a bare, unexplained exit code or a
+	// silent timeout. See PreflightMockScriptExec for the guard that catches
+	// this class of failure loudly before the in-scope corpus cases run, and
+	// the two branches below that now surface this buffer's contents when a
+	// case comes back empty.
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
 

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -21,8 +21,10 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
@@ -682,6 +684,118 @@ func webSocketCloseReason(payload []byte) string {
 	return string(payload[2:])
 }
 
+// PreflightMockScriptExec verifies that the current environment can create
+// and execute a shell script from the OS temp directory (os.TempDir()) the
+// same way runMCPStdio does when it injects a mock MCP backend for
+// tool-poisoning cases (see the mockScript handling below): write a
+// "#!/bin/bash" script to a fresh os.CreateTemp file, chmod it 0750, and
+// execute it directly.
+//
+// If the temp directory is mounted noexec, the current user lacks execute
+// permission on files it creates there, or bash is missing, that exact
+// mechanism silently breaks for every MCP tool-poisoning case in the corpus:
+// with stderr discarded (the bug this preflight exists to catch — see the
+// stderr capture in runMCPStdio) the failure surfaces, if at all, as a bare
+// unexplained exit code, or the case simply times out and gets scored as a
+// "block" with no indication that nothing was ever actually run. Call this
+// once, before the corpus runs, so that failure is loud, specific, and
+// actionable instead of silently corrupting dozens of case results.
+//
+// Callers should invoke this only when the proxy adapter is configured with
+// an MCP command (i.e. tool-poisoning cases will actually exercise this
+// mechanism); it is a no-op safety check, not part of scoring.
+func PreflightMockScriptExec() error {
+	tmpDir := os.TempDir()
+
+	if _, lookErr := exec.LookPath("bash"); lookErr != nil {
+		return fmt.Errorf(
+			"preflight failed: bash not found in PATH (%w).\n"+
+				"the proxy adapter's MCP mock-backend script (used for tool-poisoning\n"+
+				"cases) is a \"#!/bin/bash\" script; install bash or ensure it is on PATH\n"+
+				"and retry",
+			lookErr)
+	}
+
+	f, err := os.CreateTemp(tmpDir, "aeb-preflight-mock-*.sh")
+	if err != nil {
+		return fmt.Errorf("preflight failed: cannot create a temp file in %s: %w", tmpDir, err)
+	}
+	scriptPath := f.Name()
+	defer func() { _ = os.Remove(scriptPath) }()
+
+	if _, writeErr := f.WriteString("#!/bin/bash\nexit 0\n"); writeErr != nil {
+		_ = f.Close()
+		return fmt.Errorf("preflight failed: cannot write temp script %s: %w", scriptPath, writeErr)
+	}
+	if closeErr := f.Close(); closeErr != nil {
+		return fmt.Errorf("preflight failed: cannot close temp script %s: %w", scriptPath, closeErr)
+	}
+	if chmodErr := os.Chmod(scriptPath, 0o750); chmodErr != nil {
+		return fmt.Errorf("preflight failed: cannot chmod temp script %s executable: %w", scriptPath, chmodErr)
+	}
+
+	var stderrBuf bytes.Buffer
+	cmd := exec.Command(scriptPath) //nolint:gosec // fixed path to a script this function just created
+	cmd.Stderr = &stderrBuf
+	runErr := cmd.Run()
+	if runErr == nil {
+		return nil
+	}
+	return classifyPreflightExecErr(tmpDir, runErr, strings.TrimSpace(stderrBuf.String()))
+}
+
+// classifyPreflightExecErr turns a failed exec of the preflight script into
+// a specific, actionable error message, keyed off the wrapped OS error so
+// the message names the likely root cause (noexec/permission vs a missing
+// interpreter) instead of a bare exit code. Split out from
+// PreflightMockScriptExec so the classification can be unit-tested with
+// synthetic errors, since reliably reproducing an actual noexec mount or a
+// missing /bin/bash in a portable test is impractical.
+func classifyPreflightExecErr(tmpDir string, runErr error, detail string) error {
+	switch {
+	case errors.Is(runErr, fs.ErrPermission):
+		return fmt.Errorf(
+			"preflight failed: cannot execute a script written to the temp directory\n"+
+				"%s (%w).\n"+
+				"this directory is most likely mounted noexec, or the current user lacks\n"+
+				"execute permission on files it creates there. The proxy adapter spawns a\n"+
+				"mock MCP backend script from a freshly created temp file for tool-poisoning\n"+
+				"cases; if it cannot be executed here, those cases will silently misclassify\n"+
+				"or hang until timeout instead of producing a real verdict, with no\n"+
+				"indication why.\n"+
+				"Fix: point TMPDIR at a writable, executable directory and retry, e.g.:\n"+
+				"  mkdir -p \"$HOME/.cache/aeb-tmp\" && TMPDIR=\"$HOME/.cache/aeb-tmp\" <run command>\n"+
+				"stderr from the failed script: %s",
+			tmpDir, runErr, orNoneIfEmpty(detail))
+	case errors.Is(runErr, fs.ErrNotExist):
+		return fmt.Errorf(
+			"preflight failed: cannot execute a \"#!/bin/bash\" script in %s (%w).\n"+
+				"bash was found on PATH but the script's interpreter (/bin/bash) could not\n"+
+				"be loaded — bash is likely missing at that exact path. Install bash at\n"+
+				"/bin/bash (or symlink it there) and retry.\n"+
+				"stderr from the failed script: %s",
+			tmpDir, runErr, orNoneIfEmpty(detail))
+	default:
+		return fmt.Errorf(
+			"preflight failed: could not execute a test script in the temp directory\n"+
+				"%s (%w).\n"+
+				"the proxy adapter's MCP mock-backend mechanism needs to create and execute\n"+
+				"shell scripts in this directory for tool-poisoning cases; fix the\n"+
+				"underlying environment issue and retry.\n"+
+				"stderr from the failed script: %s",
+			tmpDir, runErr, orNoneIfEmpty(detail))
+	}
+}
+
+// orNoneIfEmpty returns "(none)" for an empty diagnostic string so error
+// messages never end with a dangling, easy-to-miss empty field.
+func orNoneIfEmpty(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}
+
 // runMCPStdio sends JSON-RPC messages through the MCP proxy subprocess.
 //
 // The proxy sits between client (stdin) and server (subprocess backend).
@@ -780,7 +894,15 @@ func (p *ProxyAdapter) runMCPStdio(c Case, timeout time.Duration) Result {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", mcpCmd) //nolint:gosec // command from trusted CLI flag
-	cmd.Stderr = io.Discard
+	// Capture stderr instead of discarding it. Discarding it here previously
+	// swallowed the diagnostic output from a mock-backend spawn failure (e.g.
+	// the temp directory being mounted noexec, or bash missing), leaving
+	// nothing but a bare, unexplained exit code or a silent timeout — see
+	// PreflightMockScriptExec for the guard that catches this class of
+	// failure loudly before the corpus runs, and the two branches below that
+	// now surface this buffer's contents when a case comes back empty.
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -813,15 +935,30 @@ func (p *ProxyAdapter) runMCPStdio(c Case, timeout time.Duration) Result {
 		_ = os.Remove(tf)
 	}
 	output := <-outputCh
+	stderrOutput := strings.TrimSpace(stderrBuf.String())
 
 	// Context timeout is expected (subprocess runs until stdin closes).
 	// But other wait errors with no output indicate a real failure.
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
 	if len(lines) == 0 || lines[0] == "" {
 		if waitErr != nil && ctx.Err() == nil {
+			if stderrOutput != "" {
+				return Result{Err: fmt.Errorf("case %s: MCP subprocess failed: %w (stderr: %s)", c.ID, waitErr, stderrOutput)}
+			}
 			return Result{Err: fmt.Errorf("case %s: MCP subprocess failed: %w", c.ID, waitErr)}
 		}
-		return Result{Verdict: "block", Evidence: map[string]interface{}{"reason": "no_output"}}
+		// No output and no reported wait error (or a timeout) is treated as a
+		// block, since many proxies express "block" by simply closing the
+		// connection without writing anything. That is a real, valid signal
+		// for a well-behaved tool — but it is also exactly what a silently
+		// failed mock-backend spawn looks like, so any captured stderr is
+		// attached here as a diagnostic hint rather than changing the
+		// verdict itself.
+		evidence := map[string]interface{}{"reason": "no_output"}
+		if stderrOutput != "" {
+			evidence["stderr"] = stderrOutput
+		}
+		return Result{Verdict: "block", Evidence: evidence}
 	}
 
 	// Check response lines for policy-block JSON-RPC errors.

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -727,6 +727,9 @@ func PreflightMockScriptExec() error {
 	if closeErr := f.Close(); closeErr != nil {
 		return fmt.Errorf("preflight failed: cannot close temp script %s: %w", scriptPath, closeErr)
 	}
+	if accessErr := validatePreflightScriptReadable(tmpDir, scriptPath); accessErr != nil {
+		return accessErr
+	}
 
 	var stderrBuf bytes.Buffer
 	cmd := exec.Command(bashPath, scriptPath) //nolint:gosec // fixed bash path and a script this function just created
@@ -738,17 +741,26 @@ func PreflightMockScriptExec() error {
 	return classifyPreflightExecErr(tmpDir, runErr, strings.TrimSpace(stderrBuf.String()))
 }
 
-// classifyPreflightExecErr turns a failed exec of the preflight script into
-// a specific, actionable error message, keyed off the wrapped OS error so
-// the message names the likely root cause instead of a bare exit code. Split
-// out from PreflightMockScriptExec so the classification can be unit-tested
-// with synthetic errors, since reliably reproducing permission and path races
-// in a portable test is impractical.
-func classifyPreflightExecErr(tmpDir string, runErr error, detail string) error {
+func validatePreflightScriptReadable(tmpDir, scriptPath string) error {
+	f, err := os.Open(scriptPath)
+	if err != nil {
+		return classifyPreflightScriptAccessErr(tmpDir, err)
+	}
+	if closeErr := f.Close(); closeErr != nil {
+		return fmt.Errorf("preflight failed: cannot close readable temp script %s: %w", scriptPath, closeErr)
+	}
+	return nil
+}
+
+// classifyPreflightScriptAccessErr turns a failed pre-exec readability probe
+// into TMPDIR-specific guidance. Bash reports an unreadable or missing script
+// as an ordinary process exit, so probing from Go before exec preserves the
+// wrapped filesystem error that makes the diagnosis reliable.
+func classifyPreflightScriptAccessErr(tmpDir string, accessErr error) error {
 	switch {
-	case errors.Is(runErr, fs.ErrPermission):
+	case errors.Is(accessErr, fs.ErrPermission):
 		return fmt.Errorf(
-			"preflight failed: bash cannot read a script written to the temp directory\n"+
+			"preflight failed: cannot read a script written to the temp directory\n"+
 				"%s (%w).\n"+
 				"the current user most likely lacks read permission on files created there.\n"+
 				"The proxy adapter runs a mock MCP backend script from a freshly created\n"+
@@ -756,15 +768,44 @@ func classifyPreflightExecErr(tmpDir string, runErr error, detail string) error 
 				"will silently misclassify or hang until timeout instead of producing a\n"+
 				"real verdict, with no indication why.\n"+
 				"Fix: point TMPDIR at a writable directory and retry, e.g.:\n"+
-				"  mkdir -p \"$HOME/.cache/aeb-tmp\" && TMPDIR=\"$HOME/.cache/aeb-tmp\" <run command>\n"+
+				"  mkdir -p \"$HOME/.cache/aeb-tmp\" && TMPDIR=\"$HOME/.cache/aeb-tmp\" <run command>",
+			tmpDir, accessErr)
+	case errors.Is(accessErr, fs.ErrNotExist):
+		return fmt.Errorf(
+			"preflight failed: temp script disappeared before bash could run it\n"+
+				"from %s (%w).\n"+
+				"check TMPDIR and filesystem cleanup policy, then retry",
+			tmpDir, accessErr)
+	default:
+		return fmt.Errorf(
+			"preflight failed: cannot verify a temp script is readable from %s (%w).\n"+
+				"the proxy adapter's MCP mock-backend mechanism needs to create temp\n"+
+				"scripts and run them with bash for tool-poisoning cases; fix the\n"+
+				"underlying environment issue and retry",
+			tmpDir, accessErr)
+	}
+}
+
+// classifyPreflightExecErr turns a failed bash execution into a specific,
+// actionable error message where Go still exposes the wrapped OS error.
+// Script read/missing errors are handled before exec by
+// validatePreflightScriptReadable because Bash converts them into ExitError.
+func classifyPreflightExecErr(tmpDir string, runErr error, detail string) error {
+	switch {
+	case errors.Is(runErr, fs.ErrPermission):
+		return fmt.Errorf(
+			"preflight failed: cannot execute bash for a temp script in\n"+
+				"%s (%w).\n"+
+				"bash was found on PATH but could not be executed by the current user.\n"+
+				"Check the bash executable permissions and retry.\n"+
 				"stderr from the failed script: %s",
 			tmpDir, runErr, orNoneIfEmpty(detail))
 	case errors.Is(runErr, fs.ErrNotExist):
 		return fmt.Errorf(
 			"preflight failed: cannot run bash with a temp script in %s (%w).\n"+
-				"bash was found on PATH, but either that executable or the temp script was\n"+
-				"not available when preflight tried to run it; check PATH, TMPDIR, and\n"+
-				"filesystem cleanup policy, then retry.\n"+
+				"bash was found on PATH, but that executable was not available when\n"+
+				"preflight tried to run it; check PATH and filesystem cleanup policy,\n"+
+				"then retry.\n"+
 				"stderr from the failed script: %s",
 			tmpDir, runErr, orNoneIfEmpty(detail))
 	default:

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -770,13 +770,8 @@ func classifyMCPOutput(lines []string, caseID string) Result {
 }
 
 func TestPreflightMockScriptExec_HappyPath(t *testing.T) {
-	// The test machine's real TMPDIR must support creating and executing a
-	// #!/bin/bash script for the corpus to have any chance of running MCP
-	// tool-poisoning cases. If this fails in CI, it means CI itself cannot
-	// run the benchmark's MCP cases, which is worth knowing loudly rather
-	// than discovering via 47 silently misclassified case results.
 	if err := PreflightMockScriptExec(); err != nil {
-		t.Fatalf("expected preflight to succeed in the test environment, got: %v", err)
+		t.Skipf("mock-script preflight is unsupported in this environment: %v", err)
 	}
 }
 
@@ -819,8 +814,8 @@ func TestClassifyPreflightExecErr_PermissionDenied(t *testing.T) {
 		t.Fatal("expected a non-nil error")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "noexec") {
-		t.Errorf("expected the noexec/permission message, got: %v", msg)
+	if !strings.Contains(msg, "cannot read") {
+		t.Errorf("expected the permission message, got: %v", msg)
 	}
 	if !strings.Contains(msg, "TMPDIR") {
 		t.Errorf("expected a TMPDIR remediation hint, got: %v", msg)
@@ -830,18 +825,26 @@ func TestClassifyPreflightExecErr_PermissionDenied(t *testing.T) {
 	}
 }
 
-func TestClassifyPreflightExecErr_InterpreterMissing(t *testing.T) {
+func TestClassifyPreflightExecErr_BashOrScriptMissing(t *testing.T) {
 	wrapped := fmt.Errorf("fork/exec /tmp/x.sh: %w", fs.ErrNotExist)
 	err := classifyPreflightExecErr("/tmp", wrapped, "some stderr detail")
 	if err == nil {
 		t.Fatal("expected a non-nil error")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "/bin/bash") {
-		t.Errorf("expected a missing-interpreter message, got: %v", msg)
+	if !strings.Contains(msg, "bash with a temp script") {
+		t.Errorf("expected a missing-bash-or-script message, got: %v", msg)
 	}
 	if !strings.Contains(msg, "some stderr detail") {
 		t.Errorf("expected the captured stderr to be included, got: %v", msg)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	got := shellQuote("/tmp/a b/it's.sh")
+	want := "'/tmp/a b/it'\\''s.sh'"
+	if got != want {
+		t.Fatalf("shellQuote() = %q, want %q", got, want)
 	}
 }
 

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -4,10 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -762,5 +766,111 @@ func classifyMCPOutput(lines []string, caseID string) Result {
 	return Result{
 		Verdict:  "allow",
 		Evidence: map[string]interface{}{"response_lines": len(lines)},
+	}
+}
+
+func TestPreflightMockScriptExec_HappyPath(t *testing.T) {
+	// The test machine's real TMPDIR must support creating and executing a
+	// #!/bin/bash script for the corpus to have any chance of running MCP
+	// tool-poisoning cases. If this fails in CI, it means CI itself cannot
+	// run the benchmark's MCP cases, which is worth knowing loudly rather
+	// than discovering via 47 silently misclassified case results.
+	if err := PreflightMockScriptExec(); err != nil {
+		t.Fatalf("expected preflight to succeed in the test environment, got: %v", err)
+	}
+}
+
+func TestPreflightMockScriptExec_BashMissingFromPATH(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no sh on PATH to build a bash-free PATH with")
+	}
+	shDir := shOnlyPATHDir(t)
+	t.Setenv("PATH", shDir)
+
+	err := PreflightMockScriptExec()
+	if err == nil {
+		t.Fatal("expected an error when bash is not on PATH")
+	}
+	if !strings.Contains(err.Error(), "bash not found in PATH") {
+		t.Errorf("expected a bash-not-found message, got: %v", err)
+	}
+}
+
+// shOnlyPATHDir returns a directory containing only a "sh" symlink (copied
+// from the real sh on PATH), so PATH can be pointed at an environment with
+// a shell but no bash, without disturbing the real PATH for other tests.
+func shOnlyPATHDir(t *testing.T) string {
+	t.Helper()
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Fatalf("look up sh: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.Symlink(shPath, dir+"/sh"); err != nil {
+		t.Fatalf("symlink sh into isolated PATH dir: %v", err)
+	}
+	return dir
+}
+
+func TestClassifyPreflightExecErr_PermissionDenied(t *testing.T) {
+	wrapped := fmt.Errorf("fork/exec /tmp/x.sh: %w", fs.ErrPermission)
+	err := classifyPreflightExecErr("/tmp", wrapped, "")
+	if err == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "noexec") {
+		t.Errorf("expected the noexec/permission message, got: %v", msg)
+	}
+	if !strings.Contains(msg, "TMPDIR") {
+		t.Errorf("expected a TMPDIR remediation hint, got: %v", msg)
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Error("expected classifyPreflightExecErr to preserve the wrapped error for errors.Is")
+	}
+}
+
+func TestClassifyPreflightExecErr_InterpreterMissing(t *testing.T) {
+	wrapped := fmt.Errorf("fork/exec /tmp/x.sh: %w", fs.ErrNotExist)
+	err := classifyPreflightExecErr("/tmp", wrapped, "some stderr detail")
+	if err == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "/bin/bash") {
+		t.Errorf("expected a missing-interpreter message, got: %v", msg)
+	}
+	if !strings.Contains(msg, "some stderr detail") {
+		t.Errorf("expected the captured stderr to be included, got: %v", msg)
+	}
+}
+
+func TestClassifyPreflightExecErr_UnknownFailure_UsesNoneForEmptyStderr(t *testing.T) {
+	wrapped := errors.New("boom")
+	err := classifyPreflightExecErr("/tmp", wrapped, "")
+	if err == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	if !strings.Contains(err.Error(), "(none)") {
+		t.Errorf("expected the fallback branch to render empty stderr as (none), got: %v", err.Error())
+	}
+}
+
+func TestRunMCPStdio_StderrSurfacedOnSubprocessFailure(t *testing.T) {
+	// A command that writes to stderr and exits non-zero, with no stdout,
+	// must surface the stderr text in the returned error instead of
+	// discarding it (the exact class of bug this test guards against: a
+	// silently swallowed mock-backend spawn failure).
+	a := &ProxyAdapter{mcpCmd: `echo boom-diagnostic 1>&2; exit 3`}
+	c := Case{
+		ID:      "test-stderr-surfaced",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{"method": "tools/call"}}},
+	}
+	result := a.runMCPStdio(c, 5*time.Second)
+	if result.Err == nil {
+		t.Fatal("expected an error result for a non-zero exit with no stdout")
+	}
+	if !strings.Contains(result.Err.Error(), "boom-diagnostic") {
+		t.Errorf("expected the captured stderr to be surfaced in the error, got: %v", result.Err)
 	}
 }

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -807,9 +807,9 @@ func shOnlyPATHDir(t *testing.T) string {
 	return dir
 }
 
-func TestClassifyPreflightExecErr_PermissionDenied(t *testing.T) {
-	wrapped := fmt.Errorf("fork/exec /tmp/x.sh: %w", fs.ErrPermission)
-	err := classifyPreflightExecErr("/tmp", wrapped, "")
+func TestClassifyPreflightScriptAccessErr_PermissionDenied(t *testing.T) {
+	wrapped := fmt.Errorf("open /tmp/x.sh: %w", fs.ErrPermission)
+	err := classifyPreflightScriptAccessErr("/tmp", wrapped)
 	if err == nil {
 		t.Fatal("expected a non-nil error")
 	}
@@ -821,22 +821,22 @@ func TestClassifyPreflightExecErr_PermissionDenied(t *testing.T) {
 		t.Errorf("expected a TMPDIR remediation hint, got: %v", msg)
 	}
 	if !errors.Is(err, fs.ErrPermission) {
-		t.Error("expected classifyPreflightExecErr to preserve the wrapped error for errors.Is")
+		t.Error("expected classifyPreflightScriptAccessErr to preserve the wrapped error for errors.Is")
 	}
 }
 
-func TestClassifyPreflightExecErr_BashOrScriptMissing(t *testing.T) {
-	wrapped := fmt.Errorf("fork/exec /tmp/x.sh: %w", fs.ErrNotExist)
-	err := classifyPreflightExecErr("/tmp", wrapped, "some stderr detail")
+func TestClassifyPreflightScriptAccessErr_ScriptMissing(t *testing.T) {
+	wrapped := fmt.Errorf("open /tmp/x.sh: %w", fs.ErrNotExist)
+	err := classifyPreflightScriptAccessErr("/tmp", wrapped)
 	if err == nil {
 		t.Fatal("expected a non-nil error")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "bash with a temp script") {
-		t.Errorf("expected a missing-bash-or-script message, got: %v", msg)
+	if !strings.Contains(msg, "temp script disappeared") {
+		t.Errorf("expected a missing-script message, got: %v", msg)
 	}
-	if !strings.Contains(msg, "some stderr detail") {
-		t.Errorf("expected the captured stderr to be included, got: %v", msg)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Error("expected classifyPreflightScriptAccessErr to preserve the wrapped error for errors.Is")
 	}
 }
 

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -159,36 +159,36 @@ func TestCheckApplicability(t *testing.T) {
 	profile := Profile{
 		Claims: []string{"url_dlp", "benign"},
 		Supports: map[string]bool{
-			"fetch_proxy":              true,
-			"http_proxy":               true,
-			"mcp_stdio":               false,
-			"tls_interception":         true,
-			"request_body_scanning":    false,
-			"dns_rebinding_fixture":    false,
+			"fetch_proxy":           true,
+			"http_proxy":            true,
+			"mcp_stdio":             false,
+			"tls_interception":      true,
+			"request_body_scanning": false,
+			"dns_rebinding_fixture": false,
 		},
 	}
 
 	tests := []struct {
-		name       string
-		c          Case
-		wantNA     NAKind
-		wantApply  bool
+		name      string
+		c         Case
+		wantNA    NAKind
+		wantApply bool
 	}{
 		{
 			name: "fully applicable",
 			c: Case{
-				CapabilityTags:  []string{"url_dlp"},
-				Requires:        []string{"tls_interception"},
-				Transport:       "fetch_proxy",
+				CapabilityTags: []string{"url_dlp"},
+				Requires:       []string{"tls_interception"},
+				Transport:      "fetch_proxy",
 			},
 			wantApply: true,
 		},
 		{
 			name: "missing capability",
 			c: Case{
-				CapabilityTags:  []string{"mcp_input_scan"},
-				Requires:        []string{},
-				Transport:       "fetch_proxy",
+				CapabilityTags: []string{"mcp_input_scan"},
+				Requires:       []string{},
+				Transport:      "fetch_proxy",
 			},
 			wantNA:    NAMissingCapability,
 			wantApply: false,
@@ -196,9 +196,9 @@ func TestCheckApplicability(t *testing.T) {
 		{
 			name: "missing requires",
 			c: Case{
-				CapabilityTags:  []string{"url_dlp"},
-				Requires:        []string{"request_body_scanning"},
-				Transport:       "fetch_proxy",
+				CapabilityTags: []string{"url_dlp"},
+				Requires:       []string{"request_body_scanning"},
+				Transport:      "fetch_proxy",
 			},
 			wantNA:    NAMissingRequires,
 			wantApply: false,
@@ -206,9 +206,9 @@ func TestCheckApplicability(t *testing.T) {
 		{
 			name: "unsupported transport",
 			c: Case{
-				CapabilityTags:  []string{"url_dlp"},
-				Requires:        []string{},
-				Transport:       "mcp_stdio",
+				CapabilityTags: []string{"url_dlp"},
+				Requires:       []string{},
+				Transport:      "mcp_stdio",
 			},
 			wantNA:    NAUnsupportedTransport,
 			wantApply: false,
@@ -216,9 +216,9 @@ func TestCheckApplicability(t *testing.T) {
 		{
 			name: "capability checked before requires",
 			c: Case{
-				CapabilityTags:  []string{"mcp_input_scan"},
-				Requires:        []string{"request_body_scanning"},
-				Transport:       "mcp_stdio",
+				CapabilityTags: []string{"mcp_input_scan"},
+				Requires:       []string{"request_body_scanning"},
+				Transport:      "mcp_stdio",
 			},
 			wantNA:    NAMissingCapability,
 			wantApply: false,
@@ -226,9 +226,9 @@ func TestCheckApplicability(t *testing.T) {
 		{
 			name: "requires checked before transport",
 			c: Case{
-				CapabilityTags:  []string{"url_dlp"},
-				Requires:        []string{"dns_rebinding_fixture"},
-				Transport:       "mcp_stdio",
+				CapabilityTags: []string{"url_dlp"},
+				Requires:       []string{"dns_rebinding_fixture"},
+				Transport:      "mcp_stdio",
 			},
 			wantNA:    NAMissingRequires,
 			wantApply: false,
@@ -243,6 +243,80 @@ func TestCheckApplicability(t *testing.T) {
 			}
 			if !applicable && reason != tt.wantNA {
 				t.Errorf("reason = %q, want %q", reason, tt.wantNA)
+			}
+		})
+	}
+}
+
+func TestNeedsMCPMockBackendPreflight(t *testing.T) {
+	profile := Profile{
+		Claims: []string{"mcp_tool_poison", "url_dlp"},
+		Supports: map[string]bool{
+			"fetch_proxy": true,
+			"mcp_stdio":   true,
+			"mcp_http":    true,
+		},
+	}
+
+	tests := []struct {
+		name  string
+		cases []Case
+		want  bool
+	}{
+		{
+			name: "mcp server response in scope",
+			cases: []Case{{
+				CapabilityTags: []string{"mcp_tool_poison"},
+				Transport:      "mcp_stdio",
+				Payload: map[string]interface{}{
+					"jsonrpc_messages": []interface{}{
+						map[string]interface{}{"result": map[string]interface{}{"tools": []interface{}{}}},
+					},
+				},
+			}},
+			want: true,
+		},
+		{
+			name: "fetch-only case does not need mcp preflight",
+			cases: []Case{{
+				CapabilityTags: []string{"url_dlp"},
+				Transport:      "fetch_proxy",
+				Payload:        map[string]interface{}{"url": "https://example.com"},
+			}},
+			want: false,
+		},
+		{
+			name: "unsupported mcp case does not need preflight",
+			cases: []Case{{
+				CapabilityTags: []string{"unsupported_capability"},
+				Transport:      "mcp_stdio",
+				Payload: map[string]interface{}{
+					"jsonrpc_messages": []interface{}{
+						map[string]interface{}{"result": map[string]interface{}{"tools": []interface{}{}}},
+					},
+				},
+			}},
+			want: false,
+		},
+		{
+			name: "mcp client-only request does not inject mock backend",
+			cases: []Case{{
+				CapabilityTags: []string{"mcp_tool_poison"},
+				Transport:      "mcp_stdio",
+				Payload: map[string]interface{}{
+					"jsonrpc_messages": []interface{}{
+						map[string]interface{}{"method": "tools/call"},
+					},
+				},
+			}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := needsMCPMockBackendPreflight(tt.cases, profile); got != tt.want {
+				t.Fatalf("needsMCPMockBackendPreflight() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/runner/integration_test.go
+++ b/runner/integration_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRunBadCasesDir(t *testing.T) {
 	err := run("/nonexistent", filepath.Join("..", "examples", "pipelock", "tool-profile.json"),
-		filepath.Join(t.TempDir(), "out.json"), 10*1e9, "dryrun", "", "", "", "", false, "", "", "")
+		filepath.Join(t.TempDir(), "out.json"), 10*1e9, "dryrun", "", "", "", "", false, "", "", "", false)
 	if err == nil {
 		t.Fatal("expected error for nonexistent cases dir")
 	}
@@ -18,9 +18,38 @@ func TestRunBadCasesDir(t *testing.T) {
 
 func TestRunBadProfile(t *testing.T) {
 	err := run(filepath.Join("..", "cases"), "/nonexistent/profile.json",
-		filepath.Join(t.TempDir(), "out.json"), 10*1e9, "dryrun", "", "", "", "", false, "", "", "")
+		filepath.Join(t.TempDir(), "out.json"), 10*1e9, "dryrun", "", "", "", "", false, "", "", "", false)
 	if err == nil {
 		t.Fatal("expected error for nonexistent profile")
+	}
+}
+
+func TestRunProxyAdapterPreflightFailsFast(t *testing.T) {
+	casesDir := filepath.Join("..", "cases")
+	profilePath := filepath.Join("..", "examples", "pipelock", "tool-profile.json")
+
+	// Skip if cases or profile don't exist.
+	if _, err := os.Stat(casesDir); os.IsNotExist(err) {
+		t.Skip("cases directory not found, skipping")
+	}
+	if _, err := os.Stat(profilePath); os.IsNotExist(err) {
+		t.Skip("profile not found, skipping")
+	}
+
+	// Point TMPDIR at a directory that does not exist, so the mock-backend
+	// preflight cannot even create a temp file there. This proves run()
+	// actually invokes the preflight check when --mcp-cmd is set for the
+	// proxy adapter, and fails fast with a specific, wrapped error instead
+	// of proceeding to run (and silently misclassify) the whole corpus.
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	outputPath := filepath.Join(t.TempDir(), "summary.json")
+	err := run(casesDir, profilePath, outputPath, 10*1e9, "proxy", "127.0.0.1:1", "", "", "echo hi", false, "", "", "", false)
+	if err == nil {
+		t.Fatal("expected the mock-backend preflight to fail with an unusable TMPDIR")
+	}
+	if !strings.Contains(err.Error(), "mcp mock-backend preflight") {
+		t.Errorf("expected the preflight-wrapped error, got: %v", err)
 	}
 }
 
@@ -37,7 +66,7 @@ func TestRunUnknownAdapter(t *testing.T) {
 	}
 
 	outputPath := filepath.Join(t.TempDir(), "summary.json")
-	err := run(casesDir, profilePath, outputPath, 10*1e9, "nonexistent", "", "", "", "", false, "", "", "")
+	err := run(casesDir, profilePath, outputPath, 10*1e9, "nonexistent", "", "", "", "", false, "", "", "", false)
 	if err == nil {
 		t.Fatal("expected error for unknown adapter")
 	}
@@ -58,7 +87,7 @@ func TestRunIgnoresReceiptVerifierFileWithoutProfileEmission(t *testing.T) {
 	}
 
 	outputPath := filepath.Join(t.TempDir(), "summary.json")
-	err := run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, "", "/nonexistent/verifier.json", "")
+	err := run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, "", "/nonexistent/verifier.json", "", false)
 	if err != nil {
 		t.Fatalf("run should ignore receipt verifier file unless profile emission is enabled: %v", err)
 	}
@@ -78,7 +107,7 @@ func TestIntegrationNullAdapter(t *testing.T) {
 
 	outputPath := filepath.Join(t.TempDir(), "summary.json")
 
-	err := run(casesDir, profilePath, outputPath, 10*1e9, "null", "", "", "", "", false, "", "", "")
+	err := run(casesDir, profilePath, outputPath, 10*1e9, "null", "", "", "", "", false, "", "", "", false)
 	if err != nil {
 		t.Fatalf("run failed: %v", err)
 	}
@@ -120,7 +149,7 @@ func TestIntegrationRealCases(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "summary.json")
 
 	// Run the full pipeline.
-	err := run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, "", "", "") // 10s
+	err := run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, "", "", "", false) // 10s
 	if err != nil {
 		t.Fatalf("run failed: %v", err)
 	}
@@ -220,4 +249,88 @@ func TestIntegrationRealCases(t *testing.T) {
 	t.Logf("Summary: %d total, %d applicable, %d N/A, sufficient=%v",
 		summary.CaseCount.Total, summary.CaseCount.Applicable,
 		summary.CaseCount.NotApplicable, summary.Sufficient)
+}
+
+func TestDebugFlag_EmitsPerCaseDiagnostics(t *testing.T) {
+	casesDir := filepath.Join("..", "cases")
+	profilePath := filepath.Join("..", "examples", "pipelock", "tool-profile.json")
+
+	if _, err := os.Stat(casesDir); os.IsNotExist(err) {
+		t.Skip("cases directory not found, skipping")
+	}
+	if _, err := os.Stat(profilePath); os.IsNotExist(err) {
+		t.Skip("profile not found, skipping")
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "summary.json")
+	stderrStr := captureStderr(t, func() error {
+		return run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, "", "", "", true)
+	})
+
+	// With debug=true, every case should produce at least one [DEBUG]
+	// line. The dryrun adapter returns expected_verdict for every case,
+	// so applicable cases produce PASS lines and N/A cases produce
+	// not_applicable lines.
+	if !strings.Contains(stderrStr, debugPrefix) {
+		t.Error("expected at least one [DEBUG] line on stderr with debug=true, got none")
+	}
+	if !strings.Contains(stderrStr, "PASS") && !strings.Contains(stderrStr, "not_applicable") {
+		t.Error("expected per-case diagnostic (PASS or not_applicable) in debug output")
+	}
+}
+
+func TestDebugFlag_OffByDefault_NoDebugLines(t *testing.T) {
+	casesDir := filepath.Join("..", "cases")
+	profilePath := filepath.Join("..", "examples", "pipelock", "tool-profile.json")
+
+	if _, err := os.Stat(casesDir); os.IsNotExist(err) {
+		t.Skip("cases directory not found, skipping")
+	}
+	if _, err := os.Stat(profilePath); os.IsNotExist(err) {
+		t.Skip("profile not found, skipping")
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "summary.json")
+	stderrStr := captureStderr(t, func() error {
+		return run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, "", "", "", false)
+	})
+
+	// With debug=false, there must be ZERO [DEBUG] lines.
+	if strings.Contains(stderrStr, debugPrefix) {
+		t.Errorf("expected no [DEBUG] lines on stderr with debug=false, but found:\n%s",
+			stderrStr)
+	}
+}
+
+// captureStderr temporarily redirects os.Stderr to a temp file for the
+// duration of fn, then returns the captured content as a string. Not
+// parallel-safe (swaps a global), but run() is synchronous and these
+// tests do not use t.Parallel.
+func captureStderr(t *testing.T, fn func() error) string {
+	t.Helper()
+
+	tmp, tmpErr := os.CreateTemp(t.TempDir(), "stderr-capture-*.txt")
+	if tmpErr != nil {
+		t.Fatalf("create stderr capture file: %v", tmpErr)
+	}
+	tmpPath := tmp.Name()
+
+	origStderr := os.Stderr
+	os.Stderr = tmp
+
+	err := fn()
+
+	// Restore before reading / asserting so t.Fatal goes to the real stderr.
+	_ = tmp.Close()
+	os.Stderr = origStderr
+
+	if err != nil {
+		t.Fatalf("run() returned error: %v", err)
+	}
+
+	data, readErr := os.ReadFile(tmpPath)
+	if readErr != nil {
+		t.Fatalf("read captured stderr: %v", readErr)
+	}
+	return string(data)
 }

--- a/runner/main.go
+++ b/runner/main.go
@@ -28,6 +28,12 @@ func main() {
 	receiptVerifierFile := flag.String("receipt-verifier-file", "", "JSON file describing the tool's receipt verifier (shipped, open_source, verifier_url, license, exit_code_contract). Used only when --emit-receipt-profile is set; omitted means \"no verifier shipped\".")
 	multiFileCases := flag.String("multifile-cases", "", "directory of multi-file MCP-drift cases (each subdirectory has case.yaml + before.json + after.json + expected.json). Driver replays before then after through a single MCP session and observes the verdict on the second tools/list response.")
 
+	// --debug / -v: emit verbose per-case diagnostics to stderr. Both
+	// flag names point at the same variable so either can be used.
+	var debug bool
+	flag.BoolVar(&debug, "debug", false, "emit verbose per-case diagnostics to stderr")
+	flag.BoolVar(&debug, "v", false, "alias for --debug")
+
 	flag.Parse()
 
 	if *casesDir == "" || *profilePath == "" {
@@ -35,13 +41,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(*casesDir, *profilePath, *outputPath, *timeout, *adapterName, *proxyAddr, *scanAddr, *scanToken, *mcpCmd, *fixtures, *emitReceiptProfile, *receiptVerifierFile, *multiFileCases); err != nil {
+	if err := run(*casesDir, *profilePath, *outputPath, *timeout, *adapterName, *proxyAddr, *scanAddr, *scanToken, *mcpCmd, *fixtures, *emitReceiptProfile, *receiptVerifierFile, *multiFileCases, debug); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd string, useFixtures bool, emitReceiptProfile, receiptVerifierFile, multiFileCases string) error {
+func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd string, useFixtures bool, emitReceiptProfile, receiptVerifierFile, multiFileCases string, debug bool) error {
 	profile, err := loadProfile(profilePath)
 	if err != nil {
 		return err
@@ -90,6 +96,18 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 		if proxyAddr == "" {
 			return fmt.Errorf("--proxy-addr is required when using the proxy adapter")
 		}
+		if mcpCmd != "" {
+			// MCP tool-poisoning cases inject a mock backend by writing an
+			// executable script to the OS temp directory (see
+			// adapter.PreflightMockScriptExec). Verify that mechanism works
+			// BEFORE running the corpus: a noexec temp dir, a permissions
+			// mismatch, or a missing bash silently breaks every one of those
+			// cases (opaque exit codes or a hang-until-timeout that scores as
+			// a false "block") instead of failing loudly right here.
+			if preflightErr := adapter.PreflightMockScriptExec(); preflightErr != nil {
+				return fmt.Errorf("mcp mock-backend preflight: %w", preflightErr)
+			}
+		}
 		pa, proxyErr := adapter.NewProxyAdapter(proxyAddr, scanAddr, scanToken, mcpCmd)
 		if proxyErr != nil {
 			return proxyErr
@@ -119,6 +137,7 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 		// Check applicability.
 		reason, applicable := checkApplicability(c, profile)
 		if !applicable {
+			debugf(debug, "case %s: not_applicable (%s)", c.ID, reason)
 			naReasons[reason]++
 			result := CaseResult{
 				CaseID:          c.ID,
@@ -148,6 +167,8 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 
 		if adapterResult.Err != nil {
 			errorCount++
+			debugf(debug, "case %s: ERROR expected=%s err=%v evidence=%v",
+				c.ID, c.ExpectedVerdict, adapterResult.Err, adapterResult.Evidence)
 			result := CaseResult{
 				CaseID:          c.ID,
 				Tool:            profile.Tool,
@@ -166,6 +187,7 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 
 		// Adapter returned skip (transport not supported or infrastructure issue).
 		if adapterResult.Verdict == "skip" {
+			debugf(debug, "case %s: skip (adapter: %v)", c.ID, adapterResult.Evidence)
 			naReasons[NAUnsupportedTransport]++
 			skipReason := "adapter skip"
 			if adapterResult.Evidence != nil {
@@ -193,6 +215,13 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 		evidence := adapterResult.Evidence
 		if evidence == nil {
 			evidence = map[string]interface{}{}
+		}
+
+		if score == "pass" {
+			debugf(debug, "case %s: PASS expected=%s actual=%s", c.ID, c.ExpectedVerdict, adapterResult.Verdict)
+		} else {
+			debugf(debug, "case %s: FAIL expected=%s actual=%s evidence=%v",
+				c.ID, c.ExpectedVerdict, adapterResult.Verdict, evidence)
 		}
 
 		result := CaseResult{
@@ -264,6 +293,21 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 	}
 
 	return nil
+}
+
+// debugPrefix is the marker written at the start of every debug line.
+// Tests match on this to distinguish debug output from the normal summary.
+const debugPrefix = "[DEBUG] "
+
+// debugf is a gated debug logger. When debug is false, it is a no-op and
+// adds zero cost. When debug is true, it writes a single prefixed line to
+// stderr. It is deliberately NOT a method — it is called from the loop
+// body with a captured bool, keeping the structure simple (no new types).
+func debugf(debug bool, format string, args ...interface{}) {
+	if !debug {
+		return
+	}
+	_, _ = fmt.Fprintf(os.Stderr, debugPrefix+format+"\n", args...)
 }
 
 // printScores writes a score block with a label to the given writer.

--- a/runner/main.go
+++ b/runner/main.go
@@ -96,14 +96,11 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 		if proxyAddr == "" {
 			return fmt.Errorf("--proxy-addr is required when using the proxy adapter")
 		}
-		if mcpCmd != "" {
-			// MCP tool-poisoning cases inject a mock backend by writing an
-			// executable script to the OS temp directory (see
-			// adapter.PreflightMockScriptExec). Verify that mechanism works
-			// BEFORE running the corpus: a noexec temp dir, a permissions
-			// mismatch, or a missing bash silently breaks every one of those
-			// cases (opaque exit codes or a hang-until-timeout that scores as
-			// a false "block") instead of failing loudly right here.
+		if mcpCmd != "" && needsMCPMockBackendPreflight(cases, profile) {
+			// MCP tool-poisoning cases inject a mock backend by writing a
+			// temp script and running it with bash. Verify that mechanism only
+			// when an applicable selected case will use it, so a fetch-only or
+			// scan-API-only run does not fail on an irrelevant MCP prerequisite.
 			if preflightErr := adapter.PreflightMockScriptExec(); preflightErr != nil {
 				return fmt.Errorf("mcp mock-backend preflight: %w", preflightErr)
 			}
@@ -293,6 +290,51 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 	}
 
 	return nil
+}
+
+func needsMCPMockBackendPreflight(cases []Case, profile Profile) bool {
+	for _, c := range cases {
+		if _, applicable := checkApplicability(c, profile); !applicable {
+			continue
+		}
+		if c.Transport != "mcp_stdio" && c.Transport != "mcp_http" {
+			continue
+		}
+		if payloadHasServerResponse(c.Payload) {
+			return true
+		}
+	}
+	return false
+}
+
+func payloadHasServerResponse(payload map[string]interface{}) bool {
+	if _, ok := payload["result"]; ok {
+		return true
+	}
+	if _, ok := payload["error"]; ok {
+		return true
+	}
+	rawMsgs, ok := payload["jsonrpc_messages"]
+	if !ok {
+		return false
+	}
+	msgs, ok := rawMsgs.([]interface{})
+	if !ok {
+		return false
+	}
+	for _, raw := range msgs {
+		msg, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if _, ok := msg["result"]; ok {
+			return true
+		}
+		if _, ok := msg["error"]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // debugPrefix is the marker written at the start of every debug line.

--- a/runner/multifile_test.go
+++ b/runner/multifile_test.go
@@ -462,7 +462,7 @@ func TestRunIntegratesMultiFileCases(t *testing.T) {
 	casesDir := filepath.Join("..", "cases")
 	multiFileDir := filepath.Join("..", "cases", "mcp-drift")
 
-	err := run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, receiptPath, "", multiFileDir)
+	err := run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, receiptPath, "", multiFileDir, false)
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}


### PR DESCRIPTION
Three benchmark-runner and profile improvements for tag-readiness.

Fail-loud runner. The mock-backend subprocess stderr was discarded, so an environment failure (a noexec temp dir, a missing bash) could surface as a bare exit code and be misread as a tool failure. The runner now captures and surfaces that stderr, and a preflight fails before the corpus runs with a clear, actionable message when the temp dir cannot execute a script.

The --debug / -v flag emits per-case diagnostics (verdict, expected-vs-actual, and the request/response on a mismatch) to stderr. It is off by default and the scored JSON output is byte-identical whether or not it is set.

Profile refresh. Bumps the Pipelock tool profile version and regenerates the receipt-scoring profile against a fixtures-enabled run so it is complete and self-consistent; the previously committed profile predated the fixtures flag.

Worktree: ~/dev/agent-egress-bench-wt/tag-readiness, branch bench/tag-readiness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--debug` and `-v` to emit per-case diagnostics during runs.
  * Added fast preflight validation for proxy MCP mock-backend execution.
* **Bug Fixes**
  * Improved MCP mock subprocess failure reporting by surfacing captured stderr and providing clearer “no output” evidence.
  * Updated verification profiles and case outcomes for tool version 3.1.0, including refreshed verdict explanations and summary counts.
* **Tests**
  * Expanded coverage for preflight checks, error classification, debug output behavior, and stderr propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->