### PR TITLE
fix(runner,cases): stop the continuous-gauntlet lane hanging on teardown

### DIFF
--- a/cases/hostname-exfiltration/hostname-exfil-benign-cdn-008.json
+++ b/cases/hostname-exfiltration/hostname-exfil-benign-cdn-008.json
@@ -2,13 +2,13 @@
   "schema_version": 2,
   "id": "hostname-exfil-benign-cdn-008",
   "category": "hostname_exfiltration",
-  "title": "Legitimate CDN hostname with content hash",
-  "description": "A normal CDN request where the subdomain contains a content hash. Should not trigger hostname exfiltration detection.",
+  "title": "Legitimate CDN hostname for a versioned asset",
+  "description": "A normal CDN request for a versioned library asset. Should not trigger hostname exfiltration detection.",
   "input_type": "url",
   "transport": "fetch_proxy",
   "payload": {
     "method": "GET",
-    "url": "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"
+    "url": "https://cdn.fixture.example.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"
   },
   "expected_verdict": "allow",
   "severity": "low",
@@ -18,8 +18,8 @@
   ],
   "requires": [],
   "false_positive_risk": "high",
-  "why_expected": "legitimate_cdn_content_hash",
+  "why_expected": "legitimate_cdn_asset_request",
   "safe_example": true,
-  "notes": "CloudFront and similar CDNs use hash-based subdomains for content routing. These are benign despite appearing high-entropy.",
+  "notes": "A benign CDN asset request under the benchmark fixture host, served locally so the corpus stays hermetic. It is the benign false-positive control for hostname exfiltration and must be allowed, not blocked.",
   "source": "original"
 }

--- a/examples/pipelock/pipelock-benchmark.yaml
+++ b/examples/pipelock/pipelock-benchmark.yaml
@@ -101,6 +101,10 @@ dns:
   host_overrides:
     aeb-fixture.test:
       - 127.0.0.1
+    # This hostname-exfiltration false-positive control must retain its
+    # declared hostname while the runner swaps only its dynamic fixture port.
+    cdn.fixture.example.com:
+      - 127.0.0.1
     ws-exfil-sink.test:
       - 127.0.0.2
     a2a-exfil-sink.test:
@@ -122,6 +126,7 @@ dns:
       - 93.184.216.34
 trusted_domains:
   - aeb-fixture.test
+  - cdn.fixture.example.com
   - allowed-code-api.test
   - allowed-chat-webhook.test
 

--- a/examples/pipelock/pipelock-benchmark.yaml
+++ b/examples/pipelock/pipelock-benchmark.yaml
@@ -101,10 +101,15 @@ dns:
   host_overrides:
     aeb-fixture.test:
       - 127.0.0.1
-    # This hostname-exfiltration false-positive control must retain its
-    # declared hostname while the runner swaps only its dynamic fixture port.
+    # The hostname-exfiltration false-positive control keeps its declared
+    # hostname (the runner swaps only its dynamic fixture port) and resolves to
+    # the ip_allowlist'd sink loopback, NOT to a trusted_domains entry. The
+    # allowlist makes the local fixture reachable while leaving subdomain-entropy
+    # / hostname-exfiltration scanning ACTIVE, so an allow here is the detector
+    # correctly declining a false positive rather than a destination-trust
+    # exemption. The HTTP fixture serves this address on its paired sink listener.
     cdn.fixture.example.com:
-      - 127.0.0.1
+      - 127.0.0.2
     ws-exfil-sink.test:
       - 127.0.0.2
     a2a-exfil-sink.test:
@@ -126,7 +131,6 @@ dns:
       - 93.184.216.34
 trusted_domains:
   - aeb-fixture.test
-  - cdn.fixture.example.com
   - allowed-code-api.test
   - allowed-chat-webhook.test
 

--- a/runner/adapter/command_group_other.go
+++ b/runner/adapter/command_group_other.go
@@ -1,0 +1,18 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package adapter
+
+import (
+	"os/exec"
+	"time"
+)
+
+func configureMCPCommand(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		return nil
+	}
+	cmd.WaitDelay = 5 * time.Second
+}

