### PR TITLE
fix(ci): make continuous Gauntlet candidates fail-safe

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -47,6 +47,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [[ "$GITHUB_REPOSITORY" != "luckyPipewrench/agent-egress-bench" ]]; then
+            echo "Continuous candidates are canonical only in luckyPipewrench/agent-egress-bench." >&2
+            exit 1
+          fi
+
           git fetch --force --tags origin '+refs/heads/main:refs/remotes/origin/main'
 
           dirty_output="$(git status --porcelain=v1 --untracked-files=all)"
@@ -150,6 +155,7 @@ jobs:
           stderr_path="$artifact_dir/runner.stderr"
           command_path="$artifact_dir/command.txt"
           stats_path="$artifact_dir/make-stats.txt"
+          case_index_path="$artifact_dir/case-index.json"
 
           mcp_cmd="\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh"
           managed_proxy_cmd='./examples/pipelock/start-proxy-for-benchmark.sh "$PIPELOCK_BIN"'
@@ -168,8 +174,11 @@ jobs:
             --fixtures
             --output "$summary_path"
           )
+          # Leave seven minutes inside the 35-minute job budget for decision
+          # synthesis and evidence upload if the benchmark itself hangs.
+          run_cmd=(timeout --signal=TERM --kill-after=30s 28m "${cmd[@]}")
 
-          printf '%q ' "${cmd[@]}" > "$command_path"
+          printf '%q ' "${run_cmd[@]}" > "$command_path"
           printf '\n' >> "$command_path"
           command_string="$(<"$command_path")"
 
@@ -185,9 +194,10 @@ jobs:
           fi
 
           make stats > "$stats_path"
+          "$RUNNER_TEMP/aeb-gauntlet" --cases ./cases --case-index > "$case_index_path"
 
           set +e
-          "${cmd[@]}" > "$jsonl_path" 2> "$stderr_path"
+          "${run_cmd[@]}" > "$jsonl_path" 2> "$stderr_path"
           run_status=$?
           set -e
 
@@ -205,6 +215,8 @@ jobs:
             exit 1
           fi
 
+          results_abs="$(realpath "$jsonl_path")"
+          (cd validate && go run . results "$results_abs")
           jq -e '.case_count.errors == 0' "$summary_path" >/dev/null
 
           {
@@ -213,83 +225,8 @@ jobs:
             echo "RESULTS_PATH=$jsonl_path"
             echo "COMMAND_PATH=$command_path"
             echo "STATS_PATH=$stats_path"
+            echo "CASE_INDEX_PATH=$case_index_path"
           } >> "$GITHUB_ENV"
-
-      - name: Gate result against the recorded baseline
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          python3 - <<'PY'
-          import hashlib
-          import json
-          import os
-
-          with open(os.environ["SUMMARY_PATH"], encoding="utf-8") as fh:
-              summary = json.load(fh)
-          with open("ci/gauntlet-baseline.json", encoding="utf-8") as fh:
-              baseline = json.load(fh)
-
-          failures = []
-          notes = []
-
-          # Trustworthiness of the RUN is a hard gate. These say the measurement
-          # itself is not usable, regardless of what the numbers are.
-          if summary.get("sufficient") is not True:
-              failures.append(f"sufficient={summary.get('sufficient')!r}, want true")
-          errors = summary["case_count"].get("errors")
-          if errors != 0:
-              failures.append(f"case_count.errors={errors}, want 0")
-
-          # Scores are compared against floors and ceilings, never equalities.
-          # An exact-match gate would red this lane the moment the corpus grows,
-          # which is the normal and desired state of a growing benchmark.
-          for scope, metrics in baseline.get("score_floors", {}).items():
-              for metric, floor in metrics.items():
-                  actual = summary["scores"].get(scope, {}).get(metric)
-                  if actual is None:
-                      failures.append(f"scores.{scope}.{metric} missing from summary")
-                  elif float(actual) < float(floor) - 1e-12:
-                      failures.append(
-                          f"REGRESSION scores.{scope}.{metric}={actual}, below baseline floor {floor}"
-                      )
-                  elif float(actual) > float(floor) + 1e-12:
-                      notes.append(
-                          f"scores.{scope}.{metric}={actual} is ABOVE the baseline floor {floor}; "
-                          "refresh ci/gauntlet-baseline.json in a reviewed commit to lock the gain in"
-                      )
-
-          for scope, metrics in baseline.get("score_ceilings", {}).items():
-              for metric, ceiling in metrics.items():
-                  actual = summary["scores"].get(scope, {}).get(metric)
-                  if actual is None:
-                      failures.append(f"scores.{scope}.{metric} missing from summary")
-                  elif float(actual) > float(ceiling) + 1e-12:
-                      failures.append(
-                          f"REGRESSION scores.{scope}.{metric}={actual}, above baseline ceiling {ceiling}"
-                      )
-
-          # Case counts are REPORTED, not gated. The corpus is meant to grow, and
-          # a lane that fails on growth gets switched off by whoever adds a case.
-          observed = baseline.get("observed_case_count", {})
-          for key in ("total", "applicable", "not_applicable"):
-              was = observed.get(key)
-              now = summary["case_count"].get(key)
-              if was is not None and now != was:
-                  notes.append(f"case_count.{key} moved {was} -> {now} since the baseline was recorded")
-          was_reasons = observed.get("not_applicable_reasons")
-          now_reasons = summary["case_count"].get("not_applicable_reasons", {})
-          if was_reasons is not None and now_reasons != was_reasons:
-              notes.append(f"not_applicable_reasons moved {was_reasons!r} -> {now_reasons!r}")
-
-          for note in notes:
-              print(f"::notice::{note}")
-          for failure in failures:
-              print(f"::error::{failure}")
-          if failures:
-              raise SystemExit(f"{len(failures)} baseline gate failure(s)")
-          print("baseline gate: OK")
-          PY
 
       - name: Wrap provenance artifact
         shell: bash
@@ -303,6 +240,8 @@ jobs:
           import hashlib
           import json
           import os
+          import re
+          from collections import Counter
 
           with open(os.environ["SUMMARY_PATH"], encoding="utf-8") as fh:
               summary = json.load(fh)
@@ -310,13 +249,18 @@ jobs:
               command = fh.read().strip()
           with open(os.environ["STATS_PATH"], encoding="utf-8") as fh:
               make_stats = fh.read()
+          with open(os.environ["CASE_INDEX_PATH"], encoding="utf-8") as fh:
+              case_index = json.load(fh)
 
           manifest_path = "cases/MANIFEST.txt"
           with open(manifest_path, "rb") as fh:
               manifest = fh.read()
-          manifest_ids = {line.strip() for line in manifest.decode("utf-8").splitlines() if line.strip()}
-          if not manifest_ids:
+          manifest_id_list = [line.strip() for line in manifest.decode("utf-8").splitlines() if line.strip()]
+          manifest_ids = set(manifest_id_list)
+          if not manifest_id_list:
               raise SystemExit("refusing provenance artifact: cases/MANIFEST.txt has no logical case IDs")
+          if len(manifest_ids) != len(manifest_id_list):
+              raise SystemExit("refusing provenance artifact: cases/MANIFEST.txt contains duplicate IDs")
           manifest_sha256 = hashlib.sha256(manifest).hexdigest()
           logical_case_count = len(manifest_ids)
 
@@ -330,39 +274,139 @@ jobs:
                   except json.JSONDecodeError as exc:
                       raise SystemExit(f"invalid runner JSONL at line {line_number}: {exc}") from exc
 
