### PR TITLE
feat: add buyer-reproduced assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Each tool publishes its own results independently; this repo produces no ranking
 - [SCORING.md](docs/SCORING.md): pass/fail/not_applicable/error scoring model
 - [RECEIPT-SCORING.md](docs/RECEIPT-SCORING.md): receipt evidence scoring axis for independently verifiable artifacts
 - [CONTROL-EVIDENCE.md](docs/CONTROL-EVIDENCE.md): v0 run-level control-evidence package and verifier contract
-- [ARTIFACT-PROVENANCE.md](docs/ARTIFACT-PROVENANCE.md): opt-in external `schema-valid` and `authenticated-at(T)` provenance assessments
+- [ARTIFACT-PROVENANCE.md](docs/ARTIFACT-PROVENANCE.md): opt-in external `schema-valid`, `authenticated-at(T)`, and `buyer-reproduced` provenance assessments
 - [gauntlet.md](docs/gauntlet.md): Gauntlet scoring methodology (containment, FP rate, detection, evidence)
 - [RUNNER.md](docs/RUNNER.md): runner output contract and verdict mapping
 - [ADOPTION.md](docs/ADOPTION.md): guide for vendors adopting the benchmark

--- a/control-evidence/v0/verifier/README.md
+++ b/control-evidence/v0/verifier/README.md
@@ -51,12 +51,35 @@ signature authentication, trusted ownership, freshness, result correctness,
 or scope completeness; compose it with the corresponding independent G2
 predicates instead of over-reading it.
 
+The buyer-reproduction assessor compares a later buyer-signed statement with an
+immutable source package and digest-binds a closed, normalized reproduction
+transcript:
+
+```sh
+go run ./cmd/aeb-ce-buyer-reproduced \
+  --package /srv/evidence/source-package \
+  --statement /srv/evidence/reproduction/buyer-reproduction.dsse.json \
+  --transcript /srv/evidence/reproduction/normalized-transcript.json
+```
+
+The statement and transcript must be regular files outside the source package.
+A `buyer-reproduced` PASS means the same requirement-signing key attested a
+distinct run with the exact source/input bindings and matching logical outcome
+projection re-derived from that normalized transcript. It does not authorize
+that key, prove the named binary/corpus ran, or prove the transcript was derived
+from raw protocol I/O; compose it with separately bound authentication and
+execution predicates.
+
 Replay records are append-only in v0. Back up and restore the complete private
 directory as one unit. If it is lost or damaged, issue a new buyer requirement
 and nonce; do not replace it with an empty directory and continue trusting old
 requirements. v0 deliberately has no pruning or force-accept operation.
 
-Standard output is one `control-evidence-verification-result/v0` JSON object.
+The full `aeb-cee-verify` command emits one
+`control-evidence-verification-result/v0` JSON object. The G2 assessors emit
+versioned `control-evidence-assessment/*` objects documented by their public
+schemas; `buyer-reproduced` uses v2 so the strict, published v1 contract remains
+unchanged.
 Exit status `0` means valid, `1` means a semantic non-valid result, and `2`
 means invalid CLI usage or an internal encoding failure.
 

