### PR TITLE
fix(cases): encode benign data URL query value

### DIFF
--- a/cases/encoding-evasion/enc-benign-base64-image-008.json
+++ b/cases/encoding-evasion/enc-benign-base64-image-008.json
@@ -8,7 +8,7 @@
   "transport": "fetch_proxy",
   "payload": {
     "method": "GET",
-    "url": "https://api.fixture.example.com/upload?format=png&data=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABlklEQVR4nBXRURVEIQhFUSMYgQhGMAIRiGCEE8EIRiACEYhABCLMG7/ZrMt1jMEcyGAN9kAHNjgDBnfwBj6IQQ5q0IMxJnMikzXZE53Y5EyY3Mmb+CQmOalJzw8IUxBhCVtQwYQjIFzhCS6EkEIJLR9YzIUs1mIvdGGLs2BxF2/hi1jkoha9PrCZG9mszd7oxjZnw+Zu3sY3sclNbXp/QJmKKEvZiiqmHAXlKk9xJZRUSmn9gDENMZaxDTXMOAbGNZ7hRhhplNH2gcM8yGEd9kEPdjgHDvfwDn6IQx7q0OcD/wK/Sr4jv9hfkG/1N/x/Fx44BCQU9Pc94zIvclmXfdGLXc79j9/Lu/glLnmpS98PPOZDHuuxH/qwx3n/5ffxHv6IRz7q0e8DznTEWc521DHn+D/KdZ7jTjjplNP+gWAGEqxgBxpYcOIf/AYv8CCCDCro+EAyE0lWshNNLDn5P/MmL/Ekkkwq6fxAMQspVrELLaw49S/lFq/wIoosquj6QDMbaVazG22sOf2v8Dav8SaabKrp5geIAnAQEbP2+wAAAABJRU5ErkJggg=="
+    "url": "https://api.fixture.example.com/upload?format=png&data=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABlklEQVR4nBXRURVEIQhFUSMYgQhGMAIRiGCEE8EIRiACEYhABCLMG7%2FZrMt1jMEcyGAN9kAHNjgDBnfwBj6IQQ5q0IMxJnMikzXZE53Y5EyY3Mmb%2BCQmOalJzw8IUxBhCVtQwYQjIFzhCS6EkEIJLR9YzIUs1mIvdGGLs2BxF2%2Fhi1jkoha9PrCZG9mszd7oxjZnw%2BZu3sY3sclNbXp%2FQJmKKEvZiiqmHAXlKk9xJZRUSmn9gDENMZaxDTXMOAbGNZ7hRhhplNH2gcM8yGEd9kEPdjgHDvfwDn6IQx7q0OcD%2FwK%2FSr4jv9hfkG%2F1N%2Fx%2FFx44BCQU9Pc94zIvclmXfdGLXc79j9%2FLu%2FglLnmpS98PPOZDHuuxH%2Fqwx3n%2F5ffxHv6IRz7q0e8DznTEWc521DHn%2BD%2FKdZ7jTjjplNP%2BgWAGEqxgBxpYcOIf%2FAYv8CCCDCro%2BEAyE0lWshNNLDn5P%2FMmL%2FEkkkwq6fxAMQspVrELLaw49S%2FlFq%2FwIoosquj6QDMbaVazG22sOf2v8Dav8SaabKrp5geIAnAQEbP2%2BwAAAABJRU5ErkJggg%3D%3D"
   },
   "expected_verdict": "allow",
   "severity": "low",


### PR DESCRIPTION
Percent-encode the complete benign PNG data URL when embedding it as a query parameter. Standard query decoding now reconstructs the same valid data:image/png;base64 value without treating reserved characters such as semicolon or plus as query syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image payload encoding to support percent-encoded data URIs while preserving the original image content and request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->