### PR TITLE
chore(renovate): disable dashboard and fix PR creation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended", ":semanticCommits"],
   "minimumReleaseAge": "10 days",
   "internalChecksFilter": "strict",
-  "prCreation": "not-pending",
+  "dependencyDashboard": false,
   "schedule": ["* * * * 1"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,


### PR DESCRIPTION
Disables Renovate's dependency dashboard so closed dashboard issues are not recreated.

Where this repo still had `prCreation: "not-pending"`, removes it so Renovate opens dependency PRs immediately and CI can run on pull_request events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated maintenance settings to streamline how dependency updates are managed.
  * No changes to product functionality, user workflows, or the application’s user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->