--- a/control-evidence/v0/verifier/README.md
+++ b/control-evidence/v0/verifier/README.md
@@ -63,6 +63,9 @@ go run ./cmd/aeb-ce-buyer-reproduced \
 ```
 
 The statement and transcript must be regular files outside the source package.
+The assessor reads them through already-open descriptors while validating that
+boundary, rejects symlink or path replacement, and caps the complete statement
+at 2 MiB and the transcript at 64 MiB.
 A `buyer-reproduced` PASS means the same requirement-signing key attested a
 distinct run with the exact source/input bindings and matching logical outcome
 projection re-derived from that normalized transcript. It does not authorize

--- a/control-evidence/v0/verifier/buyer_reproduced.go
+++ b/control-evidence/v0/verifier/buyer_reproduced.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -20,7 +19,7 @@ const (
 	buyerReproductionProfile  = "control-evidence-buyer-reproduction/v0"
 	buyerReproductionType     = "application/vnd.agent-egress-bench.control-evidence-buyer-reproduction.v0+json"
 	buyerAssessmentProfile    = "control-evidence-assessment/v2"
-	maxReproductionStatement  = int64(1 << 20)
+	maxReproductionStatement  = int64(2 << 20)
 	maxReproductionTranscript = int64(64 << 20)
 )
 
@@ -126,16 +125,19 @@ func AssessBuyerReproduced(options BuyerReproducedOptions) BuyerReproducedAssess
 	if _, err := os.Lstat(options.PackageDir); err != nil {
 		return finish("UNVERIFIABLE", "source_package_unavailable")
 	}
-	statementBytes, err := readBounded(options.StatementPath, maxReproductionStatement)
+	statementBytes, err := readExternalBounded(options.PackageDir, options.StatementPath, maxReproductionStatement)
 	if err != nil {
+		if errors.Is(err, errEvidenceNotExternal) {
+			return finish("FAIL", "reproduction_evidence_not_external")
+		}
 		return finish("UNVERIFIABLE", "reproduction_statement_unavailable")
 	}
-	transcriptBytes, err := readBounded(options.TranscriptPath, maxReproductionTranscript)
+	transcriptBytes, err := readExternalBounded(options.PackageDir, options.TranscriptPath, maxReproductionTranscript)
 	if err != nil || len(transcriptBytes) == 0 {
+		if errors.Is(err, errEvidenceNotExternal) {
+			return finish("FAIL", "reproduction_evidence_not_external")
+		}
 		return finish("UNVERIFIABLE", "reproduction_transcript_unavailable")
-	}
-	if !externalEvidencePath(options.PackageDir, options.StatementPath) || !externalEvidencePath(options.PackageDir, options.TranscriptPath) {
-		return finish("FAIL", "reproduction_evidence_not_external")
 	}
 	files, err := loadDirectoryPackageWithOptions(options.PackageDir, false)
 	if err != nil {
@@ -376,28 +378,4 @@ func validLogicalProjectionRow(row buyerOutcomeProjection) bool {
 	default:
 		return false
 	}
-}
-
-func externalEvidencePath(root, path string) bool {
-	resolvedRoot, err := filepath.EvalSymlinks(root)
-	if err != nil {
-		return false
-	}
-	resolvedPath, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return false
-	}
-	rootInfo, err := os.Stat(resolvedRoot)
-	if err != nil || !rootInfo.IsDir() {
-		return false
-	}
-	pathInfo, err := os.Stat(resolvedPath)
-	if err != nil || !pathInfo.Mode().IsRegular() {
-		return false
-	}
-	relative, err := filepath.Rel(resolvedRoot, resolvedPath)
-	if err != nil || relative == "." || relative == "" {
-		return false
-	}
-	return relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }

--- a/control-evidence/v0/verifier/buyer_reproduced.go
+++ b/control-evidence/v0/verifier/buyer_reproduced.go
@@ -1,0 +1,403 @@
+package verifier
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+)
+
+const (
+	buyerReproductionProfile  = "control-evidence-buyer-reproduction/v0"
+	buyerReproductionType     = "application/vnd.agent-egress-bench.control-evidence-buyer-reproduction.v0+json"
+	buyerAssessmentProfile    = "control-evidence-assessment/v2"
+	maxReproductionStatement  = int64(1 << 20)
+	maxReproductionTranscript = int64(64 << 20)
+)
+
+type BuyerReproducedOptions struct {
+	PackageDir      string
+	StatementPath   string
+	TranscriptPath  string
+	VerifierName    string
+	VerifierVersion string
+	VerifierSHA256  string
+	AssessmentTime  time.Time
+}
+
+type BuyerReproducedEvidence struct {
+	EnvelopePayloadSHA256        string `json:"envelope_payload_sha256"`
+	ReproductionStatementSHA256  string `json:"reproduction_statement_sha256"`
+	ReproductionPayloadSHA256    string `json:"reproduction_payload_sha256"`
+	ReproductionTranscriptSHA256 string `json:"reproduction_transcript_sha256"`
+	OutcomesProjectionSHA256     string `json:"outcomes_projection_sha256"`
+}
+
+type BuyerReproducedAssessment struct {
+	Profile        string `json:"profile"`
+	AssessmentTime string `json:"assessment_time,omitempty"`
+	Verifier       struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+		SHA256  string `json:"sha256"`
+	} `json:"verifier"`
+	Evidence   *BuyerReproducedEvidence `json:"evidence,omitempty"`
+	Predicates []AssessmentPredicate    `json:"predicates"`
+}
+
+type buyerReproduction struct {
+	Profile string `json:"profile"`
+	BuyerID string `json:"buyer_id"`
+	Signer  struct {
+		KeyID string `json:"key_id"`
+		Role  string `json:"role"`
+	} `json:"signer"`
+	Source struct {
+		EnvelopePayloadSHA256    string `json:"envelope_payload_sha256"`
+		RequirementPayloadSHA256 string `json:"requirement_payload_sha256"`
+		ToolProfileSHA256        string `json:"tool_profile_sha256"`
+		RunnerBinarySHA256       string `json:"runner_binary_sha256"`
+		CorpusSHA256             string `json:"corpus_sha256"`
+		CorpusManifestSHA256     string `json:"corpus_manifest_sha256"`
+		ScoringVersion           string `json:"scoring_version"`
+		PolicySHA256             string `json:"policy_sha256"`
+		AdapterSHA256            string `json:"adapter_sha256"`
+		OriginalRunID            string `json:"original_run_id"`
+	} `json:"source"`
+	Reproduction struct {
+		RunID                    string `json:"run_id"`
+		TranscriptSHA256         string `json:"transcript_sha256"`
+		OutcomesProjectionSHA256 string `json:"outcomes_projection_sha256"`
+	} `json:"reproduction"`
+}
+
+type buyerReproductionTranscript struct {
+	Profile                     string                   `json:"profile"`
+	SourceEnvelopePayloadSHA256 string                   `json:"source_envelope_payload_sha256"`
+	ReproductionRunID           string                   `json:"reproduction_run_id"`
+	Outcomes                    []buyerOutcomeProjection `json:"outcomes"`
+}
+
+type buyerOutcomeProjection struct {
+	CaseID              string       `json:"case_id"`
+	TrialIndex          int          `json:"trial_index"`
+	Transport           string       `json:"transport"`
+	ExpectedVerdict     string       `json:"expected_verdict"`
+	ActualVerdict       string       `json:"actual_verdict"`
+	Outcome             string       `json:"outcome"`
+	ScoringFacts        scoringFacts `json:"scoring_facts"`
+	NotApplicableReason string       `json:"not_applicable_reason,omitempty"`
+	ErrorReason         string       `json:"error_reason,omitempty"`
+}
+
+func AssessBuyerReproduced(options BuyerReproducedOptions) BuyerReproducedAssessment {
+	result := BuyerReproducedAssessment{Profile: buyerAssessmentProfile}
+	result.Verifier.Name = options.VerifierName
+	result.Verifier.Version = options.VerifierVersion
+	if lowerHexDigest(options.VerifierSHA256) {
+		result.Verifier.SHA256 = options.VerifierSHA256
+	}
+	finish := func(status, reason string) BuyerReproducedAssessment {
+		result.Predicates = []AssessmentPredicate{{Name: "buyer-reproduced", Status: status, Reason: reason}}
+		return result
+	}
+	if strings.TrimSpace(options.VerifierName) == "" || strings.TrimSpace(options.VerifierVersion) == "" || !lowerHexDigest(options.VerifierSHA256) {
+		return finish("UNVERIFIABLE", "verifier_identity_invalid")
+	}
+	assessmentTime := options.AssessmentTime
+	if assessmentTime.IsZero() {
+		assessmentTime = time.Now()
+	}
+	result.AssessmentTime = assessmentTime.UTC().Format(time.RFC3339)
+
+	schemas, err := loadSchemas()
+	if err != nil {
+		return finish("UNVERIFIABLE", "verifier_schema_load_failed")
+	}
+	if _, err := os.Lstat(options.PackageDir); err != nil {
+		return finish("UNVERIFIABLE", "source_package_unavailable")
+	}
+	statementBytes, err := readBounded(options.StatementPath, maxReproductionStatement)
+	if err != nil {
+		return finish("UNVERIFIABLE", "reproduction_statement_unavailable")
+	}
+	transcriptBytes, err := readBounded(options.TranscriptPath, maxReproductionTranscript)
+	if err != nil || len(transcriptBytes) == 0 {
+		return finish("UNVERIFIABLE", "reproduction_transcript_unavailable")
+	}
+	if !externalEvidencePath(options.PackageDir, options.StatementPath) || !externalEvidencePath(options.PackageDir, options.TranscriptPath) {
+		return finish("FAIL", "reproduction_evidence_not_external")
+	}
+	files, err := loadDirectoryPackageWithOptions(options.PackageDir, false)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrPermission) {
+			return finish("UNVERIFIABLE", "source_package_unavailable")
+		}
+		return finish("FAIL", "source_package_invalid")
+	}
+	source, reason := loadBuyerReproductionSource(files, schemas)
+	if reason != "" {
+		return finish("FAIL", reason)
+	}
+	statement, payload, signerKeyID, reason := verifyBuyerReproductionStatement(statementBytes, source.requirementSignerKeyID, schemas)
+	if reason != "" {
+		return finish("FAIL", reason)
+	}
+	if statement.Profile != buyerReproductionProfile || statement.BuyerID != source.requirement.BuyerID ||
+		statement.Signer.KeyID != signerKeyID || statement.Signer.Role != "buyer-reproducer" {
+		return finish("FAIL", "buyer_statement_signer_mismatch")
+	}
+	if !buyerSourceMatches(statement, source) {
+		return finish("FAIL", "buyer_statement_source_binding_mismatch")
+	}
+	if statement.Reproduction.RunID == source.envelope.RunID {
+		return finish("FAIL", "reproduction_run_id_not_fresh")
+	}
+	transcriptDigest := digestBytes(transcriptBytes)
+	if statement.Reproduction.TranscriptSHA256 != transcriptDigest {
+		return finish("FAIL", "reproduction_transcript_digest_mismatch")
+	}
+	transcript, reason := verifyBuyerReproductionTranscript(transcriptBytes, schemas)
+	if reason != "" {
+		return finish("FAIL", reason)
+	}
+	if transcript.SourceEnvelopePayloadSHA256 != source.envelopePayloadSHA256 ||
+		transcript.ReproductionRunID != statement.Reproduction.RunID {
+		return finish("FAIL", "reproduction_transcript_binding_mismatch")
+	}
+	reproducedProjection, ok := canonicalProjection(transcript.Outcomes)
+	if !ok {
+		return finish("FAIL", "reproduction_transcript_invalid")
+	}
+	if digestBytes(reproducedProjection) != statement.Reproduction.OutcomesProjectionSHA256 {
+		return finish("FAIL", "reproduction_projection_digest_mismatch")
+	}
+	sourceProjection, ok := canonicalProjection(source.outcomes)
+	if !ok || !bytes.Equal(sourceProjection, reproducedProjection) {
+		return finish("FAIL", "reproduction_outcomes_mismatch")
+	}
+	result.Evidence = &BuyerReproducedEvidence{
+		EnvelopePayloadSHA256:        source.envelopePayloadSHA256,
+		ReproductionStatementSHA256:  digestBytes(statementBytes),
+		ReproductionPayloadSHA256:    digestBytes(payload),
+		ReproductionTranscriptSHA256: transcriptDigest,
+		OutcomesProjectionSHA256:     digestBytes(reproducedProjection),
+	}
+	return finish("PASS", "buyer_signed_reproduction_matches")
+}
+
+func verifyBuyerReproductionTranscript(data []byte, schemas *schemaSet) (buyerReproductionTranscript, string) {
+	var transcript buyerReproductionTranscript
+	if err := canonicalJSON(data); err != nil {
+		return transcript, "reproduction_transcript_not_jcs"
+	}
+	value, err := strictJSON(data, &transcript)
+	if err != nil || validateSchema(schemas.buyerReproductionTranscript, value) != nil {
+		return transcript, "reproduction_transcript_invalid"
+	}
+	return transcript, ""
+}
+
+type buyerReproductionSource struct {
+	requirement              requirement
+	envelope                 runEnvelope
+	outcomes                 []buyerOutcomeProjection
+	requirementPayloadSHA256 string
+	envelopePayloadSHA256    string
+	toolProfileSHA256        string
+	requirementSignerKeyID   string
+}
+
+func loadBuyerReproductionSource(files map[string][]byte, schemas *schemaSet) (buyerReproductionSource, string) {
+	var source buyerReproductionSource
+	var packageManifest manifest
+	manifestValue, err := strictJSON(files["manifest.json"], &packageManifest)
+	if err != nil || validateSchema(schemas.manifest, manifestValue) != nil {
+		return source, "source_manifest_invalid"
+	}
+	entriesByRole := make(map[string][]manifestEntry)
+	for _, entry := range packageManifest.Entries {
+		entriesByRole[entry.Role] = append(entriesByRole[entry.Role], entry)
+	}
+	if reason := validateManifestPackage(files, packageManifest, entriesByRole); reason != "" {
+		return source, "source_manifest_invalid"
+	}
+	req, _, err := verifyDSSE[requirement](files["requirement.dsse.json"], typeRequirement, "", schemas, schemas.requirement)
+	if err != nil {
+		return source, "source_requirement_invalid"
+	}
+	env, reason := validateStructuralDSSE[runEnvelope](files["envelope.dsse.json"], typeEnvelope, schemas, schemas.envelope)
+	if reason != "" {
+		return source, "source_envelope_invalid"
+	}
+	var sourceOutcomes outcomes
+	outcomesValue, err := strictJSON(files["outcomes.json"], &sourceOutcomes)
+	if err != nil || validateSchema(schemas.outcomes, outcomesValue) != nil {
+		return source, "source_outcomes_invalid"
+	}
+	requirementDigest := digestBytes(req.PayloadBytes)
+	if env.Payload.RequirementSHA256 != requirementDigest || sourceOutcomes.RequirementSHA256 != requirementDigest ||
+		sourceOutcomes.RunID != env.Payload.RunID || env.Payload.Observations.SHA256 != digestBytes(files["outcomes.json"]) ||
+		env.Payload.Observations.RowCount != len(sourceOutcomes.Rows) {
+		return source, "source_binding_invalid"
+	}
+	if env.Payload.Artifacts.ManifestSHA256 != digestBytes(files["manifest.json"]) || env.Payload.Artifacts.Count != len(packageManifest.Entries) {
+		return source, "source_binding_invalid"
+	}
+	profiles := entriesByRole["tool-profile"]
+	if len(profiles) != 1 || profiles[0].SHA256 != req.Payload.ApprovedToolProfile.SHA256 ||
+		env.Payload.Runner.BinarySHA256 != req.Payload.ApprovedRunner.SHA256 ||
+		env.Payload.Policy.SHA256 != req.Payload.ApprovedPolicy.SHA256 ||
+		env.Payload.Adapter.SHA256 != req.Payload.ApprovedAdapter.SHA256 {
+		return source, "source_input_binding_invalid"
+	}
+	source.requirement = req.Payload
+	source.envelope = env.Payload
+	source.requirementPayloadSHA256 = requirementDigest
+	source.envelopePayloadSHA256 = digestBytes(env.PayloadBytes)
+	source.toolProfileSHA256 = profiles[0].SHA256
+	source.requirementSignerKeyID = req.SignerKeyID
+	source.outcomes = make([]buyerOutcomeProjection, len(sourceOutcomes.Rows))
+	for i, row := range sourceOutcomes.Rows {
+		source.outcomes[i] = buyerOutcomeProjection{
+			CaseID: row.CaseID, TrialIndex: row.TrialIndex, Transport: row.Transport,
+			ExpectedVerdict: row.ExpectedVerdict, ActualVerdict: row.ActualVerdict, Outcome: row.Outcome,
+			ScoringFacts: row.ScoringFacts, NotApplicableReason: row.NotApplicableReason, ErrorReason: row.ErrorReason,
+		}
+	}
+	return source, ""
+}
+
+func verifyBuyerReproductionStatement(data []byte, requiredSigner string, schemas *schemaSet) (buyerReproduction, []byte, string, string) {
+	var statement buyerReproduction
+	var wrapper dsseEnvelope
+	wrapperValue, err := strictJSON(data, &wrapper)
+	if err != nil || validateSchema(schemas.buyerReproductionStatement, wrapperValue) != nil ||
+		wrapper.PayloadType != buyerReproductionType || len(wrapper.Signatures) != 1 {
+		return statement, nil, "", "buyer_statement_wrapper_invalid"
+	}
+	payload, err := decodeBase64(wrapper.Payload)
+	if err != nil {
+		return statement, nil, "", "buyer_statement_wrapper_invalid"
+	}
+	if err := canonicalJSON(payload); err != nil {
+		return statement, nil, "", "buyer_statement_payload_not_jcs"
+	}
+	payloadValue, err := strictJSON(payload, &statement)
+	if err != nil || validateSchema(schemas.buyerReproduction, payloadValue) != nil {
+		return statement, nil, "", "buyer_statement_payload_invalid"
+	}
+	signature := wrapper.Signatures[0]
+	if signature.KeyID != requiredSigner {
+		return statement, nil, "", "buyer_statement_signer_mismatch"
+	}
+	publicKey, err := hex.DecodeString(signature.KeyID)
+	if err != nil || len(publicKey) != ed25519.PublicKeySize {
+		return statement, nil, "", "buyer_statement_signer_invalid"
+	}
+	signatureBytes, err := decodeBase64(signature.Sig)
+	if err != nil || len(signatureBytes) != ed25519.SignatureSize ||
+		!ed25519.Verify(ed25519.PublicKey(publicKey), pae(wrapper.PayloadType, payload), signatureBytes) {
+		return statement, nil, "", "buyer_statement_signature_invalid"
+	}
+	return statement, payload, signature.KeyID, ""
+}
+
+func buyerSourceMatches(statement buyerReproduction, source buyerReproductionSource) bool {
+	return statement.Source.EnvelopePayloadSHA256 == source.envelopePayloadSHA256 &&
+		statement.Source.RequirementPayloadSHA256 == source.requirementPayloadSHA256 &&
+		statement.Source.ToolProfileSHA256 == source.toolProfileSHA256 &&
+		statement.Source.RunnerBinarySHA256 == source.envelope.Runner.BinarySHA256 &&
+		statement.Source.CorpusSHA256 == source.envelope.Corpus.CorpusSHA256 &&
+		statement.Source.CorpusManifestSHA256 == source.envelope.Corpus.ManifestSHA256 &&
+		statement.Source.ScoringVersion == source.envelope.Corpus.ScoringVersion &&
+		statement.Source.PolicySHA256 == source.envelope.Policy.SHA256 &&
+		statement.Source.AdapterSHA256 == source.envelope.Adapter.SHA256 &&
+		statement.Source.OriginalRunID == source.envelope.RunID
+}
+
+func canonicalProjection(rows []buyerOutcomeProjection) ([]byte, bool) {
+	if len(rows) == 0 {
+		return nil, false
+	}
+	sorted := append([]buyerOutcomeProjection(nil), rows...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].CaseID == sorted[j].CaseID {
+			return sorted[i].TrialIndex < sorted[j].TrialIndex
+		}
+		return sorted[i].CaseID < sorted[j].CaseID
+	})
+	for i := range sorted {
+		if sorted[i].CaseID == "" || sorted[i].TrialIndex < 1 ||
+			(i > 0 && sorted[i].CaseID == sorted[i-1].CaseID && sorted[i].TrialIndex == sorted[i-1].TrialIndex) ||
+			!validLogicalProjectionRow(sorted[i]) {
+			return nil, false
+		}
+	}
+	raw, err := json.Marshal(sorted)
+	if err != nil {
+		return nil, false
+	}
+	canonical, err := jsoncanonicalizer.Transform(raw)
+	if err != nil {
+		return nil, false
+	}
+	return canonical, true
+}
+
+func validLogicalProjectionRow(row buyerOutcomeProjection) bool {
+	switch row.Outcome {
+	case "pass", "fail":
+		matches := row.ActualVerdict == row.ExpectedVerdict
+		return (row.Outcome == "pass") == matches &&
+			(row.Outcome == "pass") == (row.ScoringFacts.Classification == "correct") &&
+			row.NotApplicableReason == "" && row.ErrorReason == ""
+	case "not_applicable":
+		return row.ActualVerdict == "not_applicable" &&
+			row.ScoringFacts.Classification == "not_applicable" &&
+			row.ScoringFacts.BudgetTiming == "not_measured" &&
+			row.ScoringFacts.StructuredEvidence == "not_applicable" &&
+			row.NotApplicableReason != "" && row.ErrorReason == ""
+	case "error":
+		return row.ActualVerdict == "error" &&
+			row.ScoringFacts.Classification == "error" &&
+			row.ScoringFacts.BudgetTiming == "not_measured" &&
+			row.ScoringFacts.StructuredEvidence == "not_applicable" &&
+			row.ErrorReason != "" && row.NotApplicableReason == ""
+	default:
+		return false
+	}
+}
+
+func externalEvidencePath(root, path string) bool {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false
+	}
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	rootInfo, err := os.Stat(resolvedRoot)
+	if err != nil || !rootInfo.IsDir() {
+		return false
+	}
+	pathInfo, err := os.Stat(resolvedPath)
+	if err != nil || !pathInfo.Mode().IsRegular() {
+		return false
+	}
+	relative, err := filepath.Rel(resolvedRoot, resolvedPath)
+	if err != nil || relative == "." || relative == "" {
+		return false
+	}
+	return relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}

--- a/control-evidence/v0/verifier/buyer_reproduced_test.go
+++ b/control-evidence/v0/verifier/buyer_reproduced_test.go
@@ -1,0 +1,601 @@
+package verifier
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func TestAssessBuyerReproduced(t *testing.T) {
+	options, _, _, _ := buyerReproducedFixture(t)
+	result := AssessBuyerReproduced(options)
+	assertBuyerReproducedResult(t, result, "PASS", "buyer_signed_reproduction_matches")
+
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value any
+	strictDecodeTest(t, raw, &value)
+	if err := buyerAssessmentSchema(t).Validate(value); err != nil {
+		t.Fatalf("assessment schema: %v", err)
+	}
+	if result.Evidence == nil || result.Evidence.ReproductionTranscriptSHA256 == "" ||
+		result.Evidence.ReproductionStatementSHA256 == "" || result.Evidence.OutcomesProjectionSHA256 == "" {
+		t.Fatalf("missing evidence bindings: %#v", result.Evidence)
+	}
+}
+
+func TestAssessmentSchemaRejectsIncompleteBuyerReproducedPass(t *testing.T) {
+	options, _, _, _ := buyerReproducedFixture(t)
+	raw, err := json.Marshal(AssessBuyerReproduced(options))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{
+		"envelope_payload_sha256",
+		"reproduction_statement_sha256",
+		"reproduction_payload_sha256",
+		"reproduction_transcript_sha256",
+		"outcomes_projection_sha256",
+	} {
+		t.Run(field, func(t *testing.T) {
+			var value map[string]any
+			strictDecodeTest(t, raw, &value)
+			delete(value["evidence"].(map[string]any), field)
+			if err := buyerAssessmentSchema(t).Validate(value); err == nil {
+				t.Fatalf("assessment schema accepted buyer-reproduced PASS without %s", field)
+			}
+		})
+	}
+}
+
+func TestAssessBuyerReproducedHostile(t *testing.T) {
+	tests := []struct {
+		name, reason string
+		mutate       func(*BuyerReproducedOptions, *buyerReproduction, string, string)
+	}{
+		{"source-envelope-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Source.EnvelopePayloadSHA256 = stringsOfA(64)
+		}},
+		{"source-requirement-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Source.RequirementPayloadSHA256 = stringsOfA(64)
+		}},
+		{"source-tool-profile-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Source.ToolProfileSHA256 = stringsOfA(64)
+		}},
+		{"source-runner-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Source.RunnerBinarySHA256 = stringsOfA(64)
+		}},
+		{"source-corpus-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Source.CorpusSHA256 = stringsOfA(64)
+		}},
+		{"source-corpus-manifest-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Source.CorpusManifestSHA256 = stringsOfA(64)
+		}},
+		{"source-scoring-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Source.ScoringVersion = "different"
+		}},
+		{"source-policy-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Source.PolicySHA256 = stringsOfA(64)
+		}},
+		{"source-adapter-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Source.AdapterSHA256 = stringsOfA(64)
+		}},
+		{"same-run-id", "reproduction_run_id_not_fresh", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, transcriptPath string) {
+			statement.Reproduction.RunID = statement.Source.OriginalRunID
+			transcript := readBuyerTranscript(t, transcriptPath)
+			transcript.ReproductionRunID = statement.Source.OriginalRunID
+			writeBuyerTranscript(t, transcriptPath, transcript)
+			statement.Reproduction.TranscriptSHA256 = digestBytes(mustRead(t, transcriptPath))
+		}},
+		{"transcript-digest", "reproduction_transcript_digest_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Reproduction.TranscriptSHA256 = stringsOfA(64)
+		}},
+		{"projection-digest", "reproduction_projection_digest_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+			statement.Reproduction.OutcomesProjectionSHA256 = stringsOfA(64)
+		}},
+		{"outcomes-mismatch", "reproduction_outcomes_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, transcriptPath string) {
+			transcript := readBuyerTranscript(t, transcriptPath)
+			transcript.Outcomes[0].ActualVerdict = "allow"
+			transcript.Outcomes[0].Outcome = "fail"
+			transcript.Outcomes[0].ScoringFacts.Classification = "incorrect"
+			writeBuyerTranscript(t, transcriptPath, transcript)
+			statement.Reproduction.TranscriptSHA256 = digestBytes(mustRead(t, transcriptPath))
+			projection, ok := canonicalProjection(transcript.Outcomes)
+			if !ok {
+				panic("invalid test projection")
+			}
+			statement.Reproduction.OutcomesProjectionSHA256 = digestBytes(projection)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
+			test.mutate(&options, statement, statementPath, transcriptPath)
+			writeBuyerStatement(t, statementPath, *statement, buyerTestKey("buyer"))
+			result := AssessBuyerReproduced(options)
+			assertBuyerReproducedResult(t, result, "FAIL", test.reason)
+		})
+	}
+}
+
+func TestAssessBuyerReproducedSignatureAndInputFailures(t *testing.T) {
+	t.Run("rogue-signer", func(t *testing.T) {
+		options, statement, statementPath, _ := buyerReproducedFixture(t)
+		rogue := buyerTestKey("vendor-runner")
+		statement.Signer.KeyID = hex.EncodeToString(rogue.Public().(ed25519.PublicKey))
+		writeBuyerStatement(t, statementPath, *statement, rogue)
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "buyer_statement_signer_mismatch")
+	})
+	t.Run("corrupted-signature", func(t *testing.T) {
+		options, _, statementPath, _ := buyerReproducedFixture(t)
+		var wrapper dsseEnvelope
+		strictDecodeTest(t, mustRead(t, statementPath), &wrapper)
+		signature, err := base64.StdEncoding.Strict().DecodeString(wrapper.Signatures[0].Sig)
+		if err != nil {
+			t.Fatal(err)
+		}
+		signature[0] ^= 0xff
+		wrapper.Signatures[0].Sig = base64.StdEncoding.EncodeToString(signature)
+		mustWrite(t, statementPath, marshalJSON(t, wrapper))
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "buyer_statement_signature_invalid")
+	})
+	t.Run("statement-inside-package", func(t *testing.T) {
+		options, _, statementPath, _ := buyerReproducedFixture(t)
+		inside := filepath.Join(options.PackageDir, "reproduction.dsse.json")
+		if err := os.Rename(statementPath, inside); err != nil {
+			t.Fatal(err)
+		}
+		options.StatementPath = inside
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_evidence_not_external")
+	})
+	t.Run("missing-transcript", func(t *testing.T) {
+		options, _, _, _ := buyerReproducedFixture(t)
+		options.TranscriptPath = filepath.Join(t.TempDir(), "missing")
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "UNVERIFIABLE", "reproduction_transcript_unavailable")
+	})
+	t.Run("empty-transcript", func(t *testing.T) {
+		options, _, _, _ := buyerReproducedFixture(t)
+		empty := filepath.Join(t.TempDir(), "empty.bin")
+		mustWrite(t, empty, nil)
+		options.TranscriptPath = empty
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "UNVERIFIABLE", "reproduction_transcript_unavailable")
+	})
+}
+
+func TestAssessBuyerReproducedEarlyFailures(t *testing.T) {
+	t.Run("invalid-verifier", func(t *testing.T) {
+		options, _, _, _ := buyerReproducedFixture(t)
+		options.VerifierName = ""
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "UNVERIFIABLE", "verifier_identity_invalid")
+	})
+	t.Run("default-assessment-time", func(t *testing.T) {
+		options, _, _, _ := buyerReproducedFixture(t)
+		options.AssessmentTime = time.Time{}
+		result := AssessBuyerReproduced(options)
+		assertBuyerReproducedResult(t, result, "PASS", "buyer_signed_reproduction_matches")
+		if _, err := time.Parse(time.RFC3339, result.AssessmentTime); err != nil {
+			t.Fatalf("assessment time = %q: %v", result.AssessmentTime, err)
+		}
+	})
+	t.Run("missing-source", func(t *testing.T) {
+		options, _, _, _ := buyerReproducedFixture(t)
+		options.PackageDir = filepath.Join(t.TempDir(), "missing")
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "UNVERIFIABLE", "source_package_unavailable")
+	})
+	t.Run("missing-statement", func(t *testing.T) {
+		options, _, _, _ := buyerReproducedFixture(t)
+		options.StatementPath = filepath.Join(t.TempDir(), "missing")
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "UNVERIFIABLE", "reproduction_statement_unavailable")
+	})
+	t.Run("transcript-inside-package", func(t *testing.T) {
+		options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
+		inside := filepath.Join(options.PackageDir, "reproduction-transcript.json")
+		mustWrite(t, inside, mustRead(t, transcriptPath))
+		options.TranscriptPath = inside
+		statement.Reproduction.TranscriptSHA256 = digestBytes(mustRead(t, inside))
+		writeBuyerStatement(t, statementPath, *statement, buyerTestKey("buyer"))
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_evidence_not_external")
+	})
+	t.Run("statement-metadata-mismatch", func(t *testing.T) {
+		options, statement, statementPath, _ := buyerReproducedFixture(t)
+		statement.BuyerID = "different-buyer"
+		writeBuyerStatement(t, statementPath, *statement, buyerTestKey("buyer"))
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "buyer_statement_signer_mismatch")
+	})
+}
+
+func TestAssessBuyerReproducedRejectsMalformedSource(t *testing.T) {
+	tests := []struct {
+		name, reason string
+		mutate       func(*testing.T, string)
+	}{
+		{"manifest-syntax", "source_manifest_invalid", func(t *testing.T, root string) {
+			mustWrite(t, filepath.Join(root, "manifest.json"), []byte("{"))
+		}},
+		{"manifest-closure", "source_manifest_invalid", func(t *testing.T, root string) {
+			mustWrite(t, filepath.Join(root, "undeclared.bin"), []byte("undeclared"))
+		}},
+		{"requirement-signature", "source_requirement_invalid", func(t *testing.T, root string) {
+			path := filepath.Join(root, "requirement.dsse.json")
+			var wrapper dsseEnvelope
+			strictDecodeTest(t, mustRead(t, path), &wrapper)
+			sig, err := base64.StdEncoding.Strict().DecodeString(wrapper.Signatures[0].Sig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sig[0] ^= 0xff
+			wrapper.Signatures[0].Sig = base64.StdEncoding.EncodeToString(sig)
+			mustWrite(t, path, marshalJSON(t, wrapper))
+			rebindManifestAndEnvelope(t, root)
+		}},
+		{"envelope-structural", "source_envelope_invalid", func(t *testing.T, root string) {
+			mustWrite(t, filepath.Join(root, "envelope.dsse.json"), []byte("{}"))
+		}},
+		{"outcomes-schema", "source_outcomes_invalid", func(t *testing.T, root string) {
+			mustWrite(t, filepath.Join(root, "outcomes.json"), []byte("{}"))
+			rebindManifestAndEnvelope(t, root)
+		}},
+		{"outcomes-binding", "source_binding_invalid", func(t *testing.T, root string) {
+			path := filepath.Join(root, "outcomes.json")
+			var value map[string]any
+			strictDecodeTest(t, mustRead(t, path), &value)
+			value["run_id"] = stringsOfA(64)
+			mustWrite(t, path, marshalJSON(t, value))
+			rebindManifestAndEnvelope(t, root)
+		}},
+		{"input-binding", "source_input_binding_invalid", func(t *testing.T, root string) {
+			mutateEnvelopePayload(t, root, func(payload []byte) []byte {
+				var value map[string]any
+				strictDecodeTest(t, payload, &value)
+				value["runner"].(map[string]any)["binary_sha256"] = stringsOfA(64)
+				return marshalJSON(t, value)
+			})
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options, _, _, _ := buyerReproducedFixture(t)
+			test.mutate(t, options.PackageDir)
+			assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", test.reason)
+		})
+	}
+}
+
+func TestAssessBuyerReproducedRejectsMalformedStatement(t *testing.T) {
+	tests := []struct {
+		name, reason string
+		mutate       func(*testing.T, string)
+	}{
+		{"wrapper", "buyer_statement_wrapper_invalid", func(t *testing.T, path string) {
+			mustWrite(t, path, []byte("{"))
+		}},
+		{"payload-base64", "buyer_statement_wrapper_invalid", func(t *testing.T, path string) {
+			var wrapper dsseEnvelope
+			strictDecodeTest(t, mustRead(t, path), &wrapper)
+			wrapper.Payload = "AAAA="
+			mustWrite(t, path, marshalJSON(t, wrapper))
+		}},
+		{"payload-not-jcs", "buyer_statement_payload_not_jcs", func(t *testing.T, path string) {
+			var wrapper dsseEnvelope
+			strictDecodeTest(t, mustRead(t, path), &wrapper)
+			wrapper.Payload = base64.StdEncoding.EncodeToString([]byte(" {}"))
+			mustWrite(t, path, marshalJSON(t, wrapper))
+		}},
+		{"payload-schema", "buyer_statement_payload_invalid", func(t *testing.T, path string) {
+			var wrapper dsseEnvelope
+			strictDecodeTest(t, mustRead(t, path), &wrapper)
+			wrapper.Payload = base64.StdEncoding.EncodeToString([]byte("{}"))
+			mustWrite(t, path, marshalJSON(t, wrapper))
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options, _, statementPath, _ := buyerReproducedFixture(t)
+			test.mutate(t, statementPath)
+			assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", test.reason)
+		})
+	}
+}
+
+func TestAssessBuyerReproducedRejectsMalformedTranscript(t *testing.T) {
+	t.Run("not-jcs", func(t *testing.T) {
+		options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
+		mustWrite(t, transcriptPath, append([]byte(" "), mustRead(t, transcriptPath)...))
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_not_jcs")
+	})
+	t.Run("schema", func(t *testing.T) {
+		options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
+		mustWrite(t, transcriptPath, []byte("{}"))
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_invalid")
+	})
+	t.Run("source-binding", func(t *testing.T) {
+		options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
+		transcript := readBuyerTranscript(t, transcriptPath)
+		transcript.SourceEnvelopePayloadSHA256 = stringsOfA(64)
+		writeBuyerTranscript(t, transcriptPath, transcript)
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_binding_mismatch")
+	})
+	t.Run("run-binding", func(t *testing.T) {
+		options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
+		transcript := readBuyerTranscript(t, transcriptPath)
+		transcript.ReproductionRunID = stringsOfA(64)
+		writeBuyerTranscript(t, transcriptPath, transcript)
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_binding_mismatch")
+	})
+	t.Run("contradictory-outcome", func(t *testing.T) {
+		options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
+		transcript := readBuyerTranscript(t, transcriptPath)
+		transcript.Outcomes[0].Outcome = "fail"
+		writeBuyerTranscript(t, transcriptPath, transcript)
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_invalid")
+	})
+}
+
+func TestCanonicalProjectionNormalizationAndRejection(t *testing.T) {
+	_, _, _, transcriptPath := buyerReproducedFixture(t)
+	rows := readBuyerTranscript(t, transcriptPath).Outcomes
+	if _, ok := canonicalProjection(nil); ok {
+		t.Fatal("empty projection accepted")
+	}
+	second := rows[0]
+	second.CaseID += "-second"
+	rows = append(rows, second)
+	reversed := append([]buyerOutcomeProjection(nil), rows...)
+	for left, right := 0, len(reversed)-1; left < right; left, right = left+1, right-1 {
+		reversed[left], reversed[right] = reversed[right], reversed[left]
+	}
+	want, ok := canonicalProjection(rows)
+	if !ok {
+		t.Fatal("fixture projection invalid")
+	}
+	got, ok := canonicalProjection(reversed)
+	if !ok || !bytes.Equal(got, want) {
+		t.Fatal("projection was not order-independent")
+	}
+	for _, mutate := range []func([]buyerOutcomeProjection){
+		func(candidate []buyerOutcomeProjection) { candidate[0].CaseID = "" },
+		func(candidate []buyerOutcomeProjection) { candidate[0].TrialIndex = 0 },
+		func(candidate []buyerOutcomeProjection) { candidate[1] = candidate[0] },
+		func(candidate []buyerOutcomeProjection) { candidate[0].Outcome = "fail" },
+		func(candidate []buyerOutcomeProjection) { candidate[0].Outcome = "unknown" },
+	} {
+		candidate := append([]buyerOutcomeProjection(nil), rows...)
+		mutate(candidate)
+		if _, ok := canonicalProjection(candidate); ok {
+			t.Fatalf("invalid projection accepted: %#v", candidate[0])
+		}
+	}
+}
+
+func TestValidLogicalProjectionRow(t *testing.T) {
+	_, _, _, transcriptPath := buyerReproducedFixture(t)
+	base := readBuyerTranscript(t, transcriptPath).Outcomes[0]
+	if !validLogicalProjectionRow(base) {
+		t.Fatal("valid pass/fail fixture row rejected")
+	}
+
+	notApplicable := base
+	notApplicable.ActualVerdict = "not_applicable"
+	notApplicable.Outcome = "not_applicable"
+	notApplicable.ScoringFacts = scoringFacts{Classification: "not_applicable", BudgetTiming: "not_measured", StructuredEvidence: "not_applicable"}
+	notApplicable.NotApplicableReason = "unsupported transport"
+	if !validLogicalProjectionRow(notApplicable) {
+		t.Fatal("valid not-applicable row rejected")
+	}
+	notApplicable.ErrorReason = "contradiction"
+	if validLogicalProjectionRow(notApplicable) {
+		t.Fatal("not-applicable row with error reason accepted")
+	}
+
+	errorRow := base
+	errorRow.ActualVerdict = "error"
+	errorRow.Outcome = "error"
+	errorRow.ScoringFacts = scoringFacts{Classification: "error", BudgetTiming: "not_measured", StructuredEvidence: "not_applicable"}
+	errorRow.ErrorReason = "runner timeout"
+	if !validLogicalProjectionRow(errorRow) {
+		t.Fatal("valid error row rejected")
+	}
+	errorRow.NotApplicableReason = "contradiction"
+	if validLogicalProjectionRow(errorRow) {
+		t.Fatal("error row with not-applicable reason accepted")
+	}
+}
+
+func TestExternalEvidencePath(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "inside.json")
+	mustWrite(t, inside, []byte("{}"))
+	outside := filepath.Join(t.TempDir(), "outside.json")
+	mustWrite(t, outside, []byte("{}"))
+	if externalEvidencePath(root, inside) {
+		t.Fatal("inside evidence accepted as external")
+	}
+	if !externalEvidencePath(root, outside) {
+		t.Fatal("outside evidence rejected")
+	}
+	if externalEvidencePath(filepath.Join(root, "missing"), outside) {
+		t.Fatal("missing root accepted")
+	}
+	if externalEvidencePath(root, filepath.Join(root, "missing")) {
+		t.Fatal("missing evidence accepted")
+	}
+	if externalEvidencePath(inside, outside) {
+		t.Fatal("regular file accepted as package root")
+	}
+	if externalEvidencePath(root, t.TempDir()) {
+		t.Fatal("directory accepted as evidence file")
+	}
+}
+
+func TestBuyerReproductionEmbeddedSchemasMatchCanonical(t *testing.T) {
+	for _, name := range []string{
+		"control-evidence-buyer-reproduction.schema.json",
+		"control-evidence-buyer-reproduction-statement.schema.json",
+		"control-evidence-buyer-reproduction-transcript.schema.json",
+	} {
+		embedded, err := embeddedSchemas.ReadFile(filepath.Join("schemas", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		canonical := mustRead(t, filepath.Join("..", "..", "..", "schemas", name))
+		if string(embedded) != string(canonical) {
+			t.Fatalf("embedded %s differs from canonical schema", name)
+		}
+	}
+}
+
+func buyerReproducedFixture(t *testing.T) (BuyerReproducedOptions, *buyerReproduction, string, string) {
+	t.Helper()
+	root := schemaFixture(t)
+	schemas, err := loadSchemas()
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := loadDirectoryPackageWithOptions(root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, reason := loadBuyerReproductionSource(files, schemas)
+	if reason != "" {
+		t.Fatal(reason)
+	}
+	external := t.TempDir()
+	projection, ok := canonicalProjection(source.outcomes)
+	if !ok {
+		t.Fatal("source projection invalid")
+	}
+	statement := &buyerReproduction{Profile: buyerReproductionProfile, BuyerID: source.requirement.BuyerID}
+	statement.Signer.KeyID = source.requirementSignerKeyID
+	statement.Signer.Role = "buyer-reproducer"
+	statement.Source.EnvelopePayloadSHA256 = source.envelopePayloadSHA256
+	statement.Source.RequirementPayloadSHA256 = source.requirementPayloadSHA256
+	statement.Source.ToolProfileSHA256 = source.toolProfileSHA256
+	statement.Source.RunnerBinarySHA256 = source.envelope.Runner.BinarySHA256
+	statement.Source.CorpusSHA256 = source.envelope.Corpus.CorpusSHA256
+	statement.Source.CorpusManifestSHA256 = source.envelope.Corpus.ManifestSHA256
+	statement.Source.ScoringVersion = source.envelope.Corpus.ScoringVersion
+	statement.Source.PolicySHA256 = source.envelope.Policy.SHA256
+	statement.Source.AdapterSHA256 = source.envelope.Adapter.SHA256
+	statement.Source.OriginalRunID = source.envelope.RunID
+	statement.Reproduction.RunID = digestBytes([]byte("buyer reproduction run"))
+	transcriptPath := filepath.Join(external, "reproduction-transcript.json")
+	writeBuyerTranscript(t, transcriptPath, buyerReproductionTranscript{
+		Profile:                     "control-evidence-buyer-reproduction-transcript/v0",
+		SourceEnvelopePayloadSHA256: source.envelopePayloadSHA256,
+		ReproductionRunID:           statement.Reproduction.RunID,
+		Outcomes:                    append([]buyerOutcomeProjection(nil), source.outcomes...),
+	})
+	statement.Reproduction.TranscriptSHA256 = digestBytes(mustRead(t, transcriptPath))
+	statement.Reproduction.OutcomesProjectionSHA256 = digestBytes(projection)
+
+	statementPath := filepath.Join(external, "buyer-reproduction.dsse.json")
+	writeBuyerStatement(t, statementPath, *statement, buyerTestKey("buyer"))
+	return BuyerReproducedOptions{
+		PackageDir: root, StatementPath: statementPath, TranscriptPath: transcriptPath,
+		VerifierName: "buyer-reproduction-test", VerifierVersion: "v1",
+		VerifierSHA256: testVerifierDigest, AssessmentTime: time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+	}, statement, statementPath, transcriptPath
+}
+
+func readBuyerTranscript(t *testing.T, path string) buyerReproductionTranscript {
+	t.Helper()
+	var transcript buyerReproductionTranscript
+	strictDecodeTest(t, mustRead(t, path), &transcript)
+	return transcript
+}
+
+func writeBuyerTranscript(t *testing.T, path string, transcript buyerReproductionTranscript) {
+	t.Helper()
+	mustWrite(t, path, marshalJSON(t, transcript))
+}
+
+func rebindBuyerTranscript(t *testing.T, statement *buyerReproduction, statementPath, transcriptPath string, updateProjection bool) {
+	t.Helper()
+	statement.Reproduction.TranscriptSHA256 = digestBytes(mustRead(t, transcriptPath))
+	if updateProjection {
+		projection, ok := canonicalProjection(readBuyerTranscript(t, transcriptPath).Outcomes)
+		if !ok {
+			t.Fatal("test transcript projection invalid")
+		}
+		statement.Reproduction.OutcomesProjectionSHA256 = digestBytes(projection)
+	}
+	writeBuyerStatement(t, statementPath, *statement, buyerTestKey("buyer"))
+}
+
+func buyerAssessmentSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	data := mustRead(t, filepath.Join("..", "..", "..", "schemas", "control-evidence-assessment-v2.schema.json"))
+	compiler := jsonschema.NewCompiler()
+	compiler.AssertFormat()
+	document, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compiler.AddResource("assessment-v2.json", document); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("assessment-v2.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return schema
+}
+
+func writeBuyerStatement(t *testing.T, path string, statement buyerReproduction, privateKey ed25519.PrivateKey) {
+	t.Helper()
+	raw, err := json.Marshal(statement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := jsoncanonicalizer.Transform(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	wrapper := dsseEnvelope{
+		PayloadType: buyerReproductionType,
+		Payload:     base64.StdEncoding.EncodeToString(payload),
+		Signatures: []dsseSignature{{
+			KeyID: hex.EncodeToString(publicKey),
+			Sig:   base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, pae(buyerReproductionType, payload))),
+		}},
+	}
+	mustWrite(t, path, marshalJSON(t, wrapper))
+}
+
+func buyerTestKey(role string) ed25519.PrivateKey {
+	seed := sha256.Sum256([]byte("agent-egress-bench-control-evidence-" + role + "-test-key-v0"))
+	return ed25519.NewKeyFromSeed(seed[:])
+}
+
+func assertBuyerReproducedResult(t *testing.T, result BuyerReproducedAssessment, status, reason string) {
+	t.Helper()
+	if len(result.Predicates) != 1 || result.Predicates[0].Status != status || result.Predicates[0].Reason != reason {
+		t.Fatalf("result = %#v, want %s/%s", result, status, reason)
+	}
+}
+
+func stringsOfA(length int) string {
+	value := make([]byte, length)
+	for i := range value {
+		value[i] = 'a'
+	}
+	return string(value)
+}

--- a/control-evidence/v0/verifier/buyer_reproduced_test.go
+++ b/control-evidence/v0/verifier/buyer_reproduced_test.go
@@ -64,49 +64,49 @@ func TestAssessmentSchemaRejectsIncompleteBuyerReproducedPass(t *testing.T) {
 func TestAssessBuyerReproducedHostile(t *testing.T) {
 	tests := []struct {
 		name, reason string
-		mutate       func(*BuyerReproducedOptions, *buyerReproduction, string, string)
+		mutate       func(*testing.T, *buyerReproduction, string, string)
 	}{
-		{"source-envelope-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"source-envelope-binding", "buyer_statement_source_binding_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Source.EnvelopePayloadSHA256 = stringsOfA(64)
 		}},
-		{"source-requirement-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"source-requirement-binding", "buyer_statement_source_binding_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Source.RequirementPayloadSHA256 = stringsOfA(64)
 		}},
-		{"source-tool-profile-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"source-tool-profile-binding", "buyer_statement_source_binding_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Source.ToolProfileSHA256 = stringsOfA(64)
 		}},
-		{"source-runner-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"source-runner-binding", "buyer_statement_source_binding_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Source.RunnerBinarySHA256 = stringsOfA(64)
 		}},
-		{"source-corpus-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"source-corpus-binding", "buyer_statement_source_binding_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Source.CorpusSHA256 = stringsOfA(64)
 		}},
-		{"source-corpus-manifest-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"source-corpus-manifest-binding", "buyer_statement_source_binding_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Source.CorpusManifestSHA256 = stringsOfA(64)
 		}},
-		{"source-scoring-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"source-scoring-binding", "buyer_statement_source_binding_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Source.ScoringVersion = "different"
 		}},
-		{"source-policy-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"source-policy-binding", "buyer_statement_source_binding_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Source.PolicySHA256 = stringsOfA(64)
 		}},
-		{"source-adapter-binding", "buyer_statement_source_binding_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"source-adapter-binding", "buyer_statement_source_binding_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Source.AdapterSHA256 = stringsOfA(64)
 		}},
-		{"same-run-id", "reproduction_run_id_not_fresh", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, transcriptPath string) {
+		{"same-run-id", "reproduction_run_id_not_fresh", func(t *testing.T, statement *buyerReproduction, _, transcriptPath string) {
 			statement.Reproduction.RunID = statement.Source.OriginalRunID
 			transcript := readBuyerTranscript(t, transcriptPath)
 			transcript.ReproductionRunID = statement.Source.OriginalRunID
 			writeBuyerTranscript(t, transcriptPath, transcript)
 			statement.Reproduction.TranscriptSHA256 = digestBytes(mustRead(t, transcriptPath))
 		}},
-		{"transcript-digest", "reproduction_transcript_digest_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"transcript-digest", "reproduction_transcript_digest_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Reproduction.TranscriptSHA256 = stringsOfA(64)
 		}},
-		{"projection-digest", "reproduction_projection_digest_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, _ string) {
+		{"projection-digest", "reproduction_projection_digest_mismatch", func(_ *testing.T, statement *buyerReproduction, _, _ string) {
 			statement.Reproduction.OutcomesProjectionSHA256 = stringsOfA(64)
 		}},
-		{"outcomes-mismatch", "reproduction_outcomes_mismatch", func(_ *BuyerReproducedOptions, statement *buyerReproduction, _, transcriptPath string) {
+		{"outcomes-mismatch", "reproduction_outcomes_mismatch", func(t *testing.T, statement *buyerReproduction, _, transcriptPath string) {
 			transcript := readBuyerTranscript(t, transcriptPath)
 			transcript.Outcomes[0].ActualVerdict = "allow"
 			transcript.Outcomes[0].Outcome = "fail"
@@ -115,7 +115,7 @@ func TestAssessBuyerReproducedHostile(t *testing.T) {
 			statement.Reproduction.TranscriptSHA256 = digestBytes(mustRead(t, transcriptPath))
 			projection, ok := canonicalProjection(transcript.Outcomes)
 			if !ok {
-				panic("invalid test projection")
+				t.Fatal("invalid test projection")
 			}
 			statement.Reproduction.OutcomesProjectionSHA256 = digestBytes(projection)
 		}},
@@ -123,7 +123,7 @@ func TestAssessBuyerReproducedHostile(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
-			test.mutate(&options, statement, statementPath, transcriptPath)
+			test.mutate(t, statement, statementPath, transcriptPath)
 			writeBuyerStatement(t, statementPath, *statement, buyerTestKey("buyer"))
 			result := AssessBuyerReproduced(options)
 			assertBuyerReproducedResult(t, result, "FAIL", test.reason)
@@ -314,13 +314,13 @@ func TestAssessBuyerReproducedRejectsMalformedTranscript(t *testing.T) {
 	t.Run("not-jcs", func(t *testing.T) {
 		options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
 		mustWrite(t, transcriptPath, append([]byte(" "), mustRead(t, transcriptPath)...))
-		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath)
 		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_not_jcs")
 	})
 	t.Run("schema", func(t *testing.T) {
 		options, statement, statementPath, transcriptPath := buyerReproducedFixture(t)
 		mustWrite(t, transcriptPath, []byte("{}"))
-		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath)
 		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_invalid")
 	})
 	t.Run("source-binding", func(t *testing.T) {
@@ -328,7 +328,7 @@ func TestAssessBuyerReproducedRejectsMalformedTranscript(t *testing.T) {
 		transcript := readBuyerTranscript(t, transcriptPath)
 		transcript.SourceEnvelopePayloadSHA256 = stringsOfA(64)
 		writeBuyerTranscript(t, transcriptPath, transcript)
-		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath)
 		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_binding_mismatch")
 	})
 	t.Run("run-binding", func(t *testing.T) {
@@ -336,7 +336,7 @@ func TestAssessBuyerReproducedRejectsMalformedTranscript(t *testing.T) {
 		transcript := readBuyerTranscript(t, transcriptPath)
 		transcript.ReproductionRunID = stringsOfA(64)
 		writeBuyerTranscript(t, transcriptPath, transcript)
-		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath)
 		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_binding_mismatch")
 	})
 	t.Run("contradictory-outcome", func(t *testing.T) {
@@ -344,7 +344,7 @@ func TestAssessBuyerReproducedRejectsMalformedTranscript(t *testing.T) {
 		transcript := readBuyerTranscript(t, transcriptPath)
 		transcript.Outcomes[0].Outcome = "fail"
 		writeBuyerTranscript(t, transcriptPath, transcript)
-		rebindBuyerTranscript(t, statement, statementPath, transcriptPath, false)
+		rebindBuyerTranscript(t, statement, statementPath, transcriptPath)
 		assertBuyerReproducedResult(t, AssessBuyerReproduced(options), "FAIL", "reproduction_transcript_invalid")
 	})
 }
@@ -453,6 +453,62 @@ func TestReadExternalBounded(t *testing.T) {
 	if _, err := readExternalBounded(root, outside, 1); err == nil {
 		t.Fatal("oversized evidence accepted")
 	}
+	replacePath := filepath.Join(t.TempDir(), "replace.json")
+	replacementPath := filepath.Join(t.TempDir(), "replacement.json")
+	mustWrite(t, replacePath, []byte("original"))
+	mustWrite(t, replacementPath, []byte("replacement"))
+	swapped := false
+	_, replacementErr := readExternalBoundedWithHook(root, replacePath, 32, func() error {
+		if err := os.Rename(replacementPath, replacePath); err != nil {
+			return err
+		}
+		swapped = true
+		return nil
+	})
+	if !swapped {
+		t.Fatal("test did not replace evidence after open")
+	}
+	if replacementErr == nil {
+		t.Fatal("evidence replacement after open was accepted")
+	}
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relativeRoot, err := filepath.Rel(workingDir, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pathOutsideRoot(relativeRoot, outside) {
+		t.Fatal("mixed relative/absolute external path rejected")
+	}
+}
+
+func TestBuyerReproductionTranscriptSchemaBindsClassification(t *testing.T) {
+	_, _, _, transcriptPath := buyerReproducedFixture(t)
+	transcript := readBuyerTranscript(t, transcriptPath)
+	schemas, err := loadSchemas()
+	if err != nil {
+		t.Fatal(err)
+	}
+	validate := func(candidate buyerReproductionTranscript) error {
+		value, err := strictJSON(marshalJSON(t, candidate), nil)
+		if err != nil {
+			return err
+		}
+		return validateSchema(schemas.buyerReproductionTranscript, value)
+	}
+	if err := validate(transcript); err != nil {
+		t.Fatalf("valid transcript rejected: %v", err)
+	}
+	transcript.Outcomes[0].ScoringFacts.Classification = "incorrect"
+	if err := validate(transcript); err == nil {
+		t.Fatal("pass outcome with incorrect classification accepted")
+	}
+	transcript.Outcomes[0].Outcome = "fail"
+	if err := validate(transcript); err != nil {
+		t.Fatalf("fail outcome with incorrect classification rejected: %v", err)
+	}
 }
 
 func TestBuyerReproductionStatementLimitCoversPublishedPayloadMaximum(t *testing.T) {
@@ -557,16 +613,9 @@ func writeBuyerTranscript(t *testing.T, path string, transcript buyerReproductio
 	mustWrite(t, path, marshalJSON(t, transcript))
 }
 
-func rebindBuyerTranscript(t *testing.T, statement *buyerReproduction, statementPath, transcriptPath string, updateProjection bool) {
+func rebindBuyerTranscript(t *testing.T, statement *buyerReproduction, statementPath, transcriptPath string) {
 	t.Helper()
 	statement.Reproduction.TranscriptSHA256 = digestBytes(mustRead(t, transcriptPath))
-	if updateProjection {
-		projection, ok := canonicalProjection(readBuyerTranscript(t, transcriptPath).Outcomes)
-		if !ok {
-			t.Fatal("test transcript projection invalid")
-		}
-		statement.Reproduction.OutcomesProjectionSHA256 = digestBytes(projection)
-	}
 	writeBuyerStatement(t, statementPath, *statement, buyerTestKey("buyer"))
 }
 

--- a/control-evidence/v0/verifier/buyer_reproduced_test.go
+++ b/control-evidence/v0/verifier/buyer_reproduced_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -418,29 +419,59 @@ func TestValidLogicalProjectionRow(t *testing.T) {
 	}
 }
 
-func TestExternalEvidencePath(t *testing.T) {
+func TestReadExternalBounded(t *testing.T) {
 	root := t.TempDir()
 	inside := filepath.Join(root, "inside.json")
 	mustWrite(t, inside, []byte("{}"))
 	outside := filepath.Join(t.TempDir(), "outside.json")
 	mustWrite(t, outside, []byte("{}"))
-	if externalEvidencePath(root, inside) {
-		t.Fatal("inside evidence accepted as external")
+	if _, err := readExternalBounded(root, inside, 16); !errors.Is(err, errEvidenceNotExternal) {
+		t.Fatalf("inside evidence error = %v, want not-external", err)
 	}
-	if !externalEvidencePath(root, outside) {
-		t.Fatal("outside evidence rejected")
+	if data, err := readExternalBounded(root, outside, 16); err != nil || string(data) != "{}" {
+		t.Fatalf("outside evidence = %q, %v", data, err)
 	}
-	if externalEvidencePath(filepath.Join(root, "missing"), outside) {
+	if _, err := readExternalBounded(filepath.Join(root, "missing"), outside, 16); err == nil {
 		t.Fatal("missing root accepted")
 	}
-	if externalEvidencePath(root, filepath.Join(root, "missing")) {
+	if _, err := readExternalBounded(root, filepath.Join(root, "missing"), 16); err == nil {
 		t.Fatal("missing evidence accepted")
 	}
-	if externalEvidencePath(inside, outside) {
+	if _, err := readExternalBounded(inside, outside, 16); err == nil {
 		t.Fatal("regular file accepted as package root")
 	}
-	if externalEvidencePath(root, t.TempDir()) {
+	if _, err := readExternalBounded(root, t.TempDir(), 16); err == nil {
 		t.Fatal("directory accepted as evidence file")
+	}
+	symlink := filepath.Join(t.TempDir(), "evidence-link.json")
+	if err := os.Symlink(outside, symlink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readExternalBounded(root, symlink, 16); err == nil {
+		t.Fatal("symlink evidence accepted")
+	}
+	if _, err := readExternalBounded(root, outside, 1); err == nil {
+		t.Fatal("oversized evidence accepted")
+	}
+}
+
+func TestBuyerReproductionStatementLimitCoversPublishedPayloadMaximum(t *testing.T) {
+	const compactWrapperOverhead = int64(512)
+	var published struct {
+		Properties struct {
+			Payload struct {
+				MaxLength int64 `json:"maxLength"`
+			} `json:"payload"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(mustRead(t, filepath.Join("..", "..", "..", "schemas", "control-evidence-buyer-reproduction-statement.schema.json")), &published); err != nil {
+		t.Fatal(err)
+	}
+	if published.Properties.Payload.MaxLength < 1 {
+		t.Fatal("published statement schema has no payload maximum")
+	}
+	if maxReproductionStatement < published.Properties.Payload.MaxLength+compactWrapperOverhead {
+		t.Fatalf("statement limit %d cannot hold maximum payload plus wrapper", maxReproductionStatement)
 	}
 }
 

