### PR TITLE
fix(deps): update x/text to 0.39.0

### DIFF
--- a/control-evidence/g2/authentication/go.mod
+++ b/control-evidence/g2/authentication/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 )
 
-require golang.org/x/text v0.14.0 // indirect
+require golang.org/x/text v0.39.0 // indirect

--- a/control-evidence/g2/authentication/go.sum
+++ b/control-evidence/g2/authentication/go.sum
@@ -4,5 +4,5 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=

--- a/control-evidence/v0/conformance/_generator/go.mod
+++ b/control-evidence/v0/conformance/_generator/go.mod
@@ -1,7 +1,7 @@
 module github.com/luckyPipewrench/agent-egress-bench/control-evidence/v0/conformance/generator
 
-go 1.24
+go 1.25.0
 
 require github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 
-require golang.org/x/text v0.14.0 // indirect
+require golang.org/x/text v0.39.0 // indirect

--- a/control-evidence/v0/conformance/_generator/go.sum
+++ b/control-evidence/v0/conformance/_generator/go.sum
@@ -2,5 +2,5 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=


### PR DESCRIPTION
Update the remaining control-evidence modules from `golang.org/x/text` 0.14.0 to 0.39.0.

This resolves GO-2026-5970 / CVE-2026-56852, an infinite-loop vulnerability triggered by invalid UTF-8 during Unicode normalization. The conformance generator now declares Go 1.25, matching the repository’s existing CI toolchain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal component requirements and supporting libraries.
  * Improved compatibility with the latest Go toolchain.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->