### PR TITLE
feat: add schema-valid provenance assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Each tool publishes its own results independently; this repo produces no ranking
 - [SCORING.md](docs/SCORING.md): pass/fail/not_applicable/error scoring model
 - [RECEIPT-SCORING.md](docs/RECEIPT-SCORING.md): receipt evidence scoring axis for independently verifiable artifacts
 - [CONTROL-EVIDENCE.md](docs/CONTROL-EVIDENCE.md): v0 run-level control-evidence package and verifier contract
-- [ARTIFACT-PROVENANCE.md](docs/ARTIFACT-PROVENANCE.md): opt-in external `authenticated-at(T)` provenance assessment
+- [ARTIFACT-PROVENANCE.md](docs/ARTIFACT-PROVENANCE.md): opt-in external `schema-valid` and `authenticated-at(T)` provenance assessments
 - [gauntlet.md](docs/gauntlet.md): Gauntlet scoring methodology (containment, FP rate, detection, evidence)
 - [RUNNER.md](docs/RUNNER.md): runner output contract and verdict mapping
 - [ADOPTION.md](docs/ADOPTION.md): guide for vendors adopting the benchmark

--- a/control-evidence/v0/verifier/README.md
+++ b/control-evidence/v0/verifier/README.md
@@ -34,6 +34,23 @@ with mode `0700`, outside the package. The verifier atomically records the
 single-use challenge there. Omitting durable replay state returns
 `unverifiable`, never `valid`.
 
+The separately callable G2 format assessor needs no trust policy and does not
+verify signatures:
+
+```sh
+go run ./cmd/aeb-ce-schema-valid \
+  --package ../conformance/golden/g01-vendor-time \
+  --allow-conformance-sidecars
+```
+
+The sidecar flag exists only for the public corpus layout. Omit it for submitted
+packages so undeclared `context.json` or `expect.json` files fail closed. A
+`schema-valid` PASS proves bounded package structure, closed manifest binding,
+strict/schema-governed JSON, and JCS signed payload bytes. It does not prove
+signature authentication, trusted ownership, freshness, result correctness,
+or scope completeness; compose it with the corresponding independent G2
+predicates instead of over-reading it.
+
 Replay records are append-only in v0. Back up and restore the complete private
 directory as one unit. If it is lost or damaged, issue a new buyer requirement
 and nonce; do not replace it with an empty directory and continue trusting old

--- a/control-evidence/v0/verifier/checks.go
+++ b/control-evidence/v0/verifier/checks.go
@@ -30,39 +30,8 @@ func (s *verificationState) verifyBindingsAndManifest() *Result {
 		return failure(outcomeInvalid, "manifest_count_mismatch")
 	}
 
-	seenPaths := map[string]bool{}
-	var total int64
-	for _, entry := range s.manifest.Entries {
-		if seenPaths[entry.Path] || !normalizedPath(entry.Path) {
-			return failure(outcomeInvalid, "manifest_path_ambiguous")
-		}
-		seenPaths[entry.Path] = true
-		data, ok := s.files[entry.Path]
-		if !ok || int64(len(data)) != entry.ByteLength || digestBytes(data) != entry.SHA256 {
-			return failure(outcomeInvalid, "manifest_member_mismatch")
-		}
-		total += entry.ByteLength
-	}
-	if total != s.manifest.TotalUncompressedBytes {
-		return failure(outcomeInvalid, "manifest_total_mismatch")
-	}
-	for path := range s.files {
-		if path == "manifest.json" || path == "envelope.dsse.json" {
-			continue
-		}
-		if !seenPaths[path] {
-			return failure(outcomeInvalid, "manifest_member_uncommitted")
-		}
-	}
-	for role, path := range map[string]string{
-		"requirement": "requirement.dsse.json",
-		"outcomes":    "outcomes.json",
-		"summary":     "summary.json",
-	} {
-		entries := s.entriesByRole[role]
-		if len(entries) != 1 || entries[0].Path != path {
-			return failure(outcomeInvalid, "manifest_core_role_mismatch")
-		}
+	if reason := validateManifestPackage(s.files, s.manifest, s.entriesByRole); reason != "" {
+		return failure(outcomeInvalid, reason)
 	}
 	if entries := s.entriesByRole["policy"]; len(entries) == 1 && entries[0].SHA256 != s.req.Payload.ApprovedPolicy.SHA256 {
 		return failure(outcomeScopeMismatch, "policy_artifact_digest_mismatch")
@@ -88,6 +57,44 @@ func (s *verificationState) verifyBindingsAndManifest() *Result {
 		}
 	}
 	return nil
+}
+
+func validateManifestPackage(files map[string][]byte, value manifest, entriesByRole map[string][]manifestEntry) string {
+	seenPaths := map[string]bool{}
+	var total int64
+	for _, entry := range value.Entries {
+		if seenPaths[entry.Path] || !normalizedPath(entry.Path) {
+			return "manifest_path_ambiguous"
+		}
+		seenPaths[entry.Path] = true
+		data, ok := files[entry.Path]
+		if !ok || int64(len(data)) != entry.ByteLength || digestBytes(data) != entry.SHA256 {
+			return "manifest_member_mismatch"
+		}
+		total += entry.ByteLength
+	}
+	if total != value.TotalUncompressedBytes {
+		return "manifest_total_mismatch"
+	}
+	for path := range files {
+		if path == "manifest.json" || path == "envelope.dsse.json" {
+			continue
+		}
+		if !seenPaths[path] {
+			return "manifest_member_uncommitted"
+		}
+	}
+	for role, path := range map[string]string{
+		"requirement": "requirement.dsse.json",
+		"outcomes":    "outcomes.json",
+		"summary":     "summary.json",
+	} {
+		entries := entriesByRole[role]
+		if len(entries) != 1 || entries[0].Path != path {
+			return "manifest_core_role_mismatch"
+		}
+	}
+	return ""
 }
 
 func (s *verificationState) verifyScopeAndTime() *Result {

--- a/control-evidence/v0/verifier/cmd/aeb-ce-schema-valid/main.go
+++ b/control-evidence/v0/verifier/cmd/aeb-ce-schema-valid/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	verifier "github.com/luckyPipewrench/agent-egress-bench/control-evidence/v0/verifier"
+)
+
+func main() {
+	packageDir := flag.String("package", "", "Control Evidence v0 package directory")
+	allowSidecars := flag.Bool("allow-conformance-sidecars", false, "ignore context.json and expect.json conformance sidecars")
+	flag.Parse()
+	if *packageDir == "" {
+		fmt.Fprintln(os.Stderr, "--package is required")
+		os.Exit(2)
+	}
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "resolve verifier executable:", err)
+		os.Exit(2)
+	}
+	binary, err := os.ReadFile(self)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read verifier executable:", err)
+		os.Exit(2)
+	}
+	result := verifier.AssessSchema(verifier.SchemaOptions{
+		PackageDir:               *packageDir,
+		VerifierName:             "aeb-ce-schema-valid",
+		VerifierVersion:          "v1",
+		VerifierSHA256:           fmt.Sprintf("%x", sha256.Sum256(binary)),
+		AssessmentTime:           time.Now(),
+		AllowConformanceSidecars: *allowSidecars,
+	})
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		os.Exit(2)
+	}
+	if result.Predicates[0].Status != "PASS" {
+		os.Exit(1)
+	}
+}