--- a/control-evidence/v0/verifier/cmd/aeb-ce-buyer-reproduced/main.go
+++ b/control-evidence/v0/verifier/cmd/aeb-ce-buyer-reproduced/main.go
@@ -36,6 +36,7 @@ func main() {
 		VerifierSHA256: fmt.Sprintf("%x", sha256.Sum256(binary)), AssessmentTime: time.Now(),
 	})
 	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		fmt.Fprintln(os.Stderr, "encode assessment:", err)
 		os.Exit(2)
 	}
 	if result.Predicates[0].Status != "PASS" {

--- a/control-evidence/v0/verifier/cmd/aeb-ce-buyer-reproduced/main.go
+++ b/control-evidence/v0/verifier/cmd/aeb-ce-buyer-reproduced/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	verifier "github.com/luckyPipewrench/agent-egress-bench/control-evidence/v0/verifier"
+)
+
+func main() {
+	packageDir := flag.String("package", "", "source Control Evidence v0 package directory")
+	statementPath := flag.String("statement", "", "external buyer reproduction DSSE statement")
+	transcriptPath := flag.String("transcript", "", "external normalized reproduction transcript")
+	flag.Parse()
+	if *packageDir == "" || *statementPath == "" || *transcriptPath == "" {
+		fmt.Fprintln(os.Stderr, "--package, --statement, and --transcript are required")
+		os.Exit(2)
+	}
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "resolve verifier executable:", err)
+		os.Exit(2)
+	}
+	binary, err := os.ReadFile(self)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read verifier executable:", err)
+		os.Exit(2)
+	}
+	result := verifier.AssessBuyerReproduced(verifier.BuyerReproducedOptions{
+		PackageDir: *packageDir, StatementPath: *statementPath, TranscriptPath: *transcriptPath,
+		VerifierName: "aeb-ce-buyer-reproduced", VerifierVersion: "v1",
+		VerifierSHA256: fmt.Sprintf("%x", sha256.Sum256(binary)), AssessmentTime: time.Now(),
+	})
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		os.Exit(2)
+	}
+	if result.Predicates[0].Status != "PASS" {
+		os.Exit(1)
+	}
+}

