### PR TITLE
docs: clarify the third-party runner integration contract

### DIFF
--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -6,6 +6,25 @@ A runner connects a specific tool to the benchmark corpus. This document defines
 
 **Starter template:** [`examples/runner-template/`](../examples/runner-template/)
 
+## Can my tool be integrated?
+
+The built-in proxy adapter can drive a tool only when the tool exposes one of
+the transport shapes the runner knows how to exercise. A custom runner can
+support other shapes, but it must still produce the same JSONL output and must
+not substitute one transport for another.
+
+| Tool shape | Current status | What the runner can prove |
+|------------|----------------|---------------------------|
+| Forward proxy with a fetch endpoint such as `/fetch?url=...` | Supported by the proxy adapter as `fetch_proxy` | URL, request-body, header, response-content, and fetch-routed cases when the tool exposes the expected endpoint, accepts the case method/body/headers, and returns an observable block signal |
+| CONNECT-capable forward proxy | Supported by the proxy adapter as `http_proxy` | HTTP CONNECT and TLS-interception cases when the tool can be configured as an HTTPS forward proxy |
+| Reverse proxy or API gateway with `listen` and `upstream` routing semantics | Not supported by the proxy adapter today | A custom runner is required; the current adapter cannot route arbitrary case URLs through this shape |
+| In-process SDK or library | Not supported by the proxy adapter today | A custom runner or wrapper service is required, and the result should declare only the transports it can actually exercise |
+| MCP gateway | Not supported by a generic adapter today | Tool-specific MCP stdio or MCP HTTP commands can be driven now; a protocol-first MCP gateway adapter is planned |
+
+If none of the supported shapes match your architecture, mark the unmatched
+transports as unsupported in `supports` or write a tool-specific runner. Do not
+force a tool through the wrong shape just to get a numeric result.
+
 ## Input
 
 1. A directory of case JSON files
@@ -47,6 +66,29 @@ One JSON object per case, written to stdout (one per line, JSONL):
 ## Runner Setup
 
 Some cases require tool-specific configuration before running. These requirements are documented in each case's `notes` field and in this section.
+
+### Managed command hooks
+
+The Go runner can either target already-running endpoints or start
+operator-provided commands with managed command hooks. Managed commands receive
+endpoint and fixture values through environment variables. The runner does not
+parse or mutate tool configuration.
+
+Available managed-command environment variables:
+
+| Variable | Meaning |
+| --- | --- |
+| `AEB_PROXY_ADDR` | Host:port the managed forward/fetch proxy command should listen on |
+| `AEB_SCAN_ADDR` | Host:port the managed scan API command should listen on |
+| `AEB_MCP_HTTP_ADDR` | Host:port the managed MCP HTTP command should listen on |
+| `AEB_MCP_HTTP_URL` | URL corresponding to `AEB_MCP_HTTP_ADDR` |
+| `AEB_HTTP_FIXTURE_ADDR` | HTTP fixture address |
+| `AEB_TLS_FIXTURE_ADDR` | HTTPS fixture address for intercepted request/response cases |
+| `AEB_TLS_CA_FILE` | Fixture CA certificate path |
+| `AEB_TLS_CA_KEY_FILE` | Fixture CA private-key path |
+| `AEB_WS_FIXTURE_ADDR` | WebSocket fixture address |
+| `AEB_DNS_FIXTURE_ADDR` | DNS fixture address |
+| `AEB_MCP_HTTP_FIXTURE_URL` | MCP HTTP upstream fixture URL |
 
 ### Domain blocklist seeding
 
