### PR TITLE
feat(gauntlet-site): fail-safe scope renderer + provenance validator (Phase 2, slice 1)

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -203,6 +203,7 @@ jobs:
           {
             echo "ARTIFACT_DIR=$artifact_dir"
             echo "SUMMARY_PATH=$summary_path"
+            echo "RESULTS_PATH=$jsonl_path"
             echo "COMMAND_PATH=$command_path"
             echo "STATS_PATH=$stats_path"
           } >> "$GITHUB_ENV"
@@ -213,6 +214,7 @@ jobs:
           set -euo pipefail
 
           python3 - <<'PY'
+          import hashlib
           import json
           import os
 
@@ -301,6 +303,59 @@ jobs:
           with open(os.environ["STATS_PATH"], encoding="utf-8") as fh:
               make_stats = fh.read()
 
+          manifest_path = "cases/MANIFEST.txt"
+          with open(manifest_path, "rb") as fh:
+              manifest = fh.read()
+          manifest_ids = {line.strip() for line in manifest.decode("utf-8").splitlines() if line.strip()}
+          if not manifest_ids:
+              raise SystemExit("refusing provenance artifact: cases/MANIFEST.txt has no logical case IDs")
+          manifest_sha256 = hashlib.sha256(manifest).hexdigest()
+          logical_case_count = len(manifest_ids)
+
+          results = []
+          with open(os.environ["RESULTS_PATH"], encoding="utf-8") as fh:
+              for line_number, line in enumerate(fh, 1):
+                  if not line.strip():
+                      continue
+                  try:
+                      results.append(json.loads(line))
+                  except json.JSONDecodeError as exc:
+                      raise SystemExit(f"invalid runner JSONL at line {line_number}: {exc}") from exc
+
+          def metric_counts(expected_verdict, actual_verdict):
+              denominator = sum(row.get("expected_verdict") == expected_verdict for row in results)
+              numerator = sum(
+                  row.get("expected_verdict") == expected_verdict and row.get("actual_verdict") == actual_verdict
+                  for row in results
+              )
+              return {"numerator": numerator, "denominator": denominator}
+
+          applicable_metrics = {
+              "containment": metric_counts("block", "block"),
+              "false_positive_rate": metric_counts("allow", "block"),
+          }
+          if summary["case_count"]["total"] != logical_case_count:
+              raise SystemExit(
+                  "runner summary total does not match the pinned manifest: "
+                  f"{summary['case_count']['total']} != {logical_case_count}"
+              )
+          if summary["case_count"]["applicable"] != len(results):
+              raise SystemExit(
+                  "runner summary applicable count does not match runner JSONL: "
+                  f"{summary['case_count']['applicable']} != {len(results)}"
+              )
+          for metric, counts in applicable_metrics.items():
+              expected_score = (
+                  counts["numerator"] / counts["denominator"]
+                  if counts["denominator"] else None
+              )
+              actual_score = summary["scores"]["applicable"].get(metric)
+              if actual_score != expected_score:
+                  raise SystemExit(
+                      f"runner summary scores.applicable.{metric} does not match runner JSONL: "
+                      f"{actual_score!r} != {expected_score!r}"
+                  )
+
           repo = os.environ["GITHUB_REPOSITORY"]
           run_id = os.environ["GITHUB_RUN_ID"]
           corpus_sha = os.environ["CORPUS_GIT_SHA"]
@@ -308,6 +363,7 @@ jobs:
 
           artifact = {
               "schema_version": 1,
+              "artifact_id": f"github-actions:{repo}:{run_id}",
               "generated_at": os.environ["GENERATED_AT"],
               "canonical_url": f"https://github.com/{repo}/actions/runs/{run_id}",
               "corpus_ref_kind": os.environ["CORPUS_REF_KIND"],
@@ -325,6 +381,8 @@ jobs:
               "tool_version": summary["tool_version"],
               "corpus_version": summary["corpus_version"],
               "corpus_sha256": summary["corpus_sha256"],
+              "corpus_manifest_sha256": manifest_sha256,
+              "logical_case_count": logical_case_count,
               "tool_profile_sha256": summary["tool_profile_sha256"],
               "case_count": {
                   "total": summary["case_count"]["total"],
@@ -334,6 +392,7 @@ jobs:
                   "errors": summary["case_count"]["errors"],
               },
               "scores": summary["scores"],
+              "metric_counts": {"applicable": applicable_metrics},
               "sufficient": summary["sufficient"],
               "fixtures": True,
               "multifile_cases": True,

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ check-stats: check-gauntlet-site
 	fi; \
 	echo "check-stats: OK (cases/STATS.md matches the runner-loaded corpus)"
 
-# Fail closed before a provenance artifact can supply a published score.
-# check-stats is the existing Makefile check called by CI, so this guard runs
-# in that path without changing the current public site or publish workflow.
+# Exercise provenance-artifact validation in the existing check-stats CI path.
+# The fixture is checked against this checkout's cases/MANIFEST.txt and the
+# renderer contract; this target does not invoke or gate a site publish path.
 check-gauntlet-site:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/validate_gauntlet_scope_test.py
 	@node gauntlet-site/scope-render_test.js

--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,5 @@ check-stats: check-gauntlet-site
 # in that path without changing the current public site or publish workflow.
 check-gauntlet-site:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/validate_gauntlet_scope_test.py
+	@node gauntlet-site/scope-render_test.js
 	@python3 scripts/validate_gauntlet_scope.py gauntlet-site/testdata/complete-provenance-artifact.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: stats stats-update check-stats cases-manifest
+.PHONY: stats stats-update check-stats cases-manifest check-gauntlet-site
 
 # Regenerate cases/MANIFEST.txt after adding or removing a case. The manifest
 # pins the logical corpus so a case cannot leave it without a visible diff;
@@ -37,7 +37,7 @@ stats-update:
 # The runner's exit status is checked BEFORE the comparison. Piping it straight
 # into cmp reported the pipeline's last status, so a failing runner produced no
 # output, and an empty snapshot compared equal to it and passed.
-check-stats:
+check-stats: check-gauntlet-site
 	@test -f cases/STATS.md || { echo "check-stats: FAIL - missing cases/STATS.md; run 'make stats-update'"; exit 1; }
 	@test -s cases/STATS.md || { echo "check-stats: FAIL - cases/STATS.md is empty; run 'make stats-update'"; exit 1; }
 	@tmp=$$(mktemp); trap 'rm -f "$$tmp"' EXIT; \
@@ -56,3 +56,10 @@ check-stats:
 		exit 1; \
 	fi; \
 	echo "check-stats: OK (cases/STATS.md matches the runner-loaded corpus)"
+
+# Fail closed before a provenance artifact can supply a published score.
+# check-stats is the existing Makefile check called by CI, so this guard runs
+# in that path without changing the current public site or publish workflow.
+check-gauntlet-site:
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/validate_gauntlet_scope_test.py
+	@python3 scripts/validate_gauntlet_scope.py gauntlet-site/testdata/complete-provenance-artifact.json

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -45,6 +45,45 @@
     return value;
   }
 