--- a/control-evidence/v0/verifier/json.go
+++ b/control-evidence/v0/verifier/json.go
@@ -18,7 +18,8 @@ import (
 )
 
 type schemaSet struct {
-	dsse, requirement, envelope, manifest, outcomes, clock, observer, tokenMaterial, healthMaterial, context, toolProfile *jsonschema.Schema
+	dsse, requirement, envelope, manifest, outcomes, clock, observer, tokenMaterial, healthMaterial, context, toolProfile,
+		buyerReproduction, buyerReproductionStatement, buyerReproductionTranscript *jsonschema.Schema
 }
 
 const maxJSONDepth = 128
@@ -59,6 +60,9 @@ func loadSchemas() (*schemaSet, error) {
 		"control-evidence-health-control-material.schema.json",
 		"control-evidence-context.schema.json",
 		"tool-profile.schema.json",
+		"control-evidence-buyer-reproduction.schema.json",
+		"control-evidence-buyer-reproduction-statement.schema.json",
+		"control-evidence-buyer-reproduction-transcript.schema.json",
 	}
 	compiled := make([]*jsonschema.Schema, len(names))
 	for i, name := range names {
@@ -72,6 +76,7 @@ func loadSchemas() (*schemaSet, error) {
 		dsse: compiled[0], requirement: compiled[1], envelope: compiled[2], manifest: compiled[3],
 		outcomes: compiled[4], clock: compiled[5], observer: compiled[6], tokenMaterial: compiled[7],
 		healthMaterial: compiled[8], context: compiled[9], toolProfile: compiled[10],
+		buyerReproduction: compiled[11], buyerReproductionStatement: compiled[12], buyerReproductionTranscript: compiled[13],
 	}, nil
 }
 