--- a/runner/adapter/command_group_unix.go
+++ b/runner/adapter/command_group_unix.go
@@ -1,0 +1,23 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package adapter
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func configureMCPCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			_ = cmd.Process.Kill()
+		}
+		return nil
+	}
+	cmd.WaitDelay = 5 * time.Second
+}

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -56,6 +56,7 @@ import (
 // reaching the benign fixture under test.
 const (
 	fixtureHostname           = "aeb-fixture.test"
+	hostnameExfilFixtureHost  = "cdn.fixture.example.com"
 	wsFixtureHostname         = fixtureHostname
 	wsUntrustedSinkHostname   = "ws-exfil-sink.test"
 	a2aUntrustedSinkHostname  = "a2a-exfil-sink.test"
@@ -78,7 +79,7 @@ type ProxyAdapter struct {
 	setTLSRoute     func(path, body string)
 	setTLSRouteCT   func(path, body, contentType string)
 	setTLSRouteHost func(host, path, body, contentType string)
-	tlsRequests     func() int64 // requests the TLS fixture has served
+	tlsRequests     func() int64  // requests the TLS fixture has served
 	wsAddr          string        // trusted WS fixture for websocket cases
 	wsUntrustedAddr string        // untrusted WS fixture for reserved sink cases
 	responseRouteID atomic.Uint64 // unique low-entropy response fixture route
@@ -654,6 +655,14 @@ func (p *ProxyAdapter) routeFetchFixtureURL(targetURL string) string {
 		return targetURL
 	}
 	u.Scheme = "http"
+	// The hostname-exfiltration benign control must reach the scanner with its
+	// declared CDN hostname intact. Only redirect its port to the local fixture;
+	// replacing the host with fixtureHostname would make that control prove only
+	// that aeb-fixture.test is allowed.
+	if strings.EqualFold(u.Hostname(), hostnameExfilFixtureHost) {
+		u.Host = net.JoinHostPort(hostnameExfilFixtureHost, port)
+		return u.String()
+	}
 	u.Host = net.JoinHostPort(fixtureHostname, port)
 	return u.String()
 }
@@ -1477,6 +1486,7 @@ func (p *ProxyAdapter) runMCPStdio(c Case, timeout time.Duration) Result {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", mcpCmd) //nolint:gosec // command from trusted CLI flag
+	configureMCPCommand(cmd)
 	// Capture stderr instead of discarding it. Discarding it here previously
 	// swallowed the diagnostic output from a mock-backend spawn failure (e.g.
 	// bash missing), leaving nothing but a bare, unexplained exit code or a
@@ -1633,6 +1643,7 @@ func (p *ProxyAdapter) runMCPStdioBudgetSequence(c Case, msgList []interface{}, 
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", p.mcpCmd) //nolint:gosec // command from trusted CLI flag
+	configureMCPCommand(cmd)
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
 

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -1977,6 +1977,28 @@ func TestRunMCPStdio_StderrSurfacedOnSubprocessFailure(t *testing.T) {
 	}
 }
 
+func TestRunMCPStdioTimeoutKillsOrphanHoldingStderrPipe(t *testing.T) {
+	script := t.TempDir() + "/orphan-mcp.sh"
+	if err := os.WriteFile(script, []byte("#!/bin/sh\n( while :; do :; done ) 1>&2 &\nwhile :; do :; done\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	result := (&ProxyAdapter{mcpCmd: script}).runMCPStdio(Case{
+		ID:      "orphan-stderr",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{"method": "tools/call"}}},
+	}, time.Second)
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("MCP subprocess returned after %v; process-group kill should finish before WaitDelay", elapsed)
+	}
+	if result.Err != nil {
+		t.Fatalf("result error = %v", result.Err)
+	}
+	if result.Verdict != "block" {
+		t.Fatalf("verdict = %q, want block after timed-out subprocess", result.Verdict)
+	}
+}
+
 // A case whose host is NOT the reserved fixture domain must be left alone. The
 // host is frequently the payload itself (subdomain-encoded exfiltration,
 // credentials in userinfo), so redirecting it to the fixture would strip the
