### PR TITLE
fix(gauntlet): validate the artifact a run actually produces

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -293,6 +293,7 @@ jobs:
           export ARTIFACT_JSON="$ARTIFACT_DIR/continuous-gauntlet-pipelock-${PIPELOCK_TAG}.json"
 
           python3 - <<'PY'
+          import hashlib
           import json
           import os
 
@@ -406,6 +407,18 @@ jobs:
           PY
 
           jq empty "$ARTIFACT_JSON"
+
+          # A shell export does not survive the step boundary, so the validating
+          # step below would see an unbound variable. Persist the path instead.
+          echo "ARTIFACT_JSON=$ARTIFACT_JSON" >> "$GITHUB_ENV"
+
+      - name: Validate generated provenance artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${ARTIFACT_JSON:-}" || { echo "provenance artifact path was not published by the generating step"; exit 1; }
+          test -f "$ARTIFACT_JSON" || { echo "provenance artifact missing at $ARTIFACT_JSON"; exit 1; }
+          python3 scripts/validate_gauntlet_scope.py "$ARTIFACT_JSON"
 
       - name: Upload provenance artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: stats stats-update check-stats cases-manifest check-gauntlet-site
 
+# Default fixture for local validator/renderer contract tests. A workflow that
+# generates a real artifact must override this with that exact output path.
+GAUNTLET_SCOPE_ARTIFACT ?= gauntlet-site/testdata/complete-provenance-artifact.json
+
 # Regenerate cases/MANIFEST.txt after adding or removing a case. The manifest
 # pins the logical corpus so a case cannot leave it without a visible diff;
 # runner/corpus_manifest_test.go asserts the two agree in both directions.
@@ -57,10 +61,11 @@ check-stats: check-gauntlet-site
 	fi; \
 	echo "check-stats: OK (cases/STATS.md matches the runner-loaded corpus)"
 
-# Exercise provenance-artifact validation in the existing check-stats CI path.
-# The fixture is checked against this checkout's cases/MANIFEST.txt and the
-# renderer contract; this target does not invoke or gate a site publish path.
+# Exercise provenance-artifact validation and the renderer contract. The
+# fixture is the local-test default; callers can and must pass the generated
+# artifact path when validating an actual scoring run.
 check-gauntlet-site:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/validate_gauntlet_scope_test.py
 	@node gauntlet-site/scope-render_test.js
-	@python3 scripts/validate_gauntlet_scope.py gauntlet-site/testdata/complete-provenance-artifact.json
+	@test -f "$(GAUNTLET_SCOPE_ARTIFACT)" || { echo "check-gauntlet-site: FAIL - missing provenance artifact: $(GAUNTLET_SCOPE_ARTIFACT)"; exit 1; }
+	@python3 scripts/validate_gauntlet_scope.py "$(GAUNTLET_SCOPE_ARTIFACT)"


### PR DESCRIPTION
The scope validator only ever ran against a checked-in fixture, as a prerequisite of check-stats, so nothing validated the provenance artifact a scoring run generates and uploads. A misleading or incomplete artifact could reach the upload unchanged while the fixture kept passing.

The continuous-gauntlet workflow now validates the generated artifact in its own step, before the upload rather than after it, and check-gauntlet-site takes the artifact path as a variable so the fixture is only the local-test default. A caller validating a real run passes that run's output.

The generating step exported the artifact path with a shell export, which does not survive a step boundary, so the validating step would have seen an unbound variable and failed under set -u on every run. The path is published through GITHUB_ENV instead, and the validating step checks that it arrived and points at a real file before invoking the validator, so a missing path fails as a missing path rather than as a confusing validator error.

This narrows the gap rather than closing it. The artifact remains self-attested: the validator checks internal consistency and binds the case count to the checked-out corpus manifest, but a published score is still not bound to a runner-results digest or a corpus revision. Defining the authoritative publication consumer and the required attestation contract is a product decision and is deliberately left open here.