--- a/control-evidence/v0/verifier/json.go
+++ b/control-evidence/v0/verifier/json.go
@@ -19,10 +19,12 @@ import (
 
 type schemaSet struct {
 	dsse, requirement, envelope, manifest, outcomes, clock, observer, tokenMaterial, healthMaterial, context, toolProfile,
-		buyerReproduction, buyerReproductionStatement, buyerReproductionTranscript *jsonschema.Schema
+	buyerReproduction, buyerReproductionStatement, buyerReproductionTranscript *jsonschema.Schema
 }
 
 const maxJSONDepth = 128
+
+var errEvidenceNotExternal = errors.New("evidence is not external to the source package")
 
 //go:embed schemas/*.json
 var embeddedSchemas embed.FS
@@ -294,6 +296,87 @@ func readBounded(path string, max int64) ([]byte, error) {
 		return nil, fmt.Errorf("file exceeds %d bytes", max)
 	}
 	return data, nil
+}
+
+// readExternalBounded validates the external-path boundary against the same
+// already-open file descriptor that supplies the returned bytes. Keeping the
+// descriptor open through the final path checks prevents a symlink or rename
+// swap from validating one file while the assessor consumes another.
+func readExternalBounded(root, path string, max int64) ([]byte, error) {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, err
+	}
+	rootInfo, err := os.Stat(resolvedRoot)
+	if err != nil || !rootInfo.IsDir() {
+		return nil, errors.New("source package root is not a directory")
+	}
+
+	before, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !before.Mode().IsRegular() {
+		return nil, errors.New("evidence is not a regular file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		return nil, errors.New("evidence changed while opening")
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil, err
+	}
+	resolvedInfo, err := os.Stat(resolvedPath)
+	if err != nil || !os.SameFile(opened, resolvedInfo) {
+		return nil, errors.New("evidence path changed while opening")
+	}
+	if !pathOutsideRoot(resolvedRoot, resolvedPath) {
+		return nil, errEvidenceNotExternal
+	}
+
+	data, err := io.ReadAll(io.LimitReader(file, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > max {
+		return nil, fmt.Errorf("file exceeds %d bytes", max)
+	}
+
+	after, err := os.Lstat(path)
+	if err != nil || !os.SameFile(opened, after) {
+		return nil, errors.New("evidence changed while reading")
+	}
+	resolvedPathAfter, err := filepath.EvalSymlinks(path)
+	if err != nil || resolvedPathAfter != resolvedPath {
+		return nil, errors.New("evidence path changed while reading")
+	}
+	resolvedRootAfter, err := filepath.EvalSymlinks(root)
+	if err != nil || resolvedRootAfter != resolvedRoot {
+		return nil, errors.New("source package root changed while reading evidence")
+	}
+	rootInfoAfter, err := os.Stat(resolvedRootAfter)
+	if err != nil || !os.SameFile(rootInfo, rootInfoAfter) {
+		return nil, errors.New("source package root changed while reading evidence")
+	}
+	return data, nil
+}
+
+func pathOutsideRoot(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == "." || relative == "" {
+		return false
+	}
+	return relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator))
 }
 
 func normalizedPath(path string) bool {

--- a/control-evidence/v0/verifier/json.go
+++ b/control-evidence/v0/verifier/json.go
@@ -303,6 +303,10 @@ func readBounded(path string, max int64) ([]byte, error) {
 // descriptor open through the final path checks prevents a symlink or rename
 // swap from validating one file while the assessor consumes another.
 func readExternalBounded(root, path string, max int64) ([]byte, error) {
+	return readExternalBoundedWithHook(root, path, max, nil)
+}
+
+func readExternalBoundedWithHook(root, path string, max int64, afterOpen func() error) ([]byte, error) {
 	resolvedRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		return nil, err
@@ -330,6 +334,11 @@ func readExternalBounded(root, path string, max int64) ([]byte, error) {
 	}
 	if !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
 		return nil, errors.New("evidence changed while opening")
+	}
+	if afterOpen != nil {
+		if err := afterOpen(); err != nil {
+			return nil, fmt.Errorf("after-open check: %w", err)
+		}
 	}
 
 	resolvedPath, err := filepath.EvalSymlinks(path)
@@ -372,8 +381,20 @@ func readExternalBounded(root, path string, max int64) ([]byte, error) {
 }
 
 func pathOutsideRoot(root, path string) bool {
-	relative, err := filepath.Rel(root, path)
-	if err != nil || relative == "." || relative == "" {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	relative, err := filepath.Rel(absRoot, absPath)
+	if err != nil {
+		// Absolute paths on different volumes cannot be descendants.
+		return true
+	}
+	if relative == "." || relative == "" {
 		return false
 	}
 	return relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator))

--- a/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-statement.schema.json
+++ b/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-statement.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement.schema.json",
+  "title": "Control Evidence buyer reproduction DSSE statement v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["payloadType", "payload", "signatures"],
+  "properties": {
+    "payloadType": {"const": "application/vnd.agent-egress-bench.control-evidence-buyer-reproduction.v0+json"},
+    "payload": {"type": "string", "minLength": 4, "maxLength": 1048576, "pattern": "^[A-Za-z0-9+/]*={0,2}$"},
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["keyid", "sig"],
+        "properties": {
+          "keyid": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+          "sig": {"type": "string", "minLength": 88, "maxLength": 88, "pattern": "^[A-Za-z0-9+/]*={0,2}$"}
+        }
+      }
+    }
+  }
+}