-          def metric_counts(expected_verdict, actual_verdict):
-              denominator = sum(row.get("expected_verdict") == expected_verdict for row in results)
-              numerator = sum(
-                  row.get("expected_verdict") == expected_verdict and row.get("actual_verdict") == actual_verdict
-                  for row in results
+          result_ids = []
+          for row_number, row in enumerate(results, 1):
+              if not isinstance(row, dict):
+                  raise SystemExit(f"runner JSONL row {row_number} is not an object")
+              case_id = row.get("case_id")
+              if not isinstance(case_id, str) or not case_id:
+                  raise SystemExit(f"runner JSONL row {row_number} has no case_id")
+              result_ids.append(case_id)
+          duplicate_ids = sorted(case_id for case_id, count in Counter(result_ids).items() if count > 1)
+          if duplicate_ids:
+              raise SystemExit(f"runner JSONL contains duplicate case IDs: {duplicate_ids!r}")
+          result_id_set = set(result_ids)
+          if result_id_set != manifest_ids:
+              missing = sorted(manifest_ids - result_id_set)
+              unknown = sorted(result_id_set - manifest_ids)
+              raise SystemExit(
+                  "runner JSONL case IDs do not match cases/MANIFEST.txt: "
+                  f"missing={missing!r} unknown={unknown!r}"
               )
-              return {"numerator": numerator, "denominator": denominator}
 
-          applicable_metrics = {
-              "containment": metric_counts("block", "block"),
-              "false_positive_rate": metric_counts("allow", "block"),
+          if not isinstance(case_index, dict) or case_index.get("schema_version") != 1:
+              raise SystemExit("loader case index must be a schema_version 1 object")
+          case_index_rows = case_index.get("cases")
+          if not isinstance(case_index_rows, list):
+              raise SystemExit("loader case index cases must be an array")
+          expected_by_id = {}
+          for row_number, row in enumerate(case_index_rows, 1):
+              if not isinstance(row, dict):
+                  raise SystemExit(f"loader case index row {row_number} is not an object")
+              case_id = row.get("case_id")
+              expected = row.get("expected_verdict")
+              if not isinstance(case_id, str) or not case_id:
+                  raise SystemExit(f"loader case index row {row_number} has no case_id")
+              if case_id in expected_by_id:
+                  raise SystemExit(f"loader case index contains duplicate case ID {case_id!r}")
+              if expected not in {"block", "allow"}:
+                  raise SystemExit(
+                      f"loader case index row {row_number} has invalid normalized expected_verdict {expected!r}"
+                  )
+              expected_by_id[case_id] = expected
+          if set(expected_by_id) != manifest_ids:
+              raise SystemExit("loader case index IDs do not match cases/MANIFEST.txt")
+          for row_number, row in enumerate(results, 1):
+              expected = expected_by_id[row["case_id"]]
+              if row.get("expected_verdict") != expected:
+                  raise SystemExit(
+                      f"runner JSONL row {row_number} expected_verdict for {row['case_id']!r} "
+                      f"does not match loader case index: {row.get('expected_verdict')!r} != {expected!r}"
+                  )
+
+          def count_stat(name):
+              match = re.search(rf"(?m)^{re.escape(name)}: ([0-9]+)$", make_stats)
+              if match is None:
+                  raise SystemExit(f"make stats output is missing {name!r}")
+              return int(match.group(1))
+
+          def has_classification(evidence):
+              if not isinstance(evidence, dict):
+                  return False
+              if "kind" in evidence or "scanner" in evidence or "block_reason" in evidence:
+                  return True
+              return isinstance(evidence.get("error_message"), str) and bool(evidence["error_message"])
+
+          def has_structured_evidence(evidence):
+              if not isinstance(evidence, dict):
+                  return False
+              return any(
+                  key in evidence and evidence[key] is not None
+                  for key in ("kind", "scanner", "block_reason", "error_message", "decision", "findings")
+              )
+
+          applicable_results = [row for row in results if row.get("actual_verdict") != "not_applicable"]
+          applicable_malicious = [row for row in applicable_results if row.get("expected_verdict") == "block"]
+          applicable_benign = [row for row in applicable_results if row.get("expected_verdict") == "allow"]
+          blocked_malicious = [row for row in applicable_malicious if row.get("actual_verdict") == "block"]
+          blocked_benign = [row for row in applicable_benign if row.get("actual_verdict") == "block"]
+          classified = sum(has_classification(row.get("evidence")) for row in blocked_malicious)
+          evidence_emitted = sum(has_structured_evidence(row.get("evidence")) for row in blocked_malicious)
+          full_malicious = count_stat("block")
+          full_benign = count_stat("allow") + count_stat("warn")
+
+          metric_counts = {
+              "applicable": {
+                  "containment": {"numerator": len(blocked_malicious), "denominator": len(applicable_malicious)},
+                  "false_positive_rate": {"numerator": len(blocked_benign), "denominator": len(applicable_benign)},
+                  "detection": {"numerator": classified, "denominator": len(blocked_malicious)},
+                  "evidence": {"numerator": evidence_emitted, "denominator": len(blocked_malicious)},
+              },
+              "full": {
+                  "containment": {"numerator": len(blocked_malicious), "denominator": full_malicious},
+                  "false_positive_rate": {"numerator": len(blocked_benign), "denominator": full_benign},
+                  "detection": {"numerator": classified, "denominator": len(blocked_malicious)},
+                  "evidence": {"numerator": evidence_emitted, "denominator": len(blocked_malicious)},
+              },
           }
           if summary["case_count"]["total"] != logical_case_count:
               raise SystemExit(
                   "runner summary total does not match the pinned manifest: "
                   f"{summary['case_count']['total']} != {logical_case_count}"
               )
-          if summary["case_count"]["applicable"] != len(results):
+          if len(results) != logical_case_count:
+              raise SystemExit(
+                  "runner JSONL row count does not match the logical corpus: "
+                  f"{len(results)} != {logical_case_count}"
+              )
+          if summary["case_count"]["applicable"] != len(applicable_results):
               raise SystemExit(
                   "runner summary applicable count does not match runner JSONL: "
-                  f"{summary['case_count']['applicable']} != {len(results)}"
+                  f"{summary['case_count']['applicable']} != {len(applicable_results)}"
               )
-          for metric, counts in applicable_metrics.items():
-              expected_score = (
-                  counts["numerator"] / counts["denominator"]
-                  if counts["denominator"] else None
+          jsonl_errors = sum(row.get("actual_verdict") == "error" for row in applicable_results)
+          if summary["case_count"]["errors"] != jsonl_errors:
+              raise SystemExit(
+                  "runner summary error count does not match runner JSONL: "
+                  f"{summary['case_count']['errors']} != {jsonl_errors}"
               )
-              actual_score = summary["scores"]["applicable"].get(metric)
-              if actual_score != expected_score:
-                  raise SystemExit(
-                      f"runner summary scores.applicable.{metric} does not match runner JSONL: "
-                      f"{actual_score!r} != {expected_score!r}"
+          if full_malicious + full_benign != logical_case_count:
+              raise SystemExit(
+                  "make stats verdict counts do not match the logical corpus: "
+                  f"{full_malicious} + {full_benign} != {logical_case_count}"
+              )
+          for scope, metrics in metric_counts.items():
+              for metric, counts in metrics.items():
+                  expected_score = (
+                      counts["numerator"] / counts["denominator"]
+                      if counts["denominator"] else None
                   )
+                  actual_score = summary["scores"][scope].get(metric)
+                  if actual_score != expected_score:
+                      raise SystemExit(
+                          f"runner summary scores.{scope}.{metric} does not match bound metric counts: "
+                          f"{actual_score!r} != {expected_score!r}"
+                      )
 
           repo = os.environ["GITHUB_REPOSITORY"]
           run_id = os.environ["GITHUB_RUN_ID"]
@@ -390,6 +434,9 @@ jobs:
               "corpus_version": summary["corpus_version"],
               "corpus_sha256": summary["corpus_sha256"],
               "corpus_manifest_sha256": manifest_sha256,
+              "case_index_sha256": hashlib.sha256(
+                  json.dumps(case_index, sort_keys=True, separators=(",", ":")).encode("utf-8")
+              ).hexdigest(),
               "logical_case_count": logical_case_count,
               "tool_profile_sha256": summary["tool_profile_sha256"],
               "case_count": {
@@ -400,7 +447,7 @@ jobs:
                   "errors": summary["case_count"]["errors"],
               },
               "scores": summary["scores"],
-              "metric_counts": {"applicable": applicable_metrics},
+              "metric_counts": metric_counts,
               "sufficient": summary["sufficient"],
               "fixtures": True,
               "multifile_cases": True,
@@ -427,13 +474,108 @@ jobs:
           test -f "$ARTIFACT_JSON" || { echo "provenance artifact missing at $ARTIFACT_JSON"; exit 1; }
           python3 scripts/validate_gauntlet_scope.py "$ARTIFACT_JSON"
 
+      - name: Evaluate candidate without publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          decision_path="$ARTIFACT_DIR/promotion-decision.json"
+          python3 scripts/evaluate_gauntlet_candidate.py evaluate \
+            --candidate "$ARTIFACT_JSON" \
+            --baseline ci/gauntlet-baseline.json \
+            --evidence "raw_summary=$SUMMARY_PATH" \
+            --evidence "results=$RESULTS_PATH" \
+            --evidence "runner_stderr=$ARTIFACT_DIR/runner.stderr" \
+            --evidence "command=$COMMAND_PATH" \
+            --evidence "stats=$STATS_PATH" \
+            --evidence "case_index=$CASE_INDEX_PATH" \
+            --decision "$decision_path"
+          echo "DECISION_PATH=$decision_path" >> "$GITHUB_ENV"
+
+      # Earlier failures skip the normal evaluator. Still produce a blocked,
+      # machine-readable decision before upload so malformed or partial runs
+      # leave an auditable reason instead of only a red job status.
+      - name: Ensure fail-closed decision exists
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir="$GAUNTLET_ARTIFACT_DIR"
+          candidate_path="$artifact_dir/continuous-gauntlet-pipelock-${PIPELOCK_TAG}.json"
+          decision_path="$artifact_dir/promotion-decision.json"
+          mkdir -p "$artifact_dir"
+          if [[ ! -f "$decision_path" ]]; then
+            if [[ -f scripts/evaluate_gauntlet_candidate.py ]]; then
+              python3 scripts/evaluate_gauntlet_candidate.py evaluate \
+                --candidate "$candidate_path" \
+                --baseline ci/gauntlet-baseline.json \
+                --evidence "raw_summary=$artifact_dir/raw-summary.json" \
+                --evidence "results=$artifact_dir/results.jsonl" \
+                --evidence "runner_stderr=$artifact_dir/runner.stderr" \
+                --evidence "command=$artifact_dir/command.txt" \
+                --evidence "stats=$artifact_dir/make-stats.txt" \
+                --evidence "case_index=$artifact_dir/case-index.json" \
+                --decision "$decision_path"
+            else
+              # Checkout itself can fail before repository scripts exist. Keep
+              # that failure auditable too instead of turning it into no artifact.
+              temporary_decision="$decision_path.tmp"
+              jq -n '{
+                schema_version: 1,
+                candidate_sha256: null,
+                baseline_sha256: null,
+                evidence_sha256: {},
+                blocked: true,
+                promotion_status: "blocked",
+                failures: ["repository evaluator unavailable after an earlier workflow failure"],
+                review_notes: []
+              }' > "$temporary_decision"
+              mv "$temporary_decision" "$decision_path"
+            fi
+          fi
+          {
+            echo "DECISION_PATH=$decision_path"
+            echo "ARTIFACT_JSON=$candidate_path"
+          } >> "$GITHUB_ENV"
+          {
+            echo '## Continuous Gauntlet candidate'
+            echo
+            echo 'This run did not publish or replace a public result.'
+            echo
+            jq -r '"- Promotion status: `\(.promotion_status)`\n- Blocked: `\(.blocked)`\n- Candidate SHA-256: `\(.candidate_sha256)`"' "$decision_path"
+            jq -r '.review_notes[]? | "- Review: " + .' "$decision_path"
+            jq -r '.failures[]? | "- Failure: " + .' "$decision_path"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload provenance artifact
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: continuous-gauntlet-pipelock-${{ env.PIPELOCK_TAG }}
           path: |
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/continuous-gauntlet-pipelock-${{ env.PIPELOCK_TAG }}.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/promotion-decision.json
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/raw-summary.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/results.jsonl
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/runner.stderr
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/command.txt
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/make-stats.txt
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/case-index.json
           retention-days: 14
+
+      # Enforce only after upload. A regression must leave the candidate and
+      # its reason available for review instead of disappearing when CI turns red.
+      - name: Enforce candidate decision
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${DECISION_PATH:-}" || { echo "candidate decision was not produced" >&2; exit 1; }
+          python3 scripts/evaluate_gauntlet_candidate.py enforce "$DECISION_PATH" \
+            --candidate "$ARTIFACT_JSON" \
+            --baseline ci/gauntlet-baseline.json \
+            --evidence "raw_summary=$ARTIFACT_DIR/raw-summary.json" \
+            --evidence "results=$ARTIFACT_DIR/results.jsonl" \
+            --evidence "runner_stderr=$ARTIFACT_DIR/runner.stderr" \
+            --evidence "command=$ARTIFACT_DIR/command.txt" \
+            --evidence "stats=$ARTIFACT_DIR/make-stats.txt" \
+            --evidence "case_index=$ARTIFACT_DIR/case-index.json"

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -30,6 +30,10 @@ jobs:
       PIPELOCK_VERSION: "3.3.0"
       GAUNTLET_ARTIFACT_DIR: continuous-gauntlet-artifacts
     steps:
+      - name: Record job budget start
+        shell: bash
+        run: echo "JOB_STARTED_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Check out corpus
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -174,9 +178,22 @@ jobs:
             --fixtures
             --output "$summary_path"
           )
-          # Leave seven minutes inside the 35-minute job budget for decision
-          # synthesis and evidence upload if the benchmark itself hangs.
-          run_cmd=(timeout --signal=TERM --kill-after=30s 28m "${cmd[@]}")
+          # Compute the cap from the job's actual elapsed time. This keeps six
+          # minutes of the 35-minute job budget for decision synthesis and
+          # evidence upload even when checkout or release setup was slow.
+          now_epoch="$(date +%s)"
+          reserve_seconds=$((6 * 60))
+          job_deadline=$((JOB_STARTED_EPOCH + 35 * 60))
+          available_seconds=$((job_deadline - now_epoch - reserve_seconds))
+          benchmark_cap_seconds=$((24 * 60))
+          if (( available_seconds <= 0 )); then
+            echo "Insufficient job budget remains to run the benchmark safely." >&2
+            exit 1
+          fi
+          if (( available_seconds < benchmark_cap_seconds )); then
+            benchmark_cap_seconds=$available_seconds
+          fi
+          run_cmd=(timeout --signal=TERM --kill-after=30s "${benchmark_cap_seconds}s" "${cmd[@]}")
 
           printf '%q ' "${run_cmd[@]}" > "$command_path"
           printf '\n' >> "$command_path"
@@ -223,6 +240,7 @@ jobs:
             echo "ARTIFACT_DIR=$artifact_dir"
             echo "SUMMARY_PATH=$summary_path"
             echo "RESULTS_PATH=$jsonl_path"
+            echo "STDERR_PATH=$stderr_path"
             echo "COMMAND_PATH=$command_path"
             echo "STATS_PATH=$stats_path"
             echo "CASE_INDEX_PATH=$case_index_path"
@@ -333,8 +351,9 @@ jobs:
           def has_classification(evidence):
               if not isinstance(evidence, dict):
                   return False
-              if "kind" in evidence or "scanner" in evidence or "block_reason" in evidence:
-                  return True
+              for key in ("kind", "scanner", "block_reason"):
+                  if evidence.get(key) is not None:
+                      return True
               return isinstance(evidence.get("error_message"), str) and bool(evidence["error_message"])
 
           def has_structured_evidence(evidence):
@@ -414,7 +433,7 @@ jobs:
           pipelock_tag = os.environ["PIPELOCK_TAG"]
 
           artifact = {
-              "schema_version": 1,
+              "schema_version": 2,
               "artifact_id": f"github-actions:{repo}:{run_id}",
               "generated_at": os.environ["GENERATED_AT"],
               "canonical_url": f"https://github.com/{repo}/actions/runs/{run_id}",
@@ -484,7 +503,7 @@ jobs:
             --baseline ci/gauntlet-baseline.json \
             --evidence "raw_summary=$SUMMARY_PATH" \
             --evidence "results=$RESULTS_PATH" \
-            --evidence "runner_stderr=$ARTIFACT_DIR/runner.stderr" \
+            --evidence "runner_stderr=$STDERR_PATH" \
             --evidence "command=$COMMAND_PATH" \
             --evidence "stats=$STATS_PATH" \
             --evidence "case_index=$CASE_INDEX_PATH" \
@@ -570,12 +589,13 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${DECISION_PATH:-}" || { echo "candidate decision was not produced" >&2; exit 1; }
+          artifact_dir="$GAUNTLET_ARTIFACT_DIR"
           python3 scripts/evaluate_gauntlet_candidate.py enforce "$DECISION_PATH" \
             --candidate "$ARTIFACT_JSON" \
             --baseline ci/gauntlet-baseline.json \
-            --evidence "raw_summary=$ARTIFACT_DIR/raw-summary.json" \
-            --evidence "results=$ARTIFACT_DIR/results.jsonl" \
-            --evidence "runner_stderr=$ARTIFACT_DIR/runner.stderr" \
-            --evidence "command=$ARTIFACT_DIR/command.txt" \
-            --evidence "stats=$ARTIFACT_DIR/make-stats.txt" \
-            --evidence "case_index=$ARTIFACT_DIR/case-index.json"
+            --evidence "raw_summary=$artifact_dir/raw-summary.json" \
+            --evidence "results=$artifact_dir/results.jsonl" \
+            --evidence "runner_stderr=$artifact_dir/runner.stderr" \
+            --evidence "command=$artifact_dir/command.txt" \
+            --evidence "stats=$artifact_dir/make-stats.txt" \
+            --evidence "case_index=$artifact_dir/case-index.json"

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -267,8 +267,9 @@ jobs:
               command = fh.read().strip()
           with open(os.environ["STATS_PATH"], encoding="utf-8") as fh:
               make_stats = fh.read()
-          with open(os.environ["CASE_INDEX_PATH"], encoding="utf-8") as fh:
-              case_index = json.load(fh)
+          with open(os.environ["CASE_INDEX_PATH"], "rb") as fh:
+              case_index_bytes = fh.read()
+          case_index = json.loads(case_index_bytes)
 
           manifest_path = "cases/MANIFEST.txt"
           with open(manifest_path, "rb") as fh:
@@ -453,9 +454,7 @@ jobs:
               "corpus_version": summary["corpus_version"],
               "corpus_sha256": summary["corpus_sha256"],
               "corpus_manifest_sha256": manifest_sha256,
-              "case_index_sha256": hashlib.sha256(
-                  json.dumps(case_index, sort_keys=True, separators=(",", ":")).encode("utf-8")
-              ).hexdigest(),
+              "case_index_sha256": hashlib.sha256(case_index_bytes).hexdigest(),
               "logical_case_count": logical_case_count,
               "tool_profile_sha256": summary["tool_profile_sha256"],
               "case_count": {

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ cases-manifest:
 # Print canonical statistics from the runner's loaded corpus. Unlike the
 # manifest, this reports category and verdict metadata from each loaded case.
 stats:
+	@mkdir -p "$(TMPDIR)" "$(GOCACHE)"
 	@cd runner && go run . --stats --cases ../cases
 
 # Refresh the committed, reader-facing stats snapshot from the runner loaders.
@@ -109,6 +110,8 @@ check-stats: check-gauntlet-site
 # artifact path when validating an actual scoring run.
 check-gauntlet-site:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/validate_gauntlet_scope_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/evaluate_gauntlet_candidate_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/continuous_gauntlet_workflow_test.py
 	@node gauntlet-site/scope-render_test.js
 	@test -f "$(GAUNTLET_SCOPE_ARTIFACT)" || { echo "check-gauntlet-site: FAIL - missing provenance artifact: $(GAUNTLET_SCOPE_ARTIFACT)"; exit 1; }
 	@python3 scripts/validate_gauntlet_scope.py "$(GAUNTLET_SCOPE_ARTIFACT)"

--- a/ci/gauntlet-baseline.json
+++ b/ci/gauntlet-baseline.json
@@ -1,9 +1,12 @@
 {
   "_comment": "Baseline for the continuous gauntlet lane. Scores are floors, not equalities: the lane fails when containment or detection or evidence drops below these, or when the false-positive rate rises above its ceiling. Case counts are recorded for reporting and are EXPECTED to move as the corpus grows; a count change is reported, never failed. Update this file in a reviewed commit when a score legitimately moves, so the change is a visible diff rather than a silently-adjusted threshold.",
+  "schema_version": 1,
   "recorded_on": "2026-08-01",
   "pipelock_version": "3.3.0",
   "corpus_git_sha": "333ad01df3cedbcee7ba455011b9242e34068dac",
   "corpus_version": "v2.2.0",
+  "scoring_version": "2.4",
+  "runner_version": "0.4.2",
   "observed_case_count": {
     "total": 213,
     "applicable": 212,

--- a/ci/gauntlet-baseline.json
+++ b/ci/gauntlet-baseline.json
@@ -4,6 +4,7 @@
   "recorded_on": "2026-08-01",
   "pipelock_version": "3.3.0",
   "corpus_git_sha": "333ad01df3cedbcee7ba455011b9242e34068dac",
+  "corpus_sha256": "cb9f74802df69f418e63715200ca9d24a0bf99c2604dce4ed1f1797fa9c90357",
   "corpus_version": "v2.2.0",
   "scoring_version": "2.4",
   "runner_version": "0.4.2",

--- a/gauntlet-site/testdata/complete-provenance-artifact.json
+++ b/gauntlet-site/testdata/complete-provenance-artifact.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 2,
   "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
   "case_index_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
   "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",

--- a/gauntlet-site/testdata/complete-provenance-artifact.json
+++ b/gauntlet-site/testdata/complete-provenance-artifact.json
@@ -1,5 +1,6 @@
 {
   "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
+  "case_index_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
   "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
   "corpus_manifest_sha256": "ef82e319ad3efd7d407e15de27631f2b8fdf9f227ecc7f8253308ac44053916a",
   "logical_case_count": 214,
@@ -11,23 +12,58 @@
     "not_applicable": 1,
     "not_applicable_reasons": {
       "missing_requires": 1
-    }
+    },
+    "errors": 0
   },
   "scores": {
+    "full": {
+      "containment": 0.9937106918238994,
+      "false_positive_rate": 0,
+      "detection": 1,
+      "evidence": 1
+    },
     "applicable": {
       "containment": 1,
-      "false_positive_rate": 0
+      "false_positive_rate": 0,
+      "detection": 1,
+      "evidence": 1
     }
   },
   "metric_counts": {
     "applicable": {
       "containment": {
-        "numerator": 1,
-        "denominator": 1
+        "numerator": 158,
+        "denominator": 158
       },
       "false_positive_rate": {
         "numerator": 0,
-        "denominator": 1
+        "denominator": 55
+      },
+      "detection": {
+        "numerator": 158,
+        "denominator": 158
+      },
+      "evidence": {
+        "numerator": 158,
+        "denominator": 158
+      }
+    },
+    "full": {
+      "containment": {
+        "numerator": 158,
+        "denominator": 159
+      },
+      "false_positive_rate": {
+        "numerator": 0,
+        "denominator": 55
+      },
+      "detection": {
+        "numerator": 158,
+        "denominator": 158
+      },
+      "evidence": {
+        "numerator": 158,
+        "denominator": 158
       }
     }
   }

--- a/runner/corpus.go
+++ b/runner/corpus.go
@@ -1,11 +1,22 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"path/filepath"
 	"sort"
 )
+
+type caseIndexDocument struct {
+	SchemaVersion int              `json:"schema_version"`
+	Cases         []caseIndexEntry `json:"cases"`
+}
+
+type caseIndexEntry struct {
+	CaseID          string `json:"case_id"`
+	ExpectedVerdict string `json:"expected_verdict"`
+}
 
 type corpusStatCase struct {
 	Category        string
@@ -110,4 +121,16 @@ func writeCorpusStats(w io.Writer, cases []corpusStatCase) error {
 		}
 	}
 	return nil
+}
+
+// writeCaseIndex emits the execution loader's normalized case classification.
+// This is the per-case authority for evidence wrappers: notably, multi-file
+// warn fixtures are normalized to allow exactly as they are during scoring.
+func writeCaseIndex(w io.Writer, cases []Case) error {
+	entries := make([]caseIndexEntry, 0, len(cases))
+	for _, c := range cases {
+		entries = append(entries, caseIndexEntry{CaseID: c.ID, ExpectedVerdict: c.ExpectedVerdict})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].CaseID < entries[j].CaseID })
+	return json.NewEncoder(w).Encode(caseIndexDocument{SchemaVersion: 1, Cases: entries})
 }

--- a/runner/corpus_stats_test.go
+++ b/runner/corpus_stats_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -27,6 +28,36 @@ func TestWriteCorpusStats(t *testing.T) {
 		"  url: 2\n"
 	if got.String() != want {
 		t.Errorf("writeCorpusStats output:\n%s\nwant:\n%s", got.String(), want)
+	}
+}
+
+func TestWriteCaseIndexUsesNormalizedVerdicts(t *testing.T) {
+	cases, err := loadCorpus("../cases")
+	if err != nil {
+		t.Fatalf("loadCorpus: %v", err)
+	}
+	var output bytes.Buffer
+	if err := writeCaseIndex(&output, cases); err != nil {
+		t.Fatalf("writeCaseIndex: %v", err)
+	}
+	var index caseIndexDocument
+	if err := json.Unmarshal(output.Bytes(), &index); err != nil {
+		t.Fatalf("decode case index: %v", err)
+	}
+	if index.SchemaVersion != 1 || len(index.Cases) != len(cases) {
+		t.Fatalf("case index scope = schema %d, cases %d; want schema 1, cases %d", index.SchemaVersion, len(index.Cases), len(cases))
+	}
+	foundNormalizedWarn := false
+	for _, entry := range index.Cases {
+		if entry.CaseID == "mcp-drift-benign-001" && entry.ExpectedVerdict != "allow" {
+			t.Fatalf("warn normalization = %q, want allow", entry.ExpectedVerdict)
+		}
+		if entry.CaseID == "mcp-drift-benign-001" {
+			foundNormalizedWarn = true
+		}
+	}
+	if !foundNormalizedWarn {
+		t.Fatal("case index omitted normalized warn fixture")
 	}
 }
 

--- a/runner/corpus_stats_test.go
+++ b/runner/corpus_stats_test.go
@@ -48,7 +48,10 @@ func TestWriteCaseIndexUsesNormalizedVerdicts(t *testing.T) {
 		t.Fatalf("case index scope = schema %d, cases %d; want schema 1, cases %d", index.SchemaVersion, len(index.Cases), len(cases))
 	}
 	foundNormalizedWarn := false
-	for _, entry := range index.Cases {
+	for position, entry := range index.Cases {
+		if position > 0 && index.Cases[position-1].CaseID >= entry.CaseID {
+			t.Fatalf("case index is not strictly sorted at %q then %q", index.Cases[position-1].CaseID, entry.CaseID)
+		}
 		if entry.CaseID == "mcp-drift-benign-001" && entry.ExpectedVerdict != "allow" {
 			t.Fatalf("warn normalization = %q, want allow", entry.ExpectedVerdict)
 		}

--- a/runner/main.go
+++ b/runner/main.go
@@ -33,6 +33,7 @@ func main() {
 	receiptVerifierFile := flag.String("receipt-verifier-file", "", "JSON file describing the tool's receipt verifier (shipped, open_source, verifier_url, license, exit_code_contract). Used only when --emit-receipt-profile is set; omitted means \"no verifier shipped\".")
 	multiFileCases := flag.String("multifile-cases", "", "directory of multi-file MCP-drift cases (each subdirectory has case.yaml + before.json + after.json + expected.json). Driver replays before then after through a single MCP session and observes the verdict on the second tools/list response.")
 	stats := flag.Bool("stats", false, "print loader-backed corpus statistics (requires --cases; ignores runner profile flags)")
+	caseIndex := flag.Bool("case-index", false, "print loader-normalized case IDs and expected verdicts as JSON (requires --cases; ignores runner profile flags)")
 
 	// --debug / -v: emit verbose per-case diagnostics to stderr. Both
 	// flag names point at the same variable so either can be used.
@@ -53,6 +54,22 @@ func main() {
 		}
 		if err := writeCorpusStats(os.Stdout, cases); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "error: write corpus stats: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if *caseIndex {
+		if *casesDir == "" {
+			flag.Usage()
+			os.Exit(1)
+		}
+		cases, err := loadCorpus(*casesDir)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := writeCaseIndex(os.Stdout, cases); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: write case index: %v\n", err)
 			os.Exit(1)
 		}
 		return

--- a/runner/score.go
+++ b/runner/score.go
@@ -79,16 +79,13 @@ func isBudgetTimingFailure(c Case, actual string, evidence map[string]interface{
 // hasClassification checks if the evidence contains scanner/kind information
 // that demonstrates the tool identified what KIND of attack it blocked.
 func hasClassification(ev map[string]interface{}) bool {
-	// Scan API results include "kind" (dlp, prompt_injection, tool_call).
-	if _, ok := ev["kind"]; ok {
-		return true
-	}
-	// Fetch proxy results include "scanner" or "block_reason".
-	if _, ok := ev["scanner"]; ok {
-		return true
-	}
-	if _, ok := ev["block_reason"]; ok {
-		return true
+	// Scan API results include "kind" (dlp, prompt_injection, tool_call),
+	// while fetch proxy results include "scanner" or "block_reason". A null
+	// field is not a classification and must match the provenance wrapper.
+	for _, key := range []string{"kind", "scanner", "block_reason"} {
+		if value, ok := ev[key]; ok && value != nil {
+			return true
+		}
 	}
 	// MCP proxy results include "error_message" with scanner context.
 	if msg, ok := ev["error_message"].(string); ok && msg != "" {

--- a/runner/score_test.go
+++ b/runner/score_test.go
@@ -75,6 +75,25 @@ func TestScoreCaseWithEvidence_ExpectedBlockForwardedAllowFails(t *testing.T) {
 }
 
 func TestComputeScores(t *testing.T) {
+	t.Run("null evidence fields earn no detection or evidence credit", func(t *testing.T) {
+		for _, key := range []string{"kind", "scanner", "block_reason"} {
+			t.Run(key, func(t *testing.T) {
+				scores := computeScores([]CaseResult{{
+					CaseID:          "malicious",
+					ExpectedVerdict: "block",
+					ActualVerdict:   "block",
+					Evidence:        map[string]interface{}{key: nil},
+				}})
+				if scores.Detection == nil || *scores.Detection != 0 {
+					t.Fatalf("detection = %v, want 0 for null %s", ptrVal(scores.Detection), key)
+				}
+				if scores.Evidence == nil || *scores.Evidence != 0 {
+					t.Fatalf("evidence = %v, want 0 for null %s", ptrVal(scores.Evidence), key)
+				}
+			})
+		}
+	})
+
 	t.Run("all malicious blocked", func(t *testing.T) {
 		results := []CaseResult{
 			{CaseID: "a", ExpectedVerdict: "block", ActualVerdict: "block"},

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -2,6 +2,7 @@
 """Structural tests for the fail-safe continuous-gauntlet workflow."""
 
 import json
+import hashlib
 import os
 import re
 import subprocess
@@ -226,6 +227,10 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
         self.assertEqual(artifact["schema_version"], 2)
+        self.assertEqual(
+            artifact["case_index_sha256"],
+            hashlib.sha256((artifact_path.parent / "case-index.json").read_bytes()).hexdigest(),
+        )
         self.assertEqual(artifact["metric_counts"]["applicable"]["containment"], {
             "numerator": 1,
             "denominator": 1,

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -32,13 +32,14 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
     def setUp(self):
         self.workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    def run_wrapper(self, results):
+    def run_wrapper(self, results, detection_score=1.0, evidence_score=1.0):
+        wrapper_block = step_block(self.workflow, "Wrap provenance artifact")
         marker = "          python3 - <<'PY'\n"
-        start = self.workflow.index(marker) + len(marker)
-        end = self.workflow.index("\n          PY\n", start)
+        start = wrapper_block.index(marker) + len(marker)
+        end = wrapper_block.index("\n          PY\n", start)
         source = "\n".join(
             line[10:] if line.startswith("          ") else line
-            for line in self.workflow[start:end].splitlines()
+            for line in wrapper_block[start:end].splitlines()
         )
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
@@ -68,14 +69,14 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
                 "applicable": {
                     "containment": 1.0,
                     "false_positive_rate": 0.0,
-                    "detection": 1.0,
-                    "evidence": 1.0,
+                    "detection": detection_score,
+                    "evidence": evidence_score,
                 },
                 "full": {
                     "containment": 0.5,
                     "false_positive_rate": 0.0,
-                    "detection": 1.0,
-                    "evidence": 1.0,
+                    "detection": detection_score,
+                    "evidence": evidence_score,
                 },
             },
             "sufficient": False,
@@ -224,6 +225,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         result, artifact_path = self.run_wrapper(results)
         self.assertEqual(result.returncode, 0, result.stderr)
         artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+        self.assertEqual(artifact["schema_version"], 2)
         self.assertEqual(artifact["metric_counts"]["applicable"]["containment"], {
             "numerator": 1,
             "denominator": 1,
@@ -259,10 +261,60 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("does not match loader case index", result.stderr)
 
+    def test_null_classification_fields_do_not_earn_detection_or_evidence_credit(self):
+        for key in ("kind", "scanner", "block_reason"):
+            with self.subTest(key=key):
+                results = [
+                    {
+                        "case_id": "a",
+                        "expected_verdict": "block",
+                        "actual_verdict": "block",
+                        "evidence": {key: None},
+                    },
+                    {
+                        "case_id": "b",
+                        "expected_verdict": "allow",
+                        "actual_verdict": "allow",
+                        "evidence": {},
+                    },
+                    {
+                        "case_id": "c",
+                        "expected_verdict": "block",
+                        "actual_verdict": "not_applicable",
+                        "evidence": {},
+                    },
+                ]
+                result, artifact_path = self.run_wrapper(
+                    results, detection_score=0.0, evidence_score=0.0
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+                self.assertEqual(
+                    artifact["metric_counts"]["applicable"]["detection"],
+                    {"numerator": 0, "denominator": 1},
+                )
+                self.assertEqual(
+                    artifact["metric_counts"]["applicable"]["evidence"],
+                    {"numerator": 0, "denominator": 1},
+                )
+
     def test_runner_timeout_preserves_cleanup_budget(self):
+        budget_block = step_block(self.workflow, "Record job budget start")
         run_block = step_block(self.workflow, "Run canonical benchmark")
-        self.assertIn('run_cmd=(timeout --signal=TERM --kill-after=30s 28m "${cmd[@]}")', run_block)
+        self.assertIn("JOB_STARTED_EPOCH", budget_block)
+        self.assertIn("reserve_seconds=$((6 * 60))", run_block)
+        self.assertIn("job_deadline=$((JOB_STARTED_EPOCH + 35 * 60))", run_block)
+        self.assertIn("benchmark_cap_seconds=$((24 * 60))", run_block)
+        self.assertIn("if (( available_seconds <= 0 ))", run_block)
+        self.assertIn('run_cmd=(timeout --signal=TERM --kill-after=30s "${benchmark_cap_seconds}s" "${cmd[@]}")', run_block)
         self.assertIn('"${run_cmd[@]}" > "$jsonl_path"', run_block)
+
+    def test_early_failure_paths_use_the_always_defined_artifact_directory(self):
+        ensure_block = step_block(self.workflow, "Ensure fail-closed decision exists")
+        enforce_block = step_block(self.workflow, "Enforce candidate decision")
+        for block in (ensure_block, enforce_block):
+            self.assertIn('artifact_dir="$GAUNTLET_ARTIFACT_DIR"', block)
+        self.assertNotIn('runner_stderr=$STDERR_PATH', enforce_block)
 
 
 if __name__ == "__main__":

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Structural tests for the fail-safe continuous-gauntlet workflow."""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
+MAKEFILE = REPO_ROOT / "Makefile"
+
+
+def step_block(workflow, name):
+    marker = f"      - name: {name}\n"
+    start = workflow.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing workflow step: {name}")
+    next_step = workflow.find("\n      - name:", start + len(marker))
+    next_action = workflow.find("\n      - uses:", start + len(marker))
+    candidates = [offset for offset in (next_step, next_action) if offset >= 0]
+    end = min(candidates) if candidates else len(workflow)
+    return workflow[start:end]
+
+
+class ContinuousGauntletWorkflowTest(unittest.TestCase):
+    def setUp(self):
+        self.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def run_wrapper(self, results):
+        marker = "          python3 - <<'PY'\n"
+        start = self.workflow.index(marker) + len(marker)
+        end = self.workflow.index("\n          PY\n", start)
+        source = "\n".join(
+            line[10:] if line.startswith("          ") else line
+            for line in self.workflow[start:end].splitlines()
+        )
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        (root / "cases").mkdir()
+        (root / "cases" / "MANIFEST.txt").write_text("a\nb\nc\n", encoding="utf-8")
+        artifact_dir = root / "artifacts"
+        artifact_dir.mkdir()
+        summary_path = artifact_dir / "raw-summary.json"
+        summary = {
+            "gauntlet_version": "1",
+            "scoring_version": "2.4",
+            "runner_version": "0.4.2",
+            "tool": "Pipelock",
+            "tool_version": "3.3.0",
+            "corpus_version": "test",
+            "corpus_sha256": "a" * 64,
+            "tool_profile_sha256": "b" * 64,
+            "case_count": {
+                "total": 3,
+                "applicable": 2,
+                "not_applicable": 1,
+                "not_applicable_reasons": {"missing_requires": 1},
+                "errors": 0,
+            },
+            "scores": {
+                "applicable": {
+                    "containment": 1.0,
+                    "false_positive_rate": 0.0,
+                    "detection": 1.0,
+                    "evidence": 1.0,
+                },
+                "full": {
+                    "containment": 0.5,
+                    "false_positive_rate": 0.0,
+                    "detection": 1.0,
+                    "evidence": 1.0,
+                },
+            },
+            "sufficient": False,
+        }
+        summary_path.write_text(json.dumps(summary), encoding="utf-8")
+        results_path = artifact_dir / "results.jsonl"
+        results_path.write_text(
+            "".join(json.dumps(row) + "\n" for row in results), encoding="utf-8"
+        )
+        command_path = artifact_dir / "command.txt"
+        command_path.write_text("aeb-gauntlet --fixtures --multifile-cases cases/mcp-drift\n", encoding="utf-8")
+        stats_path = artifact_dir / "make-stats.txt"
+        stats_path.write_text("block: 2\nallow: 1\nwarn: 0\n", encoding="utf-8")
+        case_index_path = artifact_dir / "case-index.json"
+        case_index_path.write_text(
+            json.dumps({
+                "schema_version": 1,
+                "cases": [
+                    {"case_id": "a", "expected_verdict": "block"},
+                    {"case_id": "b", "expected_verdict": "allow"},
+                    {"case_id": "c", "expected_verdict": "block"},
+                ],
+            }),
+            encoding="utf-8",
+        )
+        artifact_path = artifact_dir / "candidate.json"
+        env = {
+            **os.environ,
+            "SUMMARY_PATH": str(summary_path),
+            "COMMAND_PATH": str(command_path),
+            "STATS_PATH": str(stats_path),
+            "RESULTS_PATH": str(results_path),
+            "CASE_INDEX_PATH": str(case_index_path),
+            "GITHUB_REPOSITORY": "luckyPipewrench/agent-egress-bench",
+            "GITHUB_RUN_ID": "123",
+            "CORPUS_GIT_SHA": "c" * 40,
+            "CORPUS_REF_KIND": "origin/main",
+            "CORPUS_DIRTY": "false",
+            "PIPELOCK_TAG": "v3.3.0",
+            "PIPELOCK_VERSION": "3.3.0",
+            "PIPELOCK_ASSET": "pipelock.tar.gz",
+            "PIPELOCK_REPO": "luckyPipewrench/pipelock",
+            "GENERATED_AT": "2026-08-04T00:00:00Z",
+            "ARTIFACT_JSON": str(artifact_path),
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=root,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        return result, artifact_path
+
+    def test_collection_upload_and_enforcement_order_is_fail_safe(self):
+        ensure = self.workflow.index("      - name: Ensure fail-closed decision exists")
+        upload = self.workflow.index("      - name: Upload provenance artifact")
+        enforce = self.workflow.index("      - name: Enforce candidate decision")
+        self.assertLess(ensure, upload)
+        self.assertLess(upload, enforce)
+
+        ensure_block = step_block(self.workflow, "Ensure fail-closed decision exists")
+        upload_block = step_block(self.workflow, "Upload provenance artifact")
+        enforce_block = step_block(self.workflow, "Enforce candidate decision")
+        for block in (ensure_block, upload_block, enforce_block):
+            self.assertIn("if: ${{ !cancelled() }}", block)
+        self.assertIn("promotion-decision.json", ensure_block)
+        self.assertIn("evaluate_gauntlet_candidate.py evaluate", ensure_block)
+        self.assertIn("repository evaluator unavailable after an earlier workflow failure", ensure_block)
+        self.assertIn("promotion-decision.json", upload_block)
+        self.assertIn("evaluate_gauntlet_candidate.py enforce", enforce_block)
+        for evidence in ("raw_summary", "results", "runner_stderr", "command", "stats", "case_index"):
+            self.assertIn(f'--evidence "{evidence}=', ensure_block)
+            self.assertIn(f'--evidence "{evidence}=', enforce_block)
+
+    def test_scheduled_lane_has_no_public_write_permission(self):
+        self.assertRegex(self.workflow, r"(?m)^permissions:\n  contents: read$")
+        self.assertNotIn("contents: write", self.workflow)
+        self.assertNotIn("pull-requests: write", self.workflow)
+
+    def test_checkout_failure_still_leaves_a_blocked_decision(self):
+        block = step_block(self.workflow, "Ensure fail-closed decision exists")
+        marker = "        run: |\n"
+        source = block[block.index(marker) + len(marker):]
+        source = "\n".join(
+            line[10:] if line.startswith("          ") else line
+            for line in source.splitlines()
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            github_env = root / "github-env"
+            step_summary = root / "step-summary"
+            env = {
+                **os.environ,
+                "GAUNTLET_ARTIFACT_DIR": "artifacts",
+                "PIPELOCK_TAG": "v3.3.0",
+                "GITHUB_ENV": str(github_env),
+                "GITHUB_STEP_SUMMARY": str(step_summary),
+            }
+            result = subprocess.run(
+                ["bash", "-c", source],
+                cwd=root,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            decision = json.loads(
+                (root / "artifacts" / "promotion-decision.json").read_text(encoding="utf-8")
+            )
+            self.assertTrue(decision["blocked"])
+            self.assertIn("evaluator unavailable", decision["failures"][0])
+
+    def test_stats_creates_its_declared_cache_directories(self):
+        makefile = MAKEFILE.read_text(encoding="utf-8")
+        match = re.search(r"(?ms)^stats:\n(?P<body>(?:\t.*\n)+)", makefile)
+        self.assertIsNotNone(match)
+        body = match.group("body")
+        mkdir = body.index('mkdir -p "$(TMPDIR)" "$(GOCACHE)"')
+        run = body.index("go run . --stats --cases ../cases")
+        self.assertLess(mkdir, run)
+
+    def test_wrapper_binds_every_manifest_case_and_handles_not_applicable_rows(self):
+        results = [
+            {
+                "case_id": "a",
+                "expected_verdict": "block",
+                "actual_verdict": "block",
+                "evidence": {"scanner": "test"},
+            },
+            {
+                "case_id": "b",
+                "expected_verdict": "allow",
+                "actual_verdict": "allow",
+                "evidence": {},
+            },
+            {
+                "case_id": "c",
+                "expected_verdict": "block",
+                "actual_verdict": "not_applicable",
+                "evidence": {},
+            },
+        ]
+        result, artifact_path = self.run_wrapper(results)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+        self.assertEqual(artifact["metric_counts"]["applicable"]["containment"], {
+            "numerator": 1,
+            "denominator": 1,
+        })
+        self.assertEqual(artifact["metric_counts"]["full"]["containment"], {
+            "numerator": 1,
+            "denominator": 2,
+        })
+
+    def test_wrapper_rejects_duplicate_and_unknown_case_ids(self):
+        base = [
+            {"case_id": "a", "expected_verdict": "block", "actual_verdict": "block", "evidence": {}},
+            {"case_id": "b", "expected_verdict": "allow", "actual_verdict": "allow", "evidence": {}},
+            {"case_id": "c", "expected_verdict": "block", "actual_verdict": "not_applicable", "evidence": {}},
+        ]
+        duplicate = [base[0], {**base[1], "case_id": "a"}, base[2]]
+        result, _ = self.run_wrapper(duplicate)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("duplicate case IDs", result.stderr)
+
+        unknown = [base[0], base[1], {**base[2], "case_id": "z"}]
+        result, _ = self.run_wrapper(unknown)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("do not match cases/MANIFEST.txt", result.stderr)
+
+    def test_wrapper_rejects_expected_verdict_label_swap(self):
+        swapped = [
+            {"case_id": "a", "expected_verdict": "allow", "actual_verdict": "allow", "evidence": {}},
+            {"case_id": "b", "expected_verdict": "block", "actual_verdict": "block", "evidence": {"scanner": "test"}},
+            {"case_id": "c", "expected_verdict": "block", "actual_verdict": "not_applicable", "evidence": {}},
+        ]
+        result, _ = self.run_wrapper(swapped)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not match loader case index", result.stderr)
+
+    def test_runner_timeout_preserves_cleanup_budget(self):
+        run_block = step_block(self.workflow, "Run canonical benchmark")
+        self.assertIn('run_cmd=(timeout --signal=TERM --kill-after=30s 28m "${cmd[@]}")', run_block)
+        self.assertIn('"${run_cmd[@]}" > "$jsonl_path"', run_block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -113,6 +113,22 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
 
         decision["artifact_id"] = nested_value(candidate, ("artifact_id",))
         decision["canonical_url"] = nested_value(candidate, ("canonical_url",))
+        advertised_case_index_digest = candidate.get("case_index_sha256")
+        case_index_digest = decision["evidence_sha256"].get("case_index")
+        if (
+            not isinstance(advertised_case_index_digest, str)
+            or len(advertised_case_index_digest) != 64
+            or any(character not in "0123456789abcdef" for character in advertised_case_index_digest)
+        ):
+            decision["failures"].append(
+                "candidate case_index_sha256 must be 64 lower-case hex characters"
+            )
+        elif not isinstance(case_index_digest, str):
+            decision["failures"].append("case_index evidence is required")
+        elif advertised_case_index_digest != case_index_digest:
+            decision["failures"].append(
+                "candidate case_index_sha256 does not match case_index evidence"
+            )
 
         if candidate.get("sufficient") is not True:
             decision["failures"].append(f"sufficient={candidate.get('sufficient')!r}, want true")

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -16,7 +16,14 @@ REQUIRED_FLOORS = {
 }
 REQUIRED_CEILINGS = {"applicable": {"false_positive_rate"}}
 REQUIRED_COUNT_KEYS = ("total", "applicable", "not_applicable", "not_applicable_reasons")
-REQUIRED_IDENTITIES = ("corpus_git_sha", "corpus_version", "scoring_version", "runner_version")
+REQUIRED_IDENTITIES = (
+    "corpus_git_sha",
+    "corpus_sha256",
+    "corpus_version",
+    "scoring_version",
+    "runner_version",
+)
+SCOPE_IDENTITIES = {"corpus_sha256", "corpus_version", "scoring_version", "runner_version"}
 
 
 def load_object(path):
@@ -100,6 +107,9 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
         decision["baseline_sha256"] = file_sha256(baseline_path)
         candidate = load_object(candidate_path)
         baseline = load_object(baseline_path)
+
+        if candidate.get("schema_version") != 2:
+            raise ValueError("candidate schema_version must be 2")
 
         decision["artifact_id"] = nested_value(candidate, ("artifact_id",))
         decision["canonical_url"] = nested_value(candidate, ("canonical_url",))
@@ -234,7 +244,8 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
                 raise ValueError(f"baseline {identity_key} must be a non-empty string")
             current = candidate.get(identity_key)
             if current != previous:
-                scope_changed = True
+                if identity_key in SCOPE_IDENTITIES:
+                    scope_changed = True
                 decision["review_notes"].append(
                     f"{identity_key} moved {previous!r} -> {current!r}"
                 )

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Evaluate a continuous-gauntlet candidate without publishing it."""
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import tempfile
+from pathlib import Path
+
+
+REQUIRED_FLOORS = {
+    "full": {"containment"},
+    "applicable": {"containment", "detection", "evidence"},
+}
+REQUIRED_CEILINGS = {"applicable": {"false_positive_rate"}}
+REQUIRED_COUNT_KEYS = ("total", "applicable", "not_applicable", "not_applicable_reasons")
+REQUIRED_IDENTITIES = ("corpus_git_sha", "corpus_version", "scoring_version", "runner_version")
+
+
+def load_object(path):
+    with path.open(encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def finite_number(value, label):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ValueError(f"{label} must be a finite number")
+    return float(value)
+
+
+def fraction(value, label):
+    number = finite_number(value, label)
+    if not 0 <= number <= 1:
+        raise ValueError(f"{label} must be between 0 and 1")
+    return number
+
+
+def nested_value(document, path):
+    current = document
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            raise ValueError("missing field: " + ".".join(path))
+        current = current[key]
+    return current
+
+
+def atomic_json_write(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def evaluate(candidate_path, baseline_path, evidence_paths=None):
+    evidence_paths = evidence_paths or {}
+    decision = {
+        "schema_version": 1,
+        "candidate_sha256": None,
+        "baseline_sha256": None,
+        "evidence_sha256": {},
+        "blocked": True,
+        "promotion_status": "under_review",
+        "failures": [],
+        "review_notes": [],
+    }
+
+    for label, path in sorted(evidence_paths.items()):
+        try:
+            decision["evidence_sha256"][label] = file_sha256(path)
+        except OSError as exc:
+            decision["evidence_sha256"][label] = None
+            decision["failures"].append(f"cannot hash evidence {label}: {exc}")
+
+    try:
+        decision["candidate_sha256"] = file_sha256(candidate_path)
+        decision["baseline_sha256"] = file_sha256(baseline_path)
+        candidate = load_object(candidate_path)
+        baseline = load_object(baseline_path)
+
+        decision["artifact_id"] = nested_value(candidate, ("artifact_id",))
+        decision["canonical_url"] = nested_value(candidate, ("canonical_url",))
+
+        if candidate.get("sufficient") is not True:
+            decision["failures"].append(f"sufficient={candidate.get('sufficient')!r}, want true")
+        errors = nested_value(candidate, ("case_count", "errors"))
+        if errors != 0:
+            decision["failures"].append(f"case_count.errors={errors!r}, want 0")
+
+        expected_version = baseline.get("pipelock_version")
+        actual_version = candidate.get("pipelock_version")
+        if not isinstance(expected_version, str) or not expected_version:
+            raise ValueError("baseline pipelock_version must be a non-empty string")
+        if actual_version != expected_version:
+            decision["failures"].append(
+                f"pipelock_version={actual_version!r}, baseline is {expected_version!r}"
+            )
+
+        floors = baseline.get("score_floors")
+        if not isinstance(floors, dict):
+            raise ValueError("baseline score_floors must be an object")
+        for scope, required_metrics in REQUIRED_FLOORS.items():
+            metrics = floors.get(scope)
+            if not isinstance(metrics, dict):
+                raise ValueError(f"baseline score_floors.{scope} must be an object")
+            missing = required_metrics - metrics.keys()
+            if missing:
+                raise ValueError(
+                    f"baseline score_floors.{scope} missing required metrics: {sorted(missing)!r}"
+                )
+        for scope, metrics in floors.items():
+            if not isinstance(metrics, dict):
+                raise ValueError(f"baseline score_floors.{scope} must be an object")
+            for metric, raw_floor in metrics.items():
+                floor = fraction(raw_floor, f"baseline score_floors.{scope}.{metric}")
+                actual = fraction(
+                    nested_value(candidate, ("scores", scope, metric)),
+                    f"candidate scores.{scope}.{metric}",
+                )
+                if actual < floor - 1e-12:
+                    decision["failures"].append(
+                        f"scores.{scope}.{metric}={actual}, below baseline floor {floor}"
+                    )
+                elif actual > floor + 1e-12:
+                    decision["review_notes"].append(
+                        f"scores.{scope}.{metric}={actual} is above baseline floor {floor}"
+                    )
+
+        ceilings = baseline.get("score_ceilings")
+        if not isinstance(ceilings, dict):
+            raise ValueError("baseline score_ceilings must be an object")
+        for scope, required_metrics in REQUIRED_CEILINGS.items():
+            metrics = ceilings.get(scope)
+            if not isinstance(metrics, dict):
+                raise ValueError(f"baseline score_ceilings.{scope} must be an object")
+            missing = required_metrics - metrics.keys()
+            if missing:
+                raise ValueError(
+                    f"baseline score_ceilings.{scope} missing required metrics: {sorted(missing)!r}"
+                )
+        for scope, metrics in ceilings.items():
+            if not isinstance(metrics, dict):
+                raise ValueError(f"baseline score_ceilings.{scope} must be an object")
+            for metric, raw_ceiling in metrics.items():
+                ceiling = fraction(raw_ceiling, f"baseline score_ceilings.{scope}.{metric}")
+                actual = fraction(
+                    nested_value(candidate, ("scores", scope, metric)),
+                    f"candidate scores.{scope}.{metric}",
+                )
+                if actual > ceiling + 1e-12:
+                    decision["failures"].append(
+                        f"scores.{scope}.{metric}={actual}, above baseline ceiling {ceiling}"
+                    )
+                elif actual < ceiling - 1e-12:
+                    decision["review_notes"].append(
+                        f"scores.{scope}.{metric}={actual} is below baseline ceiling {ceiling}"
+                    )
+
+        if baseline.get("schema_version") != 1:
+            raise ValueError("baseline schema_version must be 1")
+        observed = baseline.get("observed_case_count", {})
+        if not isinstance(observed, dict):
+            raise ValueError("baseline observed_case_count must be an object")
+        missing_count_keys = [key for key in REQUIRED_COUNT_KEYS if key not in observed]
+        if missing_count_keys:
+            raise ValueError(
+                f"baseline observed_case_count missing required keys: {missing_count_keys!r}"
+            )
+        for key in ("total", "applicable", "not_applicable"):
+            value = observed[key]
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"baseline observed_case_count.{key} must be a non-negative integer")
+        reasons = observed["not_applicable_reasons"]
+        if not isinstance(reasons, dict):
+            raise ValueError("baseline observed_case_count.not_applicable_reasons must be an object")
+        if any(
+            not isinstance(reason, str)
+            or not reason
+            or isinstance(count, bool)
+            or not isinstance(count, int)
+            or count < 0
+            for reason, count in reasons.items()
+        ):
+            raise ValueError(
+                "baseline observed_case_count.not_applicable_reasons must map non-empty strings to non-negative integers"
+            )
+        if observed["applicable"] + observed["not_applicable"] != observed["total"]:
+            raise ValueError("baseline observed case counts must partition total")
+        if sum(reasons.values()) != observed["not_applicable"]:
+            raise ValueError("baseline not_applicable reasons must sum to not_applicable")
+        scope_changed = False
+        for key in ("total", "applicable", "not_applicable"):
+            previous = observed.get(key)
+            current = nested_value(candidate, ("case_count", key))
+            if previous is not None and current != previous:
+                scope_changed = True
+                decision["review_notes"].append(
+                    f"case_count.{key} moved {previous!r} -> {current!r}"
+                )
+        previous_reasons = observed.get("not_applicable_reasons")
+        current_reasons = nested_value(candidate, ("case_count", "not_applicable_reasons"))
+        if previous_reasons is not None and current_reasons != previous_reasons:
+            scope_changed = True
+            decision["review_notes"].append(
+                "case_count.not_applicable_reasons changed from the reviewed baseline"
+            )
+
+        for identity_key in REQUIRED_IDENTITIES:
+            previous = baseline.get(identity_key)
+            if not isinstance(previous, str) or not previous:
+                raise ValueError(f"baseline {identity_key} must be a non-empty string")
+            current = candidate.get(identity_key)
+            if current != previous:
+                scope_changed = True
+                decision["review_notes"].append(
+                    f"{identity_key} moved {previous!r} -> {current!r}"
+                )
+
+        if not decision["failures"] and scope_changed:
+            decision["promotion_status"] = "scope_changed_requires_review"
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        decision["failures"].append(str(exc))
+
+    decision["blocked"] = bool(decision["failures"])
+    if decision["blocked"]:
+        decision["promotion_status"] = "blocked"
+    return decision
+
+
+def enforce(decision_path, candidate_path, baseline_path, evidence_paths=None):
+    evidence_paths = evidence_paths or {}
+    try:
+        decision = load_object(decision_path)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"candidate decision: BLOCKED: {exc}")
+        return 1
+    integrity_failures = []
+    recomputed = evaluate(candidate_path, baseline_path, evidence_paths)
+    if decision != recomputed:
+        integrity_failures.append("stored decision does not match a fresh evaluation")
+    for label, path, digest_key in (
+        ("candidate", candidate_path, "candidate_sha256"),
+        ("baseline", baseline_path, "baseline_sha256"),
+    ):
+        try:
+            current_digest = file_sha256(path)
+        except OSError as exc:
+            integrity_failures.append(f"cannot hash {label}: {exc}")
+            continue
+        if current_digest != decision.get(digest_key):
+            integrity_failures.append(f"{label} changed after its promotion decision was created")
+    recorded_evidence = decision.get("evidence_sha256")
+    if not isinstance(recorded_evidence, dict):
+        integrity_failures.append("decision evidence_sha256 is not an object")
+        recorded_evidence = {}
+    if set(recorded_evidence) != set(evidence_paths):
+        integrity_failures.append("decision evidence set does not match the required evidence set")
+    for label, path in sorted(evidence_paths.items()):
+        try:
+            current_digest = file_sha256(path)
+        except OSError as exc:
+            integrity_failures.append(f"cannot hash evidence {label}: {exc}")
+            continue
+        if current_digest != recorded_evidence.get(label):
+            integrity_failures.append(f"evidence {label} changed after the decision was created")
+
+    if decision.get("blocked") is not False or integrity_failures:
+        failures = decision.get("failures")
+        if not isinstance(failures, list) or not failures:
+            failures = ["decision is blocked without a recorded reason"]
+        failures = [*failures, *integrity_failures]
+        for failure in failures:
+            print(f"::error::{failure}")
+        print(f"candidate decision: BLOCKED ({len(failures)} failure(s))")
+        return 1
+    print("candidate decision: ACCEPTED FOR HUMAN REVIEW (not published)")
+    return 0
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    evaluate_parser = subparsers.add_parser("evaluate")
+    evaluate_parser.add_argument("--candidate", type=Path, required=True)
+    evaluate_parser.add_argument("--baseline", type=Path, required=True)
+    evaluate_parser.add_argument("--decision", type=Path, required=True)
+    evaluate_parser.add_argument("--evidence", action="append", default=[], metavar="NAME=PATH")
+
+    enforce_parser = subparsers.add_parser("enforce")
+    enforce_parser.add_argument("decision", type=Path)
+    enforce_parser.add_argument("--candidate", type=Path, required=True)
+    enforce_parser.add_argument("--baseline", type=Path, required=True)
+    enforce_parser.add_argument("--evidence", action="append", default=[], metavar="NAME=PATH")
+    return parser.parse_args()
+
+
+def parse_evidence(values):
+    evidence = {}
+    for value in values:
+        label, separator, raw_path = value.partition("=")
+        if not separator or not label or not raw_path:
+            raise ValueError(f"invalid --evidence value {value!r}; want NAME=PATH")
+        if label in evidence:
+            raise ValueError(f"duplicate evidence label: {label}")
+        evidence[label] = Path(raw_path)
+    return evidence
+
+
+def main():
+    args = parse_args()
+    try:
+        evidence_paths = parse_evidence(args.evidence)
+    except ValueError as exc:
+        print(f"candidate decision: BLOCKED: {exc}")
+        return 1
+    if args.command == "enforce":
+        return enforce(args.decision, args.candidate, args.baseline, evidence_paths)
+
+    decision = evaluate(args.candidate, args.baseline, evidence_paths)
+    atomic_json_write(args.decision, decision)
+    for note in decision["review_notes"]:
+        print(f"::notice::{note}")
+    for failure in decision["failures"]:
+        print(f"::error::{failure}")
+    print(f"candidate decision written to {args.decision}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -2,6 +2,7 @@
 """Tests for fail-safe continuous-gauntlet candidate evaluation."""
 
 import json
+import hashlib
 import subprocess
 import sys
 import tempfile
@@ -11,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "evaluate_gauntlet_candidate.py"
+CASE_INDEX_BYTES = b'{"schema_version":1,"cases":[]}\n'
 
 
 def candidate():
@@ -21,6 +23,7 @@ def candidate():
         "pipelock_version": "3.3.0",
         "corpus_git_sha": "b" * 40,
         "corpus_sha256": "c" * 64,
+        "case_index_sha256": hashlib.sha256(CASE_INDEX_BYTES).hexdigest(),
         "corpus_version": "v2.3.0",
         "scoring_version": "2.4",
         "runner_version": "0.4.2",
@@ -74,6 +77,7 @@ class CandidateEvaluationTest(unittest.TestCase):
         baseline_value=None,
         raw_candidate=None,
         missing_candidate=False,
+        include_case_index_evidence=True,
     ):
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
@@ -90,7 +94,12 @@ class CandidateEvaluationTest(unittest.TestCase):
         baseline_path.write_text(json.dumps(baseline_value or baseline()), encoding="utf-8")
         evidence_path = root / "results.jsonl"
         evidence_path.write_text('{"id":"case-1"}\n', encoding="utf-8")
+        case_index_path = root / "case-index.json"
+        case_index_path.write_bytes(CASE_INDEX_BYTES)
 
+        evidence_args = ["--evidence", f"results={evidence_path}"]
+        if include_case_index_evidence:
+            evidence_args.extend(["--evidence", f"case_index={case_index_path}"])
         result = subprocess.run(
             [
                 sys.executable,
@@ -100,8 +109,7 @@ class CandidateEvaluationTest(unittest.TestCase):
                 str(candidate_path),
                 "--baseline",
                 str(baseline_path),
-                "--evidence",
-                f"results={evidence_path}",
+                *evidence_args,
                 "--decision",
                 str(decision_path),
             ],
@@ -123,7 +131,12 @@ class CandidateEvaluationTest(unittest.TestCase):
     def run_enforce(self, decision_path, candidate_path, baseline_path, evidence_path=None):
         evidence_args = []
         if evidence_path is not None:
-            evidence_args = ["--evidence", f"results={evidence_path}"]
+            evidence_args = [
+                "--evidence",
+                f"results={evidence_path}",
+                "--evidence",
+                f"case_index={evidence_path.parent / 'case-index.json'}",
+            ]
         return subprocess.run(
             [
                 sys.executable,
@@ -253,6 +266,41 @@ class CandidateEvaluationTest(unittest.TestCase):
         result = self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("evidence results changed", result.stdout)
+
+    def test_case_index_substitution_fails_closed(self):
+        _, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()
+        (evidence_path.parent / "case-index.json").write_bytes(b'{"substituted":true}\n')
+
+        result = self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("evidence case_index changed", result.stdout)
+
+    def test_candidate_case_index_digest_must_match_uploaded_evidence(self):
+        value = candidate()
+        value["case_index_sha256"] = "0" * 64
+
+        decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(value)
+
+        self.assertTrue(decision["blocked"])
+        self.assertTrue(
+            any("case_index_sha256 does not match" in failure for failure in decision["failures"])
+        )
+        self.assertNotEqual(
+            self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode,
+            0,
+        )
+
+    def test_missing_candidate_digest_and_case_index_evidence_fail_closed(self):
+        value = candidate()
+        del value["case_index_sha256"]
+
+        decision, _, _, _, _ = self.run_evaluate(
+            value, include_case_index_evidence=False
+        )
+
+        self.assertTrue(decision["blocked"])
+        self.assertTrue(any("case_index_sha256" in failure for failure in decision["failures"]))
 
     def test_supporting_evidence_set_mismatch_fails_closed(self):
         _, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Tests for fail-safe continuous-gauntlet candidate evaluation."""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "evaluate_gauntlet_candidate.py"
+
+
+def candidate():
+    return {
+        "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
+        "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
+        "pipelock_version": "3.3.0",
+        "corpus_git_sha": "b" * 40,
+        "corpus_version": "v2.3.0",
+        "scoring_version": "2.4",
+        "runner_version": "0.4.2",
+        "case_count": {
+            "total": 213,
+            "applicable": 212,
+            "not_applicable": 1,
+            "not_applicable_reasons": {"missing_requires": 1},
+            "errors": 0,
+        },
+        "scores": {
+            "full": {"containment": 0.99},
+            "applicable": {
+                "containment": 1.0,
+                "detection": 1.0,
+                "evidence": 1.0,
+                "false_positive_rate": 0.0,
+            },
+        },
+        "sufficient": True,
+    }
+
+
+def baseline():
+    return {
+        "schema_version": 1,
+        "pipelock_version": "3.3.0",
+        "corpus_git_sha": "b" * 40,
+        "corpus_version": "v2.3.0",
+        "scoring_version": "2.4",
+        "runner_version": "0.4.2",
+        "observed_case_count": {
+            "total": 213,
+            "applicable": 212,
+            "not_applicable": 1,
+            "not_applicable_reasons": {"missing_requires": 1},
+        },
+        "score_floors": {
+            "full": {"containment": 0.99},
+            "applicable": {"containment": 1.0, "detection": 1.0, "evidence": 1.0},
+        },
+        "score_ceilings": {"applicable": {"false_positive_rate": 0.0}},
+    }
+
+
+class CandidateEvaluationTest(unittest.TestCase):
+    def run_evaluate(
+        self,
+        candidate_value=None,
+        baseline_value=None,
+        raw_candidate=None,
+        missing_candidate=False,
+    ):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        candidate_path = root / "candidate.json"
+        baseline_path = root / "baseline.json"
+        decision_path = root / "decision.json"
+        if missing_candidate:
+            pass
+        elif raw_candidate is None:
+            candidate_path.write_text(json.dumps(candidate_value or candidate()), encoding="utf-8")
+        else:
+            candidate_path.write_text(raw_candidate, encoding="utf-8")
+        baseline_path.write_text(json.dumps(baseline_value or baseline()), encoding="utf-8")
+        evidence_path = root / "results.jsonl"
+        evidence_path.write_text('{"id":"case-1"}\n', encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "evaluate",
+                "--candidate",
+                str(candidate_path),
+                "--baseline",
+                str(baseline_path),
+                "--evidence",
+                f"results={evidence_path}",
+                "--decision",
+                str(decision_path),
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(decision_path.is_file())
+        return (
+            json.loads(decision_path.read_text(encoding="utf-8")),
+            decision_path,
+            candidate_path,
+            baseline_path,
+            evidence_path,
+        )
+
+    def run_enforce(self, decision_path, candidate_path, baseline_path, evidence_path=None):
+        evidence_args = []
+        if evidence_path is not None:
+            evidence_args = ["--evidence", f"results={evidence_path}"]
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "enforce",
+                str(decision_path),
+                "--candidate",
+                str(candidate_path),
+                "--baseline",
+                str(baseline_path),
+                *evidence_args,
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_clean_candidate_is_preserved_for_human_review(self):
+        decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()
+        self.assertFalse(decision["blocked"])
+        self.assertEqual(decision["promotion_status"], "under_review")
+        self.assertRegex(decision["candidate_sha256"], r"^[0-9a-f]{64}$")
+        self.assertRegex(decision["evidence_sha256"]["results"], r"^[0-9a-f]{64}$")
+        self.assertEqual(
+            self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode,
+            0,
+        )
+
+    def test_each_regression_direction_blocks_after_decision_is_written(self):
+        mutations = {
+            "containment drop": lambda value: value["scores"]["applicable"].__setitem__("containment", 0.9),
+            "false positive increase": lambda value: value["scores"]["applicable"].__setitem__(
+                "false_positive_rate", 0.1
+            ),
+            "runner error": lambda value: value["case_count"].__setitem__("errors", 1),
+            "insufficient": lambda value: value.__setitem__("sufficient", False),
+            "wrong release": lambda value: value.__setitem__("pipelock_version", "3.2.0"),
+        }
+        for name, mutate in mutations.items():
+            with self.subTest(name=name):
+                value = candidate()
+                mutate(value)
+                decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(value)
+                self.assertTrue(decision["blocked"])
+                self.assertEqual(decision["promotion_status"], "blocked")
+                self.assertTrue(decision["failures"])
+                self.assertNotEqual(
+                    self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode, 0
+                )
+
+    def test_scope_change_requires_review_but_does_not_disable_the_lane(self):
+        value = candidate()
+        value["case_count"] = {
+            "total": 214,
+            "applicable": 213,
+            "not_applicable": 1,
+            "not_applicable_reasons": {"missing_requires": 1},
+            "errors": 0,
+        }
+        decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(value)
+        self.assertFalse(decision["blocked"])
+        self.assertEqual(decision["promotion_status"], "scope_changed_requires_review")
+        self.assertTrue(any("case_count.total moved" in note for note in decision["review_notes"]))
+        self.assertEqual(
+            self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode,
+            0,
+        )
+
+    def test_malformed_candidate_still_produces_a_blocked_decision(self):
+        decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(raw_candidate="{")
+        self.assertTrue(decision["blocked"])
+        self.assertEqual(decision["promotion_status"], "blocked")
+        self.assertTrue(decision["failures"])
+        self.assertNotEqual(
+            self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode, 0
+        )
+
+    def test_missing_candidate_still_produces_a_blocked_decision(self):
+        decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(
+            missing_candidate=True
+        )
+        self.assertTrue(decision["blocked"])
+        self.assertEqual(decision["promotion_status"], "blocked")
+        self.assertTrue(decision["failures"])
+        self.assertNotEqual(
+            self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode, 0
+        )
+
+    def test_missing_decision_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result = self.run_enforce(root / "missing.json", root / "candidate.json", root / "baseline.json")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("BLOCKED", result.stdout)
+
+    def test_candidate_substitution_after_decision_fails_closed(self):
+        _, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()
+        candidate_path.write_text(json.dumps({"substituted": True}), encoding="utf-8")
+        result = self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate changed", result.stdout)
+
+    def test_stored_decision_cannot_be_forged(self):
+        decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()
+        decision["review_notes"].append("forged")
+        decision_path.write_text(json.dumps(decision), encoding="utf-8")
+        result = self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("fresh evaluation", result.stdout)
+
+    def test_required_baseline_metric_cannot_be_deleted(self):
+        baseline_value = baseline()
+        del baseline_value["score_floors"]["applicable"]["containment"]
+        decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(
+            baseline_value=baseline_value
+        )
+        self.assertTrue(decision["blocked"])
+        self.assertIn("missing required metrics", decision["failures"][0])
+        self.assertNotEqual(
+            self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode, 0
+        )
+
+    def test_supporting_evidence_substitution_fails_closed(self):
+        _, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()
+        evidence_path.write_text('{"substituted":true}\n', encoding="utf-8")
+        result = self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("evidence results changed", result.stdout)
+
+    def test_required_baseline_identity_cannot_be_deleted(self):
+        for identity in ("corpus_git_sha", "corpus_version", "scoring_version", "runner_version"):
+            with self.subTest(identity=identity):
+                baseline_value = baseline()
+                del baseline_value[identity]
+                decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(
+                    baseline_value=baseline_value
+                )
+                self.assertTrue(decision["blocked"])
+                self.assertIn(f"baseline {identity}", decision["failures"][-1])
+                self.assertNotEqual(
+                    self.run_enforce(
+                        decision_path, candidate_path, baseline_path, evidence_path
+                    ).returncode,
+                    0,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -15,10 +15,12 @@ SCRIPT = REPO_ROOT / "scripts" / "evaluate_gauntlet_candidate.py"
 
 def candidate():
     return {
+        "schema_version": 2,
         "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
         "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
         "pipelock_version": "3.3.0",
         "corpus_git_sha": "b" * 40,
+        "corpus_sha256": "c" * 64,
         "corpus_version": "v2.3.0",
         "scoring_version": "2.4",
         "runner_version": "0.4.2",
@@ -47,6 +49,7 @@ def baseline():
         "schema_version": 1,
         "pipelock_version": "3.3.0",
         "corpus_git_sha": "b" * 40,
+        "corpus_sha256": "c" * 64,
         "corpus_version": "v2.3.0",
         "scoring_version": "2.4",
         "runner_version": "0.4.2",
@@ -251,8 +254,20 @@ class CandidateEvaluationTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("evidence results changed", result.stdout)
 
+    def test_supporting_evidence_set_mismatch_fails_closed(self):
+        _, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()
+        result = self.run_enforce(decision_path, candidate_path, baseline_path)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("evidence set does not match", result.stdout)
+
     def test_required_baseline_identity_cannot_be_deleted(self):
-        for identity in ("corpus_git_sha", "corpus_version", "scoring_version", "runner_version"):
+        for identity in (
+            "corpus_git_sha",
+            "corpus_sha256",
+            "corpus_version",
+            "scoring_version",
+            "runner_version",
+        ):
             with self.subTest(identity=identity):
                 baseline_value = baseline()
                 del baseline_value[identity]
@@ -267,6 +282,25 @@ class CandidateEvaluationTest(unittest.TestCase):
                     ).returncode,
                     0,
                 )
+
+    def test_git_commit_drift_is_informational_not_a_scope_change(self):
+        value = candidate()
+        value["corpus_git_sha"] = "d" * 40
+        decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(value)
+        self.assertFalse(decision["blocked"])
+        self.assertEqual(decision["promotion_status"], "under_review")
+        self.assertTrue(any("corpus_git_sha moved" in note for note in decision["review_notes"]))
+        self.assertEqual(
+            self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode,
+            0,
+        )
+
+    def test_corpus_content_drift_requires_scope_review(self):
+        value = candidate()
+        value["corpus_sha256"] = "d" * 64
+        decision, _, _, _, _ = self.run_evaluate(value)
+        self.assertFalse(decision["blocked"])
+        self.assertEqual(decision["promotion_status"], "scope_changed_requires_review")
 
 
 if __name__ == "__main__":

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -10,7 +10,27 @@ import urllib.parse
 from pathlib import Path
 
 
-REQUIRED_SCOPE_PATHS = (
+V1_REQUIRED_SCOPE_PATHS = (
+    ("schema_version",),
+    ("artifact_id",),
+    ("corpus_manifest_sha256",),
+    ("logical_case_count",),
+    ("runner_version",),
+    ("scoring_version",),
+    ("case_count", "applicable"),
+    ("case_count", "total"),
+    ("case_count", "not_applicable"),
+    ("case_count", "not_applicable_reasons"),
+    ("scores", "applicable", "containment"),
+    ("scores", "applicable", "false_positive_rate"),
+    ("metric_counts", "applicable", "containment", "numerator"),
+    ("metric_counts", "applicable", "containment", "denominator"),
+    ("metric_counts", "applicable", "false_positive_rate", "numerator"),
+    ("metric_counts", "applicable", "false_positive_rate", "denominator"),
+    ("canonical_url",),
+)
+V2_REQUIRED_SCOPE_PATHS = (
+    ("schema_version",),
     ("artifact_id",),
     ("corpus_manifest_sha256",),
     ("case_index_sha256",),
@@ -104,12 +124,92 @@ def validate_metric_fraction(document, scope, metric):
     return numerator, denominator
 
 
+def validate_canonical_url(document):
+    """Require an absolute HTTPS canonical artifact URL."""
+    canonical_url = path_value(document, ("canonical_url",))
+    if not isinstance(canonical_url, str) or not canonical_url:
+        raise ValueError("canonical_url must be a non-empty string")
+    parsed_url = urllib.parse.urlparse(canonical_url)
+    if parsed_url.scheme != "https" or not parsed_url.netloc:
+        raise ValueError("canonical_url must be an absolute https URL")
+
+
 def validate_scope(document):
-    """Raise ValueError unless an artifact can render an honest scope block."""
+    """Dispatch provenance validation by the explicit artifact schema version."""
     if not isinstance(document, dict):
         raise ValueError("artifact must be a JSON object")
+    version = path_value(document, ("schema_version",))
+    if version == 1:
+        validate_scope_v1(document)
+        return
+    if version == 2:
+        validate_scope_v2(document)
+        return
+    raise ValueError(f"unsupported schema_version: {version!r}")
 
-    for path in REQUIRED_SCOPE_PATHS:
+
+def validate_scope_v1(document):
+    """Validate the original applicable-only provenance contract."""
+    for path in V1_REQUIRED_SCOPE_PATHS:
+        path_value(document, path)
+    if document["schema_version"] != 1:
+        raise ValueError("schema_version must be 1 for a v1 artifact")
+
+    non_empty_string(document, ("artifact_id",))
+    non_empty_string(document, ("runner_version",))
+    non_empty_string(document, ("scoring_version",))
+    manifest_digest = non_empty_string(document, ("corpus_manifest_sha256",))
+    if not SHA256_HEX.fullmatch(manifest_digest):
+        raise ValueError("corpus_manifest_sha256 must be 64 lower-case hex characters")
+    manifest_count = non_negative_integer(document, ("logical_case_count",))
+    checked_out_digest, checked_out_count = checked_out_corpus_identity()
+    if manifest_digest != checked_out_digest:
+        raise ValueError("corpus_manifest_sha256 does not match checked-out cases/MANIFEST.txt")
+    if manifest_count != checked_out_count:
+        raise ValueError("logical_case_count does not match checked-out cases/MANIFEST.txt")
+
+    applicable = non_negative_integer(document, ("case_count", "applicable"))
+    total = non_negative_integer(document, ("case_count", "total"))
+    not_applicable = non_negative_integer(document, ("case_count", "not_applicable"))
+    if total == 0 or total != checked_out_count:
+        raise ValueError("case_count.total does not match checked-out logical corpus count")
+    if applicable + not_applicable != total:
+        raise ValueError("case_count.applicable plus not_applicable must equal case_count.total")
+    reasons = path_value(document, ("case_count", "not_applicable_reasons"))
+    if not isinstance(reasons, dict):
+        raise ValueError("scope field must be an object: case_count.not_applicable_reasons")
+    if any(
+        not isinstance(reason, str)
+        or not reason
+        or isinstance(count, bool)
+        or not isinstance(count, int)
+        or count < 0
+        for reason, count in reasons.items()
+    ):
+        raise ValueError("not_applicable_reasons must map strings to non-negative integers")
+    if sum(reasons.values()) != not_applicable:
+        raise ValueError("not_applicable_reasons must sum to case_count.not_applicable")
+
+    containment = path_value(document, ("scores", "applicable", "containment"))
+    _, containment_denominator = validate_metric_fraction(document, "applicable", "containment")
+    _, false_positive_denominator = validate_metric_fraction(
+        document, "applicable", "false_positive_rate"
+    )
+    if containment_denominator > applicable or false_positive_denominator > applicable:
+        raise ValueError("metric denominator cannot exceed case_count.applicable")
+    if applicable == 0 and (containment is not None or containment_denominator != 0):
+        raise ValueError("scores.applicable.containment must be null when case_count.applicable is zero")
+    if applicable > 0 and containment_denominator == 0:
+        raise ValueError("containment must have a denominator when case_count.applicable is non-zero")
+    validate_canonical_url(document)
+
+
+def validate_scope_v2(document):
+    """Validate the full/applicable, case-index-bound provenance contract."""
+    if document.get("schema_version") != 2:
+        raise ValueError("schema_version must be 2 for a v2 artifact")
+
+    for path in V2_REQUIRED_SCOPE_PATHS:
         path_value(document, path)
 
     non_empty_string(document, ("artifact_id",))
@@ -196,12 +296,7 @@ def validate_scope(document):
                     f"metric_counts.{scope}.{metric}.denominator must equal blocked malicious count"
                 )
 
-    canonical_url = path_value(document, ("canonical_url",))
-    if not isinstance(canonical_url, str) or not canonical_url:
-        raise ValueError("canonical_url must be a non-empty string")
-    parsed_url = urllib.parse.urlparse(canonical_url)
-    if parsed_url.scheme != "https" or not parsed_url.netloc:
-        raise ValueError("canonical_url must be an absolute https URL")
+    validate_canonical_url(document)
 
 
 def main(argv):

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -13,6 +13,7 @@ from pathlib import Path
 REQUIRED_SCOPE_PATHS = (
     ("artifact_id",),
     ("corpus_manifest_sha256",),
+    ("case_index_sha256",),
     ("logical_case_count",),
     ("runner_version",),
     ("scoring_version",),
@@ -20,14 +21,11 @@ REQUIRED_SCOPE_PATHS = (
     ("case_count", "total"),
     ("case_count", "not_applicable"),
     ("case_count", "not_applicable_reasons"),
-    ("scores", "applicable", "containment"),
-    ("scores", "applicable", "false_positive_rate"),
-    ("metric_counts", "applicable", "containment", "numerator"),
-    ("metric_counts", "applicable", "containment", "denominator"),
-    ("metric_counts", "applicable", "false_positive_rate", "numerator"),
-    ("metric_counts", "applicable", "false_positive_rate", "denominator"),
+    ("case_count", "errors"),
     ("canonical_url",),
 )
+METRICS = ("containment", "false_positive_rate", "detection", "evidence")
+SCOPES = ("applicable", "full")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = REPO_ROOT / "cases" / "MANIFEST.txt"
@@ -85,10 +83,10 @@ def checked_out_corpus_identity():
     return hashlib.sha256(raw).hexdigest(), len(logical_ids)
 
 
-def validate_metric_fraction(document, metric):
-    """Bind an applicable-view score to its explicit numerator/denominator."""
-    score_path = ("scores", "applicable", metric)
-    count_path = ("metric_counts", "applicable", metric)
+def validate_metric_fraction(document, scope, metric):
+    """Bind a score to its explicit numerator/denominator."""
+    score_path = ("scores", scope, metric)
+    count_path = ("metric_counts", scope, metric)
     numerator = non_negative_integer(document, count_path + ("numerator",))
     denominator = non_negative_integer(document, count_path + ("denominator",))
     if numerator > denominator:
@@ -121,6 +119,9 @@ def validate_scope(document):
     manifest_digest = non_empty_string(document, ("corpus_manifest_sha256",))
     if not SHA256_HEX.fullmatch(manifest_digest):
         raise ValueError("corpus_manifest_sha256 must be 64 lower-case hex characters")
+    case_index_digest = non_empty_string(document, ("case_index_sha256",))
+    if not SHA256_HEX.fullmatch(case_index_digest):
+        raise ValueError("case_index_sha256 must be 64 lower-case hex characters")
     manifest_count = non_negative_integer(document, ("logical_case_count",))
     checked_out_digest, checked_out_count = checked_out_corpus_identity()
     if manifest_digest != checked_out_digest:
@@ -131,6 +132,7 @@ def validate_scope(document):
     applicable = non_negative_integer(document, ("case_count", "applicable"))
     total = non_negative_integer(document, ("case_count", "total"))
     not_applicable = non_negative_integer(document, ("case_count", "not_applicable"))
+    errors = non_negative_integer(document, ("case_count", "errors"))
     if total == 0:
         raise ValueError("case_count.total must be greater than zero")
     if total != checked_out_count:
@@ -139,6 +141,8 @@ def validate_scope(document):
         raise ValueError("case_count.applicable cannot exceed case_count.total")
     if applicable + not_applicable != total:
         raise ValueError("case_count.applicable plus not_applicable must equal case_count.total")
+    if errors > applicable:
+        raise ValueError("case_count.errors cannot exceed case_count.applicable")
 
     reasons = path_value(document, ("case_count", "not_applicable_reasons"))
     if not isinstance(reasons, dict):
@@ -157,8 +161,15 @@ def validate_scope(document):
     # state it must be null rather than a made-up score; otherwise it must be a
     # finite fraction because scope-render.js publishes it as the headline.
     containment = path_value(document, ("scores", "applicable", "containment"))
-    _, containment_denominator = validate_metric_fraction(document, "containment")
-    _, false_positive_denominator = validate_metric_fraction(document, "false_positive_rate")
+    counts = {
+        scope: {
+            metric: validate_metric_fraction(document, scope, metric)
+            for metric in METRICS
+        }
+        for scope in SCOPES
+    }
+    containment_numerator, containment_denominator = counts["applicable"]["containment"]
+    _, false_positive_denominator = counts["applicable"]["false_positive_rate"]
     if containment_denominator > applicable or false_positive_denominator > applicable:
         raise ValueError("metric denominator cannot exceed case_count.applicable")
     if applicable == 0:
@@ -169,6 +180,21 @@ def validate_scope(document):
             raise ValueError("containment must have a denominator when case_count.applicable is non-zero")
     if applicable == 0 and false_positive_denominator != 0:
         raise ValueError("false_positive_rate must have a zero denominator when case_count.applicable is zero")
+    if containment_denominator + false_positive_denominator != applicable:
+        raise ValueError("applicable metric denominators must partition case_count.applicable")
+    if counts["full"]["containment"][1] + counts["full"]["false_positive_rate"][1] != total:
+        raise ValueError("full metric denominators must partition case_count.total")
+    for metric in METRICS:
+        if counts["full"][metric][0] != counts["applicable"][metric][0]:
+            raise ValueError(
+                f"metric_counts.full.{metric}.numerator must equal applicable numerator"
+            )
+    for scope in SCOPES:
+        for metric in ("detection", "evidence"):
+            if counts[scope][metric][1] != containment_numerator:
+                raise ValueError(
+                    f"metric_counts.{scope}.{metric}.denominator must equal blocked malicious count"
+                )
 
     canonical_url = path_value(document, ("canonical_url",))
     if not isinstance(canonical_url, str) or not canonical_url:

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -29,6 +29,7 @@ def complete_artifact():
     full_malicious = total - full_benign
     blocked_malicious = full_malicious - 1
     return {
+        "schema_version": 2,
         "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
         "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
         "corpus_manifest_sha256": corpus_manifest_sha256(),
@@ -122,6 +123,7 @@ class ValidateGauntletScopeTest(unittest.TestCase):
 
     def test_each_required_scope_field_fails_when_missing(self):
         required_paths = [
+            ("schema_version",),
             ("case_count", "applicable"),
             ("case_count", "total"),
             ("case_count", "not_applicable"),
@@ -157,6 +159,30 @@ class ValidateGauntletScopeTest(unittest.TestCase):
 
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn(".".join(path), result.stderr)
+
+    def test_original_v1_artifact_remains_verifiable(self):
+        artifact = complete_artifact()
+        artifact["schema_version"] = 1
+        artifact.pop("case_index_sha256")
+        artifact["case_count"].pop("errors")
+        artifact["scores"].pop("full")
+        artifact["metric_counts"].pop("full")
+        for metric in ("detection", "evidence"):
+            artifact["scores"]["applicable"].pop(metric)
+            artifact["metric_counts"]["applicable"].pop(metric)
+
+        result = self.run_validator(artifact)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_unknown_schema_version_fails(self):
+        artifact = complete_artifact()
+        artifact["schema_version"] = 99
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unsupported schema_version", result.stderr)
 
     def test_missing_corpus_digest_fails(self):
         artifact = complete_artifact()
@@ -223,6 +249,15 @@ class ValidateGauntletScopeTest(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("applicable numerator", result.stderr)
+
+    def test_full_metric_denominators_must_partition_total(self):
+        artifact = complete_artifact()
+        artifact["metric_counts"]["full"]["false_positive_rate"]["denominator"] -= 1
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("full metric denominators must partition", result.stderr)
 
     def test_metric_denominator_cannot_exceed_applicable_cases(self):
         artifact = complete_artifact()
@@ -327,8 +362,6 @@ class ValidateGauntletScopeTest(unittest.TestCase):
 
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn("containment", result.stderr)
-
-
     def test_zero_total_fails(self):
         artifact = complete_artifact()
         artifact["case_count"] = {

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -24,29 +24,51 @@ def logical_case_count():
 
 
 def complete_artifact():
+    total = logical_case_count()
+    full_benign = 55
+    full_malicious = total - full_benign
+    blocked_malicious = full_malicious - 1
     return {
         "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
         "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
         "corpus_manifest_sha256": corpus_manifest_sha256(),
+        "case_index_sha256": "c" * 64,
         "logical_case_count": logical_case_count(),
         "runner_version": "0.4.0",
         "scoring_version": "2.2",
         "case_count": {
-            "total": logical_case_count(),
-            "applicable": logical_case_count() - 1,
+            "total": total,
+            "applicable": total - 1,
             "not_applicable": 1,
             "not_applicable_reasons": {"missing_requires": 1},
+            "errors": 0,
         },
         "scores": {
+            "full": {
+                "containment": blocked_malicious / full_malicious,
+                "false_positive_rate": 0.0,
+                "detection": 1.0,
+                "evidence": 1.0,
+            },
             "applicable": {
                 "containment": 1.0,
                 "false_positive_rate": 0.0,
+                "detection": 1.0,
+                "evidence": 1.0,
             },
         },
         "metric_counts": {
             "applicable": {
-                "containment": {"numerator": 1, "denominator": 1},
-                "false_positive_rate": {"numerator": 0, "denominator": 1},
+                "containment": {"numerator": blocked_malicious, "denominator": blocked_malicious},
+                "false_positive_rate": {"numerator": 0, "denominator": full_benign},
+                "detection": {"numerator": blocked_malicious, "denominator": blocked_malicious},
+                "evidence": {"numerator": blocked_malicious, "denominator": blocked_malicious},
+            },
+            "full": {
+                "containment": {"numerator": blocked_malicious, "denominator": full_malicious},
+                "false_positive_rate": {"numerator": 0, "denominator": full_benign},
+                "detection": {"numerator": blocked_malicious, "denominator": blocked_malicious},
+                "evidence": {"numerator": blocked_malicious, "denominator": blocked_malicious},
             },
         },
     }
@@ -59,11 +81,25 @@ def all_na_artifact():
         "applicable": 0,
         "not_applicable": logical_case_count(),
         "not_applicable_reasons": {"missing_requires": logical_case_count()},
+        "errors": 0,
     }
-    artifact["scores"]["applicable"]["containment"] = None
-    artifact["scores"]["applicable"]["false_positive_rate"] = None
-    artifact["metric_counts"]["applicable"]["containment"] = {"numerator": 0, "denominator": 0}
-    artifact["metric_counts"]["applicable"]["false_positive_rate"] = {"numerator": 0, "denominator": 0}
+    artifact["scores"]["applicable"] = {metric: None for metric in ("containment", "false_positive_rate", "detection", "evidence")}
+    artifact["metric_counts"]["applicable"] = {
+        metric: {"numerator": 0, "denominator": 0}
+        for metric in ("containment", "false_positive_rate", "detection", "evidence")
+    }
+    artifact["scores"]["full"] = {
+        "containment": 0.0,
+        "false_positive_rate": None,
+        "detection": None,
+        "evidence": None,
+    }
+    artifact["metric_counts"]["full"] = {
+        "containment": {"numerator": 0, "denominator": logical_case_count()},
+        "false_positive_rate": {"numerator": 0, "denominator": 0},
+        "detection": {"numerator": 0, "denominator": 0},
+        "evidence": {"numerator": 0, "denominator": 0},
+    }
     return artifact
 
 
@@ -90,19 +126,24 @@ class ValidateGauntletScopeTest(unittest.TestCase):
             ("case_count", "total"),
             ("case_count", "not_applicable"),
             ("case_count", "not_applicable_reasons"),
-            ("scores", "applicable", "containment"),
-            ("scores", "applicable", "false_positive_rate"),
+            ("case_count", "errors"),
             ("canonical_url",),
             ("artifact_id",),
             ("corpus_manifest_sha256",),
+            ("case_index_sha256",),
             ("logical_case_count",),
             ("runner_version",),
             ("scoring_version",),
-            ("metric_counts", "applicable", "containment", "numerator"),
-            ("metric_counts", "applicable", "containment", "denominator"),
-            ("metric_counts", "applicable", "false_positive_rate", "numerator"),
-            ("metric_counts", "applicable", "false_positive_rate", "denominator"),
         ]
+        for scope in ("applicable", "full"):
+            for metric in ("containment", "false_positive_rate", "detection", "evidence"):
+                required_paths.extend(
+                    [
+                        ("scores", scope, metric),
+                        ("metric_counts", scope, metric, "numerator"),
+                        ("metric_counts", scope, metric, "denominator"),
+                    ]
+                )
 
         for path in required_paths:
             with self.subTest(path=".".join(path)):
@@ -151,6 +192,7 @@ class ValidateGauntletScopeTest(unittest.TestCase):
             "applicable": logical_case_count() - 2,
             "not_applicable": 1,
             "not_applicable_reasons": {"missing_requires": 1},
+            "errors": 0,
         }
 
         result = self.run_validator(artifact)
@@ -168,6 +210,19 @@ class ValidateGauntletScopeTest(unittest.TestCase):
 
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn(metric, result.stderr)
+
+    def test_full_and_applicable_numerators_cannot_diverge(self):
+        artifact = complete_artifact()
+        artifact["metric_counts"]["full"]["detection"]["numerator"] -= 1
+        artifact["scores"]["full"]["detection"] = (
+            artifact["metric_counts"]["full"]["detection"]["numerator"]
+            / artifact["metric_counts"]["full"]["detection"]["denominator"]
+        )
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("applicable numerator", result.stderr)
 
     def test_metric_denominator_cannot_exceed_applicable_cases(self):
         artifact = complete_artifact()
@@ -192,11 +247,37 @@ class ValidateGauntletScopeTest(unittest.TestCase):
 
     def test_null_false_positive_rate_passes_as_na(self):
         artifact = complete_artifact()
+        total = logical_case_count()
+        artifact["case_count"] = {
+            "total": total,
+            "applicable": total,
+            "not_applicable": 0,
+            "not_applicable_reasons": {},
+            "errors": 0,
+        }
+        for scope in ("applicable", "full"):
+            artifact["scores"][scope]["containment"] = 1.0
+            artifact["metric_counts"][scope]["containment"] = {
+                "numerator": total,
+                "denominator": total,
+            }
         artifact["scores"]["applicable"]["false_positive_rate"] = None
         artifact["metric_counts"]["applicable"]["false_positive_rate"] = {
             "numerator": 0,
             "denominator": 0,
         }
+        artifact["scores"]["full"]["false_positive_rate"] = None
+        artifact["metric_counts"]["full"]["false_positive_rate"] = {
+            "numerator": 0,
+            "denominator": 0,
+        }
+        for scope in ("applicable", "full"):
+            for metric in ("detection", "evidence"):
+                artifact["scores"][scope][metric] = 1.0
+                artifact["metric_counts"][scope][metric] = {
+                    "numerator": total,
+                    "denominator": total,
+                }
 
         result = self.run_validator(artifact)
 
@@ -255,6 +336,7 @@ class ValidateGauntletScopeTest(unittest.TestCase):
             "applicable": 0,
             "not_applicable": 0,
             "not_applicable_reasons": {},
+            "errors": 0,
         }
 
         result = self.run_validator(artifact)


### PR DESCRIPTION
Keeps scheduled released-binary runs read-only while preserving a machine-readable candidate and its supporting evidence before regression enforcement.

Binds gated scores to loader-normalized case identities and raw run files, distinguishes scope changes from comparable regressions, and prevents failed candidates from advancing reviewed public results. It also restores scheduled runs by creating the Go stats cache directories and bounds benchmark execution so evidence collection retains time.

This does not publish a result, badge, or continuous-verification claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added candidate evaluation against approved benchmark baselines, with clear review or blocking decisions.
  * Added case-index generation and provenance tracking for benchmark runs.
* **Bug Fixes**
  * Improved detection of missing, duplicate, unknown, or mismatched benchmark cases.
  * Added fail-safe handling for malformed results, integrity issues, checkout failures, and timeouts.
* **Tests**
  * Expanded automated coverage for workflow safety, score validation, artifact integrity, and metric consistency.
* **Chores**
  * Improved benchmark statistics setup and validation of full and applicable result metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->