### PR TITLE
docs: use observed MCP stdio bridge in methodology

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -166,7 +166,7 @@ cd runner && go build -o /tmp/aeb-gauntlet . && cd ..
   --adapter proxy --scan-token bench-test-token \
   --managed-proxy-cmd './examples/pipelock/start-proxy-for-benchmark.sh "$PIPELOCK_BIN"' \
   --managed-mcp-http-cmd './examples/pipelock/start-mcp-http-for-benchmark.sh "$PIPELOCK_BIN"' \
-  --mcp-cmd "\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" -- cat" \
+  --mcp-cmd "\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh" \
   --cases ./cases --multifile-cases ./cases/mcp-drift \
   --profile examples/pipelock/tool-profile.json \
   --fixtures \


### PR DESCRIPTION
Update the Gauntlet methodology example to pass the runner-owned upstream address through Pipelock and use the checked-in stdio bridge. This keeps the example aligned with README, runner docs, and continuous gauntlet workflow after #112.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MCP benchmark command to use the configured standard-input/output upstream bridge script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->