--- a/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-transcript.schema.json
+++ b/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-transcript.schema.json
@@ -44,6 +44,14 @@
       },
       "allOf": [
         {
+          "if": {"properties": {"outcome": {"const": "pass"}}, "required": ["outcome"]},
+          "then": {"properties": {"scoring_facts": {"properties": {"classification": {"const": "correct"}}}}}
+        },
+        {
+          "if": {"properties": {"outcome": {"const": "fail"}}, "required": ["outcome"]},
+          "then": {"properties": {"scoring_facts": {"properties": {"classification": {"const": "incorrect"}}}}}
+        },
+        {
           "if": {"properties": {"outcome": {"const": "not_applicable"}}, "required": ["outcome"]},
           "then": {
             "properties": {

--- a/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-transcript.schema.json
+++ b/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-transcript.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript.schema.json",
+  "title": "Control Evidence normalized buyer reproduction transcript v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "source_envelope_payload_sha256", "reproduction_run_id", "outcomes"],
+  "properties": {
+    "profile": {"const": "control-evidence-buyer-reproduction-transcript/v0"},
+    "source_envelope_payload_sha256": {"$ref": "#/$defs/sha256"},
+    "reproduction_run_id": {"$ref": "#/$defs/sha256"},
+    "outcomes": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1000000,
+      "items": {"$ref": "#/$defs/outcome"}
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["case_id", "trial_index", "transport", "expected_verdict", "actual_verdict", "outcome", "scoring_facts"],
+      "properties": {
+        "case_id": {"type": "string", "minLength": 1, "maxLength": 256},
+        "trial_index": {"type": "integer", "minimum": 1, "maximum": 1000000},
+        "transport": {"type": "string", "minLength": 1, "maxLength": 64},
+        "expected_verdict": {"enum": ["allow", "block", "warn"]},
+        "actual_verdict": {"enum": ["allow", "block", "warn", "not_applicable", "error"]},
+        "outcome": {"enum": ["pass", "fail", "not_applicable", "error"]},
+        "scoring_facts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["classification", "budget_timing", "structured_evidence"],
+          "properties": {
+            "classification": {"enum": ["correct", "incorrect", "not_applicable", "error"]},
+            "budget_timing": {"enum": ["within_budget", "over_budget", "not_measured"]},
+            "structured_evidence": {"enum": ["present", "absent", "not_applicable"]}
+          }
+        },
+        "not_applicable_reason": {"type": "string", "minLength": 1, "maxLength": 256},
+        "error_reason": {"type": "string", "minLength": 1, "maxLength": 256}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"outcome": {"const": "not_applicable"}}, "required": ["outcome"]},
+          "then": {
+            "properties": {
+              "actual_verdict": {"const": "not_applicable"},
+              "scoring_facts": {"properties": {"classification": {"const": "not_applicable"}, "budget_timing": {"const": "not_measured"}, "structured_evidence": {"const": "not_applicable"}}}
+            },
+            "required": ["not_applicable_reason"],
+            "not": {"required": ["error_reason"]}
+          }
+        },
+        {
+          "if": {"properties": {"outcome": {"const": "error"}}, "required": ["outcome"]},
+          "then": {
+            "properties": {
+              "actual_verdict": {"const": "error"},
+              "scoring_facts": {"properties": {"classification": {"const": "error"}, "budget_timing": {"const": "not_measured"}, "structured_evidence": {"const": "not_applicable"}}}
+            },
+            "required": ["error_reason"],
+            "not": {"required": ["not_applicable_reason"]}
+          }
+        },
+        {
+          "if": {"properties": {"outcome": {"enum": ["pass", "fail"]}}, "required": ["outcome"]},
+          "then": {"properties": {"actual_verdict": {"not": {"enum": ["not_applicable", "error"]}}}, "not": {"anyOf": [{"required": ["not_applicable_reason"]}, {"required": ["error_reason"]}]}}
+        }
+      ]
+    }
+  }
+}