@@ -96,9 +138,25 @@ If either check fails, emit `score: "not_applicable"` and `actual_verdict: "not_
 
 Do not use detector-specific `requires` to skip benign `allow` controls. Those cases measure false positives and should run whenever the transport and any true runtime prerequisites are available.
 
+A tool is scored only on capabilities it claims through `supports`. Cases outside
+that declared surface are `not_applicable`, not failures. A mostly
+`not_applicable` result is a statement about the integration and tool scope that
+was measured, not a statement about the tool's overall quality.
+
 ## Observable Verdict Rules
 
-### HTTP and fetch cases
+### HTTP-shaped cases
+
+HTTP-facing tools can expose several different shapes. They are not
+interchangeable:
+
+| Shape | Corpus transport | Current runner support |
+|-------|------------------|------------------------|
+| Fetch-style endpoint | `fetch_proxy` | Supported by the proxy adapter as an HTTP request to `/fetch?url=...` on the configured proxy address |
+| CONNECT forward proxy | `http_proxy` | Supported by the proxy adapter through HTTPS proxy settings and runner-managed fixtures |
+| Reverse proxy or API gateway | No generic transport today | Not supported by the proxy adapter; write a custom runner or mark the unmatched transports unsupported |
+
+For supported HTTP-shaped cases, map observations to verdicts this way:
 
 | Observation | Verdict |
 |-------------|---------|

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -17,6 +17,10 @@ tool-neutral managed command hooks. Managed commands receive endpoint and
 fixture values through environment variables; the runner does not parse or
 mutate Pipelock configuration.
 
+The canonical tool-neutral managed-command contract is documented in
+[`../../docs/RUNNER.md`](../../docs/RUNNER.md#managed-command-hooks). This
+example uses the same variables.
+
 Available managed-command environment variables:
 
 | Variable | Meaning |
@@ -60,7 +64,7 @@ or candidate commit they executed.
 
 ## Legacy fetch-only harness
 
-`harness.sh` runs URL cases through Pipelock's `/fetch?url=...` GET endpoint. It is preserved as a minimal worked example of the runner contract for tools that only implement a fetch-style proxy. **It is not the Gauntlet** — body, header (POST), WebSocket, MCP, and response-content cases are not exercised, and any tool whose containment is reported off this harness alone will be undersold. Use the Go runner for any published score.
+`harness.sh` runs URL cases through Pipelock's `/fetch?url=...` GET endpoint. It is preserved as a minimal worked example of the runner contract for tools that only implement a fetch-style proxy. **It is not the Gauntlet**: body, header (POST), WebSocket, MCP, and response-content cases are not exercised, and any tool whose containment is reported off this harness alone will be undersold. Use the Go runner for any published score.
 
 ```bash
 # Minimal fetch-only run (illustration, not a benchmark)

--- a/examples/runner-template/README.md
+++ b/examples/runner-template/README.md
@@ -77,7 +77,7 @@ Only claim what your tool actually does; these labels help readers interpret res
 
 ### `supports` object
 
-Which transport and scanning modes your tool supports. These map to the `requires` field in case files. If a case requires a capability you don't support, it is skipped.
+Which transport and scanning modes your tool supports. These map to the `requires` field in case files. If a case requires a capability you don't support, it is not executed and is reported as `not_applicable`, which is a statement about scope rather than a failure.
 
 | Key | What it means |
 |-----|---------------|

--- a/examples/runner-template/README.md
+++ b/examples/runner-template/README.md
@@ -10,6 +10,23 @@ A practical guide for building a runner that connects your security tool to the 
 - A `tool-profile.json` declaring your tool's capabilities
 - `bash` (the skeleton is a bash script, but you can write your runner in any language)
 
+## Can my tool be integrated?
+
+Use this check before writing code:
+
+| Tool shape | Current status | What to do |
+|------------|----------------|------------|
+| Forward proxy with a fetch endpoint such as `/fetch?url=...` | Yes | Use `supports.fetch_proxy: true` if your runner can call that endpoint with the case method/body/headers and observe block signals |
+| CONNECT-capable forward proxy | Yes | Use `supports.http_proxy: true` if your runner can send requests through it as an HTTPS forward proxy |
+| Reverse proxy or API gateway with `listen` and `upstream` routing | Not today | Write a custom runner or leave the unmatched transports unsupported |
+| In-process SDK or library | Not today | Wrap it in a runner-owned service or leave the unmatched transports unsupported |
+| MCP gateway | Not as a generic adapter today | Tool-specific MCP stdio or MCP HTTP commands can be driven now; a protocol-first MCP gateway adapter is planned |
+
+A result is scored only on capabilities you declare in `supports`. Cases outside
+that surface are `not_applicable`, not failures. A mostly `not_applicable` result
+is a statement about what was in scope for the run, not a statement about your
+tool's overall quality.
+
 ## Step 1: Create your tool profile
 
 Copy `tool-profile-template.json` to your runner directory and fill it in.
