### PR TITLE
chore: use the full copyright holder name in legal metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: agent-egress-bench
 message: "If you use this corpus in research, please cite it."
 type: dataset
 authors:
-  - name: Josh Waldrep
+  - name: Joshua Waldrep
     alias: luckyPipewrench
 repository-code: https://github.com/luckyPipewrench/agent-egress-bench
 license: Apache-2.0

--- a/LICENSE
+++ b/LICENSE
@@ -174,7 +174,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Josh Waldrep
+   Copyright 2026 Joshua Waldrep
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 agent-egress-bench
-Copyright 2026 Josh Waldrep
+Copyright 2026 Joshua Waldrep
 
 This project is licensed under the Apache License, Version 2.0.
 See LICENSE for the full license text.


### PR DESCRIPTION
## What changed

Uses the full copyright holder name in this repository's legal and citation metadata, matching the sibling repositories.

The project's convention is the full name in legal and governance documents and the short form in per-file source headers. This repository was the outlier: its LICENSE, NOTICE and CITATION.cff carried the short form while the same files in the sibling repositories carry the full one. The two forms identify the same person, so nothing about ownership or licensing changes, but a copyright notice that differs across a project's own repositories is worth not having.

Source file headers are untouched and keep the short form, which is the existing convention across roughly nineteen hundred files.