--- a/control-evidence/v0/verifier/json.go
+++ b/control-evidence/v0/verifier/json.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"embed"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -190,30 +189,9 @@ type verifiedDSSE[T any] struct {
 }
 
 func verifyDSSE[T any](data []byte, expectedType, trustedKey string, schemas *schemaSet, payloadSchema *jsonschema.Schema) (*verifiedDSSE[T], string, error) {
-	var wrapper dsseEnvelope
-	wrapperValue, err := strictJSON(data, &wrapper)
+	wrapper, payload, reason, err := decodeDSSEWrapper(data, expectedType, schemas)
 	if err != nil {
-		return nil, "dsse_wrapper_invalid", err
-	}
-	if len(wrapper.Signatures) != 1 {
-		return nil, "dsse_signature_count", errors.New("DSSE must carry exactly one signature")
-	}
-	if wrapper.PayloadType != expectedType {
-		reason := "payload_type_mismatch"
-		switch expectedType {
-		case typeRequirement:
-			reason = "requirement_payload_type_mismatch"
-		case typeObserver:
-			reason = "observer_payload_type_mismatch"
-		}
-		return nil, reason, errors.New("DSSE payload type mismatch")
-	}
-	if err := validateSchema(schemas.dsse, wrapperValue); err != nil {
-		return nil, "dsse_wrapper_invalid", err
-	}
-	payload, err := base64.StdEncoding.Strict().DecodeString(wrapper.Payload)
-	if err != nil {
-		return nil, "dsse_payload_base64_invalid", err
+		return nil, reason, err
 	}
 	sig := wrapper.Signatures[0]
 	if trustedKey != "" && sig.KeyID != trustedKey {
@@ -223,27 +201,64 @@ func verifyDSSE[T any](data []byte, expectedType, trustedKey string, schemas *sc
 	if err != nil || len(pub) != ed25519.PublicKeySize {
 		return nil, "signer_key_invalid", errors.New("invalid Ed25519 public key")
 	}
-	sigBytes, err := base64.StdEncoding.Strict().DecodeString(sig.Sig)
+	sigBytes, err := decodeBase64(sig.Sig)
 	if err != nil || len(sigBytes) != ed25519.SignatureSize {
 		return nil, "dsse_signature_invalid", errors.New("invalid Ed25519 signature encoding")
 	}
 	if !ed25519.Verify(ed25519.PublicKey(pub), pae(wrapper.PayloadType, payload), sigBytes) {
 		return nil, "dsse_signature_invalid", errors.New("Ed25519 signature verification failed")
 	}
-	if err := canonicalJSON(payload); err != nil {
-		return nil, "signed_payload_not_jcs", err
+	decoded, reason, err := decodeCanonicalPayload[T](payload, payloadSchema)
+	if err != nil {
+		return nil, reason, err
 	}
+	return &verifiedDSSE[T]{Wrapper: wrapper, Payload: decoded, PayloadBytes: payload, SignerKeyID: sig.KeyID}, "", nil
+}
+
+func decodeDSSEWrapper(data []byte, expectedType string, schemas *schemaSet) (dsseEnvelope, []byte, string, error) {
+	var wrapper dsseEnvelope
+	wrapperValue, err := strictJSON(data, &wrapper)
+	if err != nil {
+		return wrapper, nil, "dsse_wrapper_invalid", err
+	}
+	if len(wrapper.Signatures) != 1 {
+		return wrapper, nil, "dsse_signature_count", errors.New("DSSE must carry exactly one signature")
+	}
+	if wrapper.PayloadType != expectedType {
+		reason := "payload_type_mismatch"
+		switch expectedType {
+		case typeRequirement:
+			reason = "requirement_payload_type_mismatch"
+		case typeObserver:
+			reason = "observer_payload_type_mismatch"
+		}
+		return wrapper, nil, reason, errors.New("DSSE payload type mismatch")
+	}
+	if err := validateSchema(schemas.dsse, wrapperValue); err != nil {
+		return wrapper, nil, "dsse_wrapper_invalid", err
+	}
+	payload, err := decodeBase64(wrapper.Payload)
+	if err != nil {
+		return wrapper, nil, "dsse_payload_base64_invalid", err
+	}
+	return wrapper, payload, "", nil
+}
+
+func decodeCanonicalPayload[T any](payload []byte, payloadSchema *jsonschema.Schema) (T, string, error) {
 	var decoded T
+	if err := canonicalJSON(payload); err != nil {
+		return decoded, "signed_payload_not_jcs", err
+	}
 	payloadValue, err := strictJSON(payload, &decoded)
 	if err != nil {
-		return nil, "signed_payload_invalid", err
+		return decoded, "signed_payload_invalid", err
 	}
 	if payloadSchema != nil {
 		if err := validateSchema(payloadSchema, payloadValue); err != nil {
-			return nil, "signed_payload_schema_invalid", err
+			return decoded, "signed_payload_schema_invalid", err
 		}
 	}
-	return &verifiedDSSE[T]{Wrapper: wrapper, Payload: decoded, PayloadBytes: payload, SignerKeyID: sig.KeyID}, "", nil
+	return decoded, "", nil
 }
 
 func readBounded(path string, max int64) ([]byte, error) {

--- a/control-evidence/v0/verifier/schema_assessor.go
+++ b/control-evidence/v0/verifier/schema_assessor.go
@@ -1,6 +1,7 @@
 package verifier
 
 import (
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -121,8 +122,12 @@ func validateStructuralDSSE[T any](data []byte, expectedType string, schemas *sc
 	if err != nil {
 		return nil, reason
 	}
-	if _, err := decodeBase64(wrapper.Signatures[0].Sig); err != nil {
+	signature, err := decodeBase64(wrapper.Signatures[0].Sig)
+	if err != nil {
 		return nil, "dsse_signature_base64_invalid"
+	}
+	if len(signature) != ed25519.SignatureSize {
+		return nil, "dsse_signature_invalid"
 	}
 	decoded, reason, err := decodeCanonicalPayload[T](payload, payloadSchema)
 	if err != nil {

--- a/control-evidence/v0/verifier/schema_assessor.go
+++ b/control-evidence/v0/verifier/schema_assessor.go
@@ -1,0 +1,199 @@
+package verifier
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const assessmentProfile = "control-evidence-assessment/v1"
+
+type SchemaOptions struct {
+	PackageDir               string
+	VerifierName             string
+	VerifierVersion          string
+	VerifierSHA256           string
+	AssessmentTime           time.Time
+	AllowConformanceSidecars bool
+}
+
+type AssessmentPredicate struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Reason string `json:"reason"`
+}
+
+type SchemaEvidence struct {
+	EnvelopePayloadSHA256 string `json:"envelope_payload_sha256"`
+	ManifestSHA256        string `json:"manifest_sha256"`
+}
+
+type SchemaAssessment struct {
+	Profile        string `json:"profile"`
+	AssessmentTime string `json:"assessment_time,omitempty"`
+	Verifier       struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+		SHA256  string `json:"sha256"`
+	} `json:"verifier"`
+	Evidence   *SchemaEvidence       `json:"evidence,omitempty"`
+	Predicates []AssessmentPredicate `json:"predicates"`
+}
+
+func AssessSchema(options SchemaOptions) SchemaAssessment {
+	result := SchemaAssessment{Profile: assessmentProfile}
+	result.Verifier.Name = options.VerifierName
+	result.Verifier.Version = options.VerifierVersion
+	if lowerHexDigest(options.VerifierSHA256) {
+		result.Verifier.SHA256 = options.VerifierSHA256
+	}
+	finish := func(status, reason string) SchemaAssessment {
+		result.Predicates = []AssessmentPredicate{{Name: "schema-valid", Status: status, Reason: reason}}
+		return result
+	}
+	if strings.TrimSpace(options.VerifierName) == "" || strings.TrimSpace(options.VerifierVersion) == "" || !lowerHexDigest(options.VerifierSHA256) {
+		return finish("UNVERIFIABLE", "verifier_identity_invalid")
+	}
+	assessmentTime := options.AssessmentTime
+	if assessmentTime.IsZero() {
+		assessmentTime = time.Now()
+	}
+	result.AssessmentTime = assessmentTime.UTC().Format(time.RFC3339)
+
+	schemas, err := loadSchemas()
+	if err != nil {
+		return finish("UNVERIFIABLE", "verifier_schema_load_failed")
+	}
+	if _, err := os.Lstat(options.PackageDir); err != nil {
+		return finish("UNVERIFIABLE", "package_unavailable")
+	}
+	files, err := loadDirectoryPackageWithOptions(options.PackageDir, options.AllowConformanceSidecars)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrPermission) {
+			return finish("UNVERIFIABLE", "package_unavailable")
+		}
+		return finish("FAIL", "package_structure_invalid")
+	}
+
+	var packageManifest manifest
+	manifestValue, err := strictJSON(files["manifest.json"], &packageManifest)
+	if err != nil || validateSchema(schemas.manifest, manifestValue) != nil {
+		return finish("FAIL", "manifest_invalid")
+	}
+	entriesByRole := make(map[string][]manifestEntry)
+	for _, entry := range packageManifest.Entries {
+		entriesByRole[entry.Role] = append(entriesByRole[entry.Role], entry)
+	}
+	if reason := validateManifestPackage(files, packageManifest, entriesByRole); reason != "" {
+		return finish("FAIL", reason)
+	}
+
+	_, reason := validateStructuralDSSE[requirement](files["requirement.dsse.json"], typeRequirement, schemas, schemas.requirement)
+	if reason != "" {
+		return finish("FAIL", reason)
+	}
+	envelopeDSSE, reason := validateStructuralDSSE[runEnvelope](files["envelope.dsse.json"], typeEnvelope, schemas, schemas.envelope)
+	if reason != "" {
+		return finish("FAIL", reason)
+	}
+	if envelopeDSSE.Payload.Artifacts.ManifestSHA256 != digestBytes(files["manifest.json"]) || envelopeDSSE.Payload.Artifacts.Count != len(packageManifest.Entries) {
+		return finish("FAIL", "envelope_manifest_binding_mismatch")
+	}
+	if reason := validateGovernedMembers(files, entriesByRole, schemas); reason != "" {
+		return finish("FAIL", reason)
+	}
+
+	result.Evidence = &SchemaEvidence{
+		EnvelopePayloadSHA256: digestBytes(envelopeDSSE.PayloadBytes),
+		ManifestSHA256:        digestBytes(files["manifest.json"]),
+	}
+	return finish("PASS", "package_format_valid")
+}
+
+func validateStructuralDSSE[T any](data []byte, expectedType string, schemas *schemaSet, payloadSchema *jsonschema.Schema) (*verifiedDSSE[T], string) {
+	wrapper, payload, reason, err := decodeDSSEWrapper(data, expectedType, schemas)
+	if err != nil {
+		return nil, reason
+	}
+	if _, err := decodeBase64(wrapper.Signatures[0].Sig); err != nil {
+		return nil, "dsse_signature_base64_invalid"
+	}
+	decoded, reason, err := decodeCanonicalPayload[T](payload, payloadSchema)
+	if err != nil {
+		return nil, reason
+	}
+	return &verifiedDSSE[T]{Wrapper: wrapper, Payload: decoded, PayloadBytes: payload, SignerKeyID: wrapper.Signatures[0].KeyID}, ""
+}
+
+func validateGovernedMembers(files map[string][]byte, entriesByRole map[string][]manifestEntry, schemas *schemaSet) string {
+	for _, role := range []string{"requirement", "summary"} {
+		if entries := entriesByRole[role]; len(entries) != 1 || entries[0].MediaType != "application/json" {
+			return "manifest_media_type_mismatch"
+		}
+	}
+	for _, entry := range entriesByRole["outcomes"] {
+		if entry.MediaType != "application/json" || !validJSONSchema(files[entry.Path], schemas.outcomes) {
+			return "outcomes_schema_invalid"
+		}
+	}
+	for _, entry := range entriesByRole["tool-profile"] {
+		if entry.MediaType != "application/json" || !validJSONSchema(files[entry.Path], schemas.toolProfile) {
+			return "tool_profile_schema_invalid"
+		}
+	}
+	for _, entry := range entriesByRole["observer-evidence"] {
+		if entry.MediaType != "application/json" {
+			return "observer_evidence_schema_invalid"
+		}
+		if _, reason := validateStructuralDSSE[observerEvidence](files[entry.Path], typeObserver, schemas, schemas.observer); reason != "" {
+			return "observer_evidence_schema_invalid"
+		}
+	}
+	for _, entry := range entriesByRole["clock-evidence"] {
+		if entry.MediaType != "application/json" {
+			return "clock_evidence_schema_invalid"
+		}
+		if _, reason := validateStructuralDSSE[clockEvidence](files[entry.Path], typeClock, schemas, schemas.clock); reason != "" {
+			return "clock_evidence_schema_invalid"
+		}
+	}
+	for _, entries := range entriesByRole {
+		for _, entry := range entries {
+			if entry.MediaType != "application/json" || governedRole(entry.Role) {
+				continue
+			}
+			if _, err := strictJSON(files[entry.Path], nil); err != nil {
+				return "json_member_invalid"
+			}
+		}
+	}
+	return ""
+}
+
+func validJSONSchema(data []byte, schema *jsonschema.Schema) bool {
+	value, err := strictJSON(data, nil)
+	return err == nil && validateSchema(schema, value) == nil
+}
+
+func governedRole(role string) bool {
+	switch role {
+	case "requirement", "outcomes", "tool-profile", "observer-evidence", "clock-evidence":
+		return true
+	default:
+		return false
+	}
+}
+
+func lowerHexDigest(value string) bool {
+	if len(value) != sha256.Size*2 || strings.ToLower(value) != value {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size
+}

--- a/control-evidence/v0/verifier/schema_assessor_test.go
+++ b/control-evidence/v0/verifier/schema_assessor_test.go
@@ -135,6 +135,15 @@ func TestAssessSchemaHostilePackages(t *testing.T) {
 			wrapper["signatures"].([]any)[0].(map[string]any)["sig"] = strings.Repeat("A", 65)
 			mustWrite(t, path, marshalJSON(t, wrapper))
 		}},
+		{"wrong-signature-length", "dsse_signature_invalid", func(t *testing.T, root string) {
+			path := filepath.Join(root, "envelope.dsse.json")
+			var wrapper map[string]any
+			strictDecodeTest(t, mustRead(t, path), &wrapper)
+			// This is valid base64 and passes the JSON schema's encoded-length
+			// floor, but decodes to 48 bytes rather than an Ed25519 signature.
+			wrapper["signatures"].([]any)[0].(map[string]any)["sig"] = strings.Repeat("A", 64)
+			mustWrite(t, path, marshalJSON(t, wrapper))
+		}},
 		{"requirement-payload-type", "requirement_payload_type_mismatch", func(t *testing.T, root string) {
 			path := filepath.Join(root, "requirement.dsse.json")
 			var wrapper map[string]any

--- a/control-evidence/v0/verifier/schema_assessor_test.go
+++ b/control-evidence/v0/verifier/schema_assessor_test.go
@@ -1,0 +1,508 @@
+package verifier
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const testVerifierDigest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func TestAssessSchemaGoldenPackage(t *testing.T) {
+	packageDir := schemaFixture(t)
+	result := assessSchemaFixture(packageDir)
+	if got := result.Predicates[0]; got.Status != "PASS" || got.Reason != "package_format_valid" {
+		t.Fatalf("AssessSchema() = %#v", result)
+	}
+	if result.Evidence == nil || result.Evidence.ManifestSHA256 != digestBytes(mustRead(t, filepath.Join(packageDir, "manifest.json"))) {
+		t.Fatalf("evidence = %#v", result.Evidence)
+	}
+}
+
+func TestAssessSchemaAcceptsAllGoldenAndEdgePackages(t *testing.T) {
+	for _, class := range []string{"golden", "edge"} {
+		packages, err := filepath.Glob(filepath.Join("..", "conformance", class, "*"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, packageDir := range packages {
+			t.Run(filepath.Join(class, filepath.Base(packageDir)), func(t *testing.T) {
+				options := schemaOptions(packageDir)
+				options.AllowConformanceSidecars = true
+				assertSchemaResult(t, AssessSchema(options), "PASS", "package_format_valid")
+			})
+		}
+	}
+}
+
+func TestAssessSchemaRejectsConformanceSidecarsByDefault(t *testing.T) {
+	packageDir := schemaFixture(t)
+	if err := os.WriteFile(filepath.Join(packageDir, "context.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result := assessSchemaFixture(packageDir)
+	assertSchemaResult(t, result, "FAIL", "manifest_member_uncommitted")
+
+	options := schemaOptions(packageDir)
+	options.AllowConformanceSidecars = true
+	result = AssessSchema(options)
+	assertSchemaResult(t, result, "PASS", "package_format_valid")
+}
+
+func TestAssessSchemaUnavailablePackageIsNotAFormatFailure(t *testing.T) {
+	assertSchemaResult(t, assessSchemaFixture(filepath.Join(t.TempDir(), "missing")), "UNVERIFIABLE", "package_unavailable")
+}
+
+func TestAssessSchemaRejectsInvalidVerifierIdentity(t *testing.T) {
+	for _, mutate := range []func(*SchemaOptions){
+		func(options *SchemaOptions) { options.VerifierName = "" },
+		func(options *SchemaOptions) { options.VerifierVersion = " " },
+		func(options *SchemaOptions) { options.VerifierSHA256 = "AAAA" + testVerifierDigest[4:] },
+		func(options *SchemaOptions) { options.VerifierSHA256 = "abcd" },
+	} {
+		options := schemaOptions(schemaFixture(t))
+		mutate(&options)
+		assertSchemaResult(t, AssessSchema(options), "UNVERIFIABLE", "verifier_identity_invalid")
+	}
+}
+
+func TestAssessSchemaSuppliesAssessmentTimeWhenCallerOmitsIt(t *testing.T) {
+	options := schemaOptions(schemaFixture(t))
+	options.AssessmentTime = time.Time{}
+	result := AssessSchema(options)
+	assertSchemaResult(t, result, "PASS", "package_format_valid")
+	if _, err := time.Parse(time.RFC3339, result.AssessmentTime); err != nil {
+		t.Fatalf("assessment_time = %q: %v", result.AssessmentTime, err)
+	}
+}
+
+func TestAssessSchemaRejectsNonDirectoryPackage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "package.json")
+	mustWrite(t, path, []byte("{}"))
+	assertSchemaResult(t, assessSchemaFixture(path), "FAIL", "package_structure_invalid")
+}
+
+func TestAssessSchemaHostilePackages(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		mutate func(*testing.T, string)
+	}{
+		{"undeclared-member", "manifest_member_uncommitted", func(t *testing.T, root string) {
+			mustWrite(t, filepath.Join(root, "undeclared.bin"), []byte("not committed"))
+		}},
+		{"manifest-length-mismatch", "manifest_member_mismatch", func(t *testing.T, root string) {
+			mutateManifest(t, root, func(value map[string]any) {
+				entries := value["entries"].([]any)
+				entries[0].(map[string]any)["byte_length"] = json.Number("1")
+			}, false)
+		}},
+		{"duplicate-manifest-path", "manifest_path_ambiguous", func(t *testing.T, root string) {
+			mutateManifest(t, root, func(value map[string]any) {
+				entries := value["entries"].([]any)
+				value["entries"] = append(entries, entries[0])
+			}, false)
+		}},
+		{"envelope-manifest-binding", "envelope_manifest_binding_mismatch", func(t *testing.T, root string) {
+			path := filepath.Join(root, "manifest.json")
+			mustWrite(t, path, append(mustRead(t, path), '\n'))
+		}},
+		{"duplicate-manifest-key", "manifest_invalid", func(t *testing.T, root string) {
+			data := mustRead(t, filepath.Join(root, "manifest.json"))
+			data = bytes.Replace(data, []byte(`"profile":`), []byte(`"profile":"control-evidence-manifest/v0","profile":`), 1)
+			mustWrite(t, filepath.Join(root, "manifest.json"), data)
+		}},
+		{"noncanonical-envelope-payload", "signed_payload_not_jcs", func(t *testing.T, root string) {
+			mutateEnvelopePayload(t, root, func(payload []byte) []byte {
+				return append([]byte(" \n"), payload...)
+			})
+		}},
+		{"invalid-signature-base64", "dsse_signature_base64_invalid", func(t *testing.T, root string) {
+			path := filepath.Join(root, "envelope.dsse.json")
+			var wrapper map[string]any
+			strictDecodeTest(t, mustRead(t, path), &wrapper)
+			wrapper["signatures"].([]any)[0].(map[string]any)["sig"] = strings.Repeat("A", 65)
+			mustWrite(t, path, marshalJSON(t, wrapper))
+		}},
+		{"requirement-payload-type", "requirement_payload_type_mismatch", func(t *testing.T, root string) {
+			path := filepath.Join(root, "requirement.dsse.json")
+			var wrapper map[string]any
+			strictDecodeTest(t, mustRead(t, path), &wrapper)
+			wrapper["payloadType"] = typeEnvelope
+			mustWrite(t, path, marshalJSON(t, wrapper))
+			rebindManifestAndEnvelope(t, root)
+		}},
+		{"invalid-outcomes-schema", "outcomes_schema_invalid", func(t *testing.T, root string) {
+			var value map[string]any
+			strictDecodeTest(t, mustRead(t, filepath.Join(root, "outcomes.json")), &value)
+			value["unexpected"] = true
+			mustWrite(t, filepath.Join(root, "outcomes.json"), marshalJSON(t, value))
+			rebindManifestAndEnvelope(t, root)
+		}},
+		{"wrong-outcomes-media-type", "outcomes_schema_invalid", func(t *testing.T, root string) {
+			changeRoleMediaType(t, root, "outcomes", "application/octet-stream")
+		}},
+		{"wrong-core-media-type", "manifest_media_type_mismatch", func(t *testing.T, root string) {
+			mutateManifest(t, root, func(value map[string]any) {
+				for _, raw := range value["entries"].([]any) {
+					entry := raw.(map[string]any)
+					if entry["role"] == "summary" {
+						entry["media_type"] = "text/plain"
+					}
+				}
+			}, true)
+		}},
+		{"invalid-tool-profile-schema", "tool_profile_schema_invalid", func(t *testing.T, root string) {
+			path := filepath.Join(root, "tool-profile.json")
+			var value map[string]any
+			strictDecodeTest(t, mustRead(t, path), &value)
+			value["unexpected"] = true
+			mustWrite(t, path, marshalJSON(t, value))
+			rebindManifestAndEnvelope(t, root)
+		}},
+		{"wrong-tool-profile-media-type", "tool_profile_schema_invalid", func(t *testing.T, root string) {
+			changeRoleMediaType(t, root, "tool-profile", "application/octet-stream")
+		}},
+		{"invalid-observer-payload", "observer_evidence_schema_invalid", func(t *testing.T, root string) {
+			path := filepath.Join(root, "observer-target-1.dsse.json")
+			mutateDSSEPayload(t, path, func(payload []byte) []byte { return append([]byte(" "), payload...) })
+			rebindManifestAndEnvelope(t, root)
+		}},
+		{"wrong-observer-media-type", "observer_evidence_schema_invalid", func(t *testing.T, root string) {
+			changeRoleMediaType(t, root, "observer-evidence", "application/octet-stream")
+		}},
+		{"invalid-opaque-json", "json_member_invalid", func(t *testing.T, root string) {
+			path := filepath.Join(root, "policy.json")
+			mustWrite(t, path, []byte(`{"profile":"synthetic-policy/v1"} trailing`))
+			rebindManifestAndEnvelope(t, root)
+		}},
+		{"trailing-json-member", "json_member_invalid", func(t *testing.T, root string) {
+			path := filepath.Join(root, "summary.json")
+			mustWrite(t, path, append(mustRead(t, path), []byte("\nnull")...))
+			rebindManifestAndEnvelope(t, root)
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := schemaFixture(t)
+			tc.mutate(t, root)
+			assertSchemaResult(t, assessSchemaFixture(root), "FAIL", tc.reason)
+		})
+	}
+}
+
+func TestAssessSchemaRejectsInvalidClockPayload(t *testing.T) {
+	root := schemaFixtureNamed(t, "golden", "g02-customer-completion-clock")
+	var manifestValue manifest
+	if _, err := strictJSON(mustRead(t, filepath.Join(root, "manifest.json")), &manifestValue); err != nil {
+		t.Fatal(err)
+	}
+	var clockPath string
+	for _, entry := range manifestValue.Entries {
+		if entry.Role == "clock-evidence" {
+			clockPath = filepath.Join(root, entry.Path)
+			break
+		}
+	}
+	if clockPath == "" {
+		t.Fatal("golden clock fixture has no clock-evidence member")
+	}
+	mutateDSSEPayload(t, clockPath, func(payload []byte) []byte { return append([]byte(" "), payload...) })
+	rebindManifestAndEnvelope(t, root)
+	assertSchemaResult(t, assessSchemaFixture(root), "FAIL", "clock_evidence_schema_invalid")
+}
+
+func TestAssessSchemaRejectsWrongClockMediaType(t *testing.T) {
+	root := schemaFixtureNamed(t, "golden", "g02-customer-completion-clock")
+	changeRoleMediaType(t, root, "clock-evidence", "application/octet-stream")
+	assertSchemaResult(t, assessSchemaFixture(root), "FAIL", "clock_evidence_schema_invalid")
+}
+
+func TestAssessSchemaDoesNotClaimSignatureAuthentication(t *testing.T) {
+	root := schemaFixture(t)
+	path := filepath.Join(root, "envelope.dsse.json")
+	var wrapper map[string]any
+	strictDecodeTest(t, mustRead(t, path), &wrapper)
+	signatures := wrapper["signatures"].([]any)
+	signature := signatures[0].(map[string]any)["sig"].(string)
+	replacement := "A"
+	if signature[0] == 'A' {
+		replacement = "B"
+	}
+	signatures[0].(map[string]any)["sig"] = replacement + signature[1:]
+	mustWrite(t, path, marshalJSON(t, wrapper))
+	assertSchemaResult(t, assessSchemaFixture(root), "PASS", "package_format_valid")
+}
+
+func TestAssessSchemaDoesNotClaimRequiredArtifactCompleteness(t *testing.T) {
+	root := schemaFixture(t)
+	if err := os.Remove(filepath.Join(root, "policy.json")); err != nil {
+		t.Fatal(err)
+	}
+	mutateManifest(t, root, func(value map[string]any) {
+		entries := value["entries"].([]any)
+		filtered := make([]any, 0, len(entries)-1)
+		for _, raw := range entries {
+			if raw.(map[string]any)["role"] != "policy" {
+				filtered = append(filtered, raw)
+			}
+		}
+		value["entries"] = filtered
+	}, false)
+	rebindManifestAndEnvelope(t, root)
+	assertSchemaResult(t, assessSchemaFixture(root), "PASS", "package_format_valid")
+}
+
+func TestSchemaAssessmentMatchesPublishedSchema(t *testing.T) {
+	result := assessSchemaFixture(schemaFixture(t))
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := assessmentSchema(t)
+	value, err := strictJSON(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(value); err != nil {
+		t.Fatalf("assessment schema validation: %v\n%s", err, raw)
+	}
+}
+
+func TestAssessmentSchemaRejectsIncompletePassClaims(t *testing.T) {
+	schema := assessmentSchema(t)
+	base, err := json.Marshal(assessSchemaFixture(schemaFixture(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{"schema-pass-without-manifest-digest", func(value map[string]any) {
+			delete(value["evidence"].(map[string]any), "manifest_sha256")
+		}},
+		{"schema-pass-without-assessment-time", func(value map[string]any) {
+			delete(value, "assessment_time")
+		}},
+		{"schema-pass-with-external-state", func(value map[string]any) {
+			value["external_state"] = map[string]any{}
+		}},
+		{"authentication-pass-without-external-state", func(value map[string]any) {
+			value["predicates"].([]any)[0].(map[string]any)["name"] = "authenticated-at(T)"
+			delete(value["evidence"].(map[string]any), "manifest_sha256")
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var value map[string]any
+			if _, err := strictJSON(base, &value); err != nil {
+				t.Fatal(err)
+			}
+			tc.mutate(value)
+			if err := schema.Validate(value); err == nil {
+				t.Fatal("assessment schema accepted incomplete PASS claim")
+			}
+		})
+	}
+
+	failure := AssessSchema(SchemaOptions{})
+	raw, err := json.Marshal(failure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := strictJSON(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(value); err != nil {
+		t.Fatalf("schema rejected honest UNVERIFIABLE without evidence: %v", err)
+	}
+}
+
+func assessmentSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	schemaPath := filepath.Join("..", "..", "..", "schemas", "control-evidence-assessment.schema.json")
+	schemaBytes := mustRead(t, schemaPath)
+	compiler := jsonschema.NewCompiler()
+	document, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compiler.AddResource("assessment.json", document); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("assessment.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return schema
+}
+
+func schemaFixture(t *testing.T) string {
+	return schemaFixtureNamed(t, "golden", "g01-vendor-time")
+}
+
+func schemaFixtureNamed(t *testing.T, class, name string) string {
+	t.Helper()
+	source := filepath.Join("..", "conformance", class, name)
+	destination := t.TempDir()
+	err := filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil || relative == "." {
+			return err
+		}
+		target := filepath.Join(destination, relative)
+		if entry.IsDir() {
+			return os.Mkdir(target, 0o750)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o600)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Remove(filepath.Join(destination, "context.json"))
+	_ = os.Remove(filepath.Join(destination, "expect.json"))
+	return destination
+}
+
+func schemaOptions(packageDir string) SchemaOptions {
+	return SchemaOptions{PackageDir: packageDir, VerifierName: "schema-test", VerifierVersion: "v1", VerifierSHA256: testVerifierDigest, AssessmentTime: time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)}
+}
+
+func assessSchemaFixture(packageDir string) SchemaAssessment {
+	return AssessSchema(schemaOptions(packageDir))
+}
+
+func assertSchemaResult(t *testing.T, result SchemaAssessment, status, reason string) {
+	t.Helper()
+	if len(result.Predicates) != 1 || result.Predicates[0].Status != status || result.Predicates[0].Reason != reason {
+		t.Fatalf("result = %#v, want %s/%s", result, status, reason)
+	}
+}
+
+func mutateManifest(t *testing.T, root string, mutate func(map[string]any), rebind bool) {
+	t.Helper()
+	var value map[string]any
+	strictDecodeTest(t, mustRead(t, filepath.Join(root, "manifest.json")), &value)
+	mutate(value)
+	mustWrite(t, filepath.Join(root, "manifest.json"), marshalJSON(t, value))
+	if rebind {
+		rebindEnvelope(t, root)
+	}
+}
+
+func changeRoleMediaType(t *testing.T, root, role, mediaType string) {
+	t.Helper()
+	mutateManifest(t, root, func(value map[string]any) {
+		for _, raw := range value["entries"].([]any) {
+			entry := raw.(map[string]any)
+			if entry["role"] == role {
+				entry["media_type"] = mediaType
+			}
+		}
+	}, true)
+}
+
+func rebindManifestAndEnvelope(t *testing.T, root string) {
+	t.Helper()
+	path := filepath.Join(root, "manifest.json")
+	var value map[string]any
+	strictDecodeTest(t, mustRead(t, path), &value)
+	var total int64
+	for _, raw := range value["entries"].([]any) {
+		entry := raw.(map[string]any)
+		data := mustRead(t, filepath.Join(root, entry["path"].(string)))
+		entry["byte_length"] = json.Number(fmt.Sprint(len(data)))
+		entry["sha256"] = fmt.Sprintf("%x", sha256.Sum256(data))
+		total += int64(len(data))
+	}
+	value["total_uncompressed_bytes"] = json.Number(fmt.Sprint(total))
+	mustWrite(t, path, marshalJSON(t, value))
+	rebindEnvelope(t, root)
+}
+
+func rebindEnvelope(t *testing.T, root string) {
+	t.Helper()
+	mutateEnvelopePayload(t, root, func(payload []byte) []byte {
+		var value map[string]any
+		strictDecodeTest(t, payload, &value)
+		artifacts := value["artifacts"].(map[string]any)
+		manifestBytes := mustRead(t, filepath.Join(root, "manifest.json"))
+		artifacts["manifest_sha256"] = fmt.Sprintf("%x", sha256.Sum256(manifestBytes))
+		var manifestValue map[string]any
+		strictDecodeTest(t, manifestBytes, &manifestValue)
+		artifacts["count"] = json.Number(fmt.Sprint(len(manifestValue["entries"].([]any))))
+		return marshalJSON(t, value)
+	})
+}
+
+func mutateEnvelopePayload(t *testing.T, root string, mutate func([]byte) []byte) {
+	t.Helper()
+	mutateDSSEPayload(t, filepath.Join(root, "envelope.dsse.json"), mutate)
+}
+
+func mutateDSSEPayload(t *testing.T, path string, mutate func([]byte) []byte) {
+	t.Helper()
+	var wrapper map[string]any
+	strictDecodeTest(t, mustRead(t, path), &wrapper)
+	payload, err := base64.StdEncoding.Strict().DecodeString(wrapper["payload"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapper["payload"] = base64.StdEncoding.EncodeToString(mutate(payload))
+	mustWrite(t, path, marshalJSON(t, wrapper))
+}
+
+func marshalJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := jsoncanonicalizer.Transform(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return canonical
+}
+
+func strictDecodeTest(t *testing.T, data []byte, target any) {
+	t.Helper()
+	if _, err := strictJSON(data, target); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func mustWrite(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/control-evidence/v0/verifier/verifier.go
+++ b/control-evidence/v0/verifier/verifier.go
@@ -152,6 +152,10 @@ func VerifyWithOptions(packageDir string, options VerifyOptions) Result {
 }
 
 func loadDirectoryPackage(root string) (map[string][]byte, error) {
+	return loadDirectoryPackageWithOptions(root, true)
+}
+
+func loadDirectoryPackageWithOptions(root string, allowConformanceSidecars bool) (map[string][]byte, error) {
 	info, err := os.Lstat(root)
 	if err != nil || !info.IsDir() {
 		return nil, errors.New("package is not a directory")
@@ -191,7 +195,7 @@ func loadDirectoryPackage(root string) (map[string][]byte, error) {
 			return fmt.Errorf("unsafe member path %s", rel)
 		}
 		// Conformance sidecars are independent verifier inputs, not package members.
-		if rel == "context.json" || rel == "expect.json" {
+		if allowConformanceSidecars && (rel == "context.json" || rel == "expect.json") {
 			return nil
 		}
 		if len(files) >= maxMembers {

--- a/docs/ARTIFACT-PROVENANCE.md
+++ b/docs/ARTIFACT-PROVENANCE.md
@@ -1,6 +1,31 @@
 # Artifact provenance predicates
 
-This opt-in G2 assessor evaluates one predicate only: `authenticated-at(T)`.
+The opt-in G2 assessors currently evaluate two separately callable predicates:
+`schema-valid` and `authenticated-at(T)`. They do not combine those results
+into a tier, score, or producer-awarded badge. Each assessment artifact carries
+one predicate and the identity of the verifier binary that evaluated it;
+consumers compose the separate results by their shared evidence binding.
+
+`schema-valid` is a package-format claim. `PASS` means the bounded directory
+shape is safe, the manifest is closed and matches every committed member's
+path, role, media type, length, and digest, the envelope binds that exact
+manifest, schema-governed v0 documents satisfy their closed schemas, other
+JSON members are strict JSON without duplicate keys or trailing data, and
+every signed payload is RFC 8785 JCS. It does not verify any signature or
+trusted signer and makes no claim about correctness, freshness, or complete
+benchmark scope. Opaque policy, adapter, provenance, and attachment documents
+have no v0 content schema; their bytes are manifest-bound and JSON-typed ones
+must parse strictly, but `schema-valid` does not invent semantics for them.
+Whether every artifact demanded by the buyer requirement is present belongs to
+the separate `closed-scope-complete` predicate; format validity does not absorb
+that completeness claim.
+
+The schema assessor accepts directory packages only. It rejects fixture
+`context.json` and `expect.json` sidecars as undeclared members unless the
+explicit conformance-only option is selected. An unavailable package or
+verifier-schema failure is `UNVERIFIABLE`; a presented malformed package is
+`FAIL`.
+
 It reads a Control Evidence v0 directory package, an externally supplied signed
 trust policy, an independently managed verifier trust context, and a durable
 verifier-owned policy checkpoint. The trust context is the root of trust: the
@@ -16,8 +41,8 @@ assigned by the external trust-policy entry; where a v0 payload also declares
 signer authority, the two must agree. V0 observer evidence does not declare an
 authority, so this predicate does not infer observer independence or ownership.
 This assessor intentionally does not validate the complete v0 package contract:
-a separate `schema-valid` predicate must establish manifest fields, lengths,
-media types, required roles, and closed membership. Do not present
+the separate `schema-valid` predicate establishes package shape and governed
+schemas. Do not present
 `authenticated-at(T)` alone as proof of package validity or completeness. It
 also does not claim freshness, anchoring, reproduction, counterparty
 confirmation, or any tier or score.

--- a/docs/ARTIFACT-PROVENANCE.md
+++ b/docs/ARTIFACT-PROVENANCE.md
@@ -26,10 +26,11 @@ explicit conformance-only option is selected. An unavailable package or
 verifier-schema failure is `UNVERIFIABLE`; a presented malformed package is
 `FAIL`.
 
-It reads a Control Evidence v0 directory package, an externally supplied signed
-trust policy, an independently managed verifier trust context, and a durable
-verifier-owned policy checkpoint. The trust context is the root of trust: the
-buyer or verifier operator must deliver and protect it outside the producer's
+`authenticated-at(T)` reads a Control Evidence v0 directory package, an
+externally supplied signed trust policy, an independently managed verifier
+trust context, and a durable verifier-owned policy checkpoint. The trust
+context is the root of trust: the buyer or verifier operator must deliver and
+protect it outside the producer's
 control. A producer-supplied context can select its own bootstrap key and must
 never be accepted as independent input. The CLI emits its result on standard
 output; callers must retain that assessment outside the submitted package.

--- a/docs/CONTROL-EVIDENCE.md
+++ b/docs/CONTROL-EVIDENCE.md
@@ -46,6 +46,11 @@ member uses `application/vnd.agent-egress-bench.control-evidence-clock-evidence.
 ## Schemas
 
 All v0 schemas are JSON Schema draft 2020-12 and reject unknown fields.
+This applies to the schema-governed documents listed below. Preserved runner
+summaries and opaque policy, adapter, provenance, or attachment documents do
+not acquire an invented v0 content schema: their bytes remain manifest-bound,
+and JSON-typed members are still parsed with duplicate-key and trailing-data
+rejection by the G2 `schema-valid` assessor.
 
 Signed payload bytes are RFC 8785 JCS bytes. V0 schemas use closed ASCII property names and bounded
 safe integers, so non-BMP property-name ordering and unsafe JSON numbers are outside valid instances.

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -286,7 +286,7 @@ func TestRunMCPStdio_UnprovenNonEmptyResponseSkips(t *testing.T) {
 func TestRunMCPStdio_UnobservedPolicyDenyBlocks(t *testing.T) {
 	// A security decision happens before any upstream forwarding. Observation is
 	// proof for an allow, not a precondition for recognizing a policy deny.
-	result := (&ProxyAdapter{mcpCmd: `printf '{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"policy denied"}}\n'`}).runMCPStdio(
+	result := (&ProxyAdapter{mcpCmd: mcpStdioTestProxyCommand(t, "policy-deny-no-forward")}).runMCPStdio(
 		mcpStdioExpectedBlockResponseCase("mcp-stdio-unobserved-policy-deny"), 5*time.Second)
 	if result.Err != nil {
 		t.Fatalf("unexpected error: %v", result.Err)
@@ -315,7 +315,7 @@ func TestRunMCPStdio_UnobservedDenyExitSkipsButStructuredPolicyDenyBlocks(t *tes
 		t.Fatalf("upstream_requests_observed = %v, want 0; evidence=%+v", got, result.Evidence)
 	}
 
-	structured := (&ProxyAdapter{mcpCmd: `printf '{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"policy denied"}}\n'`}).runMCPStdio(
+	structured := (&ProxyAdapter{mcpCmd: mcpStdioTestProxyCommand(t, "policy-deny-no-forward")}).runMCPStdio(
 		mcpStdioExpectedBlockResponseCase("mcp-stdio-structured-policy-deny"), 5*time.Second)
 	if structured.Err != nil {
 		t.Fatalf("structured policy deny error: %v", structured.Err)
@@ -527,11 +527,15 @@ func TestMCPStdioProxyHelper(t *testing.T) {
 	if os.Getenv("AEB_MCP_STDIO_TEST_HELPER") != "1" {
 		return
 	}
+	mode := os.Args[len(os.Args)-1]
+	if mode == "policy-deny-no-forward" {
+		_, _ = fmt.Fprintln(os.Stdout, `{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"policy denied"}}`)
+		return
+	}
 	addr := os.Getenv(mcpStdioUpstreamAddrEnv)
 	if addr == "" {
 		return
 	}
-	mode := os.Args[len(os.Args)-1]
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "dial runner-owned MCP stdio upstream: %v\n", err)

--- a/schemas/control-evidence-assessment.schema.json
+++ b/schemas/control-evidence-assessment.schema.json
@@ -22,7 +22,10 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["envelope_payload_sha256"],
-      "properties": {"envelope_payload_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}}
+      "properties": {
+        "envelope_payload_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "manifest_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
     },
     "external_state": {
       "type": "object",
@@ -46,7 +49,7 @@
         "additionalProperties": false,
         "required": ["name", "status", "reason"],
         "properties": {
-          "name": {"const": "authenticated-at(T)"},
+          "name": {"enum": ["schema-valid", "authenticated-at(T)"]},
           "status": {"enum": ["PASS", "FAIL", "UNVERIFIABLE"]},
           "reason": {"type": "string", "minLength": 1, "maxLength": 256}
         }
@@ -55,7 +58,7 @@
   },
   "allOf": [
     {
-      "if": {"properties": {"predicates": {"contains": {"properties": {"status": {"const": "PASS"}}}}}},
+      "if": {"properties": {"predicates": {"contains": {"required": ["name", "status"], "properties": {"name": {"const": "authenticated-at(T)"}, "status": {"const": "PASS"}}}}}},
       "then": {
         "required": ["assessment_time", "evidence", "external_state"],
         "properties": {
@@ -67,6 +70,23 @@
             }
           },
           "external_state": {"required": ["checkpoint_sha256"]}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"predicates": {"contains": {"required": ["name", "status"], "properties": {"name": {"const": "schema-valid"}, "status": {"const": "PASS"}}}}}},
+      "then": {
+        "required": ["assessment_time", "evidence"],
+        "properties": {
+          "verifier": {
+            "properties": {
+              "name": {"minLength": 1},
+              "version": {"minLength": 1},
+              "sha256": {"pattern": "^[a-f0-9]{64}$"}
+            }
+          },
+          "evidence": {"required": ["envelope_payload_sha256", "manifest_sha256"]},
+          "external_state": false
         }
       }
     }


### PR DESCRIPTION
## Summary

- add a separately callable `schema-valid` G2 assessment and self-identifying CLI for Control Evidence v0 directory packages
- reuse the v0 safe loader, strict JSON/JCS, schema, and manifest-binding implementation so authentication and format validation cannot drift
- extend the assessment schema and documentation with exact PASS bindings and explicit non-claims

## Boundaries

`schema-valid` checks package format only. It does not authenticate signatures, establish trusted signer authority, or claim buyer-required-artifact or benchmark-scope completeness. Those remain separate predicates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an independently callable schema-validity assessment for Control Evidence packages.
  * Added a command-line verifier with JSON results, timestamps, executable identification, and status-based exit codes.
  * Added optional support for conformance sidecar files.
  * Assessments now report PASS, FAIL, or UNVERIFIABLE outcomes with reasons and evidence hashes.

* **Documentation**
  * Clarified the separate `schema-valid` and `authenticated-at(T)` assessments and how they can be combined.
  * Documented handling of opaque documents, governed schemas, package completeness, and validation limits.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->