### PR TITLE
ci: drop the invented copyright holder from the gauntlet workflow

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -1,4 +1,3 @@
-# Copyright 2026 agent-egress-bench contributors
 # SPDX-License-Identifier: Apache-2.0
 
 name: Continuous Gauntlet


### PR DESCRIPTION
## What changed

The continuous gauntlet workflow asserted copyright for "agent-egress-bench contributors". The repository LICENSE and NOTICE both name a single rights holder, so the file claimed something the project does not declare anywhere else.

The one pre-existing header in the tree carries an SPDX identifier and no copyright line. This matches that convention rather than introducing a second one, since whether the project adopts per-file copyright headers at all is still an open question and worth deciding deliberately rather than by whichever file happened to land first.

No behavior change. The workflow still parses and is otherwise untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated copyright comment from an automated workflow.
  * No changes were made to workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->