### PR TITLE
chore: add NOTICE, fix case count, and guard it in CI

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -33,14 +33,10 @@ jobs:
       - name: Validate all cases
         run: /tmp/aeb-validate cases cases
 
-      - name: Check case count
+      - name: Check case count matches README
         run: |
-          count=$(find cases -name '*.json' -type f | wc -l)
-          echo "Total cases: $count"
-          if [ "$count" -eq 0 ]; then
-            echo "ERROR: no case files found"
-            exit 1
-          fi
+          make stats
+          make check-stats
 
       - name: Scan for personal information
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: stats
+.PHONY: stats check-stats
 
 # Print canonical stats from test cases.
 # Counts are LOGICAL cases: single-file JSON cases plus each multi-file
@@ -27,3 +27,24 @@ stats:
 		fi; \
 		echo "  $$name: $$count"; \
 	done
+
+# Fail when README.md's advertised case count no longer matches the corpus.
+# The count is LOGICAL: one JSON outside cases/mcp-drift, or one
+# cases/mcp-drift/<dir>. Counting files instead inflates it, which is how the
+# advertised number has drifted before.
+check-stats:
+	@single=$$(find cases -name '*.json' -not -path 'cases/mcp-drift/*' | wc -l); \
+	drift=$$(find cases/mcp-drift -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l); \
+	actual=$$((single + drift)); \
+	stated=$$(grep -oE '[0-9]+ logical cases' README.md | head -1 | grep -oE '^[0-9]+'); \
+	if [ -z "$$stated" ]; then \
+		echo "check-stats: FAIL - no 'N logical cases' phrase found in README.md"; \
+		exit 1; \
+	fi; \
+	if [ "$$stated" != "$$actual" ]; then \
+		echo "check-stats: FAIL - README.md advertises $$stated logical cases, corpus has $$actual"; \
+		echo "  a case = one JSON outside cases/mcp-drift, or one cases/mcp-drift/<dir>"; \
+		echo "  fix: change README.md to $$actual, or run 'make stats' to see the breakdown"; \
+		exit 1; \
+	fi; \
+	echo "check-stats: OK ($$actual logical cases, README agrees)"

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+agent-egress-bench
+Copyright 2026 Josh Waldrep
+
+This project is licensed under the Apache License, Version 2.0.
+See LICENSE for the full license text.
+
+Canonical upstream:
+https://github.com/luckyPipewrench/agent-egress-bench

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://discord.gg/badNfhGKTc"><img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white"></a>
 </p>
 
-A standardized test corpus for evaluating AI agent egress security tools. 197 logical cases across 18 categories, covering secret exfiltration, prompt injection, SSRF, hostname exfiltration, MCP tool poisoning, chain detection, MCP drift, A2A protocol scanning, WebSocket DLP, encoding evasion, shell obfuscation, and cryptocurrency/financial data protection.
+A standardized test corpus for evaluating AI agent egress security tools. 213 logical cases across 18 categories, covering secret exfiltration, prompt injection, SSRF, hostname exfiltration, MCP tool poisoning, chain detection, MCP drift, A2A protocol scanning, WebSocket DLP, encoding evasion, shell obfuscation, and cryptocurrency/financial data protection.
 
 **This tests the security tool, not the agent.** Most benchmarks in this space (AgentDojo, InjecAgent, CyberSecEval, AgentHarm) test whether the LLM behaves correctly. This one tests whether the firewall, proxy, or scanner sitting between the agent and the network catches the attack.
 


### PR DESCRIPTION
## What changed

Adds a NOTICE file, corrects the advertised case count, and makes that count self-checking.

The repository had no NOTICE file and no per-file copyright headers, so an Apache-2.0 redistribution inherited no attribution obligation at all. Section 4(d) only carries attribution into a derivative work's distribution when a NOTICE exists, so adding one closes that gap without restricting reuse.

The README advertised 197 logical cases while the corpus holds 213. That number has been hand-corrected more than once and drifts again within weeks. The existing "Check case count" CI step only asserted that the count was non-zero, so it passed regardless of how far the README had diverged, and it reported a third number that matched neither the README nor `make stats`.

`make check-stats` now compares the count the README advertises against the corpus and fails on a mismatch, naming both numbers and the fix. The CI step calls it instead of the old non-zero assertion.

The count is logical rather than per-file: one JSON case outside `cases/mcp-drift`, or one `cases/mcp-drift/<dir>`. Counting files inflates it, which is how the advertised number drifted in the first place.
