### PR TITLE
docs(runner): tool-neutral opt-in contract for MCP stdio observer + Pipelock harness bridge

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -127,6 +127,13 @@ jobs:
           cd runner
           go build -o "$RUNNER_TEMP/aeb-gauntlet" .
 
+      - name: Verify MCP stdio bridge dependency
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          command -v socat || command -v ncat || command -v nc
+
       - name: Run canonical benchmark
         shell: bash
         run: |
@@ -144,7 +151,7 @@ jobs:
           command_path="$artifact_dir/command.txt"
           stats_path="$artifact_dir/make-stats.txt"
 
-          mcp_cmd="\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" -- cat"
+          mcp_cmd="\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh"
           managed_proxy_cmd='./examples/pipelock/start-proxy-for-benchmark.sh "$PIPELOCK_BIN"'
           managed_mcp_http_cmd='./examples/pipelock/start-mcp-http-for-benchmark.sh "$PIPELOCK_BIN"'
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: preflight stats stats-update check-stats cases-manifest check-gauntlet-site test-validate test-runner test-receipt-generator validate-cases
+.PHONY: preflight stats stats-update check-stats cases-manifest check-gauntlet-site test-validate test-runner test-receipt-generator test-pipelock-example validate-cases
 
 TMPDIR := $(HOME)/.cache/pipelock-tmp
 GOCACHE := $(HOME)/.cache/go-build
@@ -12,7 +12,7 @@ GAUNTLET_SCOPE_ARTIFACT ?= gauntlet-site/testdata/complete-provenance-artifact.j
 # comfortably inside the edit-to-push budget and it catches real shared-state
 # defects that ordinary go test would miss. It requires the Go toolchain needed
 # by runner/go.mod (currently Go 1.25 or newer).
-preflight: test-validate validate-cases test-runner test-receipt-generator check-stats check-gauntlet-site
+preflight: test-validate validate-cases test-runner test-receipt-generator test-pipelock-example check-stats check-gauntlet-site
 
 test-validate:
 	@mkdir -p "$(TMPDIR)" "$(GOCACHE)"
@@ -31,6 +31,9 @@ test-runner:
 test-receipt-generator:
 	@mkdir -p "$(TMPDIR)" "$(GOCACHE)"
 	@cd receipts/v0/conformance/_generator && go test -race -count=1 ./...
+
+test-pipelock-example:
+	@sh examples/pipelock/mcp-stdio-upstream-bridge_test.sh
 
 # Regenerate cases/MANIFEST.txt after adding or removing a case. The manifest
 # pins the logical corpus so a case cannot leave it without a visible diff;

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ cd runner && go build -o /tmp/aeb-gauntlet . && cd ..
   --proxy-addr 127.0.0.1:18899 \
   --scan-addr 127.0.0.1:9990 \
   --scan-token bench-test-token \
-  --mcp-cmd "pipelock mcp proxy --config $PWD/examples/pipelock/pipelock-benchmark.yaml -- cat" \
+  --mcp-cmd "pipelock mcp proxy --config $PWD/examples/pipelock/pipelock-benchmark.yaml --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh" \
   --cases ./cases \
   --multifile-cases ./cases/mcp-drift \
   --profile examples/pipelock/tool-profile.json \

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -105,11 +105,21 @@ the evaluated `--mcp-cmd` process:
 | `AEB_MCP_STDIO_UPSTREAM_ADDR` | Host:port of the runner-owned line-delimited JSON-RPC upstream for this case |
 
 This is an explicit, tool-neutral opt-in contract. Configure the evaluated
-tool's own command or configuration to use that address as its MCP stdio
+tool's own command or configuration to make that address its MCP stdio
 upstream; for example, a tool with a TCP-upstream option could be launched as
