### PR TITLE
Refresh benchmark docs for Pipelock v3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Multi-file MCP-drift case runner support:** new `--multifile-cases <dir>` flag on the gauntlet runner loads each `cases/mcp-drift/<id>/` directory, converts the `before.json` / `after.json` snapshot pair into a four-message JSON-RPC sequence, and replays the sequence through a single MCP session against the running tool. The verdict on the second `tools/list` response is what scores. Closes the coverage gap previously called out in `profiles/README.md`.
 - **Receipt-scoring corpus hash covers multi-file cases.** `computeCorpusSHA256` includes `case.yaml` plus the three JSON snapshots per multi-file case when the multi-file flag is set, so `corpus_sha256` in the emitted profile pins the full case surface the runner exercised.
-- **Pipelock receipt profile regenerated against the full corpus.** `profiles/pipelock.json` now scores all 155 applicable rows (151 single-file + 4 mcp-drift): 115 of 116 malicious blocked, 0 false positives on 39 benign baselines. `mcp-drift-collusion-004` is the one miss, recorded honestly as `blocked: no` per the rubric.
+- **Pipelock receipt profile regenerated against the full corpus.** `profiles/pipelock.json` records Pipelock 3.1.0 against the current 197-case corpus surface (193 single-file JSON cases plus 4 multi-file MCP-drift fixtures). The profile keeps unsupported or not-applicable rows explicit so receipt-evidence claims do not get inflated into scanner-containment claims.
 - **Gauntlet scoring program:** four independent metrics (containment, false positive rate, detection, evidence) with an 80% containment gate. See `docs/gauntlet.md`.
 - **Gauntlet runner CLI** (`runner/`): Go binary that runs all cases against a tool profile, computes scores, and outputs a machine-readable summary. Dry-run mode for v1.
 - **AI PR review workflow** (`/review` and `/review deep`): slash-command triggered code review via GitHub Actions.
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Corpus expanded from 73 to 155 cases: 151 single-file JSON cases plus 4 multi-file MCP-drift fixtures
+- Corpus expanded from 73 to 197 logical cases: 193 single-file JSON cases plus 4 multi-file MCP-drift fixtures across 18 categories
 - Pipelock reference profile updated with new capability claims
 - Runner template profile updated with new supports fields
 - Tool profile schema: 5 new supports fields (a2a, websocket_frame_scanning, a2a_scanning, shell_analysis, dns_rebinding_fixture)

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ Each case is a self-contained JSON file. Here's what one looks like:
 A runner feeds each case to the security tool and records whether it blocked or allowed the traffic. Runner output is one JSONL line per case:
 
 ```json
-{"case_id":"url-dlp-aws-key-001","tool":"pipelock","tool_version":"2.4.0","expected_verdict":"block","actual_verdict":"block","score":"pass","evidence":{},"notes":""}
-{"case_id":"url-benign-api-call-001","tool":"pipelock","tool_version":"2.4.0","expected_verdict":"allow","actual_verdict":"allow","score":"pass","evidence":{},"notes":""}
-{"case_id":"a2a-msg-dlp-api-key-001","tool":"pipelock","tool_version":"2.4.0","expected_verdict":"block","actual_verdict":"not_applicable","score":"not_applicable","evidence":{},"notes":"not applicable: missing_capability"}
+{"case_id":"url-dlp-aws-key-001","tool":"pipelock","tool_version":"3.1.0","expected_verdict":"block","actual_verdict":"block","score":"pass","evidence":{},"notes":""}
+{"case_id":"url-benign-api-call-001","tool":"pipelock","tool_version":"3.1.0","expected_verdict":"allow","actual_verdict":"allow","score":"pass","evidence":{},"notes":""}
+{"case_id":"a2a-msg-dlp-api-key-001","tool":"pipelock","tool_version":"3.1.0","expected_verdict":"block","actual_verdict":"not_applicable","score":"not_applicable","evidence":{},"notes":"not applicable: missing_capability"}
 ```
 
 Cases the tool can't handle (missing capabilities) score `not_applicable`, not `fail`. Nobody gets penalized for features they don't claim to support. See [docs/SCORING.md](docs/SCORING.md).


### PR DESCRIPTION
## Summary
- refresh README sample runner output to Pipelock 3.1.0
- update changelog corpus notes to the current 197-case logical corpus surface
- keep post-tag workflow pin refresh separate until the final Pipelock v3.1 tag SHA exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to reflect the expanded 197-case evaluation corpus, including multi-file fixtures and explicit unsupported cases.
  * Updated example runner output to show tool version 3.1.0.
  * Preserved existing example verdicts and scoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->