### PR TITLE
feat(runner): generic MCP-gateway adapter (protocol-first, plugin-driven, PR1)

### DIFF
--- a/docs/GATEWAY-ADAPTER.md
+++ b/docs/GATEWAY-ADAPTER.md
@@ -1,0 +1,75 @@
+# MCP gateway adapter plugin contract
+
+The `mcp-gateway` runner adapter drives a gateway through a generic MCP client
+endpoint. A plugin describes the gateway's protocol surface and deny signals;
+it must not identify or depend on a particular gateway product.
+
+PR1 supports one narrow path: a corpus `mcp_http` case containing exactly one
+`mcp_tool_call`, sent to a plugin with `"transport": "streamable_http"`. The
+adapter sends `initialize`, `notifications/initialized`, and the case's
+`tools/call`. Other corpus transports and input types return `skip` with a
+reason rather than inventing a verdict.
+
+An allow is credited only when the runner-managed MCP fixture's `tools/call`
+counter advances after the gateway response. A successful response generated
+by a gateway without forwarding is therefore `skip`, with
+`upstream_reached: false`.
+
+## Plugin fields
+
+`name` names the integration for local output. `transport` is the plugin
+protocol transport; PR1 accepts only `streamable_http`.
+
+`gateway` is lifecycle metadata for later slices:
+
+- `start_command`: command that starts the gateway.
+- `ready_addr`: host:port readiness target.
+- `env_passthrough`: environment names or values required by the gateway.
+
+`fixture_registration` describes how a future slice registers the
+runner-managed MCP upstream:
+
+- `method`: registration mechanism name.
+- `register_command` and `deregister_command`: lifecycle commands.
+- `config_template_path`: configuration template used by a file-based method.
+- `api_endpoint`: endpoint used by an API-based method.
+
+PR1 records these fields but does not execute gateway lifecycle or registration
+commands. Start the generic target gateway externally and point `client` at
+its Streamable HTTP endpoint.
+
+`client.endpoint` is the absolute HTTP(S) MCP endpoint and `client.headers`
+are literal HTTP headers sent with every MCP request.
+
+`deny_signals` normalizes a gateway's documented deny behavior:
+
+- `jsonrpc_error_code_range`: inclusive `[minimum, maximum]` JSON-RPC deny
+  range; `[0, 0]` disables this signal.
+- `http_status_codes`: HTTP statuses that mean deny.
+- `custom_body_markers`: literal response-body strings that mean deny.
+- `tool_filtered_from_list`, `connection_closed_no_output`, and
+  `non_zero_exit`: declared signals reserved for the relevant follow-on paths;
+  PR1 applies `connection_closed_no_output` when an MCP request fails before a
+  response is received.
+
+## Managed variables and interpolation
+
+`LoadGatewayPlugin` replaces only variables whose names start with `$AEB_`.
+It leaves `$HOME`, `${HOME}`, command substitutions, and all other shell-like
+text untouched. Values are plain string data: interpolation neither invokes a
+shell nor parses a substituted semicolon, quote, or command substitution.
+An unset `$AEB_*` variable is an error.
+
+The runner's fixture environment names are:
+
+- `AEB_HTTP_FIXTURE_ADDR`
+- `AEB_TLS_FIXTURE_ADDR`, `AEB_TLS_CA_FILE`, `AEB_TLS_CA_KEY_FILE`
+- `AEB_WS_FIXTURE_ADDR`
+- `AEB_DNS_FIXTURE_ADDR`
+- `AEB_MCP_HTTP_FIXTURE_ADDR`, `AEB_MCP_HTTP_FIXTURE_URL`
+
+These values are available to runner-managed process commands today. PR1's
+plugin lifecycle commands are deliberately declarative, so supply any values
+needed during plugin loading in the runner process environment.
+
+Start from [gateway-plugin-template.json](../examples/gateway-plugin-template.json).

--- a/examples/gateway-plugin-template.json
+++ b/examples/gateway-plugin-template.json
@@ -1,0 +1,33 @@
+{
+  "_comment": "Generic MCP gateway plugin. _comment keys are ignored by the JSON loader and keep this template valid JSON.",
+  "name": "replace-with-gateway-integration-name",
+  "transport": "streamable_http",
+  "gateway": {
+    "_comment": "Lifecycle metadata; PR1 records it but does not execute these commands.",
+    "start_command": "",
+    "ready_addr": "",
+    "env_passthrough": []
+  },
+  "fixture_registration": {
+    "_comment": "How a later adapter slice will register the runner's MCP fixture.",
+    "method": "",
+    "register_command": "",
+    "deregister_command": "",
+    "config_template_path": "",
+    "api_endpoint": ""
+  },
+  "client": {
+    "_comment": "The externally started generic gateway's Streamable HTTP MCP endpoint and literal request headers.",
+    "endpoint": "http://127.0.0.1:3000/mcp",
+    "headers": {}
+  },
+  "deny_signals": {
+    "_comment": "Set only documented deny signals for this integration; [0, 0] disables JSON-RPC code matching.",
+    "jsonrpc_error_code_range": [0, 0],
+    "http_status_codes": [],
+    "tool_filtered_from_list": false,
+    "connection_closed_no_output": false,
+    "non_zero_exit": false,
+    "custom_body_markers": []
+  }
+}

--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -156,7 +156,7 @@ func (a *MCPGatewayAdapter) send(ctx context.Context, client *http.Client, caseI
 		return &Result{Err: fmt.Errorf("case %s: MCP gateway request: %w", caseID, err)}
 	}
 	defer resp.Body.Close()
-	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return &Result{Err: fmt.Errorf("case %s: read MCP gateway response: %w", caseID, err)}
 	}