-`my-mcp-proxy --upstream-tcp "$AEB_MCP_STDIO_UPSTREAM_ADDR"`. The runner never
-parses a separator in `--mcp-cmd`, appends a backend command, modifies the
-command string, or passes a proof file descriptor/token to the tool.
+`my-mcp-proxy --upstream-tcp "$AEB_MCP_STDIO_UPSTREAM_ADDR"`. A stdio-only
+backend can satisfy the same contract with a transparent stdio-to-TCP bridge;
+the bridge must pass the line-delimited JSON-RPC stream in both directions, not
+merely consume its input. The runner never parses a separator in `--mcp-cmd`,
+appends a backend command, modifies the command string, or passes a proof file
+descriptor/token to the tool.
+
+This runner-owned observation is a **versioned runner-contract change**. To
+have MCP stdio cases scored, an evaluated tool must route its MCP stdio
+upstream to `$AEB_MCP_STDIO_UPSTREAM_ADDR`, either natively or through the
+documented stdio-to-TCP bridge (or any equivalent forwarding proxy). A tool
+that does not satisfy the contract receives adapter verdict `skip` because its
+allow outcome is unprovable; it is never credited as a silent false allow.
 
 The listener records matching JSON-RPC requests itself. An allow is credited
 only when every required request arrives at that listener in order (including
@@ -266,7 +276,7 @@ export PIPELOCK_BENCH_CONFIG="$PWD/examples/pipelock/pipelock-benchmark.yaml"
 /tmp/aeb-gauntlet \
   --adapter proxy \
   --scan-token bench-test-token \
-  --mcp-cmd "\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" -- cat" \
+  --mcp-cmd "\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh" \
   --managed-proxy-cmd './examples/pipelock/start-proxy-for-benchmark.sh "$PIPELOCK_BIN"' \
   --managed-mcp-http-cmd './examples/pipelock/start-mcp-http-for-benchmark.sh "$PIPELOCK_BIN"' \
   --fixtures \

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -36,6 +36,15 @@ Available managed-command environment variables:
 | `AEB_WS_FIXTURE_ADDR` | WebSocket fixture address |
 | `AEB_DNS_FIXTURE_ADDR` | DNS fixture address |
 | `AEB_MCP_HTTP_FIXTURE_URL` | MCP HTTP upstream fixture URL |
+| `AEB_MCP_STDIO_UPSTREAM_ADDR` | Runner-owned line-delimited JSON-RPC TCP upstream for MCP stdio cases |
+
+For MCP stdio, Pipelock passes the observer address to its backend explicitly
+with `--env AEB_MCP_STDIO_UPSTREAM_ADDR`: Pipelock otherwise sanitizes the
+child environment. The checked-in bridge connects its stdin/stdout to that
+address without parsing the JSON-RPC stream. It prefers `socat`, then falls
+back to `ncat` or `nc`; a machine running this example needs one of those
+programs. The continuous Gauntlet verifies that one is available before it
+runs.
 
 Example shape:
 
@@ -46,7 +55,7 @@ export PIPELOCK_BENCH_CONFIG="$PWD/examples/pipelock/pipelock-benchmark.yaml"
 /tmp/aeb-gauntlet \
   --adapter proxy \
   --scan-token bench-test-token \
-  --mcp-cmd "\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" -- cat" \
+  --mcp-cmd "\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh" \
   --managed-proxy-cmd './examples/pipelock/start-proxy-for-benchmark.sh "$PIPELOCK_BIN"' \
   --managed-mcp-http-cmd './examples/pipelock/start-mcp-http-for-benchmark.sh "$PIPELOCK_BIN"' \
   --cases ./cases \

--- a/examples/pipelock/harness.sh
+++ b/examples/pipelock/harness.sh
@@ -12,7 +12,7 @@
 #   cd runner && go build -o /tmp/aeb-gauntlet . && cd ..
 #   /tmp/aeb-gauntlet --adapter proxy --proxy-addr 127.0.0.1:18899 \
 #     --scan-addr 127.0.0.1:9990 --scan-token bench-test-token \
-#     --mcp-cmd "pipelock mcp proxy --config $PWD/examples/pipelock/pipelock-benchmark.yaml -- cat" \
+#     --mcp-cmd "pipelock mcp proxy --config $PWD/examples/pipelock/pipelock-benchmark.yaml --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh" \
 #     --cases ./cases --multifile-cases ./cases/mcp-drift \
 #     --profile examples/pipelock/tool-profile.json --fixtures \
 #     --output /tmp/gauntlet.json

--- a/examples/pipelock/mcp-stdio-upstream-bridge.sh
+++ b/examples/pipelock/mcp-stdio-upstream-bridge.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Connect a stdio MCP child to the runner-owned TCP JSON-RPC observer.
+# The stream is deliberately passed through unchanged: one JSON-RPC message per
+# line in each direction.
+set -eu
+
+addr=${AEB_MCP_STDIO_UPSTREAM_ADDR:-}
+case "$addr" in
+  *:*) ;;
+  *)
+    echo "AEB_MCP_STDIO_UPSTREAM_ADDR must be host:port" >&2
+    exit 64
+    ;;
+esac
+
+host=${addr%:*}
+port=${addr##*:}
+if [ -z "$host" ] || [ -z "$port" ]; then
+  echo "AEB_MCP_STDIO_UPSTREAM_ADDR must be host:port" >&2
+  exit 64
+fi
+
+if command -v socat >/dev/null 2>&1; then
+  exec socat - "TCP:${host}:${port}"
+fi
+if command -v ncat >/dev/null 2>&1; then
+  exec ncat "$host" "$port"
+fi
+if command -v nc >/dev/null 2>&1; then
+  exec nc "$host" "$port"
+fi
+
+echo "MCP stdio upstream bridge requires socat, ncat, or nc" >&2
+exit 69

--- a/examples/pipelock/mcp-stdio-upstream-bridge.sh
+++ b/examples/pipelock/mcp-stdio-upstream-bridge.sh
@@ -4,20 +4,37 @@
 # line in each direction.
 set -eu
 
+config_error() {
+  echo "AEB_MCP_STDIO_UPSTREAM_ADDR must be host:port with a port from 1 to 65535" >&2
+  exit 64
+}
+
 addr=${AEB_MCP_STDIO_UPSTREAM_ADDR:-}
 case "$addr" in
   *:*) ;;