@@ -64,8 +81,8 @@ Which transport and scanning modes your tool supports. These map to the `require
 
 | Key | What it means |
 |-----|---------------|
-| `fetch_proxy` | Tool provides an HTTP fetch endpoint (like `/fetch?url=...`) |
-| `http_proxy` | Tool works as a CONNECT/forward proxy |
+| `fetch_proxy` | Tool provides a runner-drivable HTTP fetch endpoint such as `/fetch?url=...` |
+| `http_proxy` | Tool works as a CONNECT-capable forward proxy |
 | `mcp_stdio` | Tool can wrap MCP servers via stdio |
 | `mcp_http` | Tool can proxy MCP over HTTP |
 | `websocket` | Tool can proxy WebSocket connections |
@@ -131,16 +148,42 @@ Look for `TODO` markers in `skeleton.sh`. There are three:
 2. **Check transport support.** Skip cases with transports your runner can't handle yet (even if your tool supports them in theory, your runner might not have the plumbing).
 3. **Feed and observe.** Send the case payload to your tool and determine the verdict.
 
+The Go runner can start managed commands and pass runner-owned fixture addresses
+through environment variables. The full managed-command contract is documented
+in [docs/RUNNER.md](../../docs/RUNNER.md#managed-command-hooks).
+
 ## Step 3: Handle each transport
 
-### HTTP cases (fetch_proxy, http_proxy)
+### Fetch endpoint cases (`fetch_proxy`)
 
-For tools that act as HTTP proxies, the pattern is:
+`fetch_proxy` cases are for tools that expose a fetch-style endpoint. The
+built-in proxy adapter calls `/fetch?url=...` on the configured proxy address
+using the method, body, and headers from the case payload. These cases exercise
+URL, request-body, header, response-content, and some blocklist or SSRF checks
+when the runner can express the case through that endpoint.
+
+The pattern is:
 
 1. Start your tool on a local port
-2. For each case, build an HTTP request from the payload
-3. Send it through your tool (via curl, wget, or direct HTTP)
-4. Check the response status code and body
+2. For each case, build the request expected by your fetch endpoint
+3. Send it to your tool's fetch endpoint
+4. Check the response status code and body for the tool's block signal
+
+### CONNECT forward-proxy cases (`http_proxy`)
+
+`http_proxy` cases are for CONNECT-capable forward proxies. The runner drives
+these by configuring the tool as an HTTPS proxy and sending requests to
+runner-managed fixtures. These cases exercise forward-proxy and TLS-intercepted
+request/response paths. A reverse proxy or API gateway is not equivalent to this
+shape because the runner cannot currently rewrite arbitrary case URLs into a
+fixed upstream route.
+
+The pattern is:
+
+1. Start your forward proxy on a local port
+2. Configure the client request to use that port as the HTTPS proxy
+3. Send the case payload through the proxy to the runner fixture
+4. Check the proxy response status code and body for the tool's block signal
 
 Verdict mapping from HTTP status codes:
 
@@ -176,12 +219,15 @@ Verdict mapping for MCP:
 Response cases (`input_type: response_content`) include a `response_body` in the payload. These are harder to test because you need to simulate a server returning that content. Options:
 
 - Start a local HTTP server that returns the `response_body`
-- Use your tool's API directly if it has a scan-content endpoint
+- Use a tool-specific runner only if it can prove the case exercised the declared transport
 - Mark as `not_applicable` in v1 and add support later
 
 ### Cases you cannot handle
 
-If your runner does not support a transport or input type, emit `not_applicable` with a reason. This is normal. The Pipelock reference runner (v1) only supports `fetch_proxy` and marks everything else `not_applicable`.
+If your runner does not support a transport or input type, emit `not_applicable`
+with a reason. This is normal. A narrow v1 runner can support one transport and
+mark the rest `not_applicable` while still producing honest results for the
+surface it actually exercises.
 
 Do not fake results. If you cannot observe the verdict, say so.
 

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -5,7 +5,9 @@
 //
 // Transport mapping:
 //   - fetch_proxy: HTTP request to /fetch?url=... on the configured proxy address
-//   - http_proxy: CONNECT-capable forward proxy via HTTPS_PROXY
+//   - http_proxy: CONNECT tunnel to the same configured proxy address. The
+//     runner sets the proxy on its own HTTP transport and does not export
+//     HTTPS_PROXY, so the tool only has to accept CONNECT on that address.
 //   - websocket: GET /ws?url=... plus runner-managed WebSocket fixtures
 //   - mcp_stdio: configured MCP stdio proxy command with JSON-RPC on stdio
 //   - mcp_http: JSON-RPC POST endpoint set with SetMCPHTTPURL
@@ -616,7 +618,9 @@ func caseRequires(c Case, requirement string) bool {
 	return false
 }
 
-// runHTTPProxy sends a request through the proxy as HTTPS_PROXY (CONNECT tunnel).
+// runHTTPProxy sends a request through the configured proxy address using a
+// CONNECT tunnel. The proxy is set on this transport directly, not via the
+// HTTPS_PROXY environment variable.
 func (p *ProxyAdapter) runHTTPProxy(c Case, timeout time.Duration) Result {
 	targetURL, _ := payloadString(c.Payload, "url")
 	if targetURL == "" {
@@ -2056,7 +2060,8 @@ func (p *ProxyAdapter) runA2AViaMCP(c Case, timeout time.Duration) Result {
 
 // extractTextFromPayload pulls scannable text from any payload format.
 func extractTextFromPayload(payload map[string]interface{}) string {
-	// A2A agent cards: scan name, URL, description, and skill descriptions.
+	// A2A agent cards: scan name, URL, description, and both the name and the
+	// description of every declared skill.
 	if card, ok := payload["agent_card"].(map[string]interface{}); ok {
 		var texts []string
 		if name, ok := card["name"].(string); ok {

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -1,18 +1,24 @@
-// Package adapter — proxy adapter sends cases through an HTTP proxy.
+// Package adapter implements the runner's built-in proxy-shaped adapter.
 //
-// Works with any tool that operates as an HTTP/HTTPS proxy. Point --proxy-addr
-// at the tool's listen address and the adapter sends real traffic through it.
+// The proxy adapter is not a generic integration layer for every HTTP-facing
+// tool. It can drive a tool that exposes the concrete benchmark surfaces below:
 //
 // Transport mapping:
-//   - fetch_proxy  → GET /fetch?url=...
-//   - http_proxy   → CONNECT tunnel via HTTPS_PROXY
-//   - websocket    → GET /ws?url=... (connection attempt)
-//   - mcp_stdio    → configured MCP stdio proxy command
+//   - fetch_proxy: HTTP request to /fetch?url=... on the configured proxy address
+//   - http_proxy: CONNECT-capable forward proxy via HTTPS_PROXY
+//   - websocket: GET /ws?url=... plus runner-managed WebSocket fixtures
+//   - mcp_stdio: configured MCP stdio proxy command with JSON-RPC on stdio
+//   - mcp_http: JSON-RPC POST endpoint set with SetMCPHTTPURL
+//
+// Tool-specific block signals are normalized by the runner after the requested
+// transport has been exercised. A reverse proxy or API gateway with
+// listen/upstream routing semantics is not drivable by this adapter today, nor
+// is an in-process SDK without a runner that presents one of these surfaces.
 //
 // Unimplemented execution paths return skip. The runner upgrades that to an
-// error when the tool profile declared the case applicable. Transports are
-// never substituted because that would turn a scanner result into false
-// evidence that the requested transport was exercised.
+// error when the tool profile declared the case applicable. Transports are never
+// substituted because that would turn a scanner result into false evidence that
+// the requested transport was exercised.
 package adapter
 
 import (
@@ -60,8 +66,8 @@ type ProxyAdapter struct {
 	proxyURL        *url.URL
 	scanURL         string                  // base URL for scan API (e.g. http://127.0.0.1:9990)
 	scanToken       string                  // bearer token for scan API auth
-	mcpCmd          string                  // MCP proxy command (e.g. "pipelock mcp proxy --config /tmp/bench.yaml -- cat")
-	mcpHTTPURL      string                  // Pipelock MCP HTTP listener URL
+	mcpCmd          string                  // MCP proxy command that wraps an upstream stdio server
+	mcpHTTPURL      string                  // MCP-over-HTTP JSON-RPC listener URL
 	httpFixtureAddr string                  // HTTP fixture for response-mitm via fetch
 	setHTTPRoute    func(path, body string) // callback to register HTTP fixture routes
 	setHTTPRouteCT  func(path, body, contentType string)
@@ -134,7 +140,7 @@ func (p *ProxyAdapter) SetWSFixtures(trustedAddr, untrustedAddr string) {
 	p.wsUntrustedAddr = untrustedAddr
 }
 
-// SetMCPHTTPURL configures the Pipelock MCP HTTP listener URL.
+// SetMCPHTTPURL configures the MCP-over-HTTP JSON-RPC listener URL.
 func (p *ProxyAdapter) SetMCPHTTPURL(rawURL string) { p.mcpHTTPURL = rawURL }
 
 // Run sends the case payload through the proxy and returns the verdict.
@@ -330,12 +336,12 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 			}
 			// Connection closed without a close frame. If we already
 			// received at least one frame from the proxy, treat the
-			// closure as a clean upstream goaway (allow) — proxies that
+			// closure as a clean upstream goaway (allow); proxies that
 			// permit traffic do not synthesize close frames on behalf of
 			// the upstream, so an EOF after the echo means "the wire ended,
 			// the proxy did not actively block." If we never received any
 			// frame, an abrupt closure suggests the proxy actively dropped
-			// the connection (RST or close without frame) — block.
+			// the connection (RST or close without frame): block.
 			if lastFrame.seen {
 				return Result{
 					Verdict: "allow",
@@ -698,17 +704,17 @@ func (p *ProxyAdapter) runHTTPProxy(c Case, timeout time.Duration) Result {
 			extractBlockEvidence(errStr, ev)
 			return Result{Verdict: "block", Evidence: ev}
 		}
-		// Proxy or upstream connection reset — may be an active block.
+		// Proxy or upstream connection reset may be an active block.
 		if strings.Contains(errStr, "reset by peer") {
 			ev := map[string]interface{}{"reason": "connection_reset"}
 			extractBlockEvidence(errStr, ev)
 			return Result{Verdict: "block", Evidence: ev}
 		}
-		// Proxy unreachable — adapter infrastructure problem.
+		// Proxy unreachable means adapter infrastructure problem.
 		if strings.Contains(errStr, "connection refused") {
 			return Result{Err: fmt.Errorf("case %s: proxy unreachable: %w", c.ID, err)}
 		}
-		// Upstream unreachable (DNS, TLS, timeout) — the proxy allowed the
+		// Upstream unreachable (DNS, TLS, timeout) means the proxy allowed the
 		// CONNECT but the upstream doesn't exist. Skip, not error.
 		return Result{
 			Verdict:  "skip",
@@ -937,7 +943,7 @@ func (p *ProxyAdapter) runWebSocket(c Case, timeout time.Duration) Result {
 	resp, err := client.Do(req)
 	if err != nil {
 		errStr := err.Error()
-		// Proxy unreachable — adapter infrastructure problem.
+		// Proxy unreachable means adapter infrastructure problem.
 		if strings.Contains(errStr, "connection refused") {
 			return Result{Err: fmt.Errorf("case %s: ws proxy unreachable: %w", c.ID, err)}
 		}
@@ -1404,7 +1410,7 @@ func (p *ProxyAdapter) runMCPStdio(c Case, timeout time.Duration) Result {
 		// No output and no reported wait error (or a timeout) is treated as a
 		// block, since many proxies express "block" by simply closing the
 		// connection without writing anything. That is a real, valid signal
-		// for a well-behaved tool — but it is also exactly what a silently
+		// for a well-behaved tool, but it is also exactly what a silently
 		// failed mock-backend spawn looks like, so any captured stderr is
 		// attached here as a diagnostic hint rather than changing the
 		// verdict itself.
@@ -1416,7 +1422,7 @@ func (p *ProxyAdapter) runMCPStdio(c Case, timeout time.Duration) Result {
 	}
 
 	// Check response lines for policy-block JSON-RPC errors.
-	// Pipelock uses -32000 to -32009 for policy decisions (scan block, chain, etc.).
+	// Tool-specific policy errors use the JSON-RPC server-error range.
 	// Standard JSON-RPC errors (-32700 to -32600) are protocol issues, not blocks.
 	for _, respLine := range lines {
 		var rpcResp struct {
@@ -1438,7 +1444,7 @@ func (p *ProxyAdapter) runMCPStdio(c Case, timeout time.Duration) Result {
 				}
 			}
 			if code <= -32600 {
-				// Standard JSON-RPC protocol error — not a policy decision.
+				// Standard JSON-RPC protocol error, not a policy decision.
 				return Result{Err: fmt.Errorf("case %s: JSON-RPC protocol error %d: %s", c.ID, code, rpcResp.Error.Message)}
 			}
 		}
@@ -2050,7 +2056,7 @@ func (p *ProxyAdapter) runA2AViaMCP(c Case, timeout time.Duration) Result {
 
 // extractTextFromPayload pulls scannable text from any payload format.
 func extractTextFromPayload(payload map[string]interface{}) string {
-	// A2A agent cards — scan name, URL, description, and skill descriptions.
+	// A2A agent cards: scan name, URL, description, and skill descriptions.
 	if card, ok := payload["agent_card"].(map[string]interface{}); ok {
 		var texts []string
 		if name, ok := card["name"].(string); ok {
@@ -2106,7 +2112,7 @@ func extractTextFromPayload(payload map[string]interface{}) string {
 }
 
 // extractBlockEvidence parses a block response body for scanner and reason fields.
-// Pipelock returns these in multiple formats depending on transport:
+// Supported block response formats include:
 //   - Fetch JSON: {"blocked":true,"block_reason":"DLP match: AWS","scanner":"dlp"}
 //   - Forward proxy text: "blocked by DLP: AWS Access ID" or "SSRF: private IP"
 //   - Kill switch: "kill switch active"
@@ -2233,7 +2239,7 @@ func classifyResponse(statusCode int, body string) Result {
 		return Result{Verdict: "allow", Evidence: evidence}
 	}
 
-	// 4xx/5xx that aren't 400/403/405/502 — the request reached the upstream and
+	// 4xx/5xx that aren't 400/403/405/502 mean the request reached the upstream and
 	// got an error response. The proxy allowed it through (not a policy block).
 	// 404, 429, 500, etc. all mean the proxy didn't intervene.
 	evidence["reason"] = fmt.Sprintf("http_%d_passthrough", statusCode)
@@ -2257,7 +2263,7 @@ func truncate(s string, n int) string {
 }
 
 // isScanDeny returns true if the verdict string indicates a block/deny.
-// Pipelock's scan API uses "deny"; older or alternative engines may use "block".
+// Scan-style APIs commonly return either "deny" or "block".
 func isScanDeny(v string) bool {
 	return v == "deny" || v == "block"
 }


### PR DESCRIPTION
## What changed

Documentation and comments only. No runner behavior, adapter logic, scoring, or case content changes.

The repository tells outside tools how to connect to the corpus, and those instructions were wrong in a way that wastes a reader's time. `runner/adapter/proxy.go` described itself as working for "any tool that operates as an HTTP/HTTPS proxy" while actually requiring a specific `/fetch` endpoint, CONNECT forward proxying, a `/ws` path, and a particular MCP command shape. A tool built as a reverse or API gateway can read that sentence, spend real effort wiring itself up, and only then discover it was never going to work.

The adapter comment now states the shapes it actually drives and says plainly which shapes it does not. Two further comments that named Pipelock inside otherwise tool-neutral code were rewritten to describe the contract generically.

`docs/RUNNER.md` now distinguishes the three different HTTP shapes a tool can have, a fetch-style endpoint, a CONNECT forward proxy, and a reverse or API gateway, and says which are currently drivable. The runner-managed fixture contract moved here as well. It previously lived only inside `examples/pipelock/`, where an outside implementer had no reason to look for it.

`examples/runner-template/README.md` separates guidance that had merged `fetch_proxy` and `http_proxy`, and adds a short section that lets an implementer determine in a few minutes whether their architecture is currently supported, including the cases where the answer is no.

The applicability principle is now stated explicitly: a tool is scored only on capabilities it declares through `supports`, cases outside that are not applicable rather than failures, and a result that is largely not-applicable describes scope rather than quality.

## Why

The corpus currently has one integrated tool. Making the contract honest and discoverable is the prerequisite for that changing, and being clear about what is unsupported matters more than being encouraging about what is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for integrating supported and unsupported tool transport patterns, including proxies, MCP, SDKs, and gateways.
  * Documented managed command configuration, endpoint requirements, fixtures, and certificate settings.
  * Clarified HTTP evaluation rules and request flows for fetch and HTTP proxies.
  * Added an integration-status matrix and improved guidance for unsupported scenarios, including when to return “not applicable.”
  * Updated example setup instructions to reference the canonical managed-command contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->