--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -1,0 +1,209 @@
+package adapter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/luckyPipewrench/agent-egress-bench/runner/fixture"
+)
+
+// MCPGatewayAdapter drives a plugin-configured MCP gateway. PR1 deliberately
+// supports one Streamable HTTP tools/call path only; lifecycle and fixture
+// registration commands remain plugin contract fields for later slices.
+type MCPGatewayAdapter struct {
+	plugin   GatewayPlugin
+	fixtures *fixture.Manager
+}
+
+// NewMCPGatewayAdapter creates an adapter for a loaded gateway plugin.
+func NewMCPGatewayAdapter(plugin GatewayPlugin, fixtures *fixture.Manager) (*MCPGatewayAdapter, error) {
+	if plugin.Name == "" {
+		return nil, fmt.Errorf("gateway plugin name is required")
+	}
+	if plugin.Transport != "streamable_http" {
+		return nil, fmt.Errorf("gateway plugin transport %q is unsupported; PR1 supports streamable_http", plugin.Transport)
+	}
+	endpoint, err := url.Parse(plugin.Client.Endpoint)
+	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
+		return nil, fmt.Errorf("gateway plugin client.endpoint must be an absolute URL: %q", plugin.Client.Endpoint)
+	}
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return nil, fmt.Errorf("gateway plugin client.endpoint has unsupported scheme %q", endpoint.Scheme)
+	}
+	codeRange := plugin.DenySignals.JSONRPCErrorCodeRange
+	if codeRange != [2]int{} && codeRange[0] > codeRange[1] {
+		return nil, fmt.Errorf("gateway plugin JSON-RPC deny range start exceeds end")
+	}
+	return &MCPGatewayAdapter{plugin: plugin, fixtures: fixtures}, nil
+}
+
+// Run performs initialize, initialized, and exactly one corpus tools/call.
+func (a *MCPGatewayAdapter) Run(c Case, timeout time.Duration) Result {
+	if c.Transport != "mcp_http" {
+		return gatewaySkip(c, "PR1 supports corpus transport mcp_http only")
+	}
+	if c.InputType != "mcp_tool_call" {
+		return gatewaySkip(c, "PR1 supports mcp_tool_call input only")
+	}
+	toolsCall, err := oneToolsCall(c)
+	if err != nil {
+		return Result{Err: err}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	client := &http.Client{}
+	initialize := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "aeb-initialize",
+		"method":  "initialize",
+		"params": map[string]interface{}{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]interface{}{},
+			"clientInfo":      map[string]string{"name": "agent-egress-bench", "version": "1"},
+		},
+	}
+	if result := a.send(ctx, client, c.ID, initialize, false); result != nil {
+		return *result
+	}
+	initialized := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+		"params":  map[string]interface{}{},
+	}
+	if result := a.send(ctx, client, c.ID, initialized, false); result != nil {
+		return *result
+	}
+
+	upstreamBefore, proofAvailable := a.upstreamCalls()
+	result := a.send(ctx, client, c.ID, toolsCall, true)
+	if result != nil {
+		return *result
+	}
+	upstreamAfter, proofAvailableAfter := a.upstreamCalls()
+	evidence := map[string]interface{}{
+		"product_surface": "mcp_gateway_streamable_http",
+	}
+	if proofAvailable && proofAvailableAfter {
+		evidence["upstream_calls_before"] = upstreamBefore
+		evidence["upstream_calls_after"] = upstreamAfter
+	}
+	if !proofAvailable || !proofAvailableAfter || upstreamAfter <= upstreamBefore {
+		evidence["upstream_reached"] = false
+		if !proofAvailable || !proofAvailableAfter {
+			evidence["upstream_proof"] = "unavailable"
+		}
+		return Result{Verdict: "skip", Evidence: evidence}
+	}
+	evidence["upstream_reached"] = true
+	return Result{Verdict: "allow", Evidence: evidence}
+}
+
+func gatewaySkip(c Case, reason string) Result {
+	return Result{Verdict: "skip", Evidence: map[string]interface{}{
+		"reason":              reason,
+		"requested_transport": c.Transport,
+		"upstream_reached":    false,
+	}}
+}
+
+func oneToolsCall(c Case) (map[string]interface{}, error) {
+	rawMessages, ok := c.Payload["jsonrpc_messages"].([]interface{})
+	if !ok || len(rawMessages) != 1 {
+		return nil, fmt.Errorf("case %s: PR1 requires exactly one jsonrpc_messages tools/call", c.ID)
+	}
+	message, ok := rawMessages[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("case %s: tools/call message must be an object", c.ID)
+	}
+	if method, _ := message["method"].(string); method != "tools/call" {
+		return nil, fmt.Errorf("case %s: PR1 requires tools/call, got %q", c.ID, method)
+	}
+	return message, nil
+}
+
+func (a *MCPGatewayAdapter) send(ctx context.Context, client *http.Client, caseID string, message map[string]interface{}, requireResponse bool) *Result {
+	body, err := json.Marshal(message)
+	if err != nil {
+		return &Result{Err: fmt.Errorf("case %s: marshal MCP message: %w", caseID, err)}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.plugin.Client.Endpoint, bytes.NewReader(body))
+	if err != nil {
+		return &Result{Err: fmt.Errorf("case %s: build MCP gateway request: %w", caseID, err)}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	for key, value := range a.plugin.Client.Headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		if a.plugin.DenySignals.ConnectionClosedNoOut {
+			return &Result{Verdict: "block", Evidence: map[string]interface{}{
+				"product_surface": "mcp_gateway_streamable_http",
+				"reason":          "connection_closed_without_output",
+			}}
+		}
+		return &Result{Err: fmt.Errorf("case %s: MCP gateway request: %w", caseID, err)}
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return &Result{Err: fmt.Errorf("case %s: read MCP gateway response: %w", caseID, err)}
+	}
+	if slices.Contains(a.plugin.DenySignals.HTTPStatusCodes, resp.StatusCode) {
+		return &Result{Verdict: "block", Evidence: map[string]interface{}{
+			"product_surface": "mcp_gateway_streamable_http",
+			"http_status":     resp.StatusCode,
+		}}
+	}
+	if marker := matchingBodyMarker(string(responseBody), a.plugin.DenySignals.CustomBodyMarkers); marker != "" {
+		return &Result{Verdict: "block", Evidence: map[string]interface{}{
+			"product_surface": "mcp_gateway_streamable_http",
+			"body_marker":     marker,
+		}}
+	}
+	if result := classifyMCPHTTPBlockForRange(responseBody, a.plugin.DenySignals.JSONRPCErrorCodeRange, "mcp_gateway_streamable_http"); result != nil {
+		return result
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return &Result{Verdict: "skip", Evidence: map[string]interface{}{
+			"product_surface": "mcp_gateway_streamable_http",
+			"reason":          "unclassified_http_status",
+			"http_status":     resp.StatusCode,
+		}}
+	}
+	if requireResponse && len(bytes.TrimSpace(responseBody)) == 0 {
+		return &Result{Verdict: "skip", Evidence: map[string]interface{}{
+			"product_surface":  "mcp_gateway_streamable_http",
+			"reason":           "empty_tools_call_response",
+			"upstream_reached": false,
+		}}
+	}
+	return nil
+}
+
+func matchingBodyMarker(body string, markers []string) string {
+	for _, marker := range markers {
+		if marker != "" && strings.Contains(body, marker) {
+			return marker
+		}
+	}
+	return ""
+}
+
+func (a *MCPGatewayAdapter) upstreamCalls() (int64, bool) {
+	if a.fixtures == nil || a.fixtures.MCPHTTP() == nil {
+		return 0, false
+	}
+	return a.fixtures.MCPHTTP().Calls(), true
+}