--- a/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction.schema.json
+++ b/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction.schema.json
@@ -13,7 +13,7 @@
       "additionalProperties": false,
       "required": ["key_id", "role"],
       "properties": {
-        "key_id": {"$ref": "#/$defs/sha256"},
+        "key_id": {"$ref": "#/$defs/hex32"},
         "role": {"const": "buyer-reproducer"}
       }
     },
@@ -31,7 +31,7 @@
         "scoring_version": {"type": "string", "minLength": 1, "maxLength": 64},
         "policy_sha256": {"$ref": "#/$defs/sha256"},
         "adapter_sha256": {"$ref": "#/$defs/sha256"},
-        "original_run_id": {"$ref": "#/$defs/sha256"}
+        "original_run_id": {"$ref": "#/$defs/hex32"}
       }
     },
     "reproduction": {
@@ -39,7 +39,7 @@
       "additionalProperties": false,
       "required": ["run_id", "transcript_sha256", "outcomes_projection_sha256"],
       "properties": {
-        "run_id": {"$ref": "#/$defs/sha256"},
+        "run_id": {"$ref": "#/$defs/hex32"},
         "transcript_sha256": {"$ref": "#/$defs/sha256"},
         "outcomes_projection_sha256": {"$ref": "#/$defs/sha256"}
       }
@@ -47,6 +47,7 @@
   },
   "$defs": {
     "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "hex32": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
     "opaqueID": {"type": "string", "minLength": 1, "maxLength": 256}
   }
 }

--- a/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction.schema.json
+++ b/control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction.schema.json",
+  "title": "Control Evidence buyer reproduction statement payload v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "buyer_id", "signer", "source", "reproduction"],
+  "properties": {
+    "profile": {"const": "control-evidence-buyer-reproduction/v0"},
+    "buyer_id": {"$ref": "#/$defs/opaqueID"},
+    "signer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key_id", "role"],
+      "properties": {
+        "key_id": {"$ref": "#/$defs/sha256"},
+        "role": {"const": "buyer-reproducer"}
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["envelope_payload_sha256", "requirement_payload_sha256", "tool_profile_sha256", "runner_binary_sha256", "corpus_sha256", "corpus_manifest_sha256", "scoring_version", "policy_sha256", "adapter_sha256", "original_run_id"],
+      "properties": {
+        "envelope_payload_sha256": {"$ref": "#/$defs/sha256"},
+        "requirement_payload_sha256": {"$ref": "#/$defs/sha256"},
+        "tool_profile_sha256": {"$ref": "#/$defs/sha256"},
+        "runner_binary_sha256": {"$ref": "#/$defs/sha256"},
+        "corpus_sha256": {"$ref": "#/$defs/sha256"},
+        "corpus_manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "scoring_version": {"type": "string", "minLength": 1, "maxLength": 64},
+        "policy_sha256": {"$ref": "#/$defs/sha256"},
+        "adapter_sha256": {"$ref": "#/$defs/sha256"},
+        "original_run_id": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "reproduction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["run_id", "transcript_sha256", "outcomes_projection_sha256"],
+      "properties": {
+        "run_id": {"$ref": "#/$defs/sha256"},
+        "transcript_sha256": {"$ref": "#/$defs/sha256"},
+        "outcomes_projection_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "opaqueID": {"type": "string", "minLength": 1, "maxLength": 256}
+  }
+}

--- a/docs/ARTIFACT-PROVENANCE.md
+++ b/docs/ARTIFACT-PROVENANCE.md
@@ -1,7 +1,7 @@
 # Artifact provenance predicates
 
-The opt-in G2 assessors currently evaluate two separately callable predicates:
-`schema-valid` and `authenticated-at(T)`. They do not combine those results
+The opt-in G2 assessors currently evaluate three separately callable predicates:
+`schema-valid`, `authenticated-at(T)`, and `buyer-reproduced`. They do not combine those results
 into a tier, score, or producer-awarded badge. Each assessment artifact carries
 one predicate and the identity of the verifier binary that evaluated it;
 consumers compose the separate results by their shared evidence binding.
@@ -30,8 +30,8 @@ verifier-schema failure is `UNVERIFIABLE`; a presented malformed package is
 externally supplied signed trust policy, an independently managed verifier
 trust context, and a durable verifier-owned policy checkpoint. The trust
 context is the root of trust: the buyer or verifier operator must deliver and
-protect it outside the producer's
-control. A producer-supplied context can select its own bootstrap key and must
+protect it outside the producer's control. A producer-supplied context can
+select its own bootstrap key and must
 never be accepted as independent input. The CLI emits its result on standard
 output; callers must retain that assessment outside the submitted package.
 
@@ -61,3 +61,31 @@ or evidence digest. A `PASS` assessment always includes the time, exact
 envelope-payload digest, policy ID/epoch/digest, checkpoint digest, and verifier
 identity. It also binds the exact independent authentication-context digest and
 the pinned bootstrap key ID.
+
+`buyer-reproduced` reads the original Control Evidence v0 package plus an
+external buyer-reproduction DSSE statement and the normalized transcript named by
+that statement. That transcript is a closed, canonical normalized-outcome
+document, not raw protocol I/O. The statement stays outside the original package so a later
+rerun cannot mutate the manifest or envelope it is comparing against. `PASS`
+means the statement is signed by the same key that signed the source buyer
+requirement, binds the exact source envelope and requirement payloads, tool
+profile, runner binary, corpus and corpus manifest, scoring version, policy,
+and adapter digests, uses a different reproduction run ID, binds the supplied
+transcript bytes, and binds the canonical logical outcome projection re-derived
+from that transcript to the source outcomes ledger.
+
+This predicate does not independently authorize the shared signing key. Compose
+it with an `authenticated-at(T)` PASS carrying the same
+`envelope_payload_sha256` to establish that the source requirement key was
+authorized for its buyer role. It also does not prove that the named binary or
+corpus bytes executed, that the transcript caused the projected outcomes, that
+the buyer environment or custody was independent, or that another observer saw
+the run. The normalized transcript is retained and digest-bound evidence; this
+assessor does not invent a generic cross-adapter raw-I/O reducer. Those stronger claims
+need separate execution, corpus-membership, and observation predicates.
+
+`schema-valid` and `authenticated-at(T)` retain the published strict
+`control-evidence-assessment/v1` output contract. `buyer-reproduced` uses the
+additive `/v2` contract; consumers compose results across versions through the
+same `envelope_payload_sha256`, not by assuming one schema version implies
+another predicate.

--- a/docs/CONTROL-EVIDENCE.md
+++ b/docs/CONTROL-EVIDENCE.md
@@ -69,6 +69,11 @@ them; a producer or verifier must not use Go HTML escaping when forming or check
 | `schemas/control-evidence-token-material.schema.json` | Decrypted closed canary-ID/input mapping |
 | `schemas/control-evidence-health-control-material.schema.json` | Decrypted closed control-ID/input mapping |
 | `schemas/control-evidence-context.schema.json` | Independent conformance trust, material, clock, and replay input |
+| `schemas/control-evidence-assessment.schema.json` | Strict external assessment v1 for `schema-valid` and `authenticated-at(T)` |
+| `schemas/control-evidence-assessment-v2.schema.json` | Additive external assessment v2 including `buyer-reproduced` |
+| `schemas/control-evidence-buyer-reproduction-statement.schema.json` | External buyer-reproduction DSSE wrapper |
+| `schemas/control-evidence-buyer-reproduction.schema.json` | Decoded buyer-reproduction statement and exact source/transcript bindings |
+| `schemas/control-evidence-buyer-reproduction-transcript.schema.json` | Closed normalized rerun-outcome transcript |
 
 The requirement pins its challenge nonce, required cases, each case's expected verdict, and canaries, observer identity/key,
 allowed signer roles, runner/adapter/tool identities, error limit, freshness policy, and independent
@@ -81,6 +86,14 @@ Required positive and negative canary ID sets must be disjoint; a canary ID cann
 The run envelope binds that requirement digest and nonce to the runner, corpus, tool, policy,
 adapter, scope, manifest, outcome ledger, times, and signer. A `result_claim` is diagnostic only;
 the verifier derives the authoritative result.
+
+Later G2 reproduction evidence is not a v0 package member. An external
+buyer-reproduction statement can bind this immutable source envelope, the exact
+input identities, a distinct run ID, retained normalized-transcript bytes, and a canonical
+logical projection re-derived from the rerun outcomes in that transcript. Its separate assessor verifies those
+bindings without turning the statement into proof that the named executable or
+corpus bytes ran or that the normalized transcript came from raw protocol I/O. See `ARTIFACT-PROVENANCE.md` for the predicate boundary and
+composition rules.
 
 ## Observation semantics
 

--- a/schemas/control-evidence-assessment-v2.schema.json
+++ b/schemas/control-evidence-assessment-v2.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-assessment-v2.schema.json",
+  "title": "Control Evidence external assessment v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "verifier", "predicates"],
+  "properties": {
+    "profile": {"const": "control-evidence-assessment/v2"},
+    "assessment_time": {"type": "string", "format": "date-time", "pattern": "Z$"},
+    "verifier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "sha256"],
+      "properties": {
+        "name": {"type": "string"},
+        "version": {"type": "string"},
+        "sha256": {"type": "string", "pattern": "^$|^[a-f0-9]{64}$"}
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["envelope_payload_sha256"],
+      "properties": {
+        "envelope_payload_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "manifest_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "reproduction_statement_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "reproduction_payload_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "reproduction_transcript_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "outcomes_projection_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    },
+    "external_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_id", "policy_epoch", "policy_sha256", "authentication_context_sha256", "bootstrap_key_id"],
+      "properties": {
+        "policy_id": {"type": "string", "minLength": 1},
+        "policy_epoch": {"type": "integer", "minimum": 1},
+        "policy_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "authentication_context_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "bootstrap_key_id": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "checkpoint_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    },
+    "predicates": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "status", "reason"],
+        "properties": {
+          "name": {"enum": ["schema-valid", "authenticated-at(T)", "buyer-reproduced"]},
+          "status": {"enum": ["PASS", "FAIL", "UNVERIFIABLE"]},
+          "reason": {"type": "string", "minLength": 1, "maxLength": 256}
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"predicates": {"contains": {"required": ["name", "status"], "properties": {"name": {"const": "authenticated-at(T)"}, "status": {"const": "PASS"}}}}}},
+      "then": {
+        "required": ["assessment_time", "evidence", "external_state"],
+        "properties": {
+          "verifier": {"properties": {"name": {"minLength": 1}, "version": {"minLength": 1}, "sha256": {"pattern": "^[a-f0-9]{64}$"}}},
+          "external_state": {"required": ["checkpoint_sha256"]}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"predicates": {"contains": {"required": ["name", "status"], "properties": {"name": {"const": "schema-valid"}, "status": {"const": "PASS"}}}}}},
+      "then": {
+        "required": ["assessment_time", "evidence"],
+        "properties": {
+          "verifier": {"properties": {"name": {"minLength": 1}, "version": {"minLength": 1}, "sha256": {"pattern": "^[a-f0-9]{64}$"}}},
+          "evidence": {"required": ["envelope_payload_sha256", "manifest_sha256"]},
+          "external_state": false
+        }
+      }
+    },
+    {
+      "if": {"properties": {"predicates": {"contains": {"required": ["name", "status"], "properties": {"name": {"const": "buyer-reproduced"}, "status": {"const": "PASS"}}}}}},
+      "then": {
+        "required": ["assessment_time", "evidence"],
+        "properties": {
+          "verifier": {"properties": {"name": {"minLength": 1}, "version": {"minLength": 1}, "sha256": {"pattern": "^[a-f0-9]{64}$"}}},
+          "evidence": {"required": ["envelope_payload_sha256", "reproduction_statement_sha256", "reproduction_payload_sha256", "reproduction_transcript_sha256", "outcomes_projection_sha256"]},
+          "external_state": false
+        }
+      }
+    }
+  ]
+}

