### PR TITLE
fix(runner): require upstream proof for MCP stdio budget-enforcement allows

### DIFF
--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -1734,11 +1734,60 @@ func (p *ProxyAdapter) runMCPStdioBudgetSequence(c Case, msgList []interface{}, 
 		}
 	}
 
+	// Build the MCP command. A budget sequence has no runner-injected server
+	// responses, so there is no case-controlled stdout to compare against.
+	// Positive proof therefore requires a runner-owned receipt channel: the
+	// mock backend emits a per-run receipt to an inherited pipe on its first
+	// request. A proxy that synthesizes responses cannot produce this receipt,
+	// so an under-budget sequence without it fails closed to skip.
+	receiptBytes := make([]byte, 32)
+	if _, err := rand.Read(receiptBytes); err != nil {
+		return Result{Err: fmt.Errorf("case %s: generate MCP stdio receipt: %w", c.ID, err)}
+	}
+	receipt := base64.RawURLEncoding.EncodeToString(receiptBytes)
+	proofReader, proofWriter, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		return Result{Err: fmt.Errorf("case %s: create MCP stdio receipt pipe: %w", c.ID, pipeErr)}
+	}
+
+	mockScript, scriptErr := os.CreateTemp("", "budget-mock-script-*.sh")
+	if scriptErr != nil {
+		_ = proofReader.Close()
+		_ = proofWriter.Close()
+		return Result{Err: fmt.Errorf("case %s: create temp script: %w", c.ID, scriptErr)}
+	}
+	_, _ = fmt.Fprintf(mockScript, `#!/bin/sh
+_n=0
+while IFS= read -r _input; do
+  _n=$((_n+1))
+  if [ "$_n" -eq 1 ]; then
+    printf '%%s\n' %s >&3
+  fi
+  _id=$(printf '%%s' "$_input" | sed -n 's/.*"id":\s*\([^,}\"]*\).*/\1/p')
+  if [ -z "$_id" ]; then
+    _id=null
+  fi
+  printf '{"jsonrpc":"2.0","id":%%s,"result":{"content":[]}}\n' "$_id"
+done
+`, shellQuote(receipt))
+	_ = mockScript.Close()
+	defer func() { _ = os.Remove(mockScript.Name()) }()
+
+	mcpCmd := p.mcpCmd
+	if idx := strings.Index(mcpCmd, " -- "); idx >= 0 {
+		mcpCmd = mcpCmd[:idx] + " -- bash " + shellQuote(mockScript.Name())
+	} else {
+		_ = proofReader.Close()
+		_ = proofWriter.Close()
+		return Result{Err: fmt.Errorf("case %s: --mcp-cmd missing ' -- ' separator, cannot inject mock backend", c.ID)}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", p.mcpCmd) //nolint:gosec // command from trusted CLI flag
+	cmd := exec.CommandContext(ctx, "sh", "-c", mcpCmd) //nolint:gosec // command from trusted CLI flag
 	configureMCPCommand(cmd)
+	cmd.ExtraFiles = []*os.File{proofWriter}
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
 
@@ -1751,8 +1800,11 @@ func (p *ProxyAdapter) runMCPStdioBudgetSequence(c Case, msgList []interface{}, 
 		return Result{Err: fmt.Errorf("case %s: stdout pipe: %w", c.ID, err)}
 	}
 	if startErr := cmd.Start(); startErr != nil {
+		_ = proofReader.Close()
+		_ = proofWriter.Close()
 		return Result{Err: fmt.Errorf("case %s: start MCP cmd: %w", c.ID, startErr)}
 	}
+	_ = proofWriter.Close()
 
 	scanner := bufio.NewScanner(stdout)
 	for i, msg := range msgList {
@@ -1811,6 +1863,22 @@ func (p *ProxyAdapter) runMCPStdioBudgetSequence(c Case, msgList []interface{}, 
 		return Result{Err: fmt.Errorf("case %s: MCP subprocess failed: %w", c.ID, waitErr)}
 	}
 
+	proof, _ := io.ReadAll(proofReader)
+	_ = proofReader.Close()
+	if !mcpStdioReceiptObserved(proof, receipt) {
+		return Result{
+			Verdict: "skip",
+			Evidence: map[string]interface{}{
+				"reason":               "mcp_stdio_upstream_receipt_missing",
+				"synthesized_response": true,
+				"budget_limit_calls":   limit,
+				"budget_scope":         scope,
+				"subject_id":           subjectID,
+				"calls_observed":       len(msgList),
+			},
+		}
+	}
+
 	return Result{
 		Verdict: "allow",
 		Evidence: map[string]interface{}{
@@ -1818,6 +1886,7 @@ func (p *ProxyAdapter) runMCPStdioBudgetSequence(c Case, msgList []interface{}, 
 			"budget_scope":       scope,
 			"subject_id":         subjectID,
 			"calls_observed":     len(msgList),
+			"upstream_reached":   true,
 		},
 	}
 }

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -1501,7 +1501,7 @@ func TestRunMCPHTTP_ForwardedListenerAllowsWithUpstreamProof(t *testing.T) {
 }
 
 func TestRunMCPStdioBudgetSequence_BlockAtOverBudgetCall(t *testing.T) {
-	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeBudgetMCPResponder(t, 4))}
+	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeBudgetMCPResponder(t, 4)) + " -- placeholder"}
 	result := a.runMCPStdio(budgetSequenceCase("dow-block", "block"), 5*time.Second)
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v", result.Err)
@@ -1518,7 +1518,7 @@ func TestRunMCPStdioBudgetSequence_BlockAtOverBudgetCall(t *testing.T) {
 }
 
 func TestRunMCPStdioBudgetSequence_ProtocolBudgetErrorBlocks(t *testing.T) {
-	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeBudgetMCPProtocolErrorResponder(t, 4, -32600, "tool call limit exceeded: 4/3"))}
+	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeBudgetMCPProtocolErrorResponder(t, 4, -32600, "tool call limit exceeded: 4/3")) + " -- placeholder"}
 	result := a.runMCPStdio(budgetSequenceCase("dow-protocol-block", "block"), 5*time.Second)
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v", result.Err)
@@ -1585,7 +1585,7 @@ func TestIsBudgetLimitProtocolError_TightBudgetPhrases(t *testing.T) {
 }
 
 func TestRunMCPStdioBudgetSequence_NonBudgetProtocolErrorFails(t *testing.T) {
-	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeBudgetMCPProtocolErrorResponder(t, 4, -32601, "method not found"))}
+	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeBudgetMCPProtocolErrorResponder(t, 4, -32601, "method not found")) + " -- placeholder"}
 	result := a.runMCPStdio(budgetSequenceCase("dow-protocol-error", "block"), 5*time.Second)
 	if result.Err == nil {
 		t.Fatalf("expected adapter error, got verdict=%q evidence=%+v", result.Verdict, result.Evidence)
@@ -1596,7 +1596,7 @@ func TestRunMCPStdioBudgetSequence_NonBudgetProtocolErrorFails(t *testing.T) {
 }
 
 func TestRunMCPStdioBudgetSequence_RecordsEarlyBlock(t *testing.T) {
-	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeBudgetMCPResponder(t, 2))}
+	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeBudgetMCPResponder(t, 2)) + " -- placeholder"}
 	result := a.runMCPStdio(budgetSequenceCase("dow-early", "block"), 5*time.Second)
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v", result.Err)
@@ -1626,7 +1626,7 @@ func TestBudgetBlockResult_OmitsTimingWhenOverBudgetIndexUnknown(t *testing.T) {
 }
 
 func TestRunMCPStdioBudgetSequence_UnderBudgetAllowed(t *testing.T) {
-	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeBudgetMCPResponder(t, 0))}
+	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(writeMCPPassthrough(t)) + " -- placeholder"}
 	c := budgetSequenceCase("dow-allow", "allow")
 	delete(c.Payload, "over_budget_call_id")
 	c.Payload["jsonrpc_messages"] = []interface{}{
@@ -1643,6 +1643,52 @@ func TestRunMCPStdioBudgetSequence_UnderBudgetAllowed(t *testing.T) {
 	}
 	if got := result.Evidence["calls_observed"]; got != 3 {
 		t.Fatalf("calls_observed = %v, want 3", got)
+	}
+	if got := result.Evidence["upstream_reached"]; got != true {
+		t.Fatalf("upstream_reached = %v, want true", got)
+	}
+}
+
+func writeMCPPassthrough(t *testing.T) string {
+	t.Helper()
+	script, err := os.CreateTemp(t.TempDir(), "mcp-passthrough-*.sh")
+	if err != nil {
+		t.Fatalf("create passthrough script: %v", err)
+	}
+	_, _ = fmt.Fprint(script, `#!/bin/sh
+# Discard the '--' separator and exec the injected mock backend.
+shift 1
+exec "$@"
+`)
+	if err := script.Close(); err != nil {
+		t.Fatalf("close passthrough script: %v", err)
+	}
+	return script.Name()
+}
+
+func TestRunMCPStdioBudgetSequence_SynthesizedUnderBudgetSkips(t *testing.T) {
+	// A proxy that synthesizes plausible JSON-RPC success responses for every
+	// call should not score allow just because the call count is within budget.
+	// Without upstream proof, an under-budget sequence must fail closed to skip.
+	dir := t.TempDir()
+	fakeProxy := dir + "/fake-budget-proxy.sh"
+	if err := os.WriteFile(fakeProxy, []byte("#!/bin/sh\n# Synthesize a success response for every stdin line without forwarding upstream.\nwhile IFS= read -r line; do\n  printf '{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[]}}\\n'\ndone\n"), 0o700); err != nil {
+		t.Fatalf("write fake proxy: %v", err)
+	}
+
+	a := &ProxyAdapter{mcpCmd: "bash " + shellQuote(fakeProxy) + " -- placeholder"}
+	c := budgetSequenceCase("dow-synthesized-allow", "allow")
+	delete(c.Payload, "over_budget_call_id")
+	c.Payload["jsonrpc_messages"] = []interface{}{
+		budgetToolCall(1, "project-alpha"),
+		budgetToolCall(2, "project-alpha"),
+	}
+	result := a.runMCPStdio(c, 5*time.Second)
+	if result.Err != nil {
+		t.Fatalf("unexpected error: %v", result.Err)
+	}
+	if result.Verdict != "skip" {
+		t.Fatalf("verdict = %q, want skip; synthesized responses without upstream proof must not allow", result.Verdict)
 	}
 }
 


### PR DESCRIPTION
## What changed

The MCP stdio budget-enforcement path scored an under-budget sequence as `allow` from the observed message count alone, without proving the responses came from the upstream backend rather than the proxy itself. This closes the last remaining allow path that could pass on locally produced responses.

A budget sequence carries no runner-injected server responses to compare against, so it now mirrors the main stdio path with a runner-owned proof channel: an injected mock backend emits a per-run receipt on an inherited pipe when it receives its first request, and an under-budget allow requires observing that receipt. When the receipt is absent the verdict fails closed to `skip` with reason `mcp_stdio_upstream_receipt_missing`.

This finishes the positive-upstream-proof work started in #94 and #103, extending it to the budget-enforcement sequence.