@@ -1992,6 +2014,34 @@ func TestRunFetchProxy_LeavesNonFixtureHostsUnrewritten(t *testing.T) {
 		if got := a.routeFetchFixtureURL(targetURL); got != targetURL {
 			t.Errorf("routeFetchFixtureURL(%q) rewrote to %q; non-fixture hosts must be preserved", targetURL, got)
 		}
+	}
+}
+
+func TestRunFetchProxy_HostnameExfiltrationControlPreservesDeclaredHost(t *testing.T) {
+	var gotTarget string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTarget = r.URL.Query().Get("url")
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer proxy.Close()
+
+	a, err := NewProxyAdapter(proxy.Listener.Addr().String(), "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.SetHTTPFixture("127.0.0.1:34567", func(string, string) {})
+	result := a.runFetchProxy(Case{
+		ID: "hostname-exfil-benign-cdn-008",
+		Payload: map[string]interface{}{
+			"url": "https://cdn.fixture.example.com/ajax/libs/lodash.js/4.17.21/lodash.min.js",
+		},
+	}, 5*time.Second)
+	if result.Verdict != "allow" {
+		t.Fatalf("verdict = %q, err = %v", result.Verdict, result.Err)
+	}
+	want := "http://cdn.fixture.example.com:34567/ajax/libs/lodash.js/4.17.21/lodash.min.js"
+	if gotTarget != want {
+		t.Fatalf("fetch target = %q, want %q", gotTarget, want)
 	}
 }
 

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1978,6 +1979,9 @@ func TestRunMCPStdio_StderrSurfacedOnSubprocessFailure(t *testing.T) {
 }
 
 func TestRunMCPStdioTimeoutKillsOrphanHoldingStderrPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("MCP stdio teardown relies on a POSIX shell and process groups")
+	}
 	script := t.TempDir() + "/orphan-mcp.sh"
 	if err := os.WriteFile(script, []byte("#!/bin/sh\n( while :; do :; done ) 1>&2 &\nwhile :; do :; done\n"), 0o700); err != nil {
 		t.Fatal(err)

--- a/runner/managed_process.go
+++ b/runner/managed_process.go
@@ -109,8 +109,13 @@ func (m *managedProcesses) Close() {
 	if m.cancel != nil {
 		m.cancel()
 	}
+	// Kill every command first, then wait for each. Killing and waiting in one
+	// loop makes total teardown additive (up to one WaitDelay per command);
+	// killing all up front bounds it to a single WaitDelay regardless of count.
 	for _, cmd := range m.cmds {
 		killManagedCommand(cmd)
+	}
+	for _, cmd := range m.cmds {
 		_ = cmd.Wait()
 	}
 	m.cmds = nil

--- a/runner/managed_process.go
+++ b/runner/managed_process.go
@@ -85,14 +85,23 @@ func (m *managedProcesses) startShellCommand(ctx context.Context, name, command 
 	output := newManagedOutputTail(maxManagedOutputBytes)
 	cmd.Stdout = output
 	cmd.Stderr = output
+	configureManagedCommand(cmd)
+	// The server can outlive a kill of its direct parent and keep the inherited
+	// stdout/stderr pipe open. In an environment with no init to reap the orphan
+	// (containers, CI runners), Wait would otherwise block forever on that pipe.
+	// WaitDelay bounds that wait: Wait force-closes the pipe and returns.
+	cmd.WaitDelay = 5 * time.Second
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start %s command: %w", name, err)
 	}
-	m.cmds = append(m.cmds, cmd)
 	if err := waitForTCPAddrs(ctx, readyAddrs, timeout); err != nil {
 		stopStartedCommand(cmd)
 		return fmt.Errorf("%s command did not listen on %s: %w; output: %s", name, strings.Join(readyAddrs, ", "), err, output.String())
 	}
+	// A command that failed readiness has already been stopped and waited above.
+	// Retain only successfully started commands so Close never signals a stale PID
+	// a second time during error cleanup.
+	m.cmds = append(m.cmds, cmd)
 	return nil
 }
 
@@ -101,14 +110,14 @@ func (m *managedProcesses) Close() {
 		m.cancel()
 	}
 	for _, cmd := range m.cmds {
+		killManagedCommand(cmd)
 		_ = cmd.Wait()
 	}
+	m.cmds = nil
 }
 
 func stopStartedCommand(cmd *exec.Cmd) {
-	if cmd.Process != nil {
-		_ = cmd.Process.Kill()
-	}
+	killManagedCommand(cmd)
 	_ = cmd.Wait()
 }
 