--- a/schemas/control-evidence-buyer-reproduction-statement.schema.json
+++ b/schemas/control-evidence-buyer-reproduction-statement.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement.schema.json",
+  "title": "Control Evidence buyer reproduction DSSE statement v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["payloadType", "payload", "signatures"],
+  "properties": {
+    "payloadType": {"const": "application/vnd.agent-egress-bench.control-evidence-buyer-reproduction.v0+json"},
+    "payload": {"type": "string", "minLength": 4, "maxLength": 1048576, "pattern": "^[A-Za-z0-9+/]*={0,2}$"},
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["keyid", "sig"],
+        "properties": {
+          "keyid": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+          "sig": {"type": "string", "minLength": 88, "maxLength": 88, "pattern": "^[A-Za-z0-9+/]*={0,2}$"}
+        }
+      }
+    }
+  }
+}

--- a/schemas/control-evidence-buyer-reproduction-transcript.schema.json
+++ b/schemas/control-evidence-buyer-reproduction-transcript.schema.json
@@ -44,6 +44,14 @@
       },
       "allOf": [
         {
+          "if": {"properties": {"outcome": {"const": "pass"}}, "required": ["outcome"]},
+          "then": {"properties": {"scoring_facts": {"properties": {"classification": {"const": "correct"}}}}}
+        },
+        {
+          "if": {"properties": {"outcome": {"const": "fail"}}, "required": ["outcome"]},
+          "then": {"properties": {"scoring_facts": {"properties": {"classification": {"const": "incorrect"}}}}}
+        },
+        {
           "if": {"properties": {"outcome": {"const": "not_applicable"}}, "required": ["outcome"]},
           "then": {
             "properties": {

--- a/schemas/control-evidence-buyer-reproduction-transcript.schema.json
+++ b/schemas/control-evidence-buyer-reproduction-transcript.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript.schema.json",
+  "title": "Control Evidence normalized buyer reproduction transcript v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "source_envelope_payload_sha256", "reproduction_run_id", "outcomes"],
+  "properties": {
+    "profile": {"const": "control-evidence-buyer-reproduction-transcript/v0"},
+    "source_envelope_payload_sha256": {"$ref": "#/$defs/sha256"},
+    "reproduction_run_id": {"$ref": "#/$defs/sha256"},
+    "outcomes": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1000000,
+      "items": {"$ref": "#/$defs/outcome"}
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["case_id", "trial_index", "transport", "expected_verdict", "actual_verdict", "outcome", "scoring_facts"],
+      "properties": {
+        "case_id": {"type": "string", "minLength": 1, "maxLength": 256},
+        "trial_index": {"type": "integer", "minimum": 1, "maximum": 1000000},
+        "transport": {"type": "string", "minLength": 1, "maxLength": 64},
+        "expected_verdict": {"enum": ["allow", "block", "warn"]},
+        "actual_verdict": {"enum": ["allow", "block", "warn", "not_applicable", "error"]},
+        "outcome": {"enum": ["pass", "fail", "not_applicable", "error"]},
+        "scoring_facts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["classification", "budget_timing", "structured_evidence"],
+          "properties": {
+            "classification": {"enum": ["correct", "incorrect", "not_applicable", "error"]},
+            "budget_timing": {"enum": ["within_budget", "over_budget", "not_measured"]},
+            "structured_evidence": {"enum": ["present", "absent", "not_applicable"]}
+          }
+        },
+        "not_applicable_reason": {"type": "string", "minLength": 1, "maxLength": 256},
+        "error_reason": {"type": "string", "minLength": 1, "maxLength": 256}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"outcome": {"const": "not_applicable"}}, "required": ["outcome"]},
+          "then": {
+            "properties": {
+              "actual_verdict": {"const": "not_applicable"},
+              "scoring_facts": {"properties": {"classification": {"const": "not_applicable"}, "budget_timing": {"const": "not_measured"}, "structured_evidence": {"const": "not_applicable"}}}
+            },
+            "required": ["not_applicable_reason"],
+            "not": {"required": ["error_reason"]}
+          }
+        },
+        {
+          "if": {"properties": {"outcome": {"const": "error"}}, "required": ["outcome"]},
+          "then": {
+            "properties": {
+              "actual_verdict": {"const": "error"},
+              "scoring_facts": {"properties": {"classification": {"const": "error"}, "budget_timing": {"const": "not_measured"}, "structured_evidence": {"const": "not_applicable"}}}
+            },
+            "required": ["error_reason"],
+            "not": {"required": ["not_applicable_reason"]}
+          }
+        },
+        {
+          "if": {"properties": {"outcome": {"enum": ["pass", "fail"]}}, "required": ["outcome"]},
+          "then": {"properties": {"actual_verdict": {"not": {"enum": ["not_applicable", "error"]}}}, "not": {"anyOf": [{"required": ["not_applicable_reason"]}, {"required": ["error_reason"]}]}}
+        }
+      ]
+    }
+  }
+}

--- a/schemas/control-evidence-buyer-reproduction.schema.json
+++ b/schemas/control-evidence-buyer-reproduction.schema.json
@@ -13,7 +13,7 @@
       "additionalProperties": false,
       "required": ["key_id", "role"],
       "properties": {
-        "key_id": {"$ref": "#/$defs/sha256"},
+        "key_id": {"$ref": "#/$defs/hex32"},
         "role": {"const": "buyer-reproducer"}
       }
     },
@@ -31,7 +31,7 @@
         "scoring_version": {"type": "string", "minLength": 1, "maxLength": 64},
         "policy_sha256": {"$ref": "#/$defs/sha256"},
         "adapter_sha256": {"$ref": "#/$defs/sha256"},
-        "original_run_id": {"$ref": "#/$defs/sha256"}
+        "original_run_id": {"$ref": "#/$defs/hex32"}
       }
     },
     "reproduction": {
@@ -39,7 +39,7 @@
       "additionalProperties": false,
       "required": ["run_id", "transcript_sha256", "outcomes_projection_sha256"],
       "properties": {
-        "run_id": {"$ref": "#/$defs/sha256"},
+        "run_id": {"$ref": "#/$defs/hex32"},
         "transcript_sha256": {"$ref": "#/$defs/sha256"},
         "outcomes_projection_sha256": {"$ref": "#/$defs/sha256"}
       }
@@ -47,6 +47,7 @@
   },
   "$defs": {
     "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "hex32": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
     "opaqueID": {"type": "string", "minLength": 1, "maxLength": 256}
   }
 }

--- a/schemas/control-evidence-buyer-reproduction.schema.json
+++ b/schemas/control-evidence-buyer-reproduction.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction.schema.json",
+  "title": "Control Evidence buyer reproduction statement payload v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile", "buyer_id", "signer", "source", "reproduction"],
+  "properties": {
+    "profile": {"const": "control-evidence-buyer-reproduction/v0"},
+    "buyer_id": {"$ref": "#/$defs/opaqueID"},
+    "signer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key_id", "role"],
+      "properties": {
+        "key_id": {"$ref": "#/$defs/sha256"},
+        "role": {"const": "buyer-reproducer"}
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["envelope_payload_sha256", "requirement_payload_sha256", "tool_profile_sha256", "runner_binary_sha256", "corpus_sha256", "corpus_manifest_sha256", "scoring_version", "policy_sha256", "adapter_sha256", "original_run_id"],
+      "properties": {
+        "envelope_payload_sha256": {"$ref": "#/$defs/sha256"},
+        "requirement_payload_sha256": {"$ref": "#/$defs/sha256"},
+        "tool_profile_sha256": {"$ref": "#/$defs/sha256"},
+        "runner_binary_sha256": {"$ref": "#/$defs/sha256"},
+        "corpus_sha256": {"$ref": "#/$defs/sha256"},
+        "corpus_manifest_sha256": {"$ref": "#/$defs/sha256"},
+        "scoring_version": {"type": "string", "minLength": 1, "maxLength": 64},
+        "policy_sha256": {"$ref": "#/$defs/sha256"},
+        "adapter_sha256": {"$ref": "#/$defs/sha256"},
+        "original_run_id": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "reproduction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["run_id", "transcript_sha256", "outcomes_projection_sha256"],
+      "properties": {
+        "run_id": {"$ref": "#/$defs/sha256"},
+        "transcript_sha256": {"$ref": "#/$defs/sha256"},
+        "outcomes_projection_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "opaqueID": {"type": "string", "minLength": 1, "maxLength": 256}
+  }
+}


### PR DESCRIPTION
## Summary

- add a separately callable `buyer-reproduced` assessment and CLI
- bind the buyer-signed statement to the exact source inputs, a distinct run ID, and a canonical normalized reproduction transcript
- derive and compare the logical outcome projection from that transcript
- add the strict assessment v2 contract while preserving the published v1 contract unchanged

## Claim boundary

A PASS establishes a buyer-signed, exact-input-bound reproduction attestation whose normalized outcome projection matches the source package.

It does not independently authorize the buyer key or prove raw-I/O causality, execution of the named binary or corpus, independent custody, or separate observation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added buyer-reproduction verification for control-evidence packages.
  * Added a command-line verifier that outputs assessment results and clear exit statuses.
  * Added validation for signed statements, reproduction transcripts, source bindings, digests, and bounded external evidence.
  * Added v2 assessment support and related schemas for buyer-reproduction evidence.

* **Documentation**
  * Documented buyer-reproduction predicates, inputs, limitations, evidence requirements, and output contracts.
  * Updated the schema inventory with the new assessment, statement, and transcript formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->