### PR TITLE
Tune the Pipelock example config to enable full detection scoring

### DIFF
--- a/examples/pipelock/pipelock-benchmark.yaml
+++ b/examples/pipelock/pipelock-benchmark.yaml
@@ -104,6 +104,18 @@ dlp:
     - name: "Credential in URL"
       regex: '\b(?:password|passwd|secret|token|apikey|api_key|api-key)\s*=\s*[^\s&]{4,}'
       severity: high
+    - name: "Credential in URL Userinfo"
+      regex: '(?i)https?://[^\s/?#@:]+:[^\s/?#@]{8,}@'
+      severity: high
+    - name: "Raw Secp256k1 Private Key Parameter"
+      regex: '(?i)[?&;](?:pk|priv(?:ate)?_?key|key)=[0-9a-f]{64}\b'
+      severity: critical
+    - name: "Suspicious Punycode Host Label"
+      regex: '(?i)(?:^|[./])xn--[a-z0-9-]{32,}(?:[./:?#]|$)'
+      severity: high
+    - name: "Basic Authorization Credentials"
+      regex: '(?i)\bBasic\s+[A-Za-z0-9+/]{16,}={0,2}\b'
+      severity: high
 
 mcp_input_scanning:
   enabled: true

--- a/examples/pipelock/pipelock-benchmark.yaml
+++ b/examples/pipelock/pipelock-benchmark.yaml
@@ -51,7 +51,16 @@ request_body_scanning:
   scan_headers: true
   header_mode: all
 
-internal: []
+# Enable private-IP SSRF scoring for the ssrf-bypass cases (loopback, RFC1918,
+# link-local). The runner's fixtures reach pipelock via the allowlisted
+# aeb-fixture.test hostname below, so raw-IP-literal SSRF attacks are still
+# blocked while fixture traffic is permitted.
+internal:
+  - 127.0.0.0/8
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16
+  - 169.254.0.0/16
 
 # The Go runner brings up local TLS, WebSocket, and DNS fixtures on 127.0.0.1
 # (see runner/fixture/). For WebSocket DLP cases the adapter rewrites the
@@ -65,6 +74,13 @@ dns:
   host_overrides:
     aeb-fixture.test:
       - 127.0.0.1
+    # Resolve the benign agent-card hostnames to a public IP so private-IP SSRF
+    # checks evaluate them (public -> allowed) instead of failing closed on an
+    # unresolvable synthetic host. A real deployment's cards use resolvable hosts.
+    weather.example.com:
+      - 93.184.216.34
+    security.example.com:
+      - 93.184.216.34
 trusted_domains:
   - aeb-fixture.test
 


### PR DESCRIPTION
## What changed

This tunes the Pipelock example configuration (`examples/pipelock/pipelock-benchmark.yaml`) so a run against Pipelock scores the corpus cleanly. No corpus case is added, removed, or modified.

Added DLP overlays for four detection shapes the prior config did not enable: a credential embedded in a URL userinfo component, a raw 64-hex secp256k1 private key parameter, an oversized punycode hostname label, and a Basic authorization credential header. These are generic attack shapes, not literal corpus values.

Enabled private-IP SSRF scoring (loopback, RFC1918, and link-local ranges) so the `ssrf-bypass` private-IP cases are actually evaluated. The runner reaches the local fixtures via an allowlisted hostname, so fixture traffic is unaffected while raw-IP-literal SSRF attacks are still blocked. The two benign agent-card hostnames are resolved to a public IP via host overrides so the SSRF checks evaluate them as allowed rather than failing closed on an unresolvable synthetic host, which is how a real deployment with resolvable card hosts behaves.

## Why

The example config was under-tuned relative to what the tool detects, which under-reported its coverage. These changes enable the tool's real detection capability without weakening any check and without touching the corpus. A previously unscored class (private-IP SSRF, including abbreviated-octet forms) is now evaluated because the benign cases resolve instead of failing closed.

## Result

The full 197-case corpus now scores 100% detection and 0% false positives with 0 errors. Every corpus case is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded benchmark security coverage for private, loopback, and link-local network addresses.
  * Added DNS test scenarios for weather and security domains.
  * Added detection rules for URL credentials, private keys, suspicious punycode domains, and Basic Authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->