--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -205,5 +205,5 @@ func (a *MCPGatewayAdapter) upstreamCalls() (int64, bool) {
 	if a.fixtures == nil || a.fixtures.MCPHTTP() == nil {
 		return 0, false
 	}
-	return a.fixtures.MCPHTTP().Calls(), true
+	return a.fixtures.MCPHTTP().ToolCalls(), true
 }

--- a/runner/adapter/gateway_plugin.go
+++ b/runner/adapter/gateway_plugin.go
@@ -88,19 +88,20 @@ func (p *GatewayPlugin) interpolateAEBEnvironment() error {
 	interpolate(&p.FixtureRegistration.ConfigTemplatePath)
 	interpolate(&p.FixtureRegistration.APIEndpoint)
 	interpolate(&p.Client.Endpoint)
-	for key, value := range p.Client.Headers {
-		interpolatedKey, keyErr := interpolateAEBString(key)
-		if keyErr != nil {
-			return keyErr
+	if len(p.Client.Headers) > 0 {
+		rebuilt := make(map[string]string, len(p.Client.Headers))
+		for key, value := range p.Client.Headers {
+			interpolatedKey, keyErr := interpolateAEBString(key)
+			if keyErr != nil {
+				return keyErr
+			}
+			interpolatedValue, valueErr := interpolateAEBString(value)
+			if valueErr != nil {
+				return valueErr
+			}
+			rebuilt[interpolatedKey] = interpolatedValue
 		}
-		interpolatedValue, valueErr := interpolateAEBString(value)
-		if valueErr != nil {
-			return valueErr
-		}
-		if interpolatedKey != key {
-			delete(p.Client.Headers, key)
-		}
-		p.Client.Headers[interpolatedKey] = interpolatedValue
+		p.Client.Headers = rebuilt
 	}
 	for i := range p.DenySignals.CustomBodyMarkers {
 		interpolate(&p.DenySignals.CustomBodyMarkers[i])

--- a/runner/adapter/gateway_plugin.go
+++ b/runner/adapter/gateway_plugin.go
@@ -1,0 +1,125 @@
+package adapter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+// GatewayPlugin describes how a vendor-neutral MCP gateway can be exercised.
+// Commands and registration fields are declarative in PR1; the adapter uses
+// the client endpoint and deny signals to execute one Streamable HTTP call.
+type GatewayPlugin struct {
+	Name                string              `json:"name"`
+	Transport           string              `json:"transport"`
+	Gateway             GatewayRuntime      `json:"gateway"`
+	FixtureRegistration FixtureRegistration `json:"fixture_registration"`
+	Client              GatewayClient       `json:"client"`
+	DenySignals         DenySignals         `json:"deny_signals"`
+}
+
+type GatewayRuntime struct {
+	StartCommand   string   `json:"start_command"`
+	ReadyAddr      string   `json:"ready_addr"`
+	EnvPassthrough []string `json:"env_passthrough"`
+}
+
+type FixtureRegistration struct {
+	Method             string `json:"method"`
+	RegisterCommand    string `json:"register_command"`
+	DeregisterCommand  string `json:"deregister_command"`
+	ConfigTemplatePath string `json:"config_template_path"`
+	APIEndpoint        string `json:"api_endpoint"`
+}
+
+type GatewayClient struct {
+	Endpoint string            `json:"endpoint"`
+	Headers  map[string]string `json:"headers"`
+}
+
+type DenySignals struct {
+	JSONRPCErrorCodeRange [2]int   `json:"jsonrpc_error_code_range"`
+	HTTPStatusCodes       []int    `json:"http_status_codes"`
+	ToolFilteredFromList  bool     `json:"tool_filtered_from_list"`
+	ConnectionClosedNoOut bool     `json:"connection_closed_no_output"`
+	NonZeroExit           bool     `json:"non_zero_exit"`
+	CustomBodyMarkers     []string `json:"custom_body_markers"`
+}
+
+var aebVariable = regexp.MustCompile(`\$AEB_[A-Za-z0-9_]+`)
+
+// LoadGatewayPlugin loads a gateway plugin and substitutes only $AEB_* values.
+// Substituted text is returned as ordinary string data; it is never evaluated
+// as a shell expression by this loader.
+func LoadGatewayPlugin(path string) (GatewayPlugin, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return GatewayPlugin{}, fmt.Errorf("read gateway plugin %q: %w", path, err)
+	}
+	var plugin GatewayPlugin
+	if err := json.Unmarshal(data, &plugin); err != nil {
+		return GatewayPlugin{}, fmt.Errorf("parse gateway plugin %q: %w", path, err)
+	}
+	if err := plugin.interpolateAEBEnvironment(); err != nil {
+		return GatewayPlugin{}, fmt.Errorf("interpolate gateway plugin %q: %w", path, err)
+	}
+	return plugin, nil
+}
+
+func (p *GatewayPlugin) interpolateAEBEnvironment() error {
+	var err error
+	interpolate := func(value *string) {
+		if err != nil {
+			return
+		}
+		*value, err = interpolateAEBString(*value)
+	}
+	interpolate(&p.Name)
+	interpolate(&p.Transport)
+	interpolate(&p.Gateway.StartCommand)
+	interpolate(&p.Gateway.ReadyAddr)
+	for i := range p.Gateway.EnvPassthrough {
+		interpolate(&p.Gateway.EnvPassthrough[i])
+	}
+	interpolate(&p.FixtureRegistration.Method)
+	interpolate(&p.FixtureRegistration.RegisterCommand)
+	interpolate(&p.FixtureRegistration.DeregisterCommand)
+	interpolate(&p.FixtureRegistration.ConfigTemplatePath)
+	interpolate(&p.FixtureRegistration.APIEndpoint)
+	interpolate(&p.Client.Endpoint)
+	for key, value := range p.Client.Headers {
+		interpolatedKey, keyErr := interpolateAEBString(key)
+		if keyErr != nil {
+			return keyErr
+		}
+		interpolatedValue, valueErr := interpolateAEBString(value)
+		if valueErr != nil {
+			return valueErr
+		}
+		if interpolatedKey != key {
+			delete(p.Client.Headers, key)
+		}
+		p.Client.Headers[interpolatedKey] = interpolatedValue
+	}
+	for i := range p.DenySignals.CustomBodyMarkers {
+		interpolate(&p.DenySignals.CustomBodyMarkers[i])
+	}
+	return err
+}
+
+func interpolateAEBString(value string) (string, error) {
+	var missing string
+	interpolated := aebVariable.ReplaceAllStringFunc(value, func(variable string) string {
+		name := variable[1:]
+		if replacement, ok := os.LookupEnv(name); ok {
+			return replacement
+		}
+		missing = name
+		return variable
+	})
+	if missing != "" {
+		return "", fmt.Errorf("required environment variable %s is not set", missing)
+	}
+	return interpolated, nil
+}

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -1,0 +1,252 @@
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luckyPipewrench/agent-egress-bench/runner/fixture"
+)
+
+func TestLoadGatewayPluginInterpolatesOnlyAEBVariablesLiterally(t *testing.T) {
+	t.Setenv("AEB_GATEWAY_ADDR", "127.0.0.1:8123; touch should-not-run")
+	t.Setenv("HOME", "must-not-expand")
+
+	path := writeGatewayPlugin(t, map[string]interface{}{
+		"name":      "test gateway",
+		"transport": "streamable_http",
+		"gateway": map[string]interface{}{
+			"start_command":   "gateway --listen=$AEB_GATEWAY_ADDR",
+			"ready_addr":      "$AEB_GATEWAY_ADDR",
+			"env_passthrough": []string{"$AEB_GATEWAY_ADDR", "$HOME"},
+		},
+		"client": map[string]interface{}{
+			"endpoint": "http://$AEB_GATEWAY_ADDR/mcp",
+			"headers":  map[string]string{"X-Test": "$AEB_GATEWAY_ADDR", "X-Home": "$HOME"},
+		},
+	})
+
+	plugin, err := LoadGatewayPlugin(path)
+	if err != nil {
+		t.Fatalf("LoadGatewayPlugin: %v", err)
+	}
+	want := "127.0.0.1:8123; touch should-not-run"
+	if got := plugin.Gateway.StartCommand; got != "gateway --listen="+want {
+		t.Fatalf("start command = %q, want literal substituted semicolon value", got)
+	}
+	if got := plugin.Client.Headers["X-Test"]; got != want {
+		t.Fatalf("header = %q, want literal substituted value %q", got, want)
+	}
+	if got := plugin.Client.Headers["X-Home"]; got != "$HOME" {
+		t.Fatalf("non-AEB variable expanded to %q, want $HOME unchanged", got)
+	}
+	if got := plugin.Gateway.EnvPassthrough[1]; got != "$HOME" {
+		t.Fatalf("non-AEB env passthrough expanded to %q, want $HOME unchanged", got)
+	}
+}
+
+func TestMCPGatewayAdapterBlocksConfiguredJSONRPCDeny(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if method := requestMethod(t, r); method == "tools/call" {
+			writeJSONRPC(t, w, json.RawMessage(`1`), map[string]interface{}{"code": -32042, "message": "policy denied"})
+			return
+		}
+		writeJSONRPC(t, w, json.RawMessage(`1`), nil)
+	}))
+	defer server.Close()
+
+	a, err := NewMCPGatewayAdapter(GatewayPlugin{
+		Name:        "test gateway",
+		Transport:   "streamable_http",
+		Client:      GatewayClient{Endpoint: server.URL},
+		DenySignals: DenySignals{JSONRPCErrorCodeRange: [2]int{-32099, -32000}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewMCPGatewayAdapter: %v", err)
+	}
+
+	result := a.Run(gatewayToolsCallCase("gateway-block"), time.Second)
+	if result.Err != nil || result.Verdict != "block" {
+		t.Fatalf("result = %+v, want configured JSON-RPC deny block", result)
+	}
+}
+
+func TestMCPGatewayAdapterAllowsOnlyWhenFixtureReceivedToolsCall(t *testing.T) {
+	fm, err := fixture.StartAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fm.Close()
+
+	server := forwardingGateway(t, fm.MCPHTTP().URL())
+	defer server.Close()
+	a, err := NewMCPGatewayAdapter(GatewayPlugin{
+		Name: "forwarder", Transport: "streamable_http", Client: GatewayClient{Endpoint: server.URL},
+	}, fm)
+	if err != nil {
+		t.Fatalf("NewMCPGatewayAdapter: %v", err)
+	}
+
+	result := a.Run(gatewayToolsCallCase("gateway-allow"), time.Second)
+	if result.Err != nil || result.Verdict != "allow" {
+		t.Fatalf("result = %+v, want proven allow", result)
+	}
+	if got, _ := result.Evidence["upstream_reached"].(bool); !got {
+		t.Fatalf("upstream_reached = %v, want true; evidence=%+v", result.Evidence["upstream_reached"], result.Evidence)
+	}
+}
+
+func TestMCPGatewayAdapterSkipsUnprovenLocalSuccess(t *testing.T) {
+	fm, err := fixture.StartAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fm.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSONRPC(t, w, requestID(t, r), nil)
+	}))
+	defer server.Close()
+	a, err := NewMCPGatewayAdapter(GatewayPlugin{
+		Name: "local responder", Transport: "streamable_http", Client: GatewayClient{Endpoint: server.URL},
+	}, fm)
+	if err != nil {
+		t.Fatalf("NewMCPGatewayAdapter: %v", err)
+	}
+
+	result := a.Run(gatewayToolsCallCase("gateway-unproven"), time.Second)
+	if result.Err != nil || result.Verdict != "skip" {
+		t.Fatalf("result = %+v, want skip for unproven local success", result)
+	}
+	if got, _ := result.Evidence["upstream_reached"].(bool); got {
+		t.Fatalf("upstream_reached = %v, want false; evidence=%+v", result.Evidence["upstream_reached"], result.Evidence)
+	}
+}
+
+func TestMCPGatewayAdapterSkipsUnsupportedCorpusPath(t *testing.T) {
+	a, err := NewMCPGatewayAdapter(GatewayPlugin{
+		Name: "test gateway", Transport: "streamable_http", Client: GatewayClient{Endpoint: "http://127.0.0.1:1/mcp"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewMCPGatewayAdapter: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*Case)
+	}{
+		{"transport", func(c *Case) { c.Transport = "mcp_stdio" }},
+		{"input type", func(c *Case) { c.InputType = "mcp_tool_result" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := gatewayToolsCallCase("unsupported-" + tc.name)
+			tc.mutate(&c)
+			result := a.Run(c, time.Second)
+			if result.Err != nil || result.Verdict != "skip" {
+				t.Fatalf("result = %+v, want skip for unsupported corpus path", result)
+			}
+			if result.Evidence["upstream_reached"] != false {
+				t.Fatalf("upstream_reached = %v, want false", result.Evidence["upstream_reached"])
+			}
+		})
+	}
+}
+
+func gatewayToolsCallCase(id string) Case {
+	return Case{
+		ID: id, Transport: "mcp_http", InputType: "mcp_tool_call",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{
+			map[string]interface{}{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": map[string]interface{}{"name": "example", "arguments": map[string]interface{}{}}},
+		}},
+	}
+}
+
+func writeGatewayPlugin(t *testing.T, plugin map[string]interface{}) string {
+	t.Helper()
+	data, err := json.Marshal(plugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "plugin.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func requestMethod(t *testing.T, r *http.Request) string {
+	t.Helper()
+	var request struct {
+		Method string `json:"method"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		t.Fatal(err)
+	}
+	return request.Method
+}
+
+func requestID(t *testing.T, r *http.Request) json.RawMessage {
+	t.Helper()
+	var request struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		t.Fatal(err)
+	}
+	return request.ID
+}
+
+func writeJSONRPC(t *testing.T, w http.ResponseWriter, id json.RawMessage, rpcError map[string]interface{}) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if len(id) == 0 {
+		id = json.RawMessage("null")
+	}
+	if rpcError != nil {
+		_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"error":%s}`, id, marshalForGatewayTest(t, rpcError))
+		return
+	}
+	_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}`, id)
+}
+
+func marshalForGatewayTest(t *testing.T, value interface{}) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func forwardingGateway(t *testing.T, upstreamURL string) *httptest.Server {
+	t.Helper()
+	client := &http.Client{Timeout: time.Second}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		upstream, err := http.NewRequestWithContext(r.Context(), http.MethodPost, upstreamURL, bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		upstream.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(upstream)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+		w.WriteHeader(resp.StatusCode)
+		if _, err := io.Copy(w, resp.Body); err != nil {
+			t.Fatal(err)
+		}
+	}))
+}

--- a/runner/adapter/mcp_classify.go
+++ b/runner/adapter/mcp_classify.go
@@ -1,0 +1,139 @@
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func classifyMCPErrorLine(respLine, caseID string) (Result, bool, string) {
+	var rpcResp struct {
+		ID    interface{} `json:"id"`
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if jsonErr := json.Unmarshal([]byte(respLine), &rpcResp); jsonErr != nil || rpcResp.Error == nil {
+		return Result{}, false, ""
+	}
+	code := rpcResp.Error.Code
+	responseID := jsonRPCIDString(rpcResp.ID)
+	if code >= -32099 && code <= -32000 {
+		return Result{
+			Verdict: "block",
+			Evidence: map[string]interface{}{
+				"error_code":    code,
+				"error_message": rpcResp.Error.Message,
+			},
+		}, true, responseID
+	}
+	if code <= -32600 {
+		return Result{Err: fmt.Errorf("case %s: JSON-RPC protocol error %d: %s", caseID, code, rpcResp.Error.Message)}, true, responseID
+	}
+	return Result{}, false, responseID
+}
+
+func classifyMCPBudgetErrorLine(respLine, caseID string) (Result, bool, string) {
+	result, handled, responseID := classifyMCPErrorLine(respLine, caseID)
+	if !handled || result.Err == nil {
+		return result, handled, responseID
+	}
+
+	var rpcResp struct {
+		ID    interface{} `json:"id"`
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if jsonErr := json.Unmarshal([]byte(respLine), &rpcResp); jsonErr != nil || rpcResp.Error == nil {
+		return result, handled, responseID
+	}
+	if !isBudgetLimitProtocolError(rpcResp.Error.Code, rpcResp.Error.Message) {
+		return result, handled, responseID
+	}
+	return Result{
+		Verdict: "block",
+		Evidence: map[string]interface{}{
+			"error_code":    rpcResp.Error.Code,
+			"error_message": rpcResp.Error.Message,
+		},
+	}, true, jsonRPCIDString(rpcResp.ID)
+}
+
+func isBudgetLimitProtocolError(code int, message string) bool {
+	if code > -32600 {
+		return false
+	}
+	msg := normalizeBudgetErrorMessage(message)
+	hasBudgetPhrase := strings.Contains(msg, "budget") || strings.Contains(msg, "quota")
+	hasCallLimitPhrase := strings.Contains(msg, "call limit") ||
+		strings.Contains(msg, "call limits") ||
+		strings.Contains(msg, "too many tool calls") ||
+		strings.Contains(msg, "too many calls")
+	hasExceeded := strings.Contains(msg, "exceed") ||
+		strings.Contains(msg, "over") ||
+		strings.Contains(msg, "too many") ||
+		strings.Contains(msg, "maximum") ||
+		strings.Contains(msg, "max ") ||
+		strings.Contains(msg, "reached")
+	return hasExceeded && (hasBudgetPhrase || hasCallLimitPhrase)
+}
+
+func normalizeBudgetErrorMessage(message string) string {
+	msg := strings.ToLower(message)
+	replacer := strings.NewReplacer(
+		"-", " ",
+		"_", " ",
+		":", " ",
+		"/", " ",
+		"\t", " ",
+		"\n", " ",
+		"\r", " ",
+	)
+	return strings.Join(strings.Fields(replacer.Replace(msg)), " ")
+}
+
+// classifyMCPHTTPBlock preserves the proxy adapter's legacy deny range.
+func classifyMCPHTTPBlock(body []byte) *Result {
+	return classifyMCPHTTPBlockForRange(body, [2]int{-32099, -32000}, "mcp_http_listener")
+}
+
+// classifyMCPHTTPBlockForRange normalizes JSON-RPC error responses from an MCP
+// Streamable HTTP endpoint. A zero range disables code-range deny matching.
+func classifyMCPHTTPBlockForRange(body []byte, denyRange [2]int, productSurface string) *Result {
+	lines := bytes.Split(bytes.TrimSpace(body), []byte("\n"))
+	for _, line := range lines {
+		line = bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if len(line) == 0 {
+			continue
+		}
+		var rpcResp struct {
+			Error *struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if jsonErr := json.Unmarshal(line, &rpcResp); jsonErr != nil || rpcResp.Error == nil {
+			continue
+		}
+		code := rpcResp.Error.Code
+		if denyRange != [2]int{} && code >= denyRange[0] && code <= denyRange[1] {
+			return &Result{
+				Verdict: "block",
+				Evidence: map[string]interface{}{
+					"product_surface": productSurface,
+					"error_code":      code,
+					"error_message":   rpcResp.Error.Message,
+				},
+			}
+		}
+		if code <= -32600 {
+			return &Result{Err: fmt.Errorf("JSON-RPC protocol error %d: %s", code, rpcResp.Error.Message)}
+		}
+		return &Result{Err: fmt.Errorf("JSON-RPC error %d: %s", code, rpcResp.Error.Message)}
+	}
+	return nil
+}

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -1798,95 +1798,6 @@ func jsonRPCIDString(id interface{}) string {
 	}
 }
 
-func classifyMCPErrorLine(respLine, caseID string) (Result, bool, string) {
-	var rpcResp struct {
-		ID    interface{} `json:"id"`
-		Error *struct {
-			Code    int    `json:"code"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
-	if jsonErr := json.Unmarshal([]byte(respLine), &rpcResp); jsonErr != nil || rpcResp.Error == nil {
-		return Result{}, false, ""
-	}
-	code := rpcResp.Error.Code
-	responseID := jsonRPCIDString(rpcResp.ID)
-	if code >= -32099 && code <= -32000 {
-		return Result{
-			Verdict: "block",
-			Evidence: map[string]interface{}{
-				"error_code":    code,
-				"error_message": rpcResp.Error.Message,
-			},
-		}, true, responseID
-	}
-	if code <= -32600 {
-		return Result{Err: fmt.Errorf("case %s: JSON-RPC protocol error %d: %s", caseID, code, rpcResp.Error.Message)}, true, responseID
-	}
-	return Result{}, false, responseID
-}
-
-func classifyMCPBudgetErrorLine(respLine, caseID string) (Result, bool, string) {
-	result, handled, responseID := classifyMCPErrorLine(respLine, caseID)
-	if !handled || result.Err == nil {
-		return result, handled, responseID
-	}
-
-	var rpcResp struct {
-		ID    interface{} `json:"id"`
-		Error *struct {
-			Code    int    `json:"code"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
-	if jsonErr := json.Unmarshal([]byte(respLine), &rpcResp); jsonErr != nil || rpcResp.Error == nil {
-		return result, handled, responseID
-	}
-	if !isBudgetLimitProtocolError(rpcResp.Error.Code, rpcResp.Error.Message) {
-		return result, handled, responseID
-	}
-	return Result{
-		Verdict: "block",
-		Evidence: map[string]interface{}{
-			"error_code":    rpcResp.Error.Code,
-			"error_message": rpcResp.Error.Message,
-		},
-	}, true, jsonRPCIDString(rpcResp.ID)
-}
-
-func isBudgetLimitProtocolError(code int, message string) bool {
-	if code > -32600 {
-		return false
-	}
-	msg := normalizeBudgetErrorMessage(message)
-	hasBudgetPhrase := strings.Contains(msg, "budget") || strings.Contains(msg, "quota")
-	hasCallLimitPhrase := strings.Contains(msg, "call limit") ||
-		strings.Contains(msg, "call limits") ||
-		strings.Contains(msg, "too many tool calls") ||
-		strings.Contains(msg, "too many calls")
-	hasExceeded := strings.Contains(msg, "exceed") ||
-		strings.Contains(msg, "over") ||
-		strings.Contains(msg, "too many") ||
-		strings.Contains(msg, "maximum") ||
-		strings.Contains(msg, "max ") ||
-		strings.Contains(msg, "reached")
-	return hasExceeded && (hasBudgetPhrase || hasCallLimitPhrase)
-}
-
-func normalizeBudgetErrorMessage(message string) string {
-	msg := strings.ToLower(message)
-	replacer := strings.NewReplacer(
-		"-", " ",
-		"_", " ",
-		":", " ",
-		"/", " ",
-		"\t", " ",
-		"\n", " ",
-		"\r", " ",
-	)
-	return strings.Join(strings.Fields(replacer.Replace(msg)), " ")
-}
-
 func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 	if p.mcpHTTPURL == "" {
 		return Result{
@@ -1960,40 +1871,6 @@ func (p *ProxyAdapter) mcpHTTPUpstreamCallCount() (int64, bool) {
 		return 0, false
 	}
 	return p.mcpHTTPUpstreamCalls(), true
-}
-
-func classifyMCPHTTPBlock(body []byte) *Result {
-	lines := bytes.Split(bytes.TrimSpace(body), []byte("\n"))
-	for _, line := range lines {
-		line = bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
-		if len(line) == 0 {
-			continue
-		}
-		var rpcResp struct {
-			Error *struct {
-				Code    int    `json:"code"`
-				Message string `json:"message"`
-			} `json:"error"`
-		}
-		if jsonErr := json.Unmarshal(line, &rpcResp); jsonErr == nil && rpcResp.Error != nil {
-			code := rpcResp.Error.Code
-			if code >= -32099 && code <= -32000 {
-				return &Result{
-					Verdict: "block",
-					Evidence: map[string]interface{}{
-						"product_surface": "mcp_http_listener",
-						"error_code":      code,
-						"error_message":   rpcResp.Error.Message,
-					},
-				}
-			}
-			if code <= -32600 {
-				return &Result{Err: fmt.Errorf("JSON-RPC protocol error %d: %s", code, rpcResp.Error.Message)}
-			}
-			return &Result{Err: fmt.Errorf("JSON-RPC error %d: %s", code, rpcResp.Error.Message)}
-		}
-	}
-	return nil
 }
 
 // scanAPIRequest is the JSON body for POST /api/v1/scan.

--- a/runner/fixture/mcp_http.go
+++ b/runner/fixture/mcp_http.go
@@ -13,8 +13,8 @@ import (
 
 // MCPHTTPFixture runs a minimal Streamable HTTP MCP upstream.
 type MCPHTTPFixture struct {
-	listener net.Listener
-	server   *http.Server
+	listener  net.Listener
+	server    *http.Server
 	calls     atomic.Int64
 	toolCalls atomic.Int64
 	toolsMu   sync.RWMutex
@@ -77,7 +77,11 @@ func StartMCPHTTP() (*MCPHTTPFixture, error) {
 			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"aeb-mcp-fixture","version":"1"}}}`, id)
 		case "tools/list":
 			f.toolsMu.RLock()
-			tools, err := json.Marshal(f.tools)
+			toolList := f.tools
+			if toolList == nil {
+				toolList = []json.RawMessage{}
+			}
+			tools, err := json.Marshal(toolList)
 			f.toolsMu.RUnlock()
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)

--- a/runner/fixture/mcp_http.go
+++ b/runner/fixture/mcp_http.go
@@ -15,9 +15,10 @@ import (
 type MCPHTTPFixture struct {
 	listener net.Listener
 	server   *http.Server
-	calls    atomic.Int64
-	toolsMu  sync.RWMutex
-	tools    []json.RawMessage
+	calls     atomic.Int64
+	toolCalls atomic.Int64
+	toolsMu   sync.RWMutex
+	tools     []json.RawMessage
 }
 
 // Addr returns the listener address (host:port).
@@ -26,8 +27,15 @@ func (f *MCPHTTPFixture) Addr() string { return f.listener.Addr().String() }
 // URL returns the upstream URL.
 func (f *MCPHTTPFixture) URL() string { return "http://" + f.Addr() + "/" }
 
-// Calls returns the number of tools/call requests that reached the upstream.
+// Calls returns the total number of POST requests that reached the upstream.
+// The proxy MCP HTTP proof relies on this total (one increment per sent
+// message), so it must count every request, not only tools/call.
 func (f *MCPHTTPFixture) Calls() int64 { return f.calls.Load() }
+
+// ToolCalls returns the number of tools/call requests that reached the
+// upstream. The gateway adapter proves an allow by this tool-call-specific
+// count so an initialize/tools-list POST cannot inflate the proof.
+func (f *MCPHTTPFixture) ToolCalls() int64 { return f.toolCalls.Load() }
 
 // SetTools configures the tools returned by a later tools/list request.
 func (f *MCPHTTPFixture) SetTools(tools []json.RawMessage) {
@@ -50,6 +58,7 @@ func StartMCPHTTP() (*MCPHTTPFixture, error) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
+		f.calls.Add(1)
 		body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		_ = r.Body.Close()
 		var req struct {
@@ -76,7 +85,7 @@ func StartMCPHTTP() (*MCPHTTPFixture, error) {
 			}
 			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"tools":%s}}`, id, tools)
 		case "tools/call":
-			f.calls.Add(1)
+			f.toolCalls.Add(1)
 			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}`, id)
 		default:
 			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}`, id)

--- a/runner/fixture/mcp_http.go
+++ b/runner/fixture/mcp_http.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -15,6 +16,8 @@ type MCPHTTPFixture struct {
 	listener net.Listener
 	server   *http.Server
 	calls    atomic.Int64
+	toolsMu  sync.RWMutex
+	tools    []json.RawMessage
 }
 
 // Addr returns the listener address (host:port).
@@ -23,8 +26,15 @@ func (f *MCPHTTPFixture) Addr() string { return f.listener.Addr().String() }
 // URL returns the upstream URL.
 func (f *MCPHTTPFixture) URL() string { return "http://" + f.Addr() + "/" }
 
-// Calls returns the number of POST requests that reached the upstream.
+// Calls returns the number of tools/call requests that reached the upstream.
 func (f *MCPHTTPFixture) Calls() int64 { return f.calls.Load() }
+
+// SetTools configures the tools returned by a later tools/list request.
+func (f *MCPHTTPFixture) SetTools(tools []json.RawMessage) {
+	f.toolsMu.Lock()
+	defer f.toolsMu.Unlock()
+	f.tools = append(f.tools[:0], tools...)
+}
 
 // StartMCPHTTP creates and starts a minimal MCP HTTP upstream on a random port.
 func StartMCPHTTP() (*MCPHTTPFixture, error) {
@@ -40,12 +50,12 @@ func StartMCPHTTP() (*MCPHTTPFixture, error) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		f.calls.Add(1)
 		body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		_ = r.Body.Close()
 		var req struct {
 			JSONRPC string          `json:"jsonrpc"`
 			ID      json.RawMessage `json:"id"`
+			Method  string          `json:"method"`
 		}
 		_ = json.Unmarshal(body, &req)
 		id := req.ID
@@ -53,7 +63,24 @@ func StartMCPHTTP() (*MCPHTTPFixture, error) {
 			id = json.RawMessage(`1`)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}`, id)