+  function nonEmptyString(value, path) {
+    if (typeof value !== 'string' || !value.trim()) {
+      throw new Error('scope field must be a non-empty string: ' + path);
+    }
+    return value;
+  }
+
+  function validateManifestDigest(value) {
+    nonEmptyString(value, 'corpus_manifest_sha256');
+    if (!/^[0-9a-f]{64}$/.test(value)) {
+      throw new Error('corpus_manifest_sha256 must be 64 lower-case hex characters');
+    }
+    return value;
+  }
+
+  function validateMetricFraction(artifact, metric) {
+    var scorePath = 'scores.applicable.' + metric;
+    var countPath = 'metric_counts.applicable.' + metric;
+    var numerator = nonNegativeInteger(scopeValue(artifact,
+      ['metric_counts', 'applicable', metric, 'numerator']), countPath + '.numerator');
+    var denominator = nonNegativeInteger(scopeValue(artifact,
+      ['metric_counts', 'applicable', metric, 'denominator']), countPath + '.denominator');
+    if (numerator > denominator) {
+      throw new Error('metric numerator cannot exceed denominator: ' + countPath);
+    }
+
+    var score = finiteFraction(scopeValue(artifact, ['scores', 'applicable', metric]), scorePath, true);
+    if (denominator === 0) {
+      if (score !== null) {
+        throw new Error('score must be null when metric denominator is zero: ' + scorePath);
+      }
+    } else if (score === null) {
+      throw new Error('score must be a number when metric denominator is non-zero: ' + scorePath);
+    } else if (score !== numerator / denominator) {
+      throw new Error('score must equal metric numerator/denominator: ' + scorePath);
+    }
+    return { numerator: numerator, denominator: denominator };
+  }
+
   function validateCanonicalURL(canonicalURL) {
     if (typeof canonicalURL !== 'string' || !/^https:\/\//i.test(canonicalURL)) {
       throw new Error('canonical_url must be an absolute https URL');
@@ -65,10 +104,20 @@
       throw new Error('artifact must be an object');
     }
 
+    nonEmptyString(scopeValue(artifact, ['artifact_id']), 'artifact_id');
+    validateManifestDigest(scopeValue(artifact, ['corpus_manifest_sha256']));
+    var logicalCaseCount = nonNegativeInteger(scopeValue(artifact, ['logical_case_count']), 'logical_case_count');
+    if (logicalCaseCount === 0) throw new Error('logical_case_count must be greater than zero');
+    nonEmptyString(scopeValue(artifact, ['runner_version']), 'runner_version');
+    nonEmptyString(scopeValue(artifact, ['scoring_version']), 'scoring_version');
+
     var applicable = nonNegativeInteger(scopeValue(artifact, ['case_count', 'applicable']), 'case_count.applicable');
     var total = nonNegativeInteger(scopeValue(artifact, ['case_count', 'total']), 'case_count.total');
     var notApplicable = nonNegativeInteger(scopeValue(artifact, ['case_count', 'not_applicable']), 'case_count.not_applicable');
     if (total === 0) throw new Error('case_count.total must be greater than zero');
+    if (total !== logicalCaseCount) {
+      throw new Error('case_count.total must equal logical_case_count');
+    }
     if (applicable > total) throw new Error('case_count.applicable cannot exceed case_count.total');
     if (applicable + notApplicable !== total) {
       throw new Error('case_count.applicable plus not_applicable must equal case_count.total');
@@ -88,15 +137,23 @@
     }
 
     var containment = scopeValue(artifact, ['scores', 'applicable', 'containment']);
+    var containmentCounts = validateMetricFraction(artifact, 'containment');
+    var falsePositiveCounts = validateMetricFraction(artifact, 'false_positive_rate');
+    if (containmentCounts.denominator > applicable || falsePositiveCounts.denominator > applicable) {
+      throw new Error('metric denominator cannot exceed case_count.applicable');
+    }
     if (applicable === 0) {
-      if (containment !== null) {
+      if (containment !== null || containmentCounts.denominator !== 0) {
         throw new Error('scores.applicable.containment must be null when case_count.applicable is zero');
       }
     } else {
-      finiteFraction(containment, 'scores.applicable.containment', false);
+      if (containmentCounts.denominator === 0) {
+        throw new Error('containment must have a denominator when case_count.applicable is non-zero');
+      }
     }
-    finiteFraction(scopeValue(artifact, ['scores', 'applicable', 'false_positive_rate']),
-      'scores.applicable.false_positive_rate', true);
+    if (applicable === 0 && falsePositiveCounts.denominator !== 0) {
+      throw new Error('false_positive_rate must have a zero denominator when case_count.applicable is zero');
+    }
 
     return {
       applicable: applicable,

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -40,8 +40,8 @@
     var block = document.createElement('div');
     block.className = 'denominator';
     block.appendChild(document.createTextNode(
-      'Containment ' + formatPercent(containment) + ' on ' + applicable + '/' + total +
-      ' applicable cases (' + notApplicable + ' N/A: ' + formatReasons(reasons) +
+      'Containment ' + formatPercent(containment) + ' on ' + applicable + ' applicable of ' + total +
+      ' total cases (' + notApplicable + ' N/A: ' + formatReasons(reasons) +
       '), false positives ' + formatPercent(falsePositiveRate) + ', '
     ));
 

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -1,0 +1,62 @@
+/*
+ * Future publish consumers call renderGauntletScope with a provenance artifact.
+ * It creates the score headline and every required scope qualifier together.
+ */
+(function(root) {
+  'use strict';
+
+  function scopeValue(artifact, path) {
+    var value = artifact;
+    for (var i = 0; i < path.length; i++) {
+      if (!value || typeof value !== 'object' || !(path[i] in value)) {
+        throw new Error('missing required scope field: ' + path.join('.'));
+      }
+      value = value[path[i]];
+    }
+    return value;
+  }
+
+  function formatPercent(value) {
+    return value === null ? 'N/A' : (value * 100).toFixed(1) + '%';
+  }
+
+  function formatReasons(reasons) {
+    var names = Object.keys(reasons).sort();
+    if (names.length === 0) return 'none';
+    return names.map(function(name) { return name + ': ' + reasons[name]; }).join(', ');
+  }
+
+  // Returns a .denominator block. Its score text is never built separately
+  // from the denominator, N/A reasons, FP rate, and canonical artifact link.
+  function renderGauntletScope(artifact) {
+    var applicable = scopeValue(artifact, ['case_count', 'applicable']);
+    var total = scopeValue(artifact, ['case_count', 'total']);
+    var notApplicable = scopeValue(artifact, ['case_count', 'not_applicable']);
+    var reasons = scopeValue(artifact, ['case_count', 'not_applicable_reasons']);
+    var containment = scopeValue(artifact, ['scores', 'applicable', 'containment']);
+    var falsePositiveRate = scopeValue(artifact, ['scores', 'applicable', 'false_positive_rate']);
+    var canonicalURL = scopeValue(artifact, ['canonical_url']);
+
+    var block = document.createElement('div');
+    block.className = 'denominator';
+    block.appendChild(document.createTextNode(
+      'Containment ' + formatPercent(containment) + ' on ' + applicable + '/' + total +
+      ' applicable cases (' + notApplicable + ' N/A: ' + formatReasons(reasons) +
+      '), false positives ' + formatPercent(falsePositiveRate) + ', '
+    ));
+
+    var badge = document.createElement('span');
+    badge.className = 'badge badge-verified';
+    badge.textContent = 'verified';
+    block.appendChild(badge);
+    block.appendChild(document.createTextNode(' '));
+
+    var link = document.createElement('a');
+    link.href = canonicalURL;
+    link.textContent = 'canonical artifact';
+    block.appendChild(link);
+    return block;
+  }
+
+  root.renderGauntletScope = renderGauntletScope;
+})(window);

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -8,7 +8,8 @@
   function scopeValue(artifact, path) {
     var value = artifact;
     for (var i = 0; i < path.length; i++) {
-      if (!value || typeof value !== 'object' || !(path[i] in value)) {
+      if (!value || typeof value !== 'object' ||
+          !Object.prototype.hasOwnProperty.call(value, path[i])) {
         throw new Error('missing required scope field: ' + path.join('.'));
       }
       value = value[path[i]];
@@ -26,16 +27,99 @@
     return names.map(function(name) { return name + ': ' + reasons[name]; }).join(', ');
   }
 
+  function nonNegativeInteger(value, path) {
+    if (!Number.isInteger(value) || value < 0) {
+      throw new Error('scope field must be a non-negative integer: ' + path);
+    }
+    return value;
+  }
+
+  function finiteFraction(value, path, allowNull) {
+    if (value === null && allowNull) return value;
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error('scope field must be a finite number' + (allowNull ? ' or null' : '') + ': ' + path);
+    }
+    if (value < 0 || value > 1) {
+      throw new Error('scope field must be between 0 and 1: ' + path);
+    }
+    return value;
+  }
+
+  function validateCanonicalURL(canonicalURL) {
+    if (typeof canonicalURL !== 'string' || !/^https:\/\//i.test(canonicalURL)) {
+      throw new Error('canonical_url must be an absolute https URL');
+    }
+    try {
+      var parsed = new URL(canonicalURL);
+      if (parsed.protocol !== 'https:' || !parsed.hostname) {
+        throw new Error('invalid canonical URL');
+      }
+    } catch (error) {
+      throw new Error('canonical_url must be an absolute https URL');
+    }
+    return canonicalURL;
+  }
+
+  function validateScope(artifact) {
+    if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
+      throw new Error('artifact must be an object');
+    }
+
+    var applicable = nonNegativeInteger(scopeValue(artifact, ['case_count', 'applicable']), 'case_count.applicable');
+    var total = nonNegativeInteger(scopeValue(artifact, ['case_count', 'total']), 'case_count.total');
+    var notApplicable = nonNegativeInteger(scopeValue(artifact, ['case_count', 'not_applicable']), 'case_count.not_applicable');
+    if (total === 0) throw new Error('case_count.total must be greater than zero');
+    if (applicable > total) throw new Error('case_count.applicable cannot exceed case_count.total');
+    if (applicable + notApplicable !== total) {
+      throw new Error('case_count.applicable plus not_applicable must equal case_count.total');
+    }
+
+    var reasons = scopeValue(artifact, ['case_count', 'not_applicable_reasons']);
+    if (!reasons || typeof reasons !== 'object' || Array.isArray(reasons)) {
+      throw new Error('scope field must be an object: case_count.not_applicable_reasons');
+    }
+    var reasonTotal = 0;
+    Object.keys(reasons).forEach(function(reason) {
+      if (!reason) throw new Error('not_applicable_reasons keys must be non-empty strings');
+      reasonTotal += nonNegativeInteger(reasons[reason], 'case_count.not_applicable_reasons.' + reason);
+    });
+    if (reasonTotal !== notApplicable) {
+      throw new Error('not_applicable_reasons must sum to case_count.not_applicable');
+    }
+
+    var containment = scopeValue(artifact, ['scores', 'applicable', 'containment']);
+    if (applicable === 0) {
+      if (containment !== null) {
+        throw new Error('scores.applicable.containment must be null when case_count.applicable is zero');
+      }
+    } else {
+      finiteFraction(containment, 'scores.applicable.containment', false);
+    }
+    finiteFraction(scopeValue(artifact, ['scores', 'applicable', 'false_positive_rate']),
+      'scores.applicable.false_positive_rate', true);
+
+    return {
+      applicable: applicable,
+      total: total,
+      notApplicable: notApplicable,
+      reasons: reasons,
+      containment: containment,
+      falsePositiveRate: scopeValue(artifact, ['scores', 'applicable', 'false_positive_rate']),
+      canonicalURL: validateCanonicalURL(scopeValue(artifact, ['canonical_url'])),
+    };
+  }
+
   // Returns a .denominator block. Its score text is never built separately
   // from the denominator, N/A reasons, FP rate, and canonical artifact link.
   function renderGauntletScope(artifact) {
-    var applicable = scopeValue(artifact, ['case_count', 'applicable']);
-    var total = scopeValue(artifact, ['case_count', 'total']);
-    var notApplicable = scopeValue(artifact, ['case_count', 'not_applicable']);
-    var reasons = scopeValue(artifact, ['case_count', 'not_applicable_reasons']);
-    var containment = scopeValue(artifact, ['scores', 'applicable', 'containment']);
-    var falsePositiveRate = scopeValue(artifact, ['scores', 'applicable', 'false_positive_rate']);
-    var canonicalURL = scopeValue(artifact, ['canonical_url']);
+    var scope = validateScope(artifact);
+    var applicable = scope.applicable;
+    var total = scope.total;
+    var notApplicable = scope.notApplicable;
+    var reasons = scope.reasons;
+    var containment = scope.containment;
+    var falsePositiveRate = scope.falsePositiveRate;
+    var canonicalURL = scope.canonicalURL;
 
     var block = document.createElement('div');
     block.className = 'denominator';

--- a/gauntlet-site/scope-render_test.js
+++ b/gauntlet-site/scope-render_test.js
@@ -25,14 +25,25 @@ require('./scope-render.js');
 function completeArtifact() {
   return {
     canonical_url: 'https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123',
+    artifact_id: 'github-actions:luckyPipewrench/agent-egress-bench:123',
+    corpus_manifest_sha256: 'ce4e2cc1cc62b8e3aebfdbea08c1b4ef2450020accf5db694bfc7927fe3e249d',
+    logical_case_count: 213,
+    runner_version: '0.4.0',
+    scoring_version: '2.2',
     case_count: {
-      total: 197,
-      applicable: 196,
+      total: 213,
+      applicable: 212,
       not_applicable: 1,
       not_applicable_reasons: { missing_requires: 1 },
     },
     scores: {
       applicable: { containment: 1, false_positive_rate: 0 },
+    },
+    metric_counts: {
+      applicable: {
+        containment: { numerator: 1, denominator: 1 },
+        false_positive_rate: { numerator: 0, denominator: 1 },
+      },
     },
   };
 }
@@ -45,7 +56,7 @@ function expectReject(mutator, message) {
 
 const rendered = window.renderGauntletScope(completeArtifact());
 assert.equal(rendered.className, 'denominator');
-assert.match(rendered.children[0].textContent, /Containment 100\.0% on 196 applicable of 197 total cases/);
+assert.match(rendered.children[0].textContent, /Containment 100\.0% on 212 applicable of 213 total cases/);
 assert.equal(rendered.children[3].href, completeArtifact().canonical_url);
 
 expectReject((artifact) => { artifact.scores.applicable.containment = '100%'; }, 'non-numeric containment');
@@ -56,17 +67,23 @@ expectReject((artifact) => { artifact.case_count.applicable = 198; }, 'applicabl
 expectReject((artifact) => { artifact.case_count.not_applicable = 0; }, 'counts do not sum to total');
 expectReject((artifact) => { artifact.case_count.not_applicable_reasons = { missing_requires: 0 }; }, 'N/A reasons do not sum');
 expectReject((artifact) => { artifact.canonical_url = 'javascript:alert(1)'; }, 'unsafe canonical URL');
+expectReject((artifact) => { delete artifact.corpus_manifest_sha256; }, 'missing corpus digest');
+expectReject((artifact) => { artifact.scores.applicable.containment = 0.5; }, 'score must equal numerator/denominator');
+expectReject((artifact) => { artifact.scores.applicable.false_positive_rate = 0.5; }, 'FP score must equal numerator/denominator');
 expectReject((artifact) => {
   artifact.case_count.applicable = 0;
-  artifact.case_count.not_applicable = 197;
-  artifact.case_count.not_applicable_reasons = { missing_requires: 197 };
+  artifact.case_count.not_applicable = 213;
+  artifact.case_count.not_applicable_reasons = { missing_requires: 213 };
 }, 'all-N/A runs cannot have a numeric containment score');
 
 const allNA = completeArtifact();
 allNA.case_count.applicable = 0;
-allNA.case_count.not_applicable = 197;
-allNA.case_count.not_applicable_reasons = { missing_requires: 197 };
+allNA.case_count.not_applicable = 213;
+allNA.case_count.not_applicable_reasons = { missing_requires: 213 };
 allNA.scores.applicable.containment = null;
+allNA.scores.applicable.false_positive_rate = null;
+allNA.metric_counts.applicable.containment = { numerator: 0, denominator: 0 };
+allNA.metric_counts.applicable.false_positive_rate = { numerator: 0, denominator: 0 };
 assert.match(window.renderGauntletScope(allNA).children[0].textContent, /Containment N\/A on 0 applicable/);
 
 console.log('scope renderer tests: OK');

--- a/gauntlet-site/scope-render_test.js
+++ b/gauntlet-site/scope-render_test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+
+function element(tagName) {
+  return {
+    tagName,
+    children: [],
+    appendChild(child) {
+      this.children.push(child);
+    },
+  };
+}
+
+global.document = {
+  createElement: element,
+  createTextNode(text) {
+    return { textContent: text };
+  },
+};
+global.window = {};
+
+require('./scope-render.js');
+
+function completeArtifact() {
+  return {
+    canonical_url: 'https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123',
+    case_count: {
+      total: 197,
+      applicable: 196,
+      not_applicable: 1,
+      not_applicable_reasons: { missing_requires: 1 },
+    },
+    scores: {
+      applicable: { containment: 1, false_positive_rate: 0 },
+    },
+  };
+}
+
+function expectReject(mutator, message) {
+  const artifact = completeArtifact();
+  mutator(artifact);
+  assert.throws(() => window.renderGauntletScope(artifact), message);
+}
+
+const rendered = window.renderGauntletScope(completeArtifact());
+assert.equal(rendered.className, 'denominator');
+assert.match(rendered.children[0].textContent, /Containment 100\.0% on 196 applicable of 197 total cases/);
+assert.equal(rendered.children[3].href, completeArtifact().canonical_url);
+
+expectReject((artifact) => { artifact.scores.applicable.containment = '100%'; }, 'non-numeric containment');
+expectReject((artifact) => { artifact.scores.applicable.false_positive_rate = 1.1; }, 'out-of-range FP rate');
+expectReject((artifact) => { artifact.case_count.total = 0; }, 'zero total');
+expectReject((artifact) => { artifact.case_count.total = -1; }, 'negative total');
+expectReject((artifact) => { artifact.case_count.applicable = 198; }, 'applicable exceeds total');
+expectReject((artifact) => { artifact.case_count.not_applicable = 0; }, 'counts do not sum to total');
+expectReject((artifact) => { artifact.case_count.not_applicable_reasons = { missing_requires: 0 }; }, 'N/A reasons do not sum');
+expectReject((artifact) => { artifact.canonical_url = 'javascript:alert(1)'; }, 'unsafe canonical URL');
+expectReject((artifact) => {
+  artifact.case_count.applicable = 0;
+  artifact.case_count.not_applicable = 197;
+  artifact.case_count.not_applicable_reasons = { missing_requires: 197 };
+}, 'all-N/A runs cannot have a numeric containment score');
+
+const allNA = completeArtifact();
+allNA.case_count.applicable = 0;
+allNA.case_count.not_applicable = 197;
+allNA.case_count.not_applicable_reasons = { missing_requires: 197 };
+allNA.scores.applicable.containment = null;
+assert.match(window.renderGauntletScope(allNA).children[0].textContent, /Containment N\/A on 0 applicable/);
+
+console.log('scope renderer tests: OK');

--- a/gauntlet-site/testdata/complete-provenance-artifact.json
+++ b/gauntlet-site/testdata/complete-provenance-artifact.json
@@ -1,0 +1,17 @@
+{
+  "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
+  "case_count": {
+    "total": 197,
+    "applicable": 196,
+    "not_applicable": 1,
+    "not_applicable_reasons": {
+      "missing_requires": 1
+    }
+  },
+  "scores": {
+    "applicable": {
+      "containment": 1,
+      "false_positive_rate": 0
+    }
+  }
+}

--- a/gauntlet-site/testdata/complete-provenance-artifact.json
+++ b/gauntlet-site/testdata/complete-provenance-artifact.json
@@ -1,8 +1,13 @@
 {
+  "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
   "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
+  "corpus_manifest_sha256": "ce4e2cc1cc62b8e3aebfdbea08c1b4ef2450020accf5db694bfc7927fe3e249d",
+  "logical_case_count": 213,
+  "runner_version": "0.4.0",
+  "scoring_version": "2.2",
   "case_count": {
-    "total": 197,
-    "applicable": 196,
+    "total": 213,
+    "applicable": 212,
     "not_applicable": 1,
     "not_applicable_reasons": {
       "missing_requires": 1
@@ -12,6 +17,18 @@
     "applicable": {
       "containment": 1,
       "false_positive_rate": 0
+    }
+  },
+  "metric_counts": {
+    "applicable": {
+      "containment": {
+        "numerator": 1,
+        "denominator": 1
+      },
+      "false_positive_rate": {
+        "numerator": 0,
+        "denominator": 1
+      }
     }
   }
 }

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -4,6 +4,7 @@
 import json
 import math
 import sys
+import urllib.parse
 from pathlib import Path
 
 
@@ -45,6 +46,8 @@ def validate_scope(document):
     applicable = non_negative_integer(document, ("case_count", "applicable"))
     total = non_negative_integer(document, ("case_count", "total"))
     not_applicable = non_negative_integer(document, ("case_count", "not_applicable"))
+    if total == 0:
+        raise ValueError("case_count.total must be greater than zero")
     if applicable > total:
         raise ValueError("case_count.applicable cannot exceed case_count.total")
     if applicable + not_applicable != total:
@@ -83,6 +86,9 @@ def validate_scope(document):
     canonical_url = path_value(document, ("canonical_url",))
     if not isinstance(canonical_url, str) or not canonical_url:
         raise ValueError("canonical_url must be a non-empty string")
+    parsed_url = urllib.parse.urlparse(canonical_url)
+    if parsed_url.scheme != "https" or not parsed_url.netloc:
+        raise ValueError("canonical_url must be an absolute https URL")
 
 
 def main(argv):

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -1,22 +1,37 @@
 #!/usr/bin/env python3
-"""Refuse incomplete provenance artifacts before scope-aware publication."""
+"""Validate scope-artifact fields against the checked-out corpus manifest."""
 
+import hashlib
 import json
 import math
+import re
 import sys
 import urllib.parse
 from pathlib import Path
 
 
 REQUIRED_SCOPE_PATHS = (
+    ("artifact_id",),
+    ("corpus_manifest_sha256",),
+    ("logical_case_count",),
+    ("runner_version",),
+    ("scoring_version",),
     ("case_count", "applicable"),
     ("case_count", "total"),
     ("case_count", "not_applicable"),
     ("case_count", "not_applicable_reasons"),
     ("scores", "applicable", "containment"),
     ("scores", "applicable", "false_positive_rate"),
+    ("metric_counts", "applicable", "containment", "numerator"),
+    ("metric_counts", "applicable", "containment", "denominator"),
+    ("metric_counts", "applicable", "false_positive_rate", "numerator"),
+    ("metric_counts", "applicable", "false_positive_rate", "denominator"),
     ("canonical_url",),
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "cases" / "MANIFEST.txt"
+SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
 
 
 def path_value(document, path):
@@ -47,6 +62,50 @@ def finite_fraction(document, path, allow_null=False):
     return value
 
 
+def non_empty_string(document, path):
+    value = path_value(document, path)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("scope field must be a non-empty string: " + ".".join(path))
+    return value
+
+
+def checked_out_corpus_identity():
+    """Return the manifest identity asserted by runner/corpus_manifest_test.go."""
+    try:
+        raw = MANIFEST_PATH.read_bytes()
+    except OSError as exc:
+        raise ValueError(f"read corpus manifest {MANIFEST_PATH}: {exc}") from exc
+
+    # The runner test treats non-empty IDs as a set when comparing the manifest
+    # to loadable cases. It separately rejects duplicate IDs, so this is the
+    # same logical count once the runner's corpus pin is green.
+    logical_ids = {line.strip() for line in raw.decode("utf-8").splitlines() if line.strip()}
+    if not logical_ids:
+        raise ValueError("checked-out corpus manifest has no logical case IDs")
+    return hashlib.sha256(raw).hexdigest(), len(logical_ids)
+
+
+def validate_metric_fraction(document, metric):
+    """Bind an applicable-view score to its explicit numerator/denominator."""
+    score_path = ("scores", "applicable", metric)
+    count_path = ("metric_counts", "applicable", metric)
+    numerator = non_negative_integer(document, count_path + ("numerator",))
+    denominator = non_negative_integer(document, count_path + ("denominator",))
+    if numerator > denominator:
+        raise ValueError("metric numerator cannot exceed denominator: " + ".".join(count_path))
+
+    score = finite_fraction(document, score_path, allow_null=True)
+    if denominator == 0:
+        if score is not None:
+            raise ValueError("score must be null when metric denominator is zero: " + ".".join(score_path))
+        return numerator, denominator
+    if score is None:
+        raise ValueError("score must be a number when metric denominator is non-zero: " + ".".join(score_path))
+    if score != numerator / denominator:
+        raise ValueError("score must equal metric numerator/denominator: " + ".".join(score_path))
+    return numerator, denominator
+
+
 def validate_scope(document):
     """Raise ValueError unless an artifact can render an honest scope block."""
     if not isinstance(document, dict):
@@ -55,11 +114,27 @@ def validate_scope(document):
     for path in REQUIRED_SCOPE_PATHS:
         path_value(document, path)
 
+    non_empty_string(document, ("artifact_id",))
+    non_empty_string(document, ("runner_version",))
+    non_empty_string(document, ("scoring_version",))
+
+    manifest_digest = non_empty_string(document, ("corpus_manifest_sha256",))
+    if not SHA256_HEX.fullmatch(manifest_digest):
+        raise ValueError("corpus_manifest_sha256 must be 64 lower-case hex characters")
+    manifest_count = non_negative_integer(document, ("logical_case_count",))
+    checked_out_digest, checked_out_count = checked_out_corpus_identity()
+    if manifest_digest != checked_out_digest:
+        raise ValueError("corpus_manifest_sha256 does not match checked-out cases/MANIFEST.txt")
+    if manifest_count != checked_out_count:
+        raise ValueError("logical_case_count does not match checked-out cases/MANIFEST.txt")
+
     applicable = non_negative_integer(document, ("case_count", "applicable"))
     total = non_negative_integer(document, ("case_count", "total"))
     not_applicable = non_negative_integer(document, ("case_count", "not_applicable"))
     if total == 0:
         raise ValueError("case_count.total must be greater than zero")
+    if total != checked_out_count:
+        raise ValueError("case_count.total does not match checked-out logical corpus count")
     if applicable > total:
         raise ValueError("case_count.applicable cannot exceed case_count.total")
     if applicable + not_applicable != total:
@@ -78,17 +153,22 @@ def validate_scope(document):
     if reason_total != not_applicable:
         raise ValueError("not_applicable_reasons must sum to case_count.not_applicable")
 
-    finite_fraction(document, ("scores", "applicable", "false_positive_rate"), allow_null=True)
-
     # Containment has no denominator when every case is N/A. In exactly that
     # state it must be null rather than a made-up score; otherwise it must be a
     # finite fraction because scope-render.js publishes it as the headline.
     containment = path_value(document, ("scores", "applicable", "containment"))
+    _, containment_denominator = validate_metric_fraction(document, "containment")
+    _, false_positive_denominator = validate_metric_fraction(document, "false_positive_rate")
+    if containment_denominator > applicable or false_positive_denominator > applicable:
+        raise ValueError("metric denominator cannot exceed case_count.applicable")
     if applicable == 0:
-        if containment is not None:
+        if containment is not None or containment_denominator != 0:
             raise ValueError("scores.applicable.containment must be null when case_count.applicable is zero")
     else:
-        finite_fraction(document, ("scores", "applicable", "containment"))
+        if containment_denominator == 0:
+            raise ValueError("containment must have a denominator when case_count.applicable is non-zero")
+    if applicable == 0 and false_positive_denominator != 0:
+        raise ValueError("false_positive_rate must have a zero denominator when case_count.applicable is zero")
 
     canonical_url = path_value(document, ("canonical_url",))
     if not isinstance(canonical_url, str) or not canonical_url:

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -35,6 +35,18 @@ def non_negative_integer(document, path):
     return value
 
 
+def finite_fraction(document, path, allow_null=False):
+    value = path_value(document, path)
+    if value is None and allow_null:
+        return value
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        suffix = " or null" if allow_null else ""
+        raise ValueError("scope field must be a number" + suffix + ": " + ".".join(path))
+    if not math.isfinite(value) or not 0 <= value <= 1:
+        raise ValueError("scope field must be between 0 and 1: " + ".".join(path))
+    return value
+
+
 def validate_scope(document):
     """Raise ValueError unless an artifact can render an honest scope block."""
     if not isinstance(document, dict):
@@ -66,22 +78,17 @@ def validate_scope(document):
     if reason_total != not_applicable:
         raise ValueError("not_applicable_reasons must sum to case_count.not_applicable")
 
-    false_positive_rate = path_value(document, ("scores", "applicable", "false_positive_rate"))
-    if false_positive_rate is not None:
-        if isinstance(false_positive_rate, bool) or not isinstance(false_positive_rate, (int, float)):
-            raise ValueError("scores.applicable.false_positive_rate must be a number or null")
-        if not math.isfinite(false_positive_rate) or not 0 <= false_positive_rate <= 1:
-            raise ValueError("scores.applicable.false_positive_rate must be between 0 and 1")
+    finite_fraction(document, ("scores", "applicable", "false_positive_rate"), allow_null=True)
 
-    # containment is the published headline score in scope-render.js, so it is
-    # required and must be a real fraction. Unlike false_positive_rate it is NOT
-    # nullable: a missing, non-numeric, or out-of-range containment must fail the
-    # gate rather than render as a misleading headline.
+    # Containment has no denominator when every case is N/A. In exactly that
+    # state it must be null rather than a made-up score; otherwise it must be a
+    # finite fraction because scope-render.js publishes it as the headline.
     containment = path_value(document, ("scores", "applicable", "containment"))
-    if isinstance(containment, bool) or not isinstance(containment, (int, float)):
-        raise ValueError("scores.applicable.containment must be a number")
-    if not math.isfinite(containment) or not 0 <= containment <= 1:
-        raise ValueError("scores.applicable.containment must be between 0 and 1")
+    if applicable == 0:
+        if containment is not None:
+            raise ValueError("scores.applicable.containment must be null when case_count.applicable is zero")
+    else:
+        finite_fraction(document, ("scores", "applicable", "containment"))
 
     canonical_url = path_value(document, ("canonical_url",))
     if not isinstance(canonical_url, str) or not canonical_url:

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Refuse incomplete provenance artifacts before scope-aware publication."""
+
+import json
+import math
+import sys
+from pathlib import Path
+
+
+REQUIRED_SCOPE_PATHS = (
+    ("case_count", "applicable"),
+    ("case_count", "total"),
+    ("case_count", "not_applicable"),
+    ("case_count", "not_applicable_reasons"),
+    ("scores", "applicable", "false_positive_rate"),
+    ("canonical_url",),
+)
+
+
+def path_value(document, path):
+    current = document
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            raise ValueError("missing required scope field: " + ".".join(path))
+        current = current[key]
+    return current
+
+
+def non_negative_integer(document, path):
+    value = path_value(document, path)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError("scope field must be a non-negative integer: " + ".".join(path))
+    return value
+
+
+def validate_scope(document):
+    """Raise ValueError unless an artifact can render an honest scope block."""
+    if not isinstance(document, dict):
+        raise ValueError("artifact must be a JSON object")
+
+    for path in REQUIRED_SCOPE_PATHS:
+        path_value(document, path)
+
+    applicable = non_negative_integer(document, ("case_count", "applicable"))
+    total = non_negative_integer(document, ("case_count", "total"))
+    not_applicable = non_negative_integer(document, ("case_count", "not_applicable"))
+    if applicable > total:
+        raise ValueError("case_count.applicable cannot exceed case_count.total")
+    if applicable + not_applicable != total:
+        raise ValueError("case_count.applicable plus not_applicable must equal case_count.total")
+
+    reasons = path_value(document, ("case_count", "not_applicable_reasons"))
+    if not isinstance(reasons, dict):
+        raise ValueError("scope field must be an object: case_count.not_applicable_reasons")
+    reason_total = 0
+    for reason, count in reasons.items():
+        if not isinstance(reason, str) or not reason:
+            raise ValueError("not_applicable_reasons keys must be non-empty strings")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise ValueError("not_applicable_reasons values must be non-negative integers")
+        reason_total += count
+    if reason_total != not_applicable:
+        raise ValueError("not_applicable_reasons must sum to case_count.not_applicable")
+
+    false_positive_rate = path_value(document, ("scores", "applicable", "false_positive_rate"))
+    if false_positive_rate is not None:
+        if isinstance(false_positive_rate, bool) or not isinstance(false_positive_rate, (int, float)):
+            raise ValueError("scores.applicable.false_positive_rate must be a number or null")
+        if not math.isfinite(false_positive_rate) or not 0 <= false_positive_rate <= 1:
+            raise ValueError("scores.applicable.false_positive_rate must be between 0 and 1")
+
+    canonical_url = path_value(document, ("canonical_url",))
+    if not isinstance(canonical_url, str) or not canonical_url:
+        raise ValueError("canonical_url must be a non-empty string")
+
+
+def main(argv):
+    if len(argv) != 2:
+        print(f"usage: {Path(argv[0]).name} ARTIFACT.json", file=sys.stderr)
+        return 2
+    try:
+        with open(argv[1], encoding="utf-8") as artifact_file:
+            artifact = json.load(artifact_file)
+        validate_scope(artifact)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"scope validation: FAIL: {exc}", file=sys.stderr)
+        return 1
+    print("scope validation: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -12,6 +12,7 @@ REQUIRED_SCOPE_PATHS = (
     ("case_count", "total"),
     ("case_count", "not_applicable"),
     ("case_count", "not_applicable_reasons"),
+    ("scores", "applicable", "containment"),
     ("scores", "applicable", "false_positive_rate"),
     ("canonical_url",),
 )
@@ -68,6 +69,16 @@ def validate_scope(document):
             raise ValueError("scores.applicable.false_positive_rate must be a number or null")
         if not math.isfinite(false_positive_rate) or not 0 <= false_positive_rate <= 1:
             raise ValueError("scores.applicable.false_positive_rate must be between 0 and 1")
+
+    # containment is the published headline score in scope-render.js, so it is
+    # required and must be a real fraction. Unlike false_positive_rate it is NOT
+    # nullable: a missing, non-numeric, or out-of-range containment must fail the
+    # gate rather than render as a misleading headline.
+    containment = path_value(document, ("scores", "applicable", "containment"))
+    if isinstance(containment, bool) or not isinstance(containment, (int, float)):
+        raise ValueError("scores.applicable.containment must be a number")
+    if not math.isfinite(containment) or not 0 <= containment <= 1:
+        raise ValueError("scores.applicable.containment must be between 0 and 1")
 
     canonical_url = path_value(document, ("canonical_url",))
     if not isinstance(canonical_url, str) or not canonical_url:

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -31,6 +31,18 @@ def complete_artifact():
     }
 
 
+def all_na_artifact():
+    artifact = complete_artifact()
+    artifact["case_count"] = {
+        "total": 197,
+        "applicable": 0,
+        "not_applicable": 197,
+        "not_applicable_reasons": {"missing_requires": 197},
+    }
+    artifact["scores"]["applicable"]["containment"] = None
+    return artifact
+
+
 class ValidateGauntletScopeTest(unittest.TestCase):
     def run_validator(self, artifact):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", encoding="utf-8") as fh:
@@ -89,11 +101,30 @@ class ValidateGauntletScopeTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_containment_is_na_only_when_no_cases_are_applicable(self):
+        all_na_result = self.run_validator(all_na_artifact())
+        self.assertEqual(all_na_result.returncode, 0, all_na_result.stderr)
+
+        all_na_with_score = all_na_artifact()
+        all_na_with_score["scores"]["applicable"]["containment"] = 0.0
+        all_na_with_score_result = self.run_validator(all_na_with_score)
+        self.assertNotEqual(all_na_with_score_result.returncode, 0)
+        self.assertIn("containment", all_na_with_score_result.stderr)
+
+        applicable_with_na = complete_artifact()
+        applicable_with_na["scores"]["applicable"]["containment"] = None
+        applicable_with_na_result = self.run_validator(applicable_with_na)
+        self.assertNotEqual(applicable_with_na_result.returncode, 0)
+        self.assertIn("containment", applicable_with_na_result.stderr)
+
+        applicable_with_score_result = self.run_validator(complete_artifact())
+        self.assertEqual(applicable_with_score_result.returncode, 0, applicable_with_score_result.stderr)
+
     def test_invalid_containment_values_fail(self):
-        # containment is the published headline; unlike false_positive_rate it is
-        # not nullable. A string, an out-of-range number, or null must all fail
-        # rather than render as a misleading score.
-        for bad in ("100%", 2, -1, None):
+        # For runs with applicable cases, containment is the published headline.
+        # A string or out-of-range number must fail rather than render a
+        # misleading score.
+        for bad in ("100%", 2, -1):
             with self.subTest(value=bad):
                 artifact = complete_artifact()
                 artifact["scores"]["applicable"]["containment"] = bad

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -54,6 +54,7 @@ class ValidateGauntletScopeTest(unittest.TestCase):
             ("case_count", "total"),
             ("case_count", "not_applicable"),
             ("case_count", "not_applicable_reasons"),
+            ("scores", "applicable", "containment"),
             ("scores", "applicable", "false_positive_rate"),
             ("canonical_url",),
         ]
@@ -87,6 +88,20 @@ class ValidateGauntletScopeTest(unittest.TestCase):
         result = self.run_validator(artifact)
 
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_invalid_containment_values_fail(self):
+        # containment is the published headline; unlike false_positive_rate it is
+        # not nullable. A string, an out-of-range number, or null must all fail
+        # rather than render as a misleading score.
+        for bad in ("100%", 2, -1, None):
+            with self.subTest(value=bad):
+                artifact = complete_artifact()
+                artifact["scores"]["applicable"]["containment"] = bad
+
+                result = self.run_validator(artifact)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("containment", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -218,6 +218,18 @@ class ValidateGauntletScopeTest(unittest.TestCase):
         self.assertNotEqual(applicable_with_na_result.returncode, 0)
         self.assertIn("containment", applicable_with_na_result.stderr)
 
+        # Likewise, a null score with a zero denominator is internally
+        # well-formed but cannot represent containment when cases applied.
+        applicable_with_zero_denominator = complete_artifact()
+        applicable_with_zero_denominator["scores"]["applicable"]["containment"] = None
+        applicable_with_zero_denominator["metric_counts"]["applicable"]["containment"] = {
+            "numerator": 0,
+            "denominator": 0,
+        }
+        applicable_with_zero_denominator_result = self.run_validator(applicable_with_zero_denominator)
+        self.assertNotEqual(applicable_with_zero_denominator_result.returncode, 0)
+        self.assertIn("containment", applicable_with_zero_denominator_result.stderr)
+
         applicable_with_score_result = self.run_validator(complete_artifact())
         self.assertEqual(applicable_with_score_result.returncode, 0, applicable_with_score_result.stderr)
 

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -104,5 +104,33 @@ class ValidateGauntletScopeTest(unittest.TestCase):
                 self.assertIn("containment", result.stderr)
 
 
+    def test_zero_total_fails(self):
+        artifact = complete_artifact()
+        artifact["case_count"] = {
+            "total": 0,
+            "applicable": 0,
+            "not_applicable": 0,
+            "not_applicable_reasons": {},
+        }
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("greater than zero", result.stderr)
+
+    def test_unsafe_canonical_url_fails(self):
+        # A non-https or non-absolute canonical_url must fail: it is rendered as
+        # a link, so a javascript:/relative/http value is a real safety gap.
+        for bad in ("javascript:alert(1)", "not-a-url", "http://example.com/x", "//example.com/x"):
+            with self.subTest(value=bad):
+                artifact = complete_artifact()
+                artifact["canonical_url"] = bad
+
+                result = self.run_validator(artifact)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("canonical_url", result.stderr)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -2,6 +2,7 @@
 """Tests for the fail-safe provenance scope validator."""
 
 import json
+import hashlib
 import subprocess
 import sys
 import tempfile
@@ -11,14 +12,28 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 VALIDATOR = REPO_ROOT / "scripts" / "validate_gauntlet_scope.py"
+MANIFEST = REPO_ROOT / "cases" / "MANIFEST.txt"
+
+
+def corpus_manifest_sha256():
+    return hashlib.sha256(MANIFEST.read_bytes()).hexdigest()
+
+
+def logical_case_count():
+    return len({line.strip() for line in MANIFEST.read_text(encoding="utf-8").splitlines() if line.strip()})
 
 
 def complete_artifact():
     return {
         "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
+        "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
+        "corpus_manifest_sha256": corpus_manifest_sha256(),
+        "logical_case_count": logical_case_count(),
+        "runner_version": "0.4.0",
+        "scoring_version": "2.2",
         "case_count": {
-            "total": 197,
-            "applicable": 196,
+            "total": logical_case_count(),
+            "applicable": logical_case_count() - 1,
             "not_applicable": 1,
             "not_applicable_reasons": {"missing_requires": 1},
         },
@@ -28,18 +43,27 @@ def complete_artifact():
                 "false_positive_rate": 0.0,
             },
         },
+        "metric_counts": {
+            "applicable": {
+                "containment": {"numerator": 1, "denominator": 1},
+                "false_positive_rate": {"numerator": 0, "denominator": 1},
+            },
+        },
     }
 
 
 def all_na_artifact():
     artifact = complete_artifact()
     artifact["case_count"] = {
-        "total": 197,
+        "total": logical_case_count(),
         "applicable": 0,
-        "not_applicable": 197,
-        "not_applicable_reasons": {"missing_requires": 197},
+        "not_applicable": logical_case_count(),
+        "not_applicable_reasons": {"missing_requires": logical_case_count()},
     }
     artifact["scores"]["applicable"]["containment"] = None
+    artifact["scores"]["applicable"]["false_positive_rate"] = None
+    artifact["metric_counts"]["applicable"]["containment"] = {"numerator": 0, "denominator": 0}
+    artifact["metric_counts"]["applicable"]["false_positive_rate"] = {"numerator": 0, "denominator": 0}
     return artifact
 
 
@@ -69,6 +93,15 @@ class ValidateGauntletScopeTest(unittest.TestCase):
             ("scores", "applicable", "containment"),
             ("scores", "applicable", "false_positive_rate"),
             ("canonical_url",),
+            ("artifact_id",),
+            ("corpus_manifest_sha256",),
+            ("logical_case_count",),
+            ("runner_version",),
+            ("scoring_version",),
+            ("metric_counts", "applicable", "containment", "numerator"),
+            ("metric_counts", "applicable", "containment", "denominator"),
+            ("metric_counts", "applicable", "false_positive_rate", "numerator"),
+            ("metric_counts", "applicable", "false_positive_rate", "denominator"),
         ]
 
         for path in required_paths:
@@ -84,6 +117,70 @@ class ValidateGauntletScopeTest(unittest.TestCase):
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn(".".join(path), result.stderr)
 
+    def test_missing_corpus_digest_fails(self):
+        artifact = complete_artifact()
+        del artifact["corpus_manifest_sha256"]
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("corpus_manifest_sha256", result.stderr)
+
+    def test_corpus_digest_must_match_checked_out_manifest(self):
+        artifact = complete_artifact()
+        artifact["corpus_manifest_sha256"] = "0" * 64
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("corpus_manifest_sha256", result.stderr)
+
+    def test_logical_case_count_must_match_checked_out_manifest(self):
+        artifact = complete_artifact()
+        artifact["logical_case_count"] -= 1
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("logical_case_count", result.stderr)
+
+    def test_case_count_total_must_match_checked_out_manifest(self):
+        artifact = complete_artifact()
+        artifact["case_count"] = {
+            "total": logical_case_count() - 1,
+            "applicable": logical_case_count() - 2,
+            "not_applicable": 1,
+            "not_applicable_reasons": {"missing_requires": 1},
+        }
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("case_count.total", result.stderr)
+
+    def test_score_must_equal_metric_numerator_over_denominator(self):
+        for metric in ("containment", "false_positive_rate"):
+            with self.subTest(metric=metric):
+                artifact = complete_artifact()
+                artifact["scores"]["applicable"][metric] = 0.5
+
+                result = self.run_validator(artifact)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(metric, result.stderr)
+
+    def test_metric_denominator_cannot_exceed_applicable_cases(self):
+        artifact = complete_artifact()
+        artifact["metric_counts"]["applicable"]["containment"] = {
+            "numerator": logical_case_count(),
+            "denominator": logical_case_count(),
+        }
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("metric denominator", result.stderr)
+
     def test_inconsistent_na_breakdown_fails(self):
         artifact = complete_artifact()
         artifact["case_count"]["not_applicable_reasons"] = {"missing_requires": 0}
@@ -96,6 +193,10 @@ class ValidateGauntletScopeTest(unittest.TestCase):
     def test_null_false_positive_rate_passes_as_na(self):
         artifact = complete_artifact()
         artifact["scores"]["applicable"]["false_positive_rate"] = None
+        artifact["metric_counts"]["applicable"]["false_positive_rate"] = {
+            "numerator": 0,
+            "denominator": 0,
+        }
 
         result = self.run_validator(artifact)
 

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Tests for the fail-safe provenance scope validator."""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = REPO_ROOT / "scripts" / "validate_gauntlet_scope.py"
+
+
+def complete_artifact():
+    return {
+        "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
+        "case_count": {
+            "total": 197,
+            "applicable": 196,
+            "not_applicable": 1,
+            "not_applicable_reasons": {"missing_requires": 1},
+        },
+        "scores": {
+            "applicable": {
+                "containment": 1.0,
+                "false_positive_rate": 0.0,
+            },
+        },
+    }
+
+
+class ValidateGauntletScopeTest(unittest.TestCase):
+    def run_validator(self, artifact):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", encoding="utf-8") as fh:
+            json.dump(artifact, fh)
+            fh.flush()
+            return subprocess.run(
+                [sys.executable, str(VALIDATOR), fh.name],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_complete_artifact_passes(self):
+        result = self.run_validator(complete_artifact())
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_each_required_scope_field_fails_when_missing(self):
+        required_paths = [
+            ("case_count", "applicable"),
+            ("case_count", "total"),
+            ("case_count", "not_applicable"),
+            ("case_count", "not_applicable_reasons"),
+            ("scores", "applicable", "false_positive_rate"),
+            ("canonical_url",),
+        ]
+
+        for path in required_paths:
+            with self.subTest(path=".".join(path)):
+                artifact = complete_artifact()
+                target = artifact
+                for key in path[:-1]:
+                    target = target[key]
+                del target[path[-1]]
+
+                result = self.run_validator(artifact)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(".".join(path), result.stderr)
+
+    def test_inconsistent_na_breakdown_fails(self):
+        artifact = complete_artifact()
+        artifact["case_count"]["not_applicable_reasons"] = {"missing_requires": 0}
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not_applicable_reasons must sum", result.stderr)
+
+    def test_null_false_positive_rate_passes_as_na(self):
+        artifact = complete_artifact()
+        artifact["scores"]["applicable"]["false_positive_rate"] = None
+
+        result = self.run_validator(artifact)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

First slice of continuous-gauntlet Phase 2 (fail-safe publish). This slice adds the honest-scope machinery only; it does not publish anything, change any workflow, or touch the live scoreboard.

Adds a reusable scope renderer (`gauntlet-site/scope-render.js`) that renders a result as one inseparable unit: the metric value, applicable-over-total, the N/A count and reasons, the false-positive rate, and the canonical artifact URL. It is structurally unable to render the headline percentage without the denominator, N/A reasons, and provenance, which is must-have #3 for any future public number.

Adds a provenance validator (`scripts/validate_gauntlet_scope.py`) plus its tests, wired into the existing `make check-stats`. The validator refuses an artifact that is missing any required scope field (applicable, total, not_applicable_reasons, false_positive_rate, canonical_url), so an incomplete result cannot be published as a bare number.

`index.html`, the current result JSON, and the continuous-gauntlet workflow are unchanged.

## Follow-up slices

Later Phase 2 slices wire the fail-safe publish path (environment approval gate writing a last-verified artifact, an under-review candidate, and a regression alert), replace the legacy `index.html` scope display (which today substitutes missing values with `0`) with this renderer, and give the canonical artifact a durable location rather than an expiring workflow-run link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a provenance artifact validator for required fields, case counts, scores, containment values, and canonical links.
  * Added a site display for containment results, case counts, false-positive rates, verification status, and artifact links.

* **Tests**
  * Added coverage for valid and invalid provenance artifacts, including missing fields and inconsistent values.

* **Chores**
  * Updated validation checks to automatically verify the site scope and complete provenance artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->