### PR TITLE
ci(review): route reviews to GPT-5.6 tiers

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -8,19 +8,27 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: pr-review-${{ github.repository }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     if: >-
+      github.event.comment.user.login == 'luckyPipewrench' &&
+      github.event.comment.author_association == 'OWNER' &&
       github.event.issue.pull_request &&
       (github.event.comment.body == '/review' ||
-       github.event.comment.body == '/review fast' ||
        github.event.comment.body == '/review deep')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Check out trusted review runner
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -30,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: pip install --require-hashes -r .github/requirements-pr-review.txt
 
+      - name: Test trusted review runner
+        run: python -m unittest scripts/pr_review_test.py
+
       - name: Determine review mode
         id: mode
         env:
@@ -38,7 +49,7 @@ jobs:
           if [ "$COMMENT_BODY" = "/review deep" ]; then
             echo "mode=deep" >> "$GITHUB_OUTPUT"
           else
-            echo "mode=fast" >> "$GITHUB_OUTPUT"
+            echo "mode=default" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run PR review
@@ -47,8 +58,11 @@ jobs:
           LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PR_REVIEW_MODEL_FAST: ${{ secrets.PR_REVIEW_MODEL_FAST }}
-          PR_REVIEW_MODEL_DEEP: ${{ secrets.PR_REVIEW_MODEL_DEEP }}
+          # Optional repository variables. Empty values fall back to the
+          # reviewed constants in scripts/pr-review.py, the single source of
+          # truth for model defaults.
+          PR_REVIEW_MODEL_FAST: ${{ vars.PR_REVIEW_MODEL_FAST }}
+          PR_REVIEW_MODEL_DEEP: ${{ vars.PR_REVIEW_MODEL_DEEP }}
           REVIEW_MODE: ${{ steps.mode.outputs.mode }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}

--- a/scripts/pr-review.py
+++ b/scripts/pr-review.py
@@ -1,22 +1,25 @@
 #!/usr/bin/env python3
 """AI-powered PR review for agent-egress-bench.
 
-Triggered by /review, /review fast, or /review deep comments on PRs.
+Triggered by /review or /review deep comments on PRs.
 Sends the PR diff to an LLM and posts the review as a single PR comment.
 
 Requires environment variables:
   GITHUB_TOKEN       - GitHub token (provided by Actions)
   REPO               - owner/repo
   PR_NUMBER          - PR number
-  REVIEW_MODE        - "fast" or "deep"
+  REVIEW_MODE        - "default" or "deep"
 
 LLM configuration (one of):
   LITELLM_BASE_URL + LITELLM_API_KEY  - LiteLLM proxy
   OPENAI_API_KEY                       - Direct OpenAI API
 
 Model selection:
-  PR_REVIEW_MODEL_FAST  - Model for /review and /review fast (default: gpt-5.4-mini)
-  PR_REVIEW_MODEL_DEEP  - Model for /review deep (default: gpt-5.4)
+  PR_REVIEW_MODEL_FAST  - Model for /review (default: gpt-5.6-luna)
+  PR_REVIEW_MODEL_DEEP  - Model for /review deep (default: gpt-5.6-terra)
+
+The PR_REVIEW_MODEL_FAST env var keeps its name for backwards compatibility
+with existing environment overrides.
 """
 
 import json
@@ -28,8 +31,19 @@ import requests
 # --- Constants ---
 
 MAX_DIFF_CHARS = 100_000  # ~25k tokens, keeps costs reasonable
-DEFAULT_MODEL_FAST = "gpt-5.4-mini"
-DEFAULT_MODEL_DEEP = "gpt-5.4"
+DEFAULT_MODEL_FAST = "gpt-5.6-luna"
+DEFAULT_MODEL_DEEP = "gpt-5.6-terra"
+DEFAULT_TEMPERATURE = 0.2
+DEFAULT_MAX_COMPLETION_TOKENS = 8192
+DEEP_MAX_COMPLETION_TOKENS = 25000
+DEFAULT_LLM_TIMEOUT_SECONDS = 120
+DEEP_LLM_TIMEOUT_SECONDS = 300
+FAST_REASONING_EFFORT = "low"
+DEEP_REASONING_EFFORT = "medium"
+
+
+class LLMReviewError(RuntimeError):
+    """Raised when the LLM call completed but did not produce a usable review."""
 
 SYSTEM_PROMPT = """You are reviewing a pull request for agent-egress-bench, an open test corpus for evaluating AI agent egress security tools. The repo contains JSON test cases, a Go validator (stdlib-only), a Gauntlet scoring runner (stdlib-only), and documentation.
 
@@ -76,32 +90,28 @@ def truncate_diff(diff: str, max_chars: int = MAX_DIFF_CHARS) -> str:
     return truncated + f"\n\n... (diff truncated at {max_chars} chars, {len(diff)} total)"
 
 
-def call_llm(diff: str, mode: str) -> str:
-    """Send the diff to the LLM and return the review."""
-    litellm_url = os.environ.get("LITELLM_BASE_URL", "")
-    litellm_key = os.environ.get("LITELLM_API_KEY", "")
-    openai_key = os.environ.get("OPENAI_API_KEY", "")
+def model_supports_custom_temperature(model: str) -> bool:
+    """Return whether chat completions should send a non-default temperature."""
+    normalized = model.strip().lower()
+    model_name = normalized.rsplit("/", 1)[-1]
+    return not model_name.startswith(("gpt-5", "o1", "o3", "o4"))
 
-    # Pick model based on mode. Use `or` so empty strings fall back to defaults.
-    if mode == "deep":
-        model = os.environ.get("PR_REVIEW_MODEL_DEEP") or DEFAULT_MODEL_DEEP
-    else:
-        model = os.environ.get("PR_REVIEW_MODEL_FAST") or DEFAULT_MODEL_FAST
 
-    # Prefer LiteLLM if configured, fall back to OpenAI.
-    if litellm_url and litellm_key:
-        api_url = litellm_url.rstrip("/") + "/chat/completions"
-        api_key = litellm_key
-    elif openai_key:
-        api_url = "https://api.openai.com/v1/chat/completions"
-        api_key = openai_key
-    else:
-        return "**Error:** No LLM API configured. Set LITELLM_BASE_URL + LITELLM_API_KEY or OPENAI_API_KEY in repo secrets."
+def model_supports_reasoning_effort(model: str) -> bool:
+    """Return whether chat completions should pin reasoning effort."""
+    normalized = model.strip().lower()
+    model_name = normalized.rsplit("/", 1)[-1]
+    return model_name.startswith(("gpt-5", "o1", "o3", "o4"))
 
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
+
+def build_llm_payload(
+    model: str,
+    diff: str,
+    *,
+    max_completion_tokens: int = DEFAULT_MAX_COMPLETION_TOKENS,
+    reasoning_effort: str = FAST_REASONING_EFFORT,
+) -> dict:
+    """Build a chat-completions payload compatible with the selected model."""
     payload = {
         "model": model,
         "messages": [
@@ -111,24 +121,113 @@ def call_llm(diff: str, mode: str) -> str:
                 "content": f"Review this pull request diff:\n\n```diff\n{diff}\n```",
             },
         ],
-        "temperature": 0.2,
-        # gpt-5.x and o-series require max_completion_tokens, not max_tokens.
-        "max_completion_tokens": 4096,
+        "max_completion_tokens": max_completion_tokens,
     }
+    if model_supports_custom_temperature(model):
+        payload["temperature"] = DEFAULT_TEMPERATURE
+    if model_supports_reasoning_effort(model):
+        payload["reasoning_effort"] = reasoning_effort
+    return payload
 
-    resp = requests.post(api_url, headers=headers, json=payload, timeout=120)
-    if resp.status_code != 200:
-        body = resp.text[:500]
-        return f"**Error:** LLM API returned {resp.status_code}.\n\n**Model:** `{model}`\n\n**Response:**\n```\n{body}\n```"
-    data = resp.json()
+
+def summarize_usage(data: dict) -> str:
+    """Return compact token usage details for operator-visible errors."""
+    usage = data.get("usage")
+    if not isinstance(usage, dict):
+        return "usage unavailable"
+    details = usage.get("completion_tokens_details") or {}
+    parts = [
+        f"prompt={usage.get('prompt_tokens', 'unknown')}",
+        f"completion={usage.get('completion_tokens', 'unknown')}",
+        f"total={usage.get('total_tokens', 'unknown')}",
+    ]
+    if isinstance(details, dict) and "reasoning_tokens" in details:
+        parts.append(f"reasoning={details['reasoning_tokens']}")
+    return ", ".join(parts)
+
+
+def extract_chat_content(data: dict) -> str:
+    """Extract visible text from a chat-completions response."""
     choices = data.get("choices", [])
-    if not choices:
-        return "**Error:** LLM returned no choices. Raw response: " + json.dumps(data)[:500]
-    message = choices[0].get("message", {})
+    if not isinstance(choices, list) or not choices:
+        raise LLMReviewError("LLM returned no choices.")
+
+    choice = choices[0] if isinstance(choices[0], dict) else {}
+    message = choice.get("message") if isinstance(choice.get("message"), dict) else {}
     content = message.get("content", "")
-    if not content:
-        return "**Error:** LLM returned empty content."
-    return content
+    if isinstance(content, list):
+        content = "".join(
+            part.get("text", "") for part in content if isinstance(part, dict)
+        )
+    if isinstance(content, str) and content.strip():
+        if choice.get("finish_reason") == "length":
+            content += (
+                "\n\n> **Warning:** Review output was truncated by the model "
+                f"completion limit ({summarize_usage(data)}). Treat this as an "
+                "incomplete review and rerun with a narrower diff if needed."
+            )
+        return content
+
+    finish_reason = choice.get("finish_reason", "unknown")
+    raise LLMReviewError(
+        "LLM returned empty content "
+        f"(finish_reason={finish_reason}; {summarize_usage(data)})."
+    )
+
+
+def model_for_mode(mode: str) -> str:
+    """Return the configured model for a review mode, with Python defaults."""
+    if mode == "deep":
+        return os.environ.get("PR_REVIEW_MODEL_DEEP") or DEFAULT_MODEL_DEEP
+    return os.environ.get("PR_REVIEW_MODEL_FAST") or DEFAULT_MODEL_FAST
+
+
+def call_llm(diff: str, mode: str) -> str:
+    """Send the diff to the LLM and return the review."""
+    litellm_url = os.environ.get("LITELLM_BASE_URL", "")
+    litellm_key = os.environ.get("LITELLM_API_KEY", "")
+    openai_key = os.environ.get("OPENAI_API_KEY", "")
+
+    model = model_for_mode(mode)
+
+    # Prefer LiteLLM if configured, fall back to OpenAI.
+    if litellm_url and litellm_key:
+        api_url = litellm_url.rstrip("/") + "/chat/completions"
+        api_key = litellm_key
+    elif openai_key:
+        api_url = "https://api.openai.com/v1/chat/completions"
+        api_key = openai_key
+    else:
+        raise LLMReviewError(
+            "No LLM API configured. Set LITELLM_BASE_URL + LITELLM_API_KEY "
+            "or OPENAI_API_KEY in repo secrets."
+        )
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    is_deep = mode == "deep"
+    payload = build_llm_payload(
+        model,
+        diff,
+        max_completion_tokens=(
+            DEEP_MAX_COMPLETION_TOKENS if is_deep else DEFAULT_MAX_COMPLETION_TOKENS
+        ),
+        reasoning_effort=(
+            DEEP_REASONING_EFFORT if is_deep else FAST_REASONING_EFFORT
+        ),
+    )
+
+    timeout = DEEP_LLM_TIMEOUT_SECONDS if is_deep else DEFAULT_LLM_TIMEOUT_SECONDS
+    resp = requests.post(api_url, headers=headers, json=payload, timeout=timeout)
+    if resp.status_code != 200:
+        raise LLMReviewError(f"LLM API returned {resp.status_code} for model `{model}`.")
+    try:
+        data = resp.json()
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise LLMReviewError("LLM returned invalid JSON.") from exc
+    return extract_chat_content(data)
 
 
 def post_comment(repo: str, pr_number: str, token: str, body: str) -> None:
@@ -146,7 +245,7 @@ def main() -> None:
     token = os.environ.get("GITHUB_TOKEN", "")
     repo = os.environ.get("REPO", "")
     pr_number = os.environ.get("PR_NUMBER", "")
-    mode = os.environ.get("REVIEW_MODE", "fast")
+    mode = os.environ.get("REVIEW_MODE", "default")
 
     if not all([token, repo, pr_number]):
         print("Missing required environment variables", file=sys.stderr)
@@ -171,16 +270,14 @@ def main() -> None:
     # Call LLM.
     try:
         review = call_llm(diff, mode)
-    except requests.RequestException as e:
+    except (requests.RequestException, LLMReviewError) as e:
         post_comment(repo, pr_number, token, f"**AI Review Error:** LLM API call failed: {e}")
         sys.exit(1)
 
     # Post review.
-    model_name = (
-        os.environ.get("PR_REVIEW_MODEL_DEEP" if mode == "deep" else "PR_REVIEW_MODEL_FAST")
-        or (DEFAULT_MODEL_DEEP if mode == "deep" else DEFAULT_MODEL_FAST)
-    )
-    header = f"## AI Security Review (`/review {mode}`)\n\n**Model:** `{model_name}`\n\n---\n\n"
+    model_name = model_for_mode(mode)
+    command = "/review" if mode == "default" else f"/review {mode}"
+    header = f"## AI Security Review (`{command}`)\n\n**Model:** `{model_name}`\n\n---\n\n"
     post_comment(repo, pr_number, token, header + review)
     print("Review posted.")
 

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Focused unit tests for the PR review runner and workflow contract."""
+
+import importlib.util
+import pathlib
+import unittest
+from unittest import mock
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("pr-review.py")
+WORKFLOW_PATH = SCRIPT_PATH.parents[1] / ".github" / "workflows" / "pr-review.yaml"
+SPEC = importlib.util.spec_from_file_location("pr_review", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"failed to load {SCRIPT_PATH}")
+pr_review = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pr_review)
+
+
+class FakeResponse:
+    def __init__(self, data: dict, status_code: int = 200, text: str = "") -> None:
+        self._data = data
+        self.status_code = status_code
+        self.text = text
+
+    def json(self) -> dict:
+        return self._data
+
+
+class InvalidJSONResponse(FakeResponse):
+    def json(self) -> dict:
+        raise ValueError("not JSON")
+
+
+class PayloadTest(unittest.TestCase):
+    def test_gpt5_payload_uses_reasoning_effort_without_temperature(self) -> None:
+        payload = pr_review.build_llm_payload("gpt-5.6-luna", "diff")
+        self.assertNotIn("temperature", payload)
+        self.assertEqual(payload["reasoning_effort"], "low")
+        self.assertEqual(
+            payload["max_completion_tokens"], pr_review.DEFAULT_MAX_COMPLETION_TOKENS
+        )
+
+    def test_deep_payload_uses_medium_reasoning_effort(self) -> None:
+        payload = pr_review.build_llm_payload(
+            "gpt-5.6-terra",
+            "diff",
+            max_completion_tokens=pr_review.DEEP_MAX_COMPLETION_TOKENS,
+            reasoning_effort=pr_review.DEEP_REASONING_EFFORT,
+        )
+        self.assertEqual(payload["reasoning_effort"], "medium")
+        self.assertEqual(
+            payload["max_completion_tokens"], pr_review.DEEP_MAX_COMPLETION_TOKENS
+        )
+
+    def test_legacy_model_keeps_temperature_without_reasoning_effort(self) -> None:
+        payload = pr_review.build_llm_payload("gpt-4.1", "diff")
+        self.assertEqual(payload["temperature"], pr_review.DEFAULT_TEMPERATURE)
+        self.assertNotIn("reasoning_effort", payload)
+
+
+class ModelRoutingTest(unittest.TestCase):
+    def test_python_constants_are_the_model_default_source(self) -> None:
+        self.assertEqual(pr_review.DEFAULT_MODEL_FAST, "gpt-5.6-luna")
+        self.assertEqual(pr_review.DEFAULT_MODEL_DEEP, "gpt-5.6-terra")
+
+    def test_workflow_delegates_defaults_to_runner(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "PR_REVIEW_MODEL_FAST: ${{ vars.PR_REVIEW_MODEL_FAST }}", workflow
+        )
+        self.assertIn(
+            "PR_REVIEW_MODEL_DEEP: ${{ vars.PR_REVIEW_MODEL_DEEP }}", workflow
+        )
+        self.assertNotRegex(workflow, r"PR_REVIEW_MODEL_(?:FAST|DEEP): gpt-")
+
+    def test_workflow_requires_owner_and_uses_trusted_runner_checkout(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("github.event.comment.user.login == 'luckyPipewrench'", workflow)
+        self.assertIn("github.event.comment.author_association == 'OWNER'", workflow)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("timeout-minutes: 10", workflow)
+        self.assertIn("group: pr-review-${{ github.repository }}-${{ github.event.issue.number }}", workflow)
+        self.assertIn("cancel-in-progress: true", workflow)
+        self.assertIn("python -m unittest scripts/pr_review_test.py", workflow)
+        self.assertNotIn("'/review fast'", workflow)
+
+    def test_workflow_keeps_credentials_in_secrets(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL }}", workflow)
+        self.assertIn("LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}", workflow)
+        self.assertIn("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}", workflow)
+
+    def test_default_and_deep_modes_cannot_swap_model_routes(self) -> None:
+        response = FakeResponse({"choices": [{"message": {"content": "review"}}]})
+        with mock.patch.dict(
+            pr_review.os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True
+        ), mock.patch.object(pr_review.requests, "post", return_value=response) as post:
+            pr_review.call_llm("diff", "default")
+            default_payload = post.call_args.kwargs["json"]
+            pr_review.call_llm("diff", "deep")
+            deep_payload = post.call_args.kwargs["json"]
+
+        self.assertEqual(default_payload["model"], pr_review.DEFAULT_MODEL_FAST)
+        self.assertEqual(default_payload["reasoning_effort"], "low")
+        self.assertEqual(deep_payload["model"], pr_review.DEFAULT_MODEL_DEEP)
+        self.assertEqual(deep_payload["reasoning_effort"], "medium")
+
+    def test_empty_overrides_fall_back_to_python_defaults(self) -> None:
+        with mock.patch.dict(
+            pr_review.os.environ,
+            {"PR_REVIEW_MODEL_FAST": "", "PR_REVIEW_MODEL_DEEP": ""},
+            clear=True,
+        ):
+            self.assertEqual(pr_review.model_for_mode("default"), "gpt-5.6-luna")
+            self.assertEqual(pr_review.model_for_mode("deep"), "gpt-5.6-terra")
+
+
+class ResponseParsingTest(unittest.TestCase):
+    def test_shape_errors_are_generic_and_fail_closed(self) -> None:
+        with self.assertRaises(pr_review.LLMReviewError) as ctx:
+            pr_review.extract_chat_content(
+                {"choices": [], "private": "provider detail"}
+            )
+        self.assertIn("no choices", str(ctx.exception))
+        self.assertNotIn("provider detail", str(ctx.exception))
+
+        with self.assertRaisesRegex(pr_review.LLMReviewError, "empty content"):
+            pr_review.extract_chat_content({"choices": [None]})
+
+    def test_extract_chat_content_accepts_content_parts(self) -> None:
+        data = {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "review "},
+                            {"type": "text", "text": "body"},
+                        ]
+                    }
+                }
+            ]
+        }
+        self.assertEqual(pr_review.extract_chat_content(data), "review body")
+
+    def test_extract_chat_content_rejects_empty_response(self) -> None:
+        data = {
+            "choices": [{"finish_reason": "length", "message": {"content": ""}}],
+            "usage": {"completion_tokens_details": {"reasoning_tokens": 4096}},
+        }
+        with self.assertRaisesRegex(pr_review.LLMReviewError, "finish_reason=length"):
+            pr_review.extract_chat_content(data)
+
+    def test_extract_chat_content_marks_truncated_review_incomplete(self) -> None:
+        data = {
+            "choices": [
+                {
+                    "finish_reason": "length",
+                    "message": {"content": "partial review"},
+                }
+            ],
+            "usage": {"completion_tokens_details": {"reasoning_tokens": 22000}},
+        }
+        content = pr_review.extract_chat_content(data)
+        self.assertIn("partial review", content)
+        self.assertIn("incomplete review", content)
+        self.assertIn("reasoning=22000", content)
+
+    def test_call_llm_raises_on_non_200_response(self) -> None:
+        response = FakeResponse({}, status_code=500, text="boom")
+        with mock.patch.dict(
+            pr_review.os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True
+        ), mock.patch.object(pr_review.requests, "post", return_value=response):
+            with self.assertRaises(pr_review.LLMReviewError) as ctx:
+                pr_review.call_llm("diff", "default")
+        self.assertIn("returned 500", str(ctx.exception))
+        self.assertNotIn("boom", str(ctx.exception))
+
+    def test_call_llm_rejects_invalid_json_response(self) -> None:
+        response = InvalidJSONResponse({})
+        with mock.patch.dict(
+            pr_review.os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True
+        ), mock.patch.object(pr_review.requests, "post", return_value=response):
+            with self.assertRaisesRegex(pr_review.LLMReviewError, "invalid JSON"):
+                pr_review.call_llm("diff", "default")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Route ordinary PR reviews to GPT-5.6 Luna with low reasoning and deep reviews to GPT-5.6 Terra with medium reasoning. Centralize default selection in the runner, accept optional repository-variable overrides, harden trusted workflow invocation, and add regression coverage for routing and API-response failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/review` and `/review deep` commands for automated pull request reviews.
  * Added model-specific review settings, usage reporting, and improved handling of incomplete or invalid responses.
  * Reviews now run with updated time limits and configurable model options.

* **Bug Fixes**
  * Improved error messages for failed, empty, truncated, or malformed review responses.

* **Tests**
  * Added coverage for review commands, model configuration, workflow security, response parsing, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->