--- a/runner/managed_process_other.go
+++ b/runner/managed_process_other.go
@@ -1,0 +1,16 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package main
+
+import "os/exec"
+
+// Managed shell launchers are Unix-oriented, but the runner itself remains
+// buildable on other platforms. Those platforms use the normal direct-process
+// cancellation path and WaitDelay bound.
+func configureManagedCommand(_ *exec.Cmd) {}
+
+func killManagedCommand(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/runner/managed_process_test.go
+++ b/runner/managed_process_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -37,6 +38,58 @@ func TestStartShellCommandRequiresAllReadyAddrs(t *testing.T) {
 	if !strings.Contains(err.Error(), scanAddr) {
 		t.Fatalf("error = %q, want missing scan address %q", err, scanAddr)
 	}
+	if got := len(managed.cmds); got != 0 {
+		t.Fatalf("managed command count after failed readiness = %d, want 0", got)
+	}
+}
+
+// A managed launcher can exit after it has spawned a child that inherited the
+// runner's stdout/stderr pipe. In a container without an init reaping that
+// child, a bare Process.Kill only kills the launcher and Cmd.Wait blocks on the
+// still-open pipe. Close must signal the full private process group and return
+// before WaitDelay is needed as a last resort.
+func TestManagedProcessesCloseKillsOrphanHoldingOutputPipe(t *testing.T) {
+	proxyAddr, err := freeLoopbackAddr()
+	if err != nil {
+		t.Fatal(err)
+	}
+	readyFile := t.TempDir() + "/orphan-ready"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	managed := &managedProcesses{cancel: cancel}
+	command := managedProcessHelperCommand()
+	err = managed.startShellCommand(ctx, "managed proxy", command, []string{
+		"AEB_MANAGED_PROCESS_HELPER=orphan-output",
+		"AEB_PROXY_ADDR=" + proxyAddr,
+		"AEB_MANAGED_PROCESS_READY_FILE=" + readyFile,
+	}, 2*time.Second, proxyAddr)
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	if len(managed.cmds) != 1 {
+		cancel()
+		t.Fatalf("managed command count = %d, want 1", len(managed.cmds))
+	}
+	cmd := managed.cmds[0]
+	defer func() {
+		// Cleanup if a regression causes Close to time out through WaitDelay:
+		// the test helper child deliberately keeps the inherited pipe open.
+		killManagedCommand(cmd)
+		cancel()
+	}()
+
+	if err := waitForFile(readyFile, time.Second); err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	managed.Close()
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("Close took %v; process-group kill should finish before WaitDelay", elapsed)
+	}
+	if len(managed.cmds) != 0 {
+		t.Fatalf("managed command count after Close = %d, want 0", len(managed.cmds))
+	}
 }
 
 func TestManagedOutputTailIsBounded(t *testing.T) {
@@ -54,11 +107,15 @@ func TestManagedOutputTailIsBounded(t *testing.T) {
 }
 
 func TestManagedProcessHelper(t *testing.T) {
-	if os.Getenv("AEB_MANAGED_PROCESS_HELPER") == "" {
+	mode := os.Getenv("AEB_MANAGED_PROCESS_HELPER")
+	if mode == "" {
 		return
 	}
-	if os.Getenv("AEB_MANAGED_PROCESS_HELPER") != "listen-proxy" {
-		t.Fatalf("unknown helper mode %q", os.Getenv("AEB_MANAGED_PROCESS_HELPER"))
+	if mode == "hold-output" {
+		select {}
+	}
+	if mode != "listen-proxy" && mode != "orphan-output" {
+		t.Fatalf("unknown helper mode %q", mode)
 	}
 
 	ln, err := net.Listen("tcp", os.Getenv("AEB_PROXY_ADDR"))
@@ -66,6 +123,25 @@ func TestManagedProcessHelper(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
+
+	if mode == "orphan-output" {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			t.Fatal(acceptErr)
+		}
+		_ = conn.Close()
+		child := exec.Command(os.Args[0], "-test.run=TestManagedProcessHelper")
+		child.Env = append(os.Environ(), "AEB_MANAGED_PROCESS_HELPER=hold-output")
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		if startErr := child.Start(); startErr != nil {
+			t.Fatal(startErr)
+		}
+		if writeErr := os.WriteFile(os.Getenv("AEB_MANAGED_PROCESS_READY_FILE"), []byte("ready"), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+		return
+	}
 
 	for {
 		conn, err := ln.Accept()
@@ -78,6 +154,19 @@ func TestManagedProcessHelper(t *testing.T) {
 
 func managedProcessHelperCommand() string {
 	return fmt.Sprintf("exec %s -test.run=TestManagedProcessHelper", strconv.Quote(os.Args[0]))
+}
+
+func waitForFile(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for %s", path)
 }
 
 // A torn-down run must abandon the readiness wait at once. Without honouring the

--- a/runner/managed_process_test.go
+++ b/runner/managed_process_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -49,6 +50,9 @@ func TestStartShellCommandRequiresAllReadyAddrs(t *testing.T) {
 // still-open pipe. Close must signal the full private process group and return
 // before WaitDelay is needed as a last resort.
 func TestManagedProcessesCloseKillsOrphanHoldingOutputPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("managed subprocess teardown relies on a POSIX shell and process groups")
+	}
 	proxyAddr, err := freeLoopbackAddr()
 	if err != nil {
 		t.Fatal(err)

--- a/runner/managed_process_unix.go
+++ b/runner/managed_process_unix.go
@@ -1,0 +1,28 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureManagedCommand gives each managed launcher a private process group.
+// A launcher may exec or fork the server it starts, so teardown must be able to
+// signal the server and its descendants without touching the runner's group.
+func configureManagedCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killManagedCommand SIGKILLs the managed command's process group. Setpgid
+// makes the direct child's PID the group ID, so the negative PID reaches the
+// launcher, server, and any inherited-stdio descendants. A failed group send
+// falls back to the direct child.
+func killManagedCommand(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/runner/receipt_observer.go
+++ b/runner/receipt_observer.go
@@ -319,6 +319,15 @@ func runReceiptVerifier(evidenceFile string, decl ReceiptEvidenceDeclaration) ve
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	// A verifier may fork a child that inherits CombinedOutput's pipe. Put the
+	// verifier in its own group so context cancellation reaches that child too;
+	// otherwise Cmd.Wait can hang forever after killing only the direct verifier.
+	configureManagedCommand(cmd)
+	cmd.Cancel = func() error {
+		killManagedCommand(cmd)
+		return nil
+	}
+	cmd.WaitDelay = 5 * time.Second
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
 		return verifyResult{verifiable: "no", reason: fmt.Sprintf("verifier timed out after %s", timeout)}

--- a/runner/receipt_profile_test.go
+++ b/runner/receipt_profile_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // stringPtr returns a pointer to s. Used in tests that build a fully-valid
@@ -539,6 +540,25 @@ func TestBuildReceiptProfile_EvidenceDirUnreadableFailsClosed(t *testing.T) {
 	}
 	if !strings.Contains(row.ReceiptObservationReason, "receipt evidence unavailable") {
 		t.Fatalf("receipt_observation_reason = %q, want unavailable reason", row.ReceiptObservationReason)
+	}
+}
+
+func TestRunReceiptVerifierTimeoutKillsOrphanHoldingOutputPipe(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "orphan-verifier.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\n( while :; do :; done ) &\nwhile :; do :; done\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	result := runReceiptVerifier("unused-evidence.jsonl", ReceiptEvidenceDeclaration{
+		VerifyCommand:        []string{script},
+		VerifyTimeoutSeconds: 1,
+	})
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("receipt verifier returned after %v; group kill should finish before WaitDelay", elapsed)
+	}
+	if !strings.Contains(result.reason, "verifier timed out") {
+		t.Fatalf("reason = %q, want verifier timeout", result.reason)
 	}
 }
 

--- a/runner/receipt_profile_test.go
+++ b/runner/receipt_profile_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -544,6 +545,9 @@ func TestBuildReceiptProfile_EvidenceDirUnreadableFailsClosed(t *testing.T) {
 }
 
 func TestRunReceiptVerifierTimeoutKillsOrphanHoldingOutputPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("verifier teardown relies on a POSIX shell and process groups")
+	}
 	script := filepath.Join(t.TempDir(), "orphan-verifier.sh")
 	if err := os.WriteFile(script, []byte("#!/bin/sh\n( while :; do :; done ) &\nwhile :; do :; done\n"), 0o700); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The continuous gauntlet lane never completed a run: every trigger hung for its full 35 minute timeout. This fixes that, plus the related issues a fresh adversarial review surfaced. Every change here is reproduced in a clean Ubuntu container that mirrors a GitHub runner.

Teardown hang. The runner starts its helper servers through a launcher shell and, on cleanup, signalled only that shell. Each launcher ends in exec, so the real server survived, was reparented to init, and kept the inherited stdout and stderr pipe open, so Wait blocked forever. A normal workstation reaps the orphan and exits fine, which is why this only ever hung in a container or on a CI runner. Each managed command now runs in its own process group, teardown signals the whole group, and a bounded WaitDelay means Wait can never block on an inherited pipe again.

The same orphan-holding-pipe pattern lived in the receipt verifier subprocess and both per-case MCP stdio spawns. Those are hardened the same way, each with a regression test that fails when the group kill is removed. The process-group handling is split into platform files so the runner still cross-compiles for non-Unix targets, which the previous inline syscalls broke.

Benign control. One benign hostname-exfiltration control fetched a live external CDN, so a clean runner with no ambient egress scored it as an upstream error. It now uses a benchmark fixture hostname whose port is routed to the local fixture while the hostname itself still reaches the scanner, so the corpus stays hermetic and the control still proves a benign CDN hostname is allowed while its malicious siblings are blocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented command timeouts from hanging when child processes retain output pipes.
  * Improved cleanup of failed or cancelled processes, including their child processes.
  * Preserved declared CDN hostnames while routing fixture requests locally, improving hostname-exfiltration detection accuracy.

* **Tests**
  * Added regression coverage for process termination, timeout handling, and CDN hostname routing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->