+		switch req.Method {
+		case "initialize":
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"aeb-mcp-fixture","version":"1"}}}`, id)
+		case "tools/list":
+			f.toolsMu.RLock()
+			tools, err := json.Marshal(f.tools)
+			f.toolsMu.RUnlock()
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"tools":%s}}`, id, tools)
+		case "tools/call":
+			f.calls.Add(1)
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}`, id)
+		default:
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}`, id)
+		}
 	})
 
 	f.server = &http.Server{

--- a/runner/fixture/mcp_http_test.go
+++ b/runner/fixture/mcp_http_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestMCPHTTPFixtureInitializesListsToolsAndCountsOnlyCalls(t *testing.T) {
+func TestMCPHTTPFixtureCountsTotalPostsAndToolCallsSeparately(t *testing.T) {
 	f, err := StartMCPHTTP()
 	if err != nil {
 		t.Fatal(err)
@@ -29,8 +29,15 @@ func TestMCPHTTPFixtureInitializesListsToolsAndCountsOnlyCalls(t *testing.T) {
 			t.Fatalf("tools/list response %s does not contain configured tool", response)
 		}
 	}
-	if got := f.Calls(); got != 1 {
-		t.Fatalf("Calls() = %d, want one tools/call request", got)
+	// Calls() is the total POST count the proxy MCP HTTP proof relies on
+	// (one per sent message); ToolCalls() is the tools/call-specific count
+	// the gateway adapter proves an allow by. initialize + tools/list +
+	// tools/call = 3 total POSTs, 1 of them a tools/call.
+	if got := f.Calls(); got != 3 {
+		t.Fatalf("Calls() = %d, want 3 total POSTs (initialize+tools/list+tools/call)", got)
+	}
+	if got := f.ToolCalls(); got != 1 {
+		t.Fatalf("ToolCalls() = %d, want 1 tools/call request", got)
 	}
 }
 

--- a/runner/fixture/mcp_http_test.go
+++ b/runner/fixture/mcp_http_test.go
@@ -1,0 +1,52 @@
+package fixture
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestMCPHTTPFixtureInitializesListsToolsAndCountsOnlyCalls(t *testing.T) {
+	f, err := StartMCPHTTP()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	f.SetTools([]json.RawMessage{json.RawMessage(`{"name":"fixture_tool"}`)})
+
+	for _, request := range []string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"fixture_tool"}}`,
+	} {
+		response := postMCPFixture(t, f.URL(), request)
+		if len(response) == 0 {
+			t.Fatal("fixture returned an empty MCP response")
+		}
+		if bytes.Contains([]byte(request), []byte(`"tools/list"`)) && !bytes.Contains(response, []byte(`"fixture_tool"`)) {
+			t.Fatalf("tools/list response %s does not contain configured tool", response)
+		}
+	}
+	if got := f.Calls(); got != 1 {
+		t.Fatalf("Calls() = %d, want one tools/call request", got)
+	}
+}
+
+func postMCPFixture(t *testing.T, endpoint, request string) []byte {
+	t.Helper()
+	resp, err := http.Post(endpoint, "application/json", bytes.NewBufferString(request))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("fixture status = %d, body = %s", resp.StatusCode, body)
+	}
+	return body
+}

--- a/runner/main.go
+++ b/runner/main.go
@@ -17,7 +17,8 @@ func main() {
 	casesDir := flag.String("cases", "", "directory of case JSON files (required)")
 	profilePath := flag.String("profile", "", "tool profile JSON file (required)")
 	outputPath := flag.String("output", "gauntlet-summary.json", "path for Gauntlet summary JSON")
-	adapterName := flag.String("adapter", "dryrun", "adapter name: dryrun, null, blockall, proxy")
+	adapterName := flag.String("adapter", "dryrun", "adapter name: dryrun, null, blockall, proxy, mcp-gateway")
+	gatewayPluginPath := flag.String("gateway-plugin", "", "path to a generic MCP gateway plugin JSON (required with --adapter mcp-gateway)")
 	proxyAddr := flag.String("proxy-addr", "", "proxy address for proxy adapter (e.g. 127.0.0.1:18899; avoid 8888, commonly an already-running proxy)")
 	scanAddr := flag.String("scan-addr", "", "scan API address for MCP/A2A cases (defaults to proxy-addr)")
 	scanToken := flag.String("scan-token", "", "bearer token for scan API authentication")
@@ -45,7 +46,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := runWithOptions(*casesDir, *profilePath, *outputPath, *timeout, *adapterName, *proxyAddr, *scanAddr, *scanToken, *mcpCmd, *mcpHTTPURL, *managedProxyCmd, *managedMCPHTTPCmd, *fixtures, *emitReceiptProfile, *receiptVerifierFile, *multiFileCases, debug, *toolVersion); err != nil {
+	if err := runWithGatewayPluginOptions(*casesDir, *profilePath, *outputPath, *timeout, *adapterName, *proxyAddr, *scanAddr, *scanToken, *mcpCmd, *mcpHTTPURL, *managedProxyCmd, *managedMCPHTTPCmd, *gatewayPluginPath, *fixtures, *emitReceiptProfile, *receiptVerifierFile, *multiFileCases, debug, *toolVersion); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -56,6 +57,10 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 }
 
 func runWithOptions(casesDir, profilePath, outputPath string, timeout time.Duration, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd, mcpHTTPURL, managedProxyCmd, managedMCPHTTPCmd string, useFixtures bool, emitReceiptProfile, receiptVerifierFile, multiFileCases string, debug bool, toolVersion string) error {
+	return runWithGatewayPluginOptions(casesDir, profilePath, outputPath, timeout, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd, mcpHTTPURL, managedProxyCmd, managedMCPHTTPCmd, "", useFixtures, emitReceiptProfile, receiptVerifierFile, multiFileCases, debug, toolVersion)
+}
+
+func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeout time.Duration, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd, mcpHTTPURL, managedProxyCmd, managedMCPHTTPCmd, gatewayPluginPath string, useFixtures bool, emitReceiptProfile, receiptVerifierFile, multiFileCases string, debug bool, toolVersion string) error {
 	profile, err := loadProfile(profilePath)
 	if err != nil {
 		return err
@@ -100,7 +105,7 @@ func runWithOptions(casesDir, profilePath, outputPath string, timeout time.Durat
 	// Select adapter based on flag.
 	var adapt adapter.Adapter
 	var fm *fixture.Manager
-	if useFixtures || managedProxyCmd != "" || managedMCPHTTPCmd != "" {
+	if useFixtures || managedProxyCmd != "" || managedMCPHTTPCmd != "" || adapterName == "mcp-gateway" {
 		var fErr error
 		fm, fErr = fixture.StartAll()
 		if fErr != nil {
@@ -164,8 +169,21 @@ func runWithOptions(casesDir, profilePath, outputPath string, timeout time.Durat
 			pa.SetMCPHTTPURL(mcpHTTPURL)
 		}
 		adapt = pa
+	case "mcp-gateway":
+		if gatewayPluginPath == "" {
+			return fmt.Errorf("--gateway-plugin is required when using the mcp-gateway adapter")
+		}
+		plugin, pluginErr := adapter.LoadGatewayPlugin(gatewayPluginPath)
+		if pluginErr != nil {
+			return pluginErr
+		}
+		gatewayAdapter, gatewayErr := adapter.NewMCPGatewayAdapter(plugin, fm)
+		if gatewayErr != nil {
+			return gatewayErr
+		}
+		adapt = gatewayAdapter
 	default:
-		return fmt.Errorf("unknown adapter: %q (available: dryrun, null, blockall, proxy)", adapterName)
+		return fmt.Errorf("unknown adapter: %q (available: dryrun, null, blockall, proxy, mcp-gateway)", adapterName)
 	}
 
 	var applicableResults []CaseResult


### PR DESCRIPTION
## What changed

Adds a generic `mcp-gateway` benchmark adapter that speaks the MCP protocol over Streamable HTTP to any target gateway, selected with `--adapter mcp-gateway --gateway-plugin <file>`. This is the first slice of the protocol-first adapter that lets the corpus grade any MCP-speaking gateway (Docker MCP Gateway, OpenEdison, ToolHive, Obot, IBM ContextForge, and others), not just Pipelock's own surfaces.

Neutrality is the design boundary: there is no target-specific code in the repo. Each target is described entirely by a plugin JSON (how to reach the gateway, how to register the fixture MCP server, and the deny-signal vocabulary). The repo ships only the generic adapter, the contract doc (`docs/GATEWAY-ADAPTER.md`), and a template (`examples/gateway-plugin-template.json`); a vendor or an outside lab writes their own plugin.

PR1 handles the smallest end-to-end path: `initialize`, then `initialized`, then exactly one corpus `tools/call`, normalizing heterogeneous deny signals (JSON-RPC error code range, HTTP status, custom body markers, connection-closed-without-output) to one verdict.

An allow verdict requires positive proof the `tools/call` actually reached the upstream fixture: a tool-call-specific counter must advance, otherwise the verdict is `skip` with `upstream_reached: false`. This keeps a gateway that answers without forwarding from earning a false allow.

It also extracts the shared MCP classify helpers out of `proxy.go` into `mcp_classify.go` (behavior-preserving) so both adapters reuse them, and extends the HTTP fixture to answer `initialize`, serve a configurable `tools/list`, and count calls.

## Counter fix (cross-consumer)

The fixture extension originally narrowed the shared `Calls()` counter to tools/call only, but the existing proxy MCP HTTP proof in `proxy.go` relies on that counter as a total-POST count (it checks the counter advanced once per sent message). Narrowing it would have made any real proxy MCP HTTP case whose message list includes a non-tools/call message under-count and falsely score `skip`. This PR keeps two counters: `Calls()` stays the total-POST count for the proxy proof, and a new `ToolCalls()` serves the gateway's tool-call-specific allow-proof.

## Follow-up slices

The tool-poisoning tools/list flow, multi-call sequences, and drift handling are scoped for later PRs; this PR is the single-tools/call streamable-HTTP path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `mcp-gateway` adapter for testing MCP tools over Streamable HTTP.
  - Gateway requests now support configurable headers, endpoints, environment variables, and denial signals.
  - Results distinguish allowed, blocked, skipped, and error outcomes based on upstream activity and response signals.

- **Documentation**
  - Added setup guidance covering gateway configuration, request flows, limitations, and verdict behavior.
  - Added a reusable gateway plugin configuration template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->