-  *)
-    echo "AEB_MCP_STDIO_UPSTREAM_ADDR must be host:port" >&2
-    exit 64
-    ;;
+  *) config_error ;;
 esac
 
 host=${addr%:*}
 port=${addr##*:}
 if [ -z "$host" ] || [ -z "$port" ]; then
-  echo "AEB_MCP_STDIO_UPSTREAM_ADDR must be host:port" >&2
-  exit 64
+  config_error
+fi
+case "$host" in
+  *:*) config_error ;;
+esac
+case "$port" in
+  *[!0-9]*) config_error ;;
+esac
+
+# Normalize leading zeroes before the range check so every accepted value is
+# passed to the connector in an unambiguous decimal form.
+while [ "${port#0}" != "$port" ]; do
+  port=${port#0}
+done
+[ -n "$port" ] || port=0
+if [ "${#port}" -gt 5 ] || [ "$port" -lt 1 ] || [ "$port" -gt 65535 ]; then
+  config_error
 fi
 
 if command -v socat >/dev/null 2>&1; then

--- a/examples/pipelock/mcp-stdio-upstream-bridge_test.sh
+++ b/examples/pipelock/mcp-stdio-upstream-bridge_test.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+bridge="$script_dir/mcp-stdio-upstream-bridge.sh"
+
+expect_config_error() {
+  addr=$1
+  set +e
+  PATH=/nonexistent AEB_MCP_STDIO_UPSTREAM_ADDR="$addr" /bin/sh "$bridge" >/dev/null 2>&1
+  status=$?
+  set -e
+  if [ "$status" -ne 64 ]; then
+    echo "expected configuration error for address '$addr', got status $status" >&2
+    exit 1
+  fi
+}
+
+expect_connector_selection() {
+  addr=$1
+  set +e
+  PATH=/nonexistent AEB_MCP_STDIO_UPSTREAM_ADDR="$addr" /bin/sh "$bridge" >/dev/null 2>&1
+  status=$?
+  set -e
+  if [ "$status" -ne 69 ]; then
+    echo "expected connector selection for address '$addr', got status $status" >&2
+    exit 1
+  fi
+}
+
+for addr in \
+  "" \
+  "127.0.0.1" \
+  ":1234" \
+  "127.0.0.1:" \
+  "127.0.0.1:abc" \
+  "127.0.0.1:0" \
+  "127.0.0.1:65536" \
+  "127.0.0.1:99999999999999999999" \
+  "127.0.0.1:1:2"
+do
+  expect_config_error "$addr"
+done
+
+expect_connector_selection "127.0.0.1:1"
+expect_connector_selection "runner.example:065535"
+
+echo "mcp stdio upstream bridge tests: OK"


### PR DESCRIPTION
## What changed

Documents the tool-neutral opt-in contract for the runner-owned MCP stdio observer and wires the Pipelock example harness to satisfy it, so Pipelock's MCP stdio cases are scored instead of abstaining.

The runner exports a line-delimited JSON-RPC upstream address as `AEB_MCP_STDIO_UPSTREAM_ADDR` and credits an MCP stdio allow only when it observes the forwarded request arrive there. An evaluated tool routes its MCP stdio upstream to that address, natively or via a transparent stdio-to-TCP bridge. A tool that does not opt in has its stdio cases scored `skip` (unprovable), never a silent allow. RUNNER.md states this as an explicit, versioned runner-contract change and keeps it neutral: any forwarding proxy can satisfy it.

The Pipelock example command routes its backend through a portable `socat`/`ncat`/`nc` bridge, and CI preflights that a supported bridge tool is present before measuring.

Follows the runner-owned observation redesign in #111.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting MCP stdio traffic to TCP-based upstream services through a transparent bridge.
  - The bridge validates upstream addresses and supports common connection utilities with fallback options.
  - Clear error statuses are provided for invalid addresses or unavailable connection tools.

- **Documentation**
  - Updated runner and integration examples with the new bridge configuration and environment variable.
  - Clarified bidirectional JSON-RPC forwarding and handling of unsupported upstream routing.

- **Tests**
  - Benchmark workflows now verify that a supported connection utility is available before running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->