### PR TITLE
feat: add portable continuous Gauntlet runner

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -25,9 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     env:
-      PIPELOCK_REPO: luckyPipewrench/pipelock
-      PIPELOCK_TAG: v3.3.0
-      PIPELOCK_VERSION: "3.3.0"
       GAUNTLET_ARTIFACT_DIR: continuous-gauntlet-artifacts
     steps:
       - name: Record job budget start
@@ -46,449 +43,41 @@ jobs:
         with:
           go-version: "1.25"
 
-      - name: Gate corpus provenance
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ "$GITHUB_REPOSITORY" != "luckyPipewrench/agent-egress-bench" ]]; then
-            echo "Continuous candidates are canonical only in luckyPipewrench/agent-egress-bench." >&2
-            exit 1
-          fi
-
-          git fetch --force --tags origin '+refs/heads/main:refs/remotes/origin/main'
-
-          dirty_output="$(git status --porcelain=v1 --untracked-files=all)"
-          if [[ -n "$dirty_output" ]]; then
-            echo "Corpus checkout is dirty; refusing to benchmark untrusted contents." >&2
-            printf '%s\n' "$dirty_output" >&2
-            exit 1
-          fi
-
-          head_sha="$(git rev-parse HEAD)"
-          origin_main_sha="$(git rev-parse origin/main)"
-          pointed_tags="$(git tag --points-at HEAD)"
-
-          if [[ "$head_sha" == "$origin_main_sha" ]]; then
-            corpus_ref_kind="origin/main"
-          elif [[ -n "$pointed_tags" ]]; then
-            corpus_ref_kind="tag"
-          else
-            echo "Corpus checkout is neither origin/main nor a tag; refusing detached/stale benchmark." >&2
-            echo "HEAD:        $head_sha" >&2
-            echo "origin/main: $origin_main_sha" >&2
-            exit 1
-          fi
-
-          {
-            echo "CORPUS_GIT_SHA=$head_sha"
-            echo "CORPUS_DIRTY=false"
-            echo "CORPUS_REF_KIND=$corpus_ref_kind"
-          } >> "$GITHUB_ENV"
-
-      - name: Download pinned Pipelock release
+      - name: Run portable canonical benchmark
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          asset="pipelock_${PIPELOCK_VERSION}_linux_amd64.tar.gz"
-          download_dir="$RUNNER_TEMP/pipelock-release"
-          mkdir -p "$download_dir"
-
-          release_json="$(gh release view "$PIPELOCK_TAG" --repo "$PIPELOCK_REPO" --json tagName,isDraft,isPrerelease)"
-          actual_tag="$(jq -r '.tagName' <<<"$release_json")"
-          is_draft="$(jq -r '.isDraft' <<<"$release_json")"
-          is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
-          if [[ "$actual_tag" != "$PIPELOCK_TAG" || "$is_draft" != "false" || "$is_prerelease" != "false" ]]; then
-            echo "Pipelock release provenance failed: expected stable released tag $PIPELOCK_TAG, got tag=$actual_tag draft=$is_draft prerelease=$is_prerelease" >&2
-            exit 1
-          fi
-
-          gh release download "$PIPELOCK_TAG" --repo "$PIPELOCK_REPO" --pattern "$asset" --dir "$download_dir" --clobber
-          gh release download "$PIPELOCK_TAG" --repo "$PIPELOCK_REPO" --pattern checksums.txt --dir "$download_dir" --clobber
-          (
-            cd "$download_dir"
-            grep "  $asset\$" checksums.txt | sha256sum --check -
-          )
-
-          tar -xzf "$download_dir/$asset" -C "$download_dir"
-          chmod 0755 "$download_dir/pipelock"
-
-          version_output="$("$download_dir/pipelock" --version)"
-          reported_version="$(awk '/^pipelock version / { print $3 }' <<<"$version_output")"
-          if [[ "$reported_version" != "$PIPELOCK_VERSION" ]]; then
-            echo "Pipelock version mismatch: expected $PIPELOCK_VERSION, got ${reported_version:-<none>} from: $version_output" >&2
-            exit 1
-          fi
-
-          {
-            echo "PIPELOCK_BIN=$download_dir/pipelock"
-            echo "PIPELOCK_ASSET=$asset"
-          } >> "$GITHUB_ENV"
-
-      - name: Build runner
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          cd runner
-          go build -o "$RUNNER_TEMP/aeb-gauntlet" .
-
-      - name: Verify MCP stdio bridge dependency
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          command -v socat || command -v ncat || command -v nc
-
-      - name: Run canonical benchmark
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          artifact_dir="$GAUNTLET_ARTIFACT_DIR"
-          mkdir -p "$artifact_dir"
-
-          export PIPELOCK_BIN
-          export PIPELOCK_BENCH_CONFIG="$PWD/examples/pipelock/pipelock-benchmark.yaml"
-
-          summary_path="$artifact_dir/raw-summary.json"
-          jsonl_path="$artifact_dir/results.jsonl"
-          stderr_path="$artifact_dir/runner.stderr"
-          command_path="$artifact_dir/command.txt"
-          stats_path="$artifact_dir/make-stats.txt"
-          case_index_path="$artifact_dir/case-index.json"
-
-          mcp_cmd="\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh"
-          managed_proxy_cmd='./examples/pipelock/start-proxy-for-benchmark.sh "$PIPELOCK_BIN"'
-          managed_mcp_http_cmd='./examples/pipelock/start-mcp-http-for-benchmark.sh "$PIPELOCK_BIN"'
-
-          cmd=(
-            "$RUNNER_TEMP/aeb-gauntlet"
-            --adapter proxy
-            --scan-token bench-test-token
-            --mcp-cmd "$mcp_cmd"
-            --managed-proxy-cmd "$managed_proxy_cmd"
-            --managed-mcp-http-cmd "$managed_mcp_http_cmd"
-            --cases ./cases
-            --multifile-cases ./cases/mcp-drift
-            --profile examples/pipelock/tool-profile.json
-            --fixtures
-            --output "$summary_path"
-          )
-          # Compute the cap from the job's actual elapsed time. This keeps six
-          # minutes of the 35-minute job budget for decision synthesis and
-          # evidence upload even when checkout or release setup was slow.
-          now_epoch="$(date +%s)"
-          reserve_seconds=$((6 * 60))
           job_deadline=$((JOB_STARTED_EPOCH + 35 * 60))
-          available_seconds=$((job_deadline - now_epoch - reserve_seconds))
-          benchmark_cap_seconds=$((24 * 60))
-          if (( available_seconds <= 0 )); then
-            echo "Insufficient job budget remains to run the benchmark safely." >&2
-            exit 1
-          fi
-          if (( available_seconds < benchmark_cap_seconds )); then
-            benchmark_cap_seconds=$available_seconds
-          fi
-          run_cmd=(timeout --signal=TERM --kill-after=30s "${benchmark_cap_seconds}s" "${cmd[@]}")
+          ./scripts/run-pipelock-gauntlet.sh \
+            --output-dir "$GAUNTLET_ARTIFACT_DIR" \
+            --deadline-epoch "$job_deadline" \
+            --reserve-seconds $((6 * 60)) \
+            --benchmark-timeout-seconds $((24 * 60))
 
-          printf '%q ' "${run_cmd[@]}" > "$command_path"
-          printf '\n' >> "$command_path"
-          command_string="$(<"$command_path")"
-
-          if ! grep -Eq '(^|[[:space:]])--fixtures($|[[:space:]])' "$command_path"; then
-            echo "Recorded command does not include --fixtures." >&2
-            echo "$command_string" >&2
-            exit 1
-          fi
-          if ! grep -Eq '(^|[[:space:]])--multifile-cases($|[[:space:]])' "$command_path"; then
-            echo "Recorded command does not include --multifile-cases." >&2
-            echo "$command_string" >&2
-            exit 1
-          fi
-
-          make stats > "$stats_path"
-          "$RUNNER_TEMP/aeb-gauntlet" --cases ./cases --case-index > "$case_index_path"
-
-          set +e
-          "${run_cmd[@]}" > "$jsonl_path" 2> "$stderr_path"
-          run_status=$?
-          set -e
-
-          # Exit status first. A flag-parse or startup failure also produces no
-          # Fixtures line, and reporting the missing line instead of the real
-          # exit code hides why the run actually died.
-          if [[ "$run_status" -ne 0 ]]; then
-            echo "Gauntlet runner failed with exit code $run_status." >&2
-            cat "$stderr_path" >&2
-            exit "$run_status"
-          fi
-          if ! grep -Eq '^Fixtures: HTTP=.* TLS=.* WS=.* DNS=.* MCP_HTTP=' "$stderr_path"; then
-            echo "Runner did not report fixture startup; refusing untrusted benchmark." >&2
-            cat "$stderr_path" >&2
-            exit 1
-          fi
-
-          results_abs="$(realpath "$jsonl_path")"
-          (cd validate && go run . results "$results_abs")
-          jq -e '.case_count.errors == 0' "$summary_path" >/dev/null
-
-          {
-            echo "ARTIFACT_DIR=$artifact_dir"
-            echo "SUMMARY_PATH=$summary_path"
-            echo "RESULTS_PATH=$jsonl_path"
-            echo "STDERR_PATH=$stderr_path"
-            echo "COMMAND_PATH=$command_path"
-            echo "STATS_PATH=$stats_path"
-            echo "CASE_INDEX_PATH=$case_index_path"
-          } >> "$GITHUB_ENV"
-
-      - name: Wrap provenance artifact
+      - name: Finalize GitHub provenance artifact
         shell: bash
         run: |
           set -euo pipefail
-
-          export GENERATED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          export ARTIFACT_JSON="$ARTIFACT_DIR/continuous-gauntlet-pipelock-${PIPELOCK_TAG}.json"
-
-          python3 - <<'PY'
-          import hashlib
-          import json
-          import os
-          import re
-          from collections import Counter
-
-          with open(os.environ["SUMMARY_PATH"], encoding="utf-8") as fh:
-              summary = json.load(fh)
-          with open(os.environ["COMMAND_PATH"], encoding="utf-8") as fh:
-              command = fh.read().strip()
-          with open(os.environ["STATS_PATH"], encoding="utf-8") as fh:
-              make_stats = fh.read()
-          with open(os.environ["CASE_INDEX_PATH"], "rb") as fh:
-              case_index_bytes = fh.read()
-          case_index = json.loads(case_index_bytes)
-
-          manifest_path = "cases/MANIFEST.txt"
-          with open(manifest_path, "rb") as fh:
-              manifest = fh.read()
-          manifest_id_list = [line.strip() for line in manifest.decode("utf-8").splitlines() if line.strip()]
-          manifest_ids = set(manifest_id_list)
-          if not manifest_id_list:
-              raise SystemExit("refusing provenance artifact: cases/MANIFEST.txt has no logical case IDs")
-          if len(manifest_ids) != len(manifest_id_list):
-              raise SystemExit("refusing provenance artifact: cases/MANIFEST.txt contains duplicate IDs")
-          manifest_sha256 = hashlib.sha256(manifest).hexdigest()
-          logical_case_count = len(manifest_ids)
-
-          results = []
-          with open(os.environ["RESULTS_PATH"], encoding="utf-8") as fh:
-              for line_number, line in enumerate(fh, 1):
-                  if not line.strip():
-                      continue
-                  try:
-                      results.append(json.loads(line))
-                  except json.JSONDecodeError as exc:
-                      raise SystemExit(f"invalid runner JSONL at line {line_number}: {exc}") from exc
-
-          result_ids = []
-          for row_number, row in enumerate(results, 1):
-              if not isinstance(row, dict):
-                  raise SystemExit(f"runner JSONL row {row_number} is not an object")
-              case_id = row.get("case_id")
-              if not isinstance(case_id, str) or not case_id:
-                  raise SystemExit(f"runner JSONL row {row_number} has no case_id")
-              result_ids.append(case_id)
-          duplicate_ids = sorted(case_id for case_id, count in Counter(result_ids).items() if count > 1)
-          if duplicate_ids:
-              raise SystemExit(f"runner JSONL contains duplicate case IDs: {duplicate_ids!r}")
-          result_id_set = set(result_ids)
-          if result_id_set != manifest_ids:
-              missing = sorted(manifest_ids - result_id_set)
-              unknown = sorted(result_id_set - manifest_ids)
-              raise SystemExit(
-                  "runner JSONL case IDs do not match cases/MANIFEST.txt: "
-                  f"missing={missing!r} unknown={unknown!r}"
-              )
-
-          if not isinstance(case_index, dict) or case_index.get("schema_version") != 1:
-              raise SystemExit("loader case index must be a schema_version 1 object")
-          case_index_rows = case_index.get("cases")
-          if not isinstance(case_index_rows, list):
-              raise SystemExit("loader case index cases must be an array")
-          expected_by_id = {}
-          for row_number, row in enumerate(case_index_rows, 1):
-              if not isinstance(row, dict):
-                  raise SystemExit(f"loader case index row {row_number} is not an object")
-              case_id = row.get("case_id")
-              expected = row.get("expected_verdict")
-              if not isinstance(case_id, str) or not case_id:
-                  raise SystemExit(f"loader case index row {row_number} has no case_id")
-              if case_id in expected_by_id:
-                  raise SystemExit(f"loader case index contains duplicate case ID {case_id!r}")
-              if expected not in {"block", "allow"}:
-                  raise SystemExit(
-                      f"loader case index row {row_number} has invalid normalized expected_verdict {expected!r}"
-                  )
-              expected_by_id[case_id] = expected
-          if set(expected_by_id) != manifest_ids:
-              raise SystemExit("loader case index IDs do not match cases/MANIFEST.txt")
-          for row_number, row in enumerate(results, 1):
-              expected = expected_by_id[row["case_id"]]
-              if row.get("expected_verdict") != expected:
-                  raise SystemExit(
-                      f"runner JSONL row {row_number} expected_verdict for {row['case_id']!r} "
-                      f"does not match loader case index: {row.get('expected_verdict')!r} != {expected!r}"
-                  )
-
-          def count_stat(name):
-              match = re.search(rf"(?m)^{re.escape(name)}: ([0-9]+)$", make_stats)
-              if match is None:
-                  raise SystemExit(f"make stats output is missing {name!r}")
-              return int(match.group(1))
-
-          def has_classification(evidence):
-              if not isinstance(evidence, dict):
-                  return False
-              for key in ("kind", "scanner", "block_reason"):
-                  if evidence.get(key) is not None:
-                      return True
-              return isinstance(evidence.get("error_message"), str) and bool(evidence["error_message"])
-
-          def has_structured_evidence(evidence):
-              if not isinstance(evidence, dict):
-                  return False
-              return any(
-                  key in evidence and evidence[key] is not None
-                  for key in ("kind", "scanner", "block_reason", "error_message", "decision", "findings")
-              )
-
-          applicable_results = [row for row in results if row.get("actual_verdict") != "not_applicable"]
-          applicable_malicious = [row for row in applicable_results if row.get("expected_verdict") == "block"]
-          applicable_benign = [row for row in applicable_results if row.get("expected_verdict") == "allow"]
-          blocked_malicious = [row for row in applicable_malicious if row.get("actual_verdict") == "block"]
-          blocked_benign = [row for row in applicable_benign if row.get("actual_verdict") == "block"]
-          classified = sum(has_classification(row.get("evidence")) for row in blocked_malicious)
-          evidence_emitted = sum(has_structured_evidence(row.get("evidence")) for row in blocked_malicious)
-          full_malicious = count_stat("block")
-          full_benign = count_stat("allow") + count_stat("warn")
-
-          metric_counts = {
-              "applicable": {
-                  "containment": {"numerator": len(blocked_malicious), "denominator": len(applicable_malicious)},
-                  "false_positive_rate": {"numerator": len(blocked_benign), "denominator": len(applicable_benign)},
-                  "detection": {"numerator": classified, "denominator": len(blocked_malicious)},
-                  "evidence": {"numerator": evidence_emitted, "denominator": len(blocked_malicious)},
-              },
-              "full": {
-                  "containment": {"numerator": len(blocked_malicious), "denominator": full_malicious},
-                  "false_positive_rate": {"numerator": len(blocked_benign), "denominator": full_benign},
-                  "detection": {"numerator": classified, "denominator": len(blocked_malicious)},
-                  "evidence": {"numerator": evidence_emitted, "denominator": len(blocked_malicious)},
-              },
-          }
-          if summary["case_count"]["total"] != logical_case_count:
-              raise SystemExit(
-                  "runner summary total does not match the pinned manifest: "
-                  f"{summary['case_count']['total']} != {logical_case_count}"
-              )
-          if len(results) != logical_case_count:
-              raise SystemExit(
-                  "runner JSONL row count does not match the logical corpus: "
-                  f"{len(results)} != {logical_case_count}"
-              )
-          if summary["case_count"]["applicable"] != len(applicable_results):
-              raise SystemExit(
-                  "runner summary applicable count does not match runner JSONL: "
-                  f"{summary['case_count']['applicable']} != {len(applicable_results)}"
-              )
-          jsonl_errors = sum(row.get("actual_verdict") == "error" for row in applicable_results)
-          if summary["case_count"]["errors"] != jsonl_errors:
-              raise SystemExit(
-                  "runner summary error count does not match runner JSONL: "
-                  f"{summary['case_count']['errors']} != {jsonl_errors}"
-              )
-          if full_malicious + full_benign != logical_case_count:
-              raise SystemExit(
-                  "make stats verdict counts do not match the logical corpus: "
-                  f"{full_malicious} + {full_benign} != {logical_case_count}"
-              )
-          for scope, metrics in metric_counts.items():
-              for metric, counts in metrics.items():
-                  expected_score = (
-                      counts["numerator"] / counts["denominator"]
-                      if counts["denominator"] else None
-                  )
-                  actual_score = summary["scores"][scope].get(metric)
-                  if actual_score != expected_score:
-                      raise SystemExit(
-                          f"runner summary scores.{scope}.{metric} does not match bound metric counts: "
-                          f"{actual_score!r} != {expected_score!r}"
-                      )
-
-          repo = os.environ["GITHUB_REPOSITORY"]
-          run_id = os.environ["GITHUB_RUN_ID"]
-          corpus_sha = os.environ["CORPUS_GIT_SHA"]
-          pipelock_tag = os.environ["PIPELOCK_TAG"]
-
-          artifact = {
-              "schema_version": 2,
-              "artifact_id": f"github-actions:{repo}:{run_id}",
-              "generated_at": os.environ["GENERATED_AT"],
-              "canonical_url": f"https://github.com/{repo}/actions/runs/{run_id}",
-              "corpus_ref_kind": os.environ["CORPUS_REF_KIND"],
-              "corpus_git_sha": corpus_sha,
-              "corpus_commit_url": f"https://github.com/{repo}/commit/{corpus_sha}",
-              "dirty": os.environ["CORPUS_DIRTY"].lower() == "true",
-              "pipelock_tag": pipelock_tag,
-              "pipelock_version": os.environ["PIPELOCK_VERSION"],
-              "pipelock_asset": os.environ["PIPELOCK_ASSET"],
-              "pipelock_release_url": f"https://github.com/{os.environ['PIPELOCK_REPO']}/releases/tag/{pipelock_tag}",
-              "gauntlet_version": summary["gauntlet_version"],
-              "scoring_version": summary["scoring_version"],
-              "runner_version": summary["runner_version"],
-              "tool": summary["tool"],
-              "tool_version": summary["tool_version"],
-              "corpus_version": summary["corpus_version"],
-              "corpus_sha256": summary["corpus_sha256"],
-              "corpus_manifest_sha256": manifest_sha256,
-              "case_index_sha256": hashlib.sha256(case_index_bytes).hexdigest(),
-              "logical_case_count": logical_case_count,
-              "tool_profile_sha256": summary["tool_profile_sha256"],
-              "case_count": {
-                  "total": summary["case_count"]["total"],
-                  "applicable": summary["case_count"]["applicable"],
-                  "not_applicable": summary["case_count"]["not_applicable"],
-                  "not_applicable_reasons": summary["case_count"]["not_applicable_reasons"],
-                  "errors": summary["case_count"]["errors"],
-              },
-              "scores": summary["scores"],
-              "metric_counts": metric_counts,
-              "sufficient": summary["sufficient"],
-              "fixtures": True,
-              "multifile_cases": True,
-              "command": command,
-              "make_stats": make_stats,
-          }
-
-          with open(os.environ["ARTIFACT_JSON"], "w", encoding="utf-8") as fh:
-              json.dump(artifact, fh, indent=2, sort_keys=True)
-              fh.write("\n")
-          PY
-
-          jq empty "$ARTIFACT_JSON"
-
-          # A shell export does not survive the step boundary, so the validating
-          # step below would see an unbound variable. Persist the path instead.
-          echo "ARTIFACT_JSON=$ARTIFACT_JSON" >> "$GITHUB_ENV"
+          artifact_dir="$GAUNTLET_ARTIFACT_DIR"
+          artifact_json="$artifact_dir/continuous-gauntlet-pipelock.json"
+          python3 scripts/build_gauntlet_provenance.py finalize \
+            --repo-root . \
+            --bundle "$artifact_dir/run-bundle.json" \
+            --artifact-id "github-actions:${GITHUB_REPOSITORY}:${GITHUB_RUN_ID}" \
+            --canonical-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --output "$artifact_json"
+          {
+            echo "ARTIFACT_JSON=$artifact_json"
+            echo "DECISION_PATH=$artifact_dir/promotion-decision.json"
+          } >> "$GITHUB_ENV"
 
       - name: Validate generated provenance artifact
         shell: bash
         run: |
           set -euo pipefail
-          test -n "${ARTIFACT_JSON:-}" || { echo "provenance artifact path was not published by the generating step"; exit 1; }
+          test -n "${ARTIFACT_JSON:-}" || { echo "provenance artifact path was not published by the finalizer"; exit 1; }
           test -f "$ARTIFACT_JSON" || { echo "provenance artifact missing at $ARTIFACT_JSON"; exit 1; }
           python3 scripts/validate_gauntlet_scope.py "$ARTIFACT_JSON"
 
@@ -496,18 +85,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          decision_path="$ARTIFACT_DIR/promotion-decision.json"
+          artifact_dir="$GAUNTLET_ARTIFACT_DIR"
           python3 scripts/evaluate_gauntlet_candidate.py evaluate \
             --candidate "$ARTIFACT_JSON" \
             --baseline ci/gauntlet-baseline.json \
-            --evidence "raw_summary=$SUMMARY_PATH" \
-            --evidence "results=$RESULTS_PATH" \
-            --evidence "runner_stderr=$STDERR_PATH" \
-            --evidence "command=$COMMAND_PATH" \
-            --evidence "stats=$STATS_PATH" \
-            --evidence "case_index=$CASE_INDEX_PATH" \
-            --decision "$decision_path"
-          echo "DECISION_PATH=$decision_path" >> "$GITHUB_ENV"
+            --evidence "raw_summary=$artifact_dir/raw-summary.json" \
+            --evidence "results=$artifact_dir/results.jsonl" \
+            --evidence "runner_stderr=$artifact_dir/runner.stderr" \
+            --evidence "command=$artifact_dir/command.txt" \
+            --evidence "stats=$artifact_dir/make-stats.txt" \
+            --evidence "case_index=$artifact_dir/case-index.json" \
+            --evidence "entrypoint_command=$artifact_dir/entrypoint-command.txt" \
+            --evidence "run_metadata=$artifact_dir/run-metadata.json" \
+            --evidence "pipelock_release=$artifact_dir/pipelock-release.json" \
+            --evidence "release_checksums=$artifact_dir/checksums.txt" \
+            --evidence "pipelock_version_output=$artifact_dir/pipelock-version.txt" \
+            --evidence "corpus_manifest=$artifact_dir/corpus-manifest.txt" \
+            --evidence "execution_decision=$artifact_dir/execution-decision.json" \
+            --evidence "run_bundle=$artifact_dir/run-bundle.json" \
+            --decision "$DECISION_PATH"
 
       # Earlier failures skip the normal evaluator. Still produce a blocked,
       # machine-readable decision before upload so malformed or partial runs
@@ -518,7 +114,7 @@ jobs:
         run: |
           set -euo pipefail
           artifact_dir="$GAUNTLET_ARTIFACT_DIR"
-          candidate_path="$artifact_dir/continuous-gauntlet-pipelock-${PIPELOCK_TAG}.json"
+          candidate_path="$artifact_dir/continuous-gauntlet-pipelock.json"
           decision_path="$artifact_dir/promotion-decision.json"
           mkdir -p "$artifact_dir"
           if [[ ! -f "$decision_path" ]]; then
@@ -532,10 +128,16 @@ jobs:
                 --evidence "command=$artifact_dir/command.txt" \
                 --evidence "stats=$artifact_dir/make-stats.txt" \
                 --evidence "case_index=$artifact_dir/case-index.json" \
+                --evidence "entrypoint_command=$artifact_dir/entrypoint-command.txt" \
+                --evidence "run_metadata=$artifact_dir/run-metadata.json" \
+                --evidence "pipelock_release=$artifact_dir/pipelock-release.json" \
+                --evidence "release_checksums=$artifact_dir/checksums.txt" \
+                --evidence "pipelock_version_output=$artifact_dir/pipelock-version.txt" \
+                --evidence "corpus_manifest=$artifact_dir/corpus-manifest.txt" \
+                --evidence "execution_decision=$artifact_dir/execution-decision.json" \
+                --evidence "run_bundle=$artifact_dir/run-bundle.json" \
                 --decision "$decision_path"
             else
-              # Checkout itself can fail before repository scripts exist. Keep
-              # that failure auditable too instead of turning it into no artifact.
               temporary_decision="$decision_path.tmp"
               jq -n '{
                 schema_version: 1,
@@ -568,10 +170,18 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: continuous-gauntlet-pipelock-${{ env.PIPELOCK_TAG }}
+          name: continuous-gauntlet-pipelock
           path: |
-            ${{ env.GAUNTLET_ARTIFACT_DIR }}/continuous-gauntlet-pipelock-${{ env.PIPELOCK_TAG }}.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/continuous-gauntlet-pipelock.json
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/promotion-decision.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/execution-decision.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/run-bundle.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/run-metadata.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/pipelock-release.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/pipelock-version.txt
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/corpus-manifest.txt
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/checksums.txt
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/entrypoint-command.txt
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/raw-summary.json
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/results.jsonl
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/runner.stderr
@@ -597,4 +207,12 @@ jobs:
             --evidence "runner_stderr=$artifact_dir/runner.stderr" \
             --evidence "command=$artifact_dir/command.txt" \
             --evidence "stats=$artifact_dir/make-stats.txt" \
-            --evidence "case_index=$artifact_dir/case-index.json"
+            --evidence "case_index=$artifact_dir/case-index.json" \
+            --evidence "entrypoint_command=$artifact_dir/entrypoint-command.txt" \
+            --evidence "run_metadata=$artifact_dir/run-metadata.json" \
+            --evidence "pipelock_release=$artifact_dir/pipelock-release.json" \
+            --evidence "release_checksums=$artifact_dir/checksums.txt" \
+            --evidence "pipelock_version_output=$artifact_dir/pipelock-version.txt" \
+            --evidence "corpus_manifest=$artifact_dir/corpus-manifest.txt" \
+            --evidence "execution_decision=$artifact_dir/execution-decision.json" \
+            --evidence "run_bundle=$artifact_dir/run-bundle.json"

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -23,9 +23,10 @@ jobs:
   pipelock-release:
     name: Pipelock release benchmark
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 35 # Keep synchronized with JOB_TIMEOUT_MINUTES below.
     env:
       GAUNTLET_ARTIFACT_DIR: continuous-gauntlet-artifacts
+      JOB_TIMEOUT_MINUTES: "35"
     steps:
       - name: Record job budget start
         shell: bash
@@ -45,11 +46,9 @@ jobs:
 
       - name: Run portable canonical benchmark
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          job_deadline=$((JOB_STARTED_EPOCH + 35 * 60))
+          job_deadline=$((JOB_STARTED_EPOCH + JOB_TIMEOUT_MINUTES * 60))
           ./scripts/run-pipelock-gauntlet.sh \
             --output-dir "$GAUNTLET_ARTIFACT_DIR" \
             --deadline-epoch "$job_deadline" \

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ CLAUDE.local.md
 # Test output
 *.jsonl
 !receipts/v0/conformance/**/*.jsonl
+/continuous-gauntlet-runs/
+/continuous-gauntlet-artifacts/
 
 # Playwright
 .playwright-mcp/

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ check-stats: check-gauntlet-site
 check-gauntlet-site:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/validate_gauntlet_scope_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/evaluate_gauntlet_candidate_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/build_gauntlet_provenance_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/continuous_gauntlet_workflow_test.py
 	@node gauntlet-site/scope-render_test.js
 	@test -f "$(GAUNTLET_SCOPE_ARTIFACT)" || { echo "check-gauntlet-site: FAIL - missing provenance artifact: $(GAUNTLET_SCOPE_ARTIFACT)"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -87,29 +87,19 @@ cd validate && go build -o aeb-validate .
 
 **Run against a tool.** Each tool ships its own runner. The Go program in [`runner/`](runner/) is the reference implementation; it brings up HTTP, TLS, WebSocket, DNS, and MCP HTTP fixtures, executes declared transports through the selected adapter, and emits the Gauntlet summary and an optional receipt-scoring profile.
 
-For Pipelock, the full reproducible invocation is in [docs/RUNNER.md](docs/RUNNER.md#reproducing-a-receipt-profile). The short form:
+For the pinned Pipelock release, use the portable entry point from a clean Linux clone on `origin/main` or a tag:
 
 ```bash
-# 1. Start a benchmark-configured tool instance (Pipelock shown):
-pipelock run --config examples/pipelock/pipelock-benchmark.yaml \
-  --listen 127.0.0.1:18899 &
-
-# 2. Build and run the gauntlet against it:
-cd runner && go build -o /tmp/aeb-gauntlet . && cd ..
-/tmp/aeb-gauntlet \
-  --adapter proxy \
-  --proxy-addr 127.0.0.1:18899 \
-  --scan-addr 127.0.0.1:9990 \
-  --scan-token bench-test-token \
-  --mcp-cmd "pipelock mcp proxy --config $PWD/examples/pipelock/pipelock-benchmark.yaml --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh" \
-  --cases ./cases \
-  --multifile-cases ./cases/mcp-drift \
-  --profile examples/pipelock/tool-profile.json \
-  --fixtures \
-  --output /tmp/gauntlet.json
+./scripts/run-pipelock-gauntlet.sh
 ```
 
-The runner writes per-case JSONL results to stdout (one object per case, see [docs/RUNNER.md](docs/RUNNER.md)) and a Gauntlet summary JSON to the path passed via `--output` (containment, false-positive rate, detection, evidence, per-category, see [docs/gauntlet.md](docs/gauntlet.md)). `--emit-receipt-profile` additionally writes a byte-reproducible receipt-scoring profile (see [docs/RECEIPT-SCORING.md](docs/RECEIPT-SCORING.md)). See [`examples/pipelock/`](examples/pipelock/) for a complete profile and config example.
+The command downloads the reviewed Pipelock release, verifies its published checksum and reported version, starts the required local fixtures and managed Pipelock processes, runs the single-file and multi-file cases, and leaves one timestamped directory under `continuous-gauntlet-runs/`. That directory contains the exact internal command, stdout results, stderr, summary, case index, corpus stats, release identity, file digests, and a machine-readable execution decision.
+
+It requires Linux, Go 1.25 or newer, Python 3, Git, curl, jq, tar, GNU timeout, SHA-256 utilities, and one of `socat`, `ncat`, or `nc`. Use `--output-dir` to place the self-contained run directory somewhere else. The [Pipelock reference-runner guide](examples/pipelock/README.md) documents the evidence files, explicit development mode, the underlying long-form command, and a neutral scheduling example.
+
+The raw directory intentionally has no made-up public URL. GitHub Actions or another retaining platform adds its real artifact ID and HTTPS location later, without modifying the evidence bytes. Creating a schedule and publishing a result are separate operator decisions.
+
+For other tools, the runner writes per-case JSONL results to stdout (one object per case, see [docs/RUNNER.md](docs/RUNNER.md)) and a Gauntlet summary JSON to the path passed via `--output` (containment, false-positive rate, detection, evidence, per-category, see [docs/gauntlet.md](docs/gauntlet.md)). `--emit-receipt-profile` additionally writes a byte-reproducible receipt-scoring profile (see [docs/RECEIPT-SCORING.md](docs/RECEIPT-SCORING.md)).
 
 > A minimal legacy shell example for fetch-only cases lives at [`examples/pipelock/harness.sh`](examples/pipelock/harness.sh). It covers a single transport (`/fetch?url=...` GET) and is kept for illustration only — it is not the Gauntlet and will misreport every body, header, WebSocket, MCP, and response-content case. Use the Go runner for any real benchmark.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Most cases are self-contained JSON files with the attack payload, expected verdi
 
 ## Quick start
 
-**Prerequisites:** [Go 1.24+](https://go.dev/dl/) for the validator. The runner uses its own Go module dependencies for fixtures and multi-file case parsing.
+**Prerequisites:** [Go 1.25+](https://go.dev/dl/) for the validator and portable runner. The runner uses its own Go module dependencies for fixtures and multi-file case parsing.
 
 **Build the validator:**
 

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -269,6 +269,8 @@ Reproducibility:
 
 Example shape for a tool-specific benchmark run:
 
+> For the pinned Pipelock release, `./scripts/run-pipelock-gauntlet.sh` is the normal operator command. The long form below is an advanced reference for adapter and receipt-profile development.
+
 ```bash
 cd runner && go build -o /tmp/aeb-gauntlet . && cd ..
 export PIPELOCK_BIN=/path/to/pipelock
@@ -288,7 +290,7 @@ export PIPELOCK_BENCH_CONFIG="$PWD/examples/pipelock/pipelock-benchmark.yaml"
   --receipt-verifier-file examples/pipelock/receipt-verifier.json \
   --timeout 15s
 
-# 3. Compare byte-for-byte with the committed artifact.
+# Compare byte-for-byte with the committed artifact.
 sha256sum /tmp/pipelock.json profiles/pipelock.json
 diff -q /tmp/pipelock.json profiles/pipelock.json
 ```

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -154,28 +154,17 @@ corpus bytes are unchanged.
 
 ## Running the Gauntlet
 
-Build and run the Gauntlet runner:
+For the reviewed Pipelock release, run the portable entry point from a clean Linux clone:
 
 ```bash
-# Path to the tool under test, and the config the managed harness starts it with.
-export PIPELOCK_BIN=/path/to/pipelock
-export PIPELOCK_BENCH_CONFIG="$PWD/examples/pipelock/pipelock-benchmark.yaml"
-
-cd runner && go build -o /tmp/aeb-gauntlet . && cd ..
-/tmp/aeb-gauntlet \
-  --adapter proxy --scan-token bench-test-token \
-  --managed-proxy-cmd './examples/pipelock/start-proxy-for-benchmark.sh "$PIPELOCK_BIN"' \
-  --managed-mcp-http-cmd './examples/pipelock/start-mcp-http-for-benchmark.sh "$PIPELOCK_BIN"' \
-  --mcp-cmd "\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh" \
-  --cases ./cases --multifile-cases ./cases/mcp-drift \
-  --profile examples/pipelock/tool-profile.json \
-  --fixtures \
-  --output summary.json
+./scripts/run-pipelock-gauntlet.sh
 ```
 
-`--fixtures` and `--multifile-cases` are not optional for a comparable score. Without `--fixtures` the runner starts no local HTTP, TLS, WebSocket, DNS or MCP endpoints, so cases that target them fail for lack of a server rather than on policy, and the false-positive rate becomes meaningless. The managed-command flags start the tool under test with TLS interception wired up; a plain listening proxy scores the response-interception cases incorrectly. Confirm the run printed a line beginning `Fixtures:` before trusting any number it produces.
+The entry point pins and verifies the released binary, supplies the required managed commands, enables the local fixtures, includes the multi-file MCP drift corpus, validates the result rows, and leaves a hash-bound evidence directory. It rejects a recorded command with the fixture or multi-file flags missing. Without fixtures, cases can fail because no local server exists rather than because policy blocked them, and the false-positive rate becomes meaningless. A plain listening proxy also scores response-interception cases incorrectly because it does not receive the runner's TLS fixture configuration.
 
-Per-case JSONL results are written to stdout. The summary JSON file is written to the path specified by `--output`. See [RUNNER.md](RUNNER.md) for the full runner contract and verdict mapping rules.
+The raw portable directory is the common execution layer. It has a local run ID but no invented public URL. GitHub Actions or another retaining platform supplies a real artifact ID and canonical HTTPS URL during a separate finalization step. The [Pipelock reference-runner guide](../examples/pipelock/README.md) documents every evidence file, explicit development mode, the underlying long-form command, and a Linux scheduling example.
+
+For other tools and adapter development, use the Go runner directly. Per-case JSONL results are written to stdout and the summary JSON file is written to the path specified by `--output`. See [RUNNER.md](RUNNER.md) for the full runner contract and verdict mapping rules.
 
 ## Submission
 

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -40,6 +40,10 @@ Important files in the completed directory:
 | `corpus-manifest.txt` | Exact logical-case manifest bytes behind the recorded manifest digest |
 | `make-stats.txt` | Loader-backed corpus counts used for full denominators |
 | `pipelock-release.json` | Release tag, version, archive digest, binary digest, and reported version |
+| `checksums.txt` | Published checksum bytes that bind the downloaded release archive |
+| `pipelock-version.txt` | Version output from the executed Pipelock binary |
+| `run-metadata.json` | Corpus identity, ref kind, dirty state, and canonicality decision |
+| `entrypoint-command.txt` | Exact operator command that started the run |
 
 A runner error or timeout still leaves a blocked decision plus whatever evidence was produced. A successful portable run still is not a published result. A platform must retain the directory, assign a real artifact ID and HTTPS URL, finalize the candidate, and apply its reviewed publication policy.
 

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -7,9 +7,66 @@ This directory contains the Pipelock-specific artifacts the Go runner needs to s
 - [`tool-profile.json`](tool-profile.json): Pipelock's capability claims (what it supports, what it does not).
 - [`pipelock-benchmark.yaml`](pipelock-benchmark.yaml): bench-only config (every scanner enabled, action=block, test blocklist domain included).
 - [`receipt-verifier.json`](receipt-verifier.json): Pipelock's verifier metadata for the optional receipt-scoring profile.
+- [`release.env`](release.env): the single reviewed Pipelock release tag and version used by the portable runner and GitHub workflow.
 - [`harness.sh`](harness.sh): legacy fetch-only example, kept for illustration.
 
-## Development run
+## Portable release run
+
+From a clean Linux clone on `origin/main` or a repository tag:
+
+```bash
+./scripts/run-pipelock-gauntlet.sh
+```
+
+The default output is a unique directory under `continuous-gauntlet-runs/`. To choose the location explicitly:
+
+```bash
+./scripts/run-pipelock-gauntlet.sh --output-dir /var/lib/agent-egress-bench/runs/manual-20260805
+```
+
+The destination must not already exist. The command verifies the corpus Git identity and cleanliness, downloads the release named by `release.env`, rejects draft or prerelease assets, verifies the archive against the release's `checksums.txt`, and verifies the extracted binary's version before running it. It then builds the repository runner and executes every canonical fixture and multi-file MCP drift case.
+
+Important files in the completed directory:
+
+| File | Meaning |
+| --- | --- |
+| `execution-decision.json` | Whether execution completed, whether platform finalization is eligible, and any blocking failure |
+| `run-bundle.json` | Hash-bound portable bundle used by a later platform finalizer |
+| `raw-summary.json` | Four-axis Gauntlet summary and case counts |
+| `results.jsonl` | One result row per logical case |
+| `runner.stderr` | Fixture startup proof and runner diagnostics |
+| `command.txt` | Exact internal runner command, including timeout and all canonical flags |
+| `case-index.json` | Loader-normalized case IDs and expected verdicts |
+| `corpus-manifest.txt` | Exact logical-case manifest bytes behind the recorded manifest digest |
+| `make-stats.txt` | Loader-backed corpus counts used for full denominators |
+| `pipelock-release.json` | Release tag, version, archive digest, binary digest, and reported version |
+
+A runner error or timeout still leaves a blocked decision plus whatever evidence was produced. A successful portable run still is not a published result. A platform must retain the directory, assign a real artifact ID and HTTPS URL, finalize the candidate, and apply its reviewed publication policy.
+
+### Explicit development mode
+
+To test uncommitted runner changes with an already-built Pipelock binary:
+
+```bash
+./scripts/run-pipelock-gauntlet.sh \
+  --development \
+  --development-binary /usr/local/bin/pipelock
+```
+
+The output records why the run is noncanonical. The provenance finalizer refuses to turn that bundle into a publication candidate. A binary found on `PATH` is never selected silently.
+
+### Repeating the command on Linux
+
+Scheduling is an ordinary operator task, separate from evidence validation or publication. For example, if the repository is installed at `/opt/agent-egress-bench`, this crontab entry starts the same command every day at 06:17 UTC:
+
+```cron
+CRON_TZ=UTC
+17 6 * * * cd /opt/agent-egress-bench && ./scripts/run-pipelock-gauntlet.sh
+```
+
+That timer does not update the repository, delete old runs, upload evidence, or publish a result. The machine operator must choose update, retention, and publication policies separately. Run the command manually once and inspect `execution-decision.json` and `run-bundle.json` before connecting it to any timer.
+
+## Advanced runner invocation
 
 The runner can either target already-running endpoints (`--proxy-addr`,
 `--scan-addr`, `--mcp-http-url`) or start operator-provided commands with the
@@ -46,7 +103,7 @@ back to `ncat` or `nc`; a machine running this example needs one of those
 programs. The continuous Gauntlet verifies that one is available before it
 runs.
 
-Example shape:
+The portable entry point above is the normal Pipelock operator surface. The long form below is retained for runner development and to make the managed-command contract inspectable:
 
 ```bash
 cd runner && go build -o /tmp/aeb-gauntlet . && cd ..

--- a/examples/pipelock/release.env
+++ b/examples/pipelock/release.env
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Reviewed release identity used by the portable Pipelock Gauntlet runner.
+PIPELOCK_REPO=luckyPipewrench/pipelock
+PIPELOCK_TAG=v3.3.0
+PIPELOCK_VERSION=3.3.0

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -1,0 +1,725 @@
+#!/usr/bin/env python3
+"""Build and finalize hash-bound continuous Gauntlet evidence."""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import tempfile
+from collections import Counter
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+RAW_EVIDENCE = {
+    "raw_summary": "raw-summary.json",
+    "results": "results.jsonl",
+    "runner_stderr": "runner.stderr",
+    "command": "command.txt",
+    "stats": "make-stats.txt",
+    "case_index": "case-index.json",
+    "entrypoint_command": "entrypoint-command.txt",
+    "run_metadata": "run-metadata.json",
+    "pipelock_release": "pipelock-release.json",
+    "release_checksums": "checksums.txt",
+    "pipelock_version_output": "pipelock-version.txt",
+    "corpus_manifest": "corpus-manifest.txt",
+}
+SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
+
+
+def atomic_json_write(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def load_object(path):
+    with path.open(encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def evidence_hashes(run_dir, require_all):
+    hashes = {}
+    for label, relative_path in RAW_EVIDENCE.items():
+        path = run_dir / relative_path
+        if not path.is_file():
+            if require_all:
+                raise ValueError(f"required evidence is missing: {label} ({relative_path})")
+            hashes[label] = None
+            continue
+        hashes[label] = file_sha256(path)
+    return hashes
+
+
+def require_non_empty_string(document, key, label=None):
+    value = document.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label or key} must be a non-empty string")
+    return value
+
+
+def require_sha256(document, key, allow_null=False):
+    value = document.get(key)
+    if value is None and allow_null:
+        return value
+    if not isinstance(value, str) or not SHA256_HEX.fullmatch(value):
+        raise ValueError(f"{key} must be 64 lower-case hex characters")
+    return value
+
+
+def read_results(path):
+    results = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid runner JSONL at line {line_number}: {exc}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"runner JSONL row {line_number} is not an object")
+            results.append(row)
+    return results
+
+
+def load_manifest(repo_root, run_dir):
+    manifest_path = run_dir / RAW_EVIDENCE["corpus_manifest"]
+    manifest = manifest_path.read_bytes()
+    checked_out_manifest = (repo_root / "cases" / "MANIFEST.txt").read_bytes()
+    if manifest != checked_out_manifest:
+        raise ValueError("retained corpus manifest does not match the checked-out corpus manifest")
+    id_list = [line.strip() for line in manifest.decode("utf-8").splitlines() if line.strip()]
+    ids = set(id_list)
+    if not id_list:
+        raise ValueError("refusing provenance bundle: cases/MANIFEST.txt has no logical case IDs")
+    if len(ids) != len(id_list):
+        raise ValueError("refusing provenance bundle: cases/MANIFEST.txt contains duplicate IDs")
+    return manifest, ids
+
+
+def load_case_index(path, manifest_ids):
+    case_index_bytes = path.read_bytes()
+    case_index = json.loads(case_index_bytes)
+    if not isinstance(case_index, dict) or case_index.get("schema_version") != 1:
+        raise ValueError("loader case index must be a schema_version 1 object")
+    rows = case_index.get("cases")
+    if not isinstance(rows, list):
+        raise ValueError("loader case index cases must be an array")
+    expected_by_id = {}
+    for row_number, row in enumerate(rows, 1):
+        if not isinstance(row, dict):
+            raise ValueError(f"loader case index row {row_number} is not an object")
+        case_id = row.get("case_id")
+        expected = row.get("expected_verdict")
+        if not isinstance(case_id, str) or not case_id:
+            raise ValueError(f"loader case index row {row_number} has no case_id")
+        if case_id in expected_by_id:
+            raise ValueError(f"loader case index contains duplicate case ID {case_id!r}")
+        if expected not in {"block", "allow"}:
+            raise ValueError(
+                f"loader case index row {row_number} has invalid normalized expected_verdict {expected!r}"
+            )
+        expected_by_id[case_id] = expected
+    if set(expected_by_id) != manifest_ids:
+        raise ValueError("loader case index IDs do not match cases/MANIFEST.txt")
+    return case_index_bytes, expected_by_id
+
+
+def count_stat(make_stats, name):
+    match = re.search(rf"(?m)^{re.escape(name)}: ([0-9]+)$", make_stats)
+    if match is None:
+        raise ValueError(f"make stats output is missing {name!r}")
+    return int(match.group(1))
+
+
+def has_classification(evidence):
+    if not isinstance(evidence, dict):
+        return False
+    for key in ("kind", "scanner", "block_reason"):
+        if evidence.get(key) is not None:
+            return True
+    return isinstance(evidence.get("error_message"), str) and bool(evidence["error_message"])
+
+
+def has_structured_evidence(evidence):
+    if not isinstance(evidence, dict):
+        return False
+    return any(
+        key in evidence and evidence[key] is not None
+        for key in ("kind", "scanner", "block_reason", "error_message", "decision", "findings")
+    )
+
+
+def expected_fraction(numerator, denominator):
+    return numerator / denominator if denominator else None
+
+
+def verify_score(summary, scope, metric, numerator, denominator):
+    try:
+        actual = summary["scores"][scope][metric]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(f"runner summary is missing scores.{scope}.{metric}") from exc
+    expected = expected_fraction(numerator, denominator)
+    if actual != expected:
+        raise ValueError(
+            f"runner summary scores.{scope}.{metric} does not match bound metric counts: "
+            f"{actual!r} != {expected!r}"
+        )
+
+
+def measurements(repo_root, run_dir):
+    summary = load_object(run_dir / RAW_EVIDENCE["raw_summary"])
+    command = (run_dir / RAW_EVIDENCE["command"]).read_text(encoding="utf-8").strip()
+    make_stats = (run_dir / RAW_EVIDENCE["stats"]).read_text(encoding="utf-8")
+    stderr = (run_dir / RAW_EVIDENCE["runner_stderr"]).read_text(encoding="utf-8")
+    results = read_results(run_dir / RAW_EVIDENCE["results"])
+    manifest, manifest_ids = load_manifest(repo_root, run_dir)
+    case_index_bytes, expected_by_id = load_case_index(
+        run_dir / RAW_EVIDENCE["case_index"], manifest_ids
+    )
+
+    try:
+        command_argv = shlex.split(command)
+    except ValueError as exc:
+        raise ValueError(f"recorded runner command is not valid shell syntax: {exc}") from exc
+    if "--fixtures" not in command_argv:
+        raise ValueError("recorded runner command does not include --fixtures")
+    if "--multifile-cases" not in command_argv:
+        raise ValueError("recorded runner command does not include --multifile-cases")
+    if not re.search(r"(?m)^Fixtures: HTTP=.* TLS=.* WS=.* DNS=.* MCP_HTTP=", stderr):
+        raise ValueError("runner stderr does not prove fixture startup")
+
+    result_ids = []
+    for row_number, row in enumerate(results, 1):
+        case_id = row.get("case_id")
+        if not isinstance(case_id, str) or not case_id:
+            raise ValueError(f"runner JSONL row {row_number} has no case_id")
+        result_ids.append(case_id)
+    duplicate_ids = sorted(case_id for case_id, count in Counter(result_ids).items() if count > 1)
+    if duplicate_ids:
+        raise ValueError(f"runner JSONL contains duplicate case IDs: {duplicate_ids!r}")
+    result_id_set = set(result_ids)
+    if result_id_set != manifest_ids:
+        missing = sorted(manifest_ids - result_id_set)
+        unknown = sorted(result_id_set - manifest_ids)
+        raise ValueError(
+            "runner JSONL case IDs do not match cases/MANIFEST.txt: "
+            f"missing={missing!r} unknown={unknown!r}"
+        )
+    for row_number, row in enumerate(results, 1):
+        expected = expected_by_id[row["case_id"]]
+        if row.get("expected_verdict") != expected:
+            raise ValueError(
+                f"runner JSONL row {row_number} expected_verdict for {row['case_id']!r} "
+                f"does not match loader case index: {row.get('expected_verdict')!r} != {expected!r}"
+            )
+        actual = row.get("actual_verdict")
+        score = row.get("score")
+        evidence = row.get("evidence")
+        if actual not in {"block", "allow", "not_applicable", "error"}:
+            raise ValueError(f"runner JSONL row {row_number} has invalid actual_verdict {actual!r}")
+        if score not in {"pass", "fail", "not_applicable", "error"}:
+            raise ValueError(f"runner JSONL row {row_number} has invalid score {score!r}")
+        if not isinstance(evidence, dict):
+            raise ValueError(f"runner JSONL row {row_number} evidence must be an object")
+        if not isinstance(row.get("notes"), str):
+            raise ValueError(f"runner JSONL row {row_number} notes must be a string")
+        if row.get("tool") != summary.get("tool") or row.get("tool_version") != summary.get(
+            "tool_version"
+        ):
+            raise ValueError(f"runner JSONL row {row_number} tool identity does not match summary")
+        case_specific_failure = (
+            score == "fail"
+            and "over_budget_call_id" in evidence
+            and evidence.get("budget_block_timing") == "before_over_budget"
+        )
+        if actual == "not_applicable":
+            expected_score = "not_applicable"
+        elif actual == "error":
+            expected_score = "error"
+        elif actual == expected:
+            expected_score = "fail" if case_specific_failure else "pass"
+        else:
+            expected_score = "fail"
+        if score != expected_score:
+            raise ValueError(
+                f"runner JSONL row {row_number} score {score!r} does not match its verdicts"
+            )
+
+    applicable_results = [row for row in results if row.get("actual_verdict") != "not_applicable"]
+    applicable_malicious = [
+        row for row in applicable_results if row.get("expected_verdict") == "block"
+    ]
+    applicable_benign = [
+        row for row in applicable_results if row.get("expected_verdict") == "allow"
+    ]
+    blocked_malicious = [
+        row for row in applicable_malicious if row.get("actual_verdict") == "block"
+    ]
+    blocked_benign = [
+        row for row in applicable_benign if row.get("actual_verdict") == "block"
+    ]
+    classified = sum(has_classification(row.get("evidence")) for row in blocked_malicious)
+    evidence_emitted = sum(
+        has_structured_evidence(row.get("evidence")) for row in blocked_malicious
+    )
+    full_malicious = count_stat(make_stats, "block")
+    full_benign = count_stat(make_stats, "allow") + count_stat(make_stats, "warn")
+    metric_counts = {
+        "applicable": {
+            "containment": {
+                "numerator": len(blocked_malicious),
+                "denominator": len(applicable_malicious),
+            },
+            "false_positive_rate": {
+                "numerator": len(blocked_benign),
+                "denominator": len(applicable_benign),
+            },
+            "detection": {"numerator": classified, "denominator": len(blocked_malicious)},
+            "evidence": {
+                "numerator": evidence_emitted,
+                "denominator": len(blocked_malicious),
+            },
+        },
+        "full": {
+            "containment": {
+                "numerator": len(blocked_malicious),
+                "denominator": full_malicious,
+            },
+            "false_positive_rate": {
+                "numerator": len(blocked_benign),
+                "denominator": full_benign,
+            },
+            "detection": {"numerator": classified, "denominator": len(blocked_malicious)},
+            "evidence": {
+                "numerator": evidence_emitted,
+                "denominator": len(blocked_malicious),
+            },
+        },
+    }
+
+    logical_case_count = len(manifest_ids)
+    case_count = summary.get("case_count")
+    if not isinstance(case_count, dict):
+        raise ValueError("runner summary case_count must be an object")
+    if case_count.get("total") != logical_case_count:
+        raise ValueError(
+            "runner summary total does not match the pinned manifest: "
+            f"{case_count.get('total')!r} != {logical_case_count}"
+        )
+    if len(results) != logical_case_count:
+        raise ValueError(
+            "runner JSONL row count does not match the logical corpus: "
+            f"{len(results)} != {logical_case_count}"
+        )
+    if case_count.get("applicable") != len(applicable_results):
+        raise ValueError("runner summary applicable count does not match runner JSONL")
+    not_applicable_count = logical_case_count - len(applicable_results)
+    if case_count.get("not_applicable") != not_applicable_count:
+        raise ValueError("runner summary not_applicable count does not match runner JSONL")
+    not_applicable_reasons = case_count.get("not_applicable_reasons")
+    if not isinstance(not_applicable_reasons, dict) or any(
+        not isinstance(reason, str)
+        or not reason
+        or isinstance(count, bool)
+        or not isinstance(count, int)
+        or count < 0
+        for reason, count in not_applicable_reasons.items()
+    ):
+        raise ValueError("runner summary not_applicable_reasons is invalid")
+    if sum(not_applicable_reasons.values()) != not_applicable_count:
+        raise ValueError("runner summary not_applicable reasons do not sum to the N/A count")
+    jsonl_errors = sum(row.get("actual_verdict") == "error" for row in applicable_results)
+    if case_count.get("errors") != jsonl_errors:
+        raise ValueError("runner summary error count does not match runner JSONL")
+    if jsonl_errors != 0:
+        raise ValueError(f"runner produced {jsonl_errors} error result(s)")
+    if full_malicious + full_benign != logical_case_count:
+        raise ValueError("make stats verdict counts do not match the logical corpus")
+    for scope, metrics in metric_counts.items():
+        for metric, counts in metrics.items():
+            verify_score(summary, scope, metric, counts["numerator"], counts["denominator"])
+    full_containment = expected_fraction(
+        metric_counts["full"]["containment"]["numerator"],
+        metric_counts["full"]["containment"]["denominator"],
+    )
+    expected_sufficient = full_containment is None or full_containment >= 0.80
+    if summary.get("sufficient") is not expected_sufficient:
+        raise ValueError("runner summary sufficient flag does not match the full containment gate")
+
+    return {
+        "summary": summary,
+        "command": command,
+        "make_stats": make_stats,
+        "metric_counts": metric_counts,
+        "manifest_sha256": hashlib.sha256(manifest).hexdigest(),
+        "case_index_sha256": hashlib.sha256(case_index_bytes).hexdigest(),
+        "logical_case_count": logical_case_count,
+    }
+
+
+def validate_metadata(metadata):
+    if metadata.get("schema_version") != 1:
+        raise ValueError("run metadata schema_version must be 1")
+    for key in (
+        "local_run_id",
+        "generated_at",
+        "corpus_repository",
+        "corpus_ref_kind",
+        "corpus_git_sha",
+    ):
+        require_non_empty_string(metadata, key, f"run metadata {key}")
+    if not isinstance(metadata.get("dirty"), bool):
+        raise ValueError("run metadata dirty must be boolean")
+    if not isinstance(metadata.get("canonical_execution"), bool):
+        raise ValueError("run metadata canonical_execution must be boolean")
+    reasons = metadata.get("noncanonical_reasons")
+    if not isinstance(reasons, list) or any(not isinstance(item, str) or not item for item in reasons):
+        raise ValueError("run metadata noncanonical_reasons must be an array of strings")
+    if metadata["canonical_execution"] and (metadata["dirty"] or reasons):
+        raise ValueError("canonical execution cannot be dirty or have noncanonical reasons")
+    if not re.fullmatch(r"[0-9a-f]{40}", metadata["corpus_git_sha"]):
+        raise ValueError("run metadata corpus_git_sha must be 40 lower-case hex characters")
+    if metadata["corpus_ref_kind"] not in {"origin/main", "tag", "development"}:
+        raise ValueError("run metadata corpus_ref_kind is invalid")
+    if metadata["canonical_execution"]:
+        if metadata["corpus_ref_kind"] not in {"origin/main", "tag"}:
+            raise ValueError("canonical execution requires origin/main or a tag")
+        if metadata["corpus_repository"] != "luckyPipewrench/agent-egress-bench":
+            raise ValueError("canonical execution names an unexpected corpus repository")
+
+
+def validate_release(release, metadata, run_dir):
+    if release.get("schema_version") != 1:
+        raise ValueError("Pipelock release metadata schema_version must be 1")
+    for key in ("repository", "tag", "version", "asset", "binary_sha256", "version_output"):
+        require_non_empty_string(release, key, f"Pipelock release {key}")
+    require_sha256(release, "binary_sha256")
+    require_sha256(release, "asset_sha256", allow_null=not release.get("released_binary", False))
+    if not isinstance(release.get("released_binary"), bool):
+        raise ValueError("Pipelock release released_binary must be boolean")
+    if metadata["canonical_execution"] and not release["released_binary"]:
+        raise ValueError("canonical execution requires a released Pipelock binary")
+    if metadata["canonical_execution"] and release["repository"] != "luckyPipewrench/pipelock":
+        raise ValueError("canonical execution names an unexpected Pipelock repository")
+    if release["tag"] != "v" + release["version"]:
+        raise ValueError("Pipelock release tag and version do not match")
+    expected_version_line = f"pipelock version {release['version']}"
+    if expected_version_line not in release["version_output"].splitlines():
+        raise ValueError("Pipelock release version_output does not report the pinned version")
+    retained_version = (run_dir / RAW_EVIDENCE["pipelock_version_output"]).read_text(
+        encoding="utf-8"
+    ).strip()
+    if retained_version != release["version_output"].strip():
+        raise ValueError("retained Pipelock version output does not match release metadata")
+    if release["released_binary"]:
+        expected_asset = re.escape(f"pipelock_{release['version']}_linux_")
+        if not re.fullmatch(expected_asset + r"(?:amd64|arm64)\.tar\.gz", release["asset"]):
+            raise ValueError("Pipelock release asset name does not match the pinned Linux version")
+        matches = []
+        checksums = (run_dir / RAW_EVIDENCE["release_checksums"]).read_text(encoding="utf-8")
+        for line in checksums.splitlines():
+            fields = line.split()
+            if len(fields) == 2 and fields[1].lstrip("*") == release["asset"]:
+                matches.append(fields[0])
+        if matches != [release["asset_sha256"]]:
+            raise ValueError("release checksums do not bind the recorded Pipelock asset digest")
+
+
+def build_complete_bundle(repo_root, run_dir):
+    metadata = load_object(run_dir / RAW_EVIDENCE["run_metadata"])
+    release = load_object(run_dir / RAW_EVIDENCE["pipelock_release"])
+    validate_metadata(metadata)
+    validate_release(release, metadata, run_dir)
+    if not (run_dir / RAW_EVIDENCE["entrypoint_command"]).read_text(encoding="utf-8").strip():
+        raise ValueError("entrypoint command evidence is empty")
+    measured = measurements(repo_root, run_dir)
+    summary = measured["summary"]
+    if summary.get("tool_version") != release["version"]:
+        raise ValueError(
+            "runner summary tool_version does not match the executed Pipelock release: "
+            f"{summary.get('tool_version')!r} != {release['version']!r}"
+        )
+    hashes = evidence_hashes(run_dir, require_all=True)
+    candidate_scope = {
+        "schema_version": 2,
+        "local_run_id": metadata["local_run_id"],
+        "generated_at": metadata["generated_at"],
+        "corpus_ref_kind": metadata["corpus_ref_kind"],
+        "corpus_git_sha": metadata["corpus_git_sha"],
+        "corpus_commit_url": (
+            f"https://github.com/{metadata['corpus_repository']}/commit/{metadata['corpus_git_sha']}"
+        ),
+        "dirty": metadata["dirty"],
+        "pipelock_tag": release["tag"],
+        "pipelock_version": release["version"],
+        "pipelock_asset": release["asset"],
+        "pipelock_asset_sha256": release.get("asset_sha256"),
+        "pipelock_binary_sha256": release["binary_sha256"],
+        "pipelock_release_url": f"https://github.com/{release['repository']}/releases/tag/{release['tag']}",
+        "gauntlet_version": summary["gauntlet_version"],
+        "scoring_version": summary["scoring_version"],
+        "runner_version": summary["runner_version"],
+        "tool": summary["tool"],
+        "tool_version": summary["tool_version"],
+        "corpus_version": summary["corpus_version"],
+        "corpus_sha256": summary["corpus_sha256"],
+        "corpus_manifest_sha256": measured["manifest_sha256"],
+        "case_index_sha256": measured["case_index_sha256"],
+        "logical_case_count": measured["logical_case_count"],
+        "tool_profile_sha256": summary["tool_profile_sha256"],
+        "case_count": {
+            "total": summary["case_count"]["total"],
+            "applicable": summary["case_count"]["applicable"],
+            "not_applicable": summary["case_count"]["not_applicable"],
+            "not_applicable_reasons": summary["case_count"]["not_applicable_reasons"],
+            "errors": summary["case_count"]["errors"],
+        },
+        "scores": summary["scores"],
+        "metric_counts": measured["metric_counts"],
+        "sufficient": summary["sufficient"],
+        "fixtures": True,
+        "multifile_cases": True,
+        "command": measured["command"],
+        "make_stats": measured["make_stats"],
+        "evidence_sha256": hashes,
+    }
+    return {
+        "schema_version": 1,
+        "bundle_status": "complete",
+        "local_run_id": metadata["local_run_id"],
+        "publication_eligible": metadata["canonical_execution"] and release["released_binary"],
+        "noncanonical_reasons": metadata["noncanonical_reasons"],
+        "evidence_sha256": hashes,
+        "candidate_scope": candidate_scope,
+    }
+
+
+def build_partial_bundle(run_dir, failure):
+    metadata_path = run_dir / RAW_EVIDENCE["run_metadata"]
+    metadata = load_object(metadata_path) if metadata_path.is_file() else {}
+    return {
+        "schema_version": 1,
+        "bundle_status": "partial",
+        "local_run_id": metadata.get("local_run_id"),
+        "publication_eligible": False,
+        "noncanonical_reasons": metadata.get("noncanonical_reasons", []),
+        "evidence_sha256": evidence_hashes(run_dir, require_all=False),
+        "failure": failure,
+    }
+
+
+def bundle_command(args):
+    run_dir = args.run_dir.resolve()
+    output_path = run_dir / "run-bundle.json"
+    decision_path = run_dir / "execution-decision.json"
+    if args.failure:
+        bundle = build_partial_bundle(run_dir, args.failure)
+        decision = {
+            "schema_version": 1,
+            "local_run_id": bundle.get("local_run_id"),
+            "blocked": True,
+            "execution_status": "blocked",
+            "publication_eligible": False,
+            "failures": [args.failure],
+            "evidence_sha256": bundle["evidence_sha256"],
+        }
+    else:
+        bundle = build_complete_bundle(args.repo_root.resolve(), run_dir)
+        decision = {
+            "schema_version": 1,
+            "local_run_id": bundle["local_run_id"],
+            "blocked": False,
+            "execution_status": "complete",
+            "publication_eligible": bundle["publication_eligible"],
+            "failures": [],
+            "review_notes": bundle["noncanonical_reasons"],
+            "evidence_sha256": bundle["evidence_sha256"],
+        }
+    atomic_json_write(output_path, bundle)
+    atomic_json_write(decision_path, decision)
+
+
+def finalize_command(args):
+    bundle_path = args.bundle.resolve()
+    run_dir = bundle_path.parent
+    output_path = args.output.resolve()
+    protected_paths = {
+        (run_dir / relative_path).resolve() for relative_path in RAW_EVIDENCE.values()
+    }
+    protected_paths.update(
+        {
+            bundle_path,
+            (run_dir / "execution-decision.json").resolve(),
+            (run_dir / "promotion-decision.json").resolve(),
+        }
+    )
+    if output_path in protected_paths:
+        raise ValueError("candidate output cannot overwrite retained evidence or a decision")
+    if output_path.exists():
+        raise ValueError("candidate output must not already exist")
+    bundle = load_object(bundle_path)
+    if bundle.get("schema_version") != 1 or bundle.get("bundle_status") != "complete":
+        raise ValueError("portable run bundle is not complete")
+    if bundle.get("publication_eligible") is not True:
+        raise ValueError("portable run bundle is noncanonical and cannot be finalized")
+    recorded_hashes = bundle.get("evidence_sha256")
+    if not isinstance(recorded_hashes, dict) or set(recorded_hashes) != set(RAW_EVIDENCE):
+        raise ValueError("portable run bundle evidence set is incomplete")
+    current_hashes = evidence_hashes(run_dir, require_all=True)
+    for label in sorted(RAW_EVIDENCE):
+        if recorded_hashes.get(label) != current_hashes[label]:
+            raise ValueError(f"evidence {label} changed after the portable bundle was created")
+    recomputed_bundle = build_complete_bundle(args.repo_root.resolve(), run_dir)
+    if bundle != recomputed_bundle:
+        raise ValueError("portable run bundle does not match a fresh reconstruction from evidence")
+
+    artifact_id = args.artifact_id.strip()
+    if not artifact_id:
+        raise ValueError("artifact_id must be non-empty")
+    canonical_url = args.canonical_url.strip()
+    parsed = urlparse(canonical_url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("canonical_url must be an absolute https URL")
+    candidate_scope = bundle.get("candidate_scope")
+    if not isinstance(candidate_scope, dict):
+        raise ValueError("portable run bundle candidate_scope must be an object")
+    candidate = dict(candidate_scope)
+    candidate.update(
+        {
+            "artifact_id": artifact_id,
+            "canonical_url": canonical_url,
+            "portable_bundle_sha256": file_sha256(bundle_path),
+        }
+    )
+    atomic_json_write(output_path, candidate)
+
+
+def start_command(args):
+    metadata = {
+        "schema_version": 1,
+        "local_run_id": args.local_run_id,
+        "generated_at": args.generated_at,
+        "corpus_repository": args.corpus_repository,
+        "corpus_ref_kind": args.corpus_ref_kind,
+        "corpus_git_sha": args.corpus_git_sha,
+        "dirty": args.dirty,
+        "canonical_execution": args.canonical_execution,
+        "noncanonical_reasons": args.noncanonical_reason,
+    }
+    validate_metadata(metadata)
+    atomic_json_write(args.output, metadata)
+
+
+def release_command(args):
+    release = {
+        "schema_version": 1,
+        "repository": args.repository,
+        "tag": args.tag,
+        "version": args.version,
+        "asset": args.asset,
+        "asset_sha256": args.asset_sha256,
+        "binary_sha256": args.binary_sha256,
+        "version_output": args.version_output,
+        "released_binary": args.released_binary,
+    }
+    atomic_json_write(args.output, release)
+
+
+def bool_value(value):
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    raise argparse.ArgumentTypeError("want true or false")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    start = subparsers.add_parser("start")
+    start.add_argument("--output", type=Path, required=True)
+    start.add_argument("--local-run-id", required=True)
+    start.add_argument("--generated-at", required=True)
+    start.add_argument("--corpus-repository", required=True)
+    start.add_argument("--corpus-ref-kind", required=True)
+    start.add_argument("--corpus-git-sha", required=True)
+    start.add_argument("--dirty", type=bool_value, required=True)
+    start.add_argument("--canonical-execution", type=bool_value, required=True)
+    start.add_argument("--noncanonical-reason", action="append", default=[])
+
+    release = subparsers.add_parser("release")
+    release.add_argument("--output", type=Path, required=True)
+    release.add_argument("--repository", required=True)
+    release.add_argument("--tag", required=True)
+    release.add_argument("--version", required=True)
+    release.add_argument("--asset", required=True)
+    release.add_argument("--asset-sha256")
+    release.add_argument("--binary-sha256", required=True)
+    release.add_argument("--version-output", required=True)
+    release.add_argument("--released-binary", type=bool_value, required=True)
+
+    bundle = subparsers.add_parser("bundle")
+    bundle.add_argument("--repo-root", type=Path, required=True)
+    bundle.add_argument("--run-dir", type=Path, required=True)
+    bundle.add_argument("--failure")
+
+    finalize = subparsers.add_parser("finalize")
+    finalize.add_argument(
+        "--repo-root", type=Path, default=Path(__file__).resolve().parents[1]
+    )
+    finalize.add_argument("--bundle", type=Path, required=True)
+    finalize.add_argument("--artifact-id", required=True)
+    finalize.add_argument("--canonical-url", required=True)
+    finalize.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        if args.command == "start":
+            start_command(args)
+        elif args.command == "release":
+            release_command(args)
+        elif args.command == "bundle":
+            bundle_command(args)
+        else:
+            finalize_command(args)
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        print(f"provenance: BLOCKED: {exc}", file=os.sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shlex
+import sys
 import tempfile
 from collections import Counter
 from pathlib import Path
@@ -196,6 +197,16 @@ def verify_score(summary, scope, metric, numerator, denominator):
 
 def measurements(repo_root, run_dir):
     summary = load_object(run_dir / RAW_EVIDENCE["raw_summary"])
+    for key in (
+        "gauntlet_version",
+        "scoring_version",
+        "runner_version",
+        "tool",
+        "corpus_version",
+    ):
+        require_non_empty_string(summary, key, f"runner summary {key}")
+    for key in ("corpus_sha256", "tool_profile_sha256"):
+        require_sha256(summary, key)
     command = (run_dir / RAW_EVIDENCE["command"]).read_text(encoding="utf-8").strip()
     make_stats = (run_dir / RAW_EVIDENCE["stats"]).read_text(encoding="utf-8")
     stderr = (run_dir / RAW_EVIDENCE["runner_stderr"]).read_text(encoding="utf-8")
@@ -716,7 +727,7 @@ def main():
         else:
             finalize_command(args)
     except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
-        print(f"provenance: BLOCKED: {exc}", file=os.sys.stderr)
+        print(f"provenance: BLOCKED: {exc}", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -230,21 +230,52 @@ class ProvenanceBuilderTest(unittest.TestCase):
 
     def test_bundle_rejects_duplicate_unknown_and_swapped_case_labels(self):
         mutations = {
-            "duplicate": [self.results[0], {**self.results[1], "case_id": "a"}, self.results[2]],
-            "unknown": [self.results[0], self.results[1], {**self.results[2], "case_id": "z"}],
-            "swapped": [
-                {**self.results[0], "expected_verdict": "allow"},
-                {**self.results[1], "expected_verdict": "block"},
-                self.results[2],
-            ],
+            "duplicate": (
+                [self.results[0], {**self.results[1], "case_id": "a"}, self.results[2]],
+                "runner JSONL contains duplicate case IDs",
+            ),
+            "unknown": (
+                [self.results[0], self.results[1], {**self.results[2], "case_id": "z"}],
+                "runner JSONL case IDs do not match cases/MANIFEST.txt",
+            ),
+            "swapped": (
+                [
+                    {**self.results[0], "expected_verdict": "allow"},
+                    {**self.results[1], "expected_verdict": "block"},
+                    self.results[2],
+                ],
+                "does not match loader case index",
+            ),
         }
-        for name, rows in mutations.items():
+        for name, (rows, expected_message) in mutations.items():
             with self.subTest(name=name):
                 (self.run_dir / "results.jsonl").write_text(
                     "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
                 )
                 result = self.bundle()
                 self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_message, result.stderr)
+                self.write_fixture()
+
+    def test_candidate_scope_rejects_malformed_summary_identity_fields(self):
+        mutations = {
+            "tool": (None, "runner summary tool must be a non-empty string"),
+            "corpus_version": ("", "runner summary corpus_version must be a non-empty string"),
+            "corpus_sha256": (None, "corpus_sha256 must be 64 lower-case hex characters"),
+            "tool_profile_sha256": (
+                "not-a-digest",
+                "tool_profile_sha256 must be 64 lower-case hex characters",
+            ),
+        }
+        for key, (value, expected_message) in mutations.items():
+            with self.subTest(key=key):
+                summary_path = self.run_dir / "raw-summary.json"
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+                summary[key] = value
+                summary_path.write_text(json.dumps(summary), encoding="utf-8")
+                result = self.bundle()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_message, result.stderr)
                 self.write_fixture()
 
     def test_null_classification_fields_earn_no_detection_or_evidence_credit(self):
@@ -415,7 +446,7 @@ class ProvenanceBuilderTest(unittest.TestCase):
         )
         result = self.bundle()
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("score", result.stderr)
+        self.assertIn("score 'pass' does not match its verdicts", result.stderr)
 
     def test_reviewed_release_pin_matches_profile_and_baseline(self):
         pin = parsed_release_pin()
@@ -471,7 +502,9 @@ class PortableRunnerFailureTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("must not already exist", result.stderr)
 
-    def run_with_fake_runner(self, mode, timeout_seconds="10"):
+    def run_with_fake_runner(
+        self, mode, timeout_seconds="10", *, missing_origin=False, inject_tokens=False
+    ):
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
         root = Path(temporary.name)
@@ -481,7 +514,13 @@ class PortableRunnerFailureTest(unittest.TestCase):
 
         pipelock = root / "pipelock"
         pipelock.write_text(
-            f"#!/bin/sh\nprintf '%s\\n' 'pipelock version {PIN_VERSION}'\n",
+            f"""#!/bin/sh
+if [ -n "${{GH_TOKEN:-}}" ] || [ -n "${{GITHUB_TOKEN:-}}" ]; then
+  printf '%s\\n' 'credential environment reached Pipelock' >&2
+  exit 97
+fi
+printf '%s\\n' 'pipelock version {PIN_VERSION}'
+""",
             encoding="utf-8",
         )
         pipelock.chmod(0o755)
@@ -520,7 +559,33 @@ exit 99
         )
         fake_make.chmod(0o755)
 
+        if missing_origin:
+            fake_git = fake_bin / "git"
+            fake_git.write_text(
+                """#!/bin/sh
+if [ "$#" -eq 3 ] && [ "$1" = "remote" ] && [ "$2" = "get-url" ] && [ "$3" = "origin" ]; then
+  exit 2
+fi
+PATH=${PATH#*:}
+export PATH
+exec git "$@"
+""",
+                encoding="utf-8",
+            )
+            fake_git.chmod(0o755)
+
         started = time.monotonic()
+        env = {
+            **os.environ,
+            "PATH": str(fake_bin) + os.pathsep + os.environ["PATH"],
+            "AEB_FAKE_RUNNER_MODE": mode,
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+        env.pop("GH_TOKEN", None)
+        env.pop("GITHUB_TOKEN", None)
+        if inject_tokens:
+            env["GH_TOKEN"] = "synthetic-gh-token"
+            env["GITHUB_TOKEN"] = "synthetic-github-token"
         result = subprocess.run(
             [
                 "bash",
@@ -534,17 +599,26 @@ exit 99
                 str(output_dir),
             ],
             cwd=REPO_ROOT,
-            env={
-                **os.environ,
-                "PATH": str(fake_bin) + os.pathsep + os.environ["PATH"],
-                "AEB_FAKE_RUNNER_MODE": mode,
-                "PYTHONDONTWRITEBYTECODE": "1",
-            },
+            env=env,
             text=True,
             capture_output=True,
             check=False,
         )
         return result, output_dir, time.monotonic() - started
+
+    def test_development_mode_without_origin_reaches_the_runner(self):
+        result, output_dir, _ = self.run_with_fake_runner("error", missing_origin=True)
+        self.assertEqual(result.returncode, 23, result.stderr)
+        metadata = json.loads((output_dir / "run-metadata.json").read_text(encoding="utf-8"))
+        self.assertIn(
+            "origin did not match luckyPipewrench/agent-egress-bench",
+            metadata["noncanonical_reasons"],
+        )
+
+    def test_github_tokens_are_not_inherited_by_the_tool_under_test(self):
+        result, _, _ = self.run_with_fake_runner("error", inject_tokens=True)
+        self.assertEqual(result.returncode, 23, result.stderr)
+        self.assertNotIn("credential environment reached Pipelock", result.stderr)
 
     def test_runner_error_leaves_command_stderr_partial_evidence_and_blocked_decision(self):
         result, output_dir, _ = self.run_with_fake_runner("error")
@@ -567,7 +641,8 @@ exit 99
     def test_hung_runner_is_terminated_and_leaves_blocked_evidence(self):
         result, output_dir, elapsed = self.run_with_fake_runner("hang", timeout_seconds="1")
         self.assertNotEqual(result.returncode, 0)
-        self.assertLess(elapsed, 5)
+        # The stub sleeps 10 seconds; finishing sooner proves the benchmark timeout fired.
+        self.assertLess(elapsed, 9)
         decision = json.loads(
             (output_dir / "execution-decision.json").read_text(encoding="utf-8")
         )

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""Tests for portable Gauntlet evidence construction and finalization."""
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILDER = REPO_ROOT / "scripts" / "build_gauntlet_provenance.py"
+RUNNER = REPO_ROOT / "scripts" / "run-pipelock-gauntlet.sh"
+RELEASE_PIN = REPO_ROOT / "examples" / "pipelock" / "release.env"
+
+
+def parsed_release_pin():
+    values = {}
+    for line in RELEASE_PIN.read_text(encoding="utf-8").splitlines():
+        if not line or line.startswith("#"):
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
+PIN = parsed_release_pin()
+PIN_VERSION = PIN["PIPELOCK_VERSION"]
+PIN_TAG = PIN["PIPELOCK_TAG"]
+
+
+class ProvenanceBuilderTest(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.run_dir = self.root / "run"
+        (self.root / "cases").mkdir()
+        self.run_dir.mkdir()
+        (self.root / "cases" / "MANIFEST.txt").write_text("a\nb\nc\n", encoding="utf-8")
+        self.results = [
+            {
+                "case_id": "a",
+                "tool": "Pipelock",
+                "tool_version": PIN_VERSION,
+                "expected_verdict": "block",
+                "actual_verdict": "block",
+                "score": "pass",
+                "evidence": {"scanner": "test"},
+                "notes": "",
+            },
+            {
+                "case_id": "b",
+                "tool": "Pipelock",
+                "tool_version": PIN_VERSION,
+                "expected_verdict": "allow",
+                "actual_verdict": "allow",
+                "score": "pass",
+                "evidence": {},
+                "notes": "",
+            },
+            {
+                "case_id": "c",
+                "tool": "Pipelock",
+                "tool_version": PIN_VERSION,
+                "expected_verdict": "block",
+                "actual_verdict": "not_applicable",
+                "score": "not_applicable",
+                "evidence": {},
+                "notes": "",
+            },
+        ]
+        self.write_fixture()
+
+    def write_fixture(self, detection_score=1.0, evidence_score=1.0):
+        summary = {
+            "gauntlet_version": "1",
+            "scoring_version": "2.4",
+            "runner_version": "0.4.2",
+            "tool": "Pipelock",
+            "tool_version": PIN_VERSION,
+            "corpus_version": "test",
+            "corpus_sha256": "a" * 64,
+            "tool_profile_sha256": "b" * 64,
+            "case_count": {
+                "total": 3,
+                "applicable": 2,
+                "not_applicable": 1,
+                "not_applicable_reasons": {"missing_requires": 1},
+                "errors": 0,
+            },
+            "scores": {
+                "applicable": {
+                    "containment": 1.0,
+                    "false_positive_rate": 0.0,
+                    "detection": detection_score,
+                    "evidence": evidence_score,
+                },
+                "full": {
+                    "containment": 0.5,
+                    "false_positive_rate": 0.0,
+                    "detection": detection_score,
+                    "evidence": evidence_score,
+                },
+            },
+            "sufficient": False,
+        }
+        (self.run_dir / "raw-summary.json").write_text(json.dumps(summary), encoding="utf-8")
+        (self.run_dir / "results.jsonl").write_text(
+            "".join(json.dumps(row) + "\n" for row in self.results), encoding="utf-8"
+        )
+        (self.run_dir / "runner.stderr").write_text(
+            "Fixtures: HTTP=x TLS=x WS=x DNS=x MCP_HTTP=x\n", encoding="utf-8"
+        )
+        (self.run_dir / "command.txt").write_text(
+            "timeout 10s aeb-gauntlet --fixtures --multifile-cases cases/mcp-drift\n",
+            encoding="utf-8",
+        )
+        (self.run_dir / "make-stats.txt").write_text(
+            "block: 2\nallow: 1\nwarn: 0\n", encoding="utf-8"
+        )
+        (self.run_dir / "case-index.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "cases": [
+                        {"case_id": "a", "expected_verdict": "block"},
+                        {"case_id": "b", "expected_verdict": "allow"},
+                        {"case_id": "c", "expected_verdict": "block"},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (self.run_dir / "entrypoint-command.txt").write_text(
+            "./scripts/run-pipelock-gauntlet.sh\n", encoding="utf-8"
+        )
+        (self.run_dir / "run-metadata.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "local_run_id": "local:test:1",
+                    "generated_at": "2026-08-04T00:00:00Z",
+                    "corpus_repository": "luckyPipewrench/agent-egress-bench",
+                    "corpus_ref_kind": "origin/main",
+                    "corpus_git_sha": "c" * 40,
+                    "dirty": False,
+                    "canonical_execution": True,
+                    "noncanonical_reasons": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (self.run_dir / "pipelock-release.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "repository": "luckyPipewrench/pipelock",
+                    "tag": PIN_TAG,
+                    "version": PIN_VERSION,
+                    "asset": f"pipelock_{PIN_VERSION}_linux_amd64.tar.gz",
+                    "asset_sha256": "d" * 64,
+                    "binary_sha256": "e" * 64,
+                    "version_output": f"pipelock version {PIN_VERSION}",
+                    "released_binary": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (self.run_dir / "checksums.txt").write_text(
+            "d" * 64 + f"  pipelock_{PIN_VERSION}_linux_amd64.tar.gz\n",
+            encoding="utf-8",
+        )
+        (self.run_dir / "pipelock-version.txt").write_text(
+            f"pipelock version {PIN_VERSION}\n", encoding="utf-8"
+        )
+        (self.run_dir / "corpus-manifest.txt").write_text("a\nb\nc\n", encoding="utf-8")
+
+    def run_builder(self, *arguments):
+        return subprocess.run(
+            [sys.executable, str(BUILDER), *map(str, arguments)],
+            cwd=self.root,
+            text=True,
+            capture_output=True,
+            check=False,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        )
+
+    def bundle(self):
+        return self.run_builder(
+            "bundle", "--repo-root", self.root, "--run-dir", self.run_dir
+        )
+
+    def finalize(self, output=None):
+        return self.run_builder(
+            "finalize",
+            "--repo-root",
+            self.root,
+            "--bundle",
+            self.run_dir / "run-bundle.json",
+            "--artifact-id",
+            "github-actions:luckyPipewrench/agent-egress-bench:123",
+            "--canonical-url",
+            "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
+            "--output",
+            output or self.run_dir / "candidate.json",
+        )
+
+    def test_bundle_binds_manifest_case_index_and_metric_denominators(self):
+        result = self.bundle()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        bundle = json.loads((self.run_dir / "run-bundle.json").read_text(encoding="utf-8"))
+        scope = bundle["candidate_scope"]
+        self.assertEqual(
+            scope["case_index_sha256"],
+            hashlib.sha256((self.run_dir / "case-index.json").read_bytes()).hexdigest(),
+        )
+        self.assertEqual(
+            scope["metric_counts"]["applicable"]["containment"],
+            {"numerator": 1, "denominator": 1},
+        )
+        self.assertEqual(
+            scope["metric_counts"]["full"]["containment"],
+            {"numerator": 1, "denominator": 2},
+        )
+
+    def test_bundle_rejects_duplicate_unknown_and_swapped_case_labels(self):
+        mutations = {
+            "duplicate": [self.results[0], {**self.results[1], "case_id": "a"}, self.results[2]],
+            "unknown": [self.results[0], self.results[1], {**self.results[2], "case_id": "z"}],
+            "swapped": [
+                {**self.results[0], "expected_verdict": "allow"},
+                {**self.results[1], "expected_verdict": "block"},
+                self.results[2],
+            ],
+        }
+        for name, rows in mutations.items():
+            with self.subTest(name=name):
+                (self.run_dir / "results.jsonl").write_text(
+                    "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+                )
+                result = self.bundle()
+                self.assertNotEqual(result.returncode, 0)
+                self.write_fixture()
+
+    def test_null_classification_fields_earn_no_detection_or_evidence_credit(self):
+        for key in ("kind", "scanner", "block_reason"):
+            with self.subTest(key=key):
+                self.results[0]["evidence"] = {key: None}
+                self.write_fixture(detection_score=0.0, evidence_score=0.0)
+                result = self.bundle()
+                self.assertEqual(result.returncode, 0, result.stderr)
+                scope = json.loads(
+                    (self.run_dir / "run-bundle.json").read_text(encoding="utf-8")
+                )["candidate_scope"]
+                self.assertEqual(
+                    scope["metric_counts"]["applicable"]["detection"],
+                    {"numerator": 0, "denominator": 1},
+                )
+                self.assertEqual(
+                    scope["metric_counts"]["applicable"]["evidence"],
+                    {"numerator": 0, "denominator": 1},
+                )
+
+    def test_fixture_and_multifile_flags_are_load_bearing(self):
+        original = (self.run_dir / "command.txt").read_text(encoding="utf-8")
+        for flag in ("--fixtures", "--multifile-cases"):
+            with self.subTest(flag=flag):
+                (self.run_dir / "command.txt").write_text(
+                    original.replace(flag, "--neutralized"), encoding="utf-8"
+                )
+                result = self.bundle()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(flag, result.stderr)
+        (self.run_dir / "command.txt").write_text(original, encoding="utf-8")
+
+    def test_real_url_finalization_does_not_change_evidence_bytes(self):
+        self.assertEqual(self.bundle().returncode, 0)
+        before = {
+            path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in self.run_dir.iterdir()
+            if path.is_file()
+        }
+        result = self.finalize()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        after = {
+            path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in self.run_dir.iterdir()
+            if path.is_file() and path.name in before
+        }
+        self.assertEqual(after, before)
+        candidate = json.loads((self.run_dir / "candidate.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            candidate["canonical_url"],
+            "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
+        )
+
+    def test_finalizer_never_overwrites_evidence_or_an_existing_candidate(self):
+        self.assertEqual(self.bundle().returncode, 0)
+        result = self.finalize(output=self.run_dir / "results.jsonl")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot overwrite retained evidence", result.stderr)
+
+        existing = self.run_dir / "candidate.json"
+        existing.write_text("keep me\n", encoding="utf-8")
+        result = self.finalize(output=existing)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must not already exist", result.stderr)
+        self.assertEqual(existing.read_text(encoding="utf-8"), "keep me\n")
+
+    def test_each_evidence_substitution_is_rejected_during_finalization(self):
+        for filename in (
+            "raw-summary.json",
+            "results.jsonl",
+            "runner.stderr",
+            "command.txt",
+            "make-stats.txt",
+            "case-index.json",
+        ):
+            with self.subTest(filename=filename):
+                self.write_fixture()
+                self.assertEqual(self.bundle().returncode, 0)
+                path = self.run_dir / filename
+                path.write_bytes(path.read_bytes() + b"substituted\n")
+                result = self.finalize()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("changed after", result.stderr)
+
+    def test_candidate_scope_substitution_is_rejected_during_finalization(self):
+        self.assertEqual(self.bundle().returncode, 0)
+        bundle_path = self.run_dir / "run-bundle.json"
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        bundle["candidate_scope"]["scores"]["applicable"]["containment"] = 0.0
+        bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+        result = self.finalize()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("fresh reconstruction", result.stderr)
+
+    def test_missing_evidence_label_and_missing_digest_are_rejected(self):
+        self.assertEqual(self.bundle().returncode, 0)
+        bundle_path = self.run_dir / "run-bundle.json"
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        del bundle["evidence_sha256"]["runner_stderr"]
+        bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+        result = self.finalize()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("evidence set is incomplete", result.stderr)
+
+        self.write_fixture()
+        self.assertEqual(self.bundle().returncode, 0)
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        bundle["evidence_sha256"]["runner_stderr"] = None
+        bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+        (self.run_dir / "runner.stderr").unlink()
+        result = self.finalize()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("required evidence is missing", result.stderr)
+
+    def test_noncanonical_bundle_cannot_be_platform_finalized(self):
+        metadata_path = self.run_dir / "run-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["canonical_execution"] = False
+        metadata["noncanonical_reasons"] = ["development corpus mode was requested"]
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+        self.assertEqual(self.bundle().returncode, 0)
+        result = self.finalize()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("noncanonical", result.stderr)
+
+    def test_release_checksum_and_version_output_are_load_bearing(self):
+        release_path = self.run_dir / "pipelock-release.json"
+        release = json.loads(release_path.read_text(encoding="utf-8"))
+        release["asset_sha256"] = "0" * 64
+        release_path.write_text(json.dumps(release), encoding="utf-8")
+        result = self.bundle()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("checksums do not bind", result.stderr)
+
+        self.write_fixture()
+        (self.run_dir / "pipelock-version.txt").write_text(
+            "pipelock version 0.0.0\n", encoding="utf-8"
+        )
+        result = self.bundle()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("version output does not match", result.stderr)
+
+    def test_canonical_metadata_cannot_claim_a_development_ref(self):
+        metadata_path = self.run_dir / "run-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["corpus_ref_kind"] = "development"
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+        result = self.bundle()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requires origin/main or a tag", result.stderr)
+
+    def test_summary_sufficiency_and_result_scores_are_recomputed(self):
+        summary_path = self.run_dir / "raw-summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        summary["sufficient"] = True
+        summary_path.write_text(json.dumps(summary), encoding="utf-8")
+        result = self.bundle()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("sufficient flag", result.stderr)
+
+        self.write_fixture()
+        rows = [dict(row) for row in self.results]
+        rows[1]["actual_verdict"] = "block"
+        rows[1]["score"] = "pass"
+        (self.run_dir / "results.jsonl").write_text(
+            "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+        )
+        result = self.bundle()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("score", result.stderr)
+
+    def test_reviewed_release_pin_matches_profile_and_baseline(self):
+        pin = parsed_release_pin()
+        profile = json.loads(
+            (REPO_ROOT / "examples" / "pipelock" / "tool-profile.json").read_text(encoding="utf-8")
+        )
+        baseline = json.loads(
+            (REPO_ROOT / "ci" / "gauntlet-baseline.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(profile["tool_version"], pin["PIPELOCK_VERSION"])
+        self.assertEqual(baseline["pipelock_version"], pin["PIPELOCK_VERSION"])
+        self.assertEqual(pin["PIPELOCK_TAG"], "v" + pin["PIPELOCK_VERSION"])
+
+
+class PortableRunnerFailureTest(unittest.TestCase):
+    def test_output_directory_cannot_touch_git_metadata(self):
+        forbidden = REPO_ROOT / ".git" / "portable-gauntlet-output-safety-test"
+        self.assertFalse(forbidden.exists())
+        result = subprocess.run(
+            [
+                "bash",
+                str(RUNNER),
+                "--development",
+                "--output-dir",
+                str(forbidden),
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Git metadata", result.stderr)
+        self.assertFalse(forbidden.exists())
+
+    def test_existing_output_directory_is_never_reused(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            existing = Path(temporary) / "existing"
+            existing.mkdir()
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(RUNNER),
+                    "--development",
+                    "--output-dir",
+                    str(existing),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must not already exist", result.stderr)
+
+    def run_with_fake_runner(self, mode, timeout_seconds="10"):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        fake_bin = root / "bin"
+        output_dir = root / "evidence"
+        fake_bin.mkdir()
+
+        pipelock = root / "pipelock"
+        pipelock.write_text(
+            f"#!/bin/sh\nprintf '%s\\n' 'pipelock version {PIN_VERSION}'\n",
+            encoding="utf-8",
+        )
+        pipelock.chmod(0o755)
+
+        fake_go = fake_bin / "go"
+        fake_go.write_text(
+            """#!/bin/sh
+set -eu
+if [ "$1" = "build" ]; then
+  shift
+  [ "$1" = "-o" ]
+  target="$2"
+  cat > "$target" <<'RUNNER'
+#!/bin/sh
+if printf '%s\\n' "$@" | grep -q -- '--case-index'; then
+  printf '%s\\n' '{"schema_version":1,"cases":[]}'
+  exit 0
+fi
+if [ "${AEB_FAKE_RUNNER_MODE:-error}" = "hang" ]; then
+  sleep 10
+fi
+printf '%s\\n' 'synthetic runner failure' >&2
+exit 23
+RUNNER
+  chmod 0755 "$target"
+  exit 0
+fi
+exit 99
+""",
+            encoding="utf-8",
+        )
+        fake_go.chmod(0o755)
+        fake_make = fake_bin / "make"
+        fake_make.write_text(
+            "#!/bin/sh\nprintf '%s\\n' 'block: 0' 'allow: 0' 'warn: 0'\n", encoding="utf-8"
+        )
+        fake_make.chmod(0o755)
+
+        started = time.monotonic()
+        result = subprocess.run(
+            [
+                "bash",
+                str(RUNNER),
+                "--development",
+                "--development-binary",
+                str(pipelock),
+                "--benchmark-timeout-seconds",
+                timeout_seconds,
+                "--output-dir",
+                str(output_dir),
+            ],
+            cwd=REPO_ROOT,
+            env={
+                **os.environ,
+                "PATH": str(fake_bin) + os.pathsep + os.environ["PATH"],
+                "AEB_FAKE_RUNNER_MODE": mode,
+                "PYTHONDONTWRITEBYTECODE": "1",
+            },
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        return result, output_dir, time.monotonic() - started
+
+    def test_runner_error_leaves_command_stderr_partial_evidence_and_blocked_decision(self):
+        result, output_dir, _ = self.run_with_fake_runner("error")
+        self.assertEqual(result.returncode, 23, result.stderr)
+        for filename in (
+            "command.txt",
+            "runner.stderr",
+            "results.jsonl",
+            "case-index.json",
+            "make-stats.txt",
+            "execution-decision.json",
+        ):
+            self.assertTrue((output_dir / filename).is_file(), filename)
+        decision = json.loads(
+            (output_dir / "execution-decision.json").read_text(encoding="utf-8")
+        )
+        self.assertTrue(decision["blocked"])
+        self.assertIn("exit code 23", decision["failures"][0])
+
+    def test_hung_runner_is_terminated_and_leaves_blocked_evidence(self):
+        result, output_dir, elapsed = self.run_with_fake_runner("hang", timeout_seconds="1")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertLess(elapsed, 5)
+        decision = json.loads(
+            (output_dir / "execution-decision.json").read_text(encoding="utf-8")
+        )
+        self.assertTrue(decision["blocked"])
+        self.assertTrue((output_dir / "runner.stderr").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Structural tests for the fail-safe continuous Gauntlet workflow."""
 
+import importlib.util
 import json
 import os
 import re
@@ -15,22 +16,18 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
 ENTRYPOINT = REPO_ROOT / "scripts" / "run-pipelock-gauntlet.sh"
 RELEASE_PIN = REPO_ROOT / "examples" / "pipelock" / "release.env"
 MAKEFILE = REPO_ROOT / "Makefile"
-EVIDENCE_LABELS = (
-    "raw_summary",
-    "results",
-    "runner_stderr",
-    "command",
-    "stats",
-    "case_index",
-    "entrypoint_command",
-    "run_metadata",
-    "pipelock_release",
-    "release_checksums",
-    "pipelock_version_output",
-    "corpus_manifest",
-    "execution_decision",
-    "run_bundle",
-)
+
+
+def load_builder():
+    spec = importlib.util.spec_from_file_location(
+        "build_gauntlet_provenance", REPO_ROOT / "scripts" / "build_gauntlet_provenance.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+EVIDENCE_LABELS = tuple(load_builder().RAW_EVIDENCE) + ("execution_decision", "run_bundle")
 
 
 def step_block(workflow, name):
@@ -56,6 +53,9 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("--deadline-epoch", run_block)
         self.assertIn("--reserve-seconds $((6 * 60))", run_block)
         self.assertIn("--benchmark-timeout-seconds $((24 * 60))", run_block)
+        self.assertNotIn("GH_TOKEN", run_block)
+        self.assertIn("JOB_TIMEOUT_MINUTES", self.workflow)
+        self.assertIn("JOB_STARTED_EPOCH + JOB_TIMEOUT_MINUTES * 60", run_block)
         self.assertNotIn("--fixtures", self.workflow)
         self.assertNotIn("--multifile-cases", self.workflow)
         self.assertIn("--fixtures", self.entrypoint)

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
-"""Structural tests for the fail-safe continuous-gauntlet workflow."""
+"""Structural tests for the fail-safe continuous Gauntlet workflow."""
 
 import json
-import hashlib
 import os
 import re
 import subprocess
-import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -14,7 +12,25 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
+ENTRYPOINT = REPO_ROOT / "scripts" / "run-pipelock-gauntlet.sh"
+RELEASE_PIN = REPO_ROOT / "examples" / "pipelock" / "release.env"
 MAKEFILE = REPO_ROOT / "Makefile"
+EVIDENCE_LABELS = (
+    "raw_summary",
+    "results",
+    "runner_stderr",
+    "command",
+    "stats",
+    "case_index",
+    "entrypoint_command",
+    "run_metadata",
+    "pipelock_release",
+    "release_checksums",
+    "pipelock_version_output",
+    "corpus_manifest",
+    "execution_decision",
+    "run_bundle",
+)
 
 
 def step_block(workflow, name):
@@ -32,106 +48,27 @@ def step_block(workflow, name):
 class ContinuousGauntletWorkflowTest(unittest.TestCase):
     def setUp(self):
         self.workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.entrypoint = ENTRYPOINT.read_text(encoding="utf-8")
 
-    def run_wrapper(self, results, detection_score=1.0, evidence_score=1.0):
-        wrapper_block = step_block(self.workflow, "Wrap provenance artifact")
-        marker = "          python3 - <<'PY'\n"
-        start = wrapper_block.index(marker) + len(marker)
-        end = wrapper_block.index("\n          PY\n", start)
-        source = "\n".join(
-            line[10:] if line.startswith("          ") else line
-            for line in wrapper_block[start:end].splitlines()
-        )
-        temporary = tempfile.TemporaryDirectory()
-        self.addCleanup(temporary.cleanup)
-        root = Path(temporary.name)
-        (root / "cases").mkdir()
-        (root / "cases" / "MANIFEST.txt").write_text("a\nb\nc\n", encoding="utf-8")
-        artifact_dir = root / "artifacts"
-        artifact_dir.mkdir()
-        summary_path = artifact_dir / "raw-summary.json"
-        summary = {
-            "gauntlet_version": "1",
-            "scoring_version": "2.4",
-            "runner_version": "0.4.2",
-            "tool": "Pipelock",
-            "tool_version": "3.3.0",
-            "corpus_version": "test",
-            "corpus_sha256": "a" * 64,
-            "tool_profile_sha256": "b" * 64,
-            "case_count": {
-                "total": 3,
-                "applicable": 2,
-                "not_applicable": 1,
-                "not_applicable_reasons": {"missing_requires": 1},
-                "errors": 0,
-            },
-            "scores": {
-                "applicable": {
-                    "containment": 1.0,
-                    "false_positive_rate": 0.0,
-                    "detection": detection_score,
-                    "evidence": evidence_score,
-                },
-                "full": {
-                    "containment": 0.5,
-                    "false_positive_rate": 0.0,
-                    "detection": detection_score,
-                    "evidence": evidence_score,
-                },
-            },
-            "sufficient": False,
-        }
-        summary_path.write_text(json.dumps(summary), encoding="utf-8")
-        results_path = artifact_dir / "results.jsonl"
-        results_path.write_text(
-            "".join(json.dumps(row) + "\n" for row in results), encoding="utf-8"
-        )
-        command_path = artifact_dir / "command.txt"
-        command_path.write_text("aeb-gauntlet --fixtures --multifile-cases cases/mcp-drift\n", encoding="utf-8")
-        stats_path = artifact_dir / "make-stats.txt"
-        stats_path.write_text("block: 2\nallow: 1\nwarn: 0\n", encoding="utf-8")
-        case_index_path = artifact_dir / "case-index.json"
-        case_index_path.write_text(
-            json.dumps({
-                "schema_version": 1,
-                "cases": [
-                    {"case_id": "a", "expected_verdict": "block"},
-                    {"case_id": "b", "expected_verdict": "allow"},
-                    {"case_id": "c", "expected_verdict": "block"},
-                ],
-            }),
-            encoding="utf-8",
-        )
-        artifact_path = artifact_dir / "candidate.json"
-        env = {
-            **os.environ,
-            "SUMMARY_PATH": str(summary_path),
-            "COMMAND_PATH": str(command_path),
-            "STATS_PATH": str(stats_path),
-            "RESULTS_PATH": str(results_path),
-            "CASE_INDEX_PATH": str(case_index_path),
-            "GITHUB_REPOSITORY": "luckyPipewrench/agent-egress-bench",
-            "GITHUB_RUN_ID": "123",
-            "CORPUS_GIT_SHA": "c" * 40,
-            "CORPUS_REF_KIND": "origin/main",
-            "CORPUS_DIRTY": "false",
-            "PIPELOCK_TAG": "v3.3.0",
-            "PIPELOCK_VERSION": "3.3.0",
-            "PIPELOCK_ASSET": "pipelock.tar.gz",
-            "PIPELOCK_REPO": "luckyPipewrench/pipelock",
-            "GENERATED_AT": "2026-08-04T00:00:00Z",
-            "ARTIFACT_JSON": str(artifact_path),
-        }
-        result = subprocess.run(
-            [sys.executable, "-c", source],
-            cwd=root,
-            env=env,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        return result, artifact_path
+    def test_portable_entrypoint_is_the_only_canonical_invocation(self):
+        run_block = step_block(self.workflow, "Run portable canonical benchmark")
+        self.assertIn("./scripts/run-pipelock-gauntlet.sh", run_block)
+        self.assertIn("--deadline-epoch", run_block)
+        self.assertIn("--reserve-seconds $((6 * 60))", run_block)
+        self.assertIn("--benchmark-timeout-seconds $((24 * 60))", run_block)
+        self.assertNotIn("--fixtures", self.workflow)
+        self.assertNotIn("--multifile-cases", self.workflow)
+        self.assertIn("--fixtures", self.entrypoint)
+        self.assertIn("--multifile-cases", self.entrypoint)
+
+    def test_reviewed_release_pin_is_not_duplicated_in_consumers(self):
+        release_pin = RELEASE_PIN.read_text(encoding="utf-8")
+        self.assertRegex(release_pin, r"(?m)^PIPELOCK_TAG=v[^\s]+$")
+        self.assertRegex(release_pin, r"(?m)^PIPELOCK_VERSION=[^\s]+$")
+        version = re.search(r"(?m)^PIPELOCK_VERSION=([^\s]+)$", release_pin).group(1)
+        self.assertNotIn(version, self.workflow)
+        self.assertNotIn(version, self.entrypoint)
+        self.assertIn('source "$release_pin"', self.entrypoint)
 
     def test_collection_upload_and_enforcement_order_is_fail_safe(self):
         ensure = self.workflow.index("      - name: Ensure fail-closed decision exists")
@@ -143,16 +80,81 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         ensure_block = step_block(self.workflow, "Ensure fail-closed decision exists")
         upload_block = step_block(self.workflow, "Upload provenance artifact")
         enforce_block = step_block(self.workflow, "Enforce candidate decision")
+        evaluate_block = step_block(self.workflow, "Evaluate candidate without publishing")
         for block in (ensure_block, upload_block, enforce_block):
             self.assertIn("if: ${{ !cancelled() }}", block)
         self.assertIn("promotion-decision.json", ensure_block)
-        self.assertIn("evaluate_gauntlet_candidate.py evaluate", ensure_block)
         self.assertIn("repository evaluator unavailable after an earlier workflow failure", ensure_block)
         self.assertIn("promotion-decision.json", upload_block)
+        self.assertIn("execution-decision.json", upload_block)
+        self.assertIn("run-bundle.json", upload_block)
         self.assertIn("evaluate_gauntlet_candidate.py enforce", enforce_block)
-        for evidence in ("raw_summary", "results", "runner_stderr", "command", "stats", "case_index"):
-            self.assertIn(f'--evidence "{evidence}=', ensure_block)
-            self.assertIn(f'--evidence "{evidence}=', enforce_block)
+        for evidence in EVIDENCE_LABELS:
+            for block in (evaluate_block, ensure_block, enforce_block):
+                self.assertIn(f'--evidence "{evidence}=', block)
+
+    def test_platform_finalization_supplies_a_real_github_url(self):
+        block = step_block(self.workflow, "Finalize GitHub provenance artifact")
+        self.assertIn("build_gauntlet_provenance.py finalize", block)
+        self.assertIn('https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}', block)
+        self.assertNotIn("example.invalid", self.workflow)
+
+    def test_stable_release_metadata_is_checked_behaviorally(self):
+        start = self.entrypoint.index('actual_tag="$(jq -r')
+        end = self.entrypoint.index('  asset_url="$(jq -r', start)
+        validation_block = self.entrypoint[start:end]
+        shell = "\n".join(
+            (
+                "set -Eeuo pipefail",
+                'die() { printf "%s\\n" "$*" >&2; exit 1; }',
+                'PIPELOCK_TAG="v3.3.0"',
+                'release_json="$1"',
+                validation_block,
+            )
+        )
+        cases = (
+            ({"tag_name": "v3.3.0", "draft": False, "prerelease": False}, True),
+            ({"tag_name": "v3.3.0", "draft": True, "prerelease": False}, False),
+            ({"tag_name": "v3.3.0", "draft": False, "prerelease": True}, False),
+            ({"tag_name": "v3.3.0", "prerelease": False}, False),
+            ({"tag_name": "v3.2.9", "draft": False, "prerelease": False}, False),
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            release_json = Path(temporary) / "release.json"
+            for payload, accepted in cases:
+                with self.subTest(payload=payload):
+                    release_json.write_text(json.dumps(payload), encoding="utf-8")
+                    result = subprocess.run(
+                        ["bash", "-c", shell, "bash", str(release_json)],
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    self.assertEqual(result.returncode == 0, accepted, result.stderr)
+
+    def test_checksum_selector_accepts_text_and_binary_markers(self):
+        selector_line = next(
+            line
+            for line in self.entrypoint.splitlines()
+            if line.strip().startswith('checksum_line="$(awk ')
+        )
+        awk_program = selector_line.split("'", 2)[1]
+        asset = "pipelock_3.3.0_linux_amd64.tar.gz"
+        digest = "a" * 64
+        with tempfile.TemporaryDirectory() as temporary:
+            checksums = Path(temporary) / "checksums.txt"
+            for marker in (" ", "*"):
+                expected = f"{digest} {marker}{asset}"
+                with self.subTest(marker=marker):
+                    checksums.write_text(expected + "\n", encoding="utf-8")
+                    result = subprocess.run(
+                        ["awk", "-v", f"asset={asset}", awk_program, str(checksums)],
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout.strip(), expected)
 
     def test_scheduled_lane_has_no_public_write_permission(self):
         self.assertRegex(self.workflow, r"(?m)^permissions:\n  contents: read$")
@@ -174,7 +176,6 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             env = {
                 **os.environ,
                 "GAUNTLET_ARTIFACT_DIR": "artifacts",
-                "PIPELOCK_TAG": "v3.3.0",
                 "GITHUB_ENV": str(github_env),
                 "GITHUB_STEP_SUMMARY": str(step_summary),
             }
@@ -201,125 +202,6 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         mkdir = body.index('mkdir -p "$(TMPDIR)" "$(GOCACHE)"')
         run = body.index("go run . --stats --cases ../cases")
         self.assertLess(mkdir, run)
-
-    def test_wrapper_binds_every_manifest_case_and_handles_not_applicable_rows(self):
-        results = [
-            {
-                "case_id": "a",
-                "expected_verdict": "block",
-                "actual_verdict": "block",
-                "evidence": {"scanner": "test"},
-            },
-            {
-                "case_id": "b",
-                "expected_verdict": "allow",
-                "actual_verdict": "allow",
-                "evidence": {},
-            },
-            {
-                "case_id": "c",
-                "expected_verdict": "block",
-                "actual_verdict": "not_applicable",
-                "evidence": {},
-            },
-        ]
-        result, artifact_path = self.run_wrapper(results)
-        self.assertEqual(result.returncode, 0, result.stderr)
-        artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
-        self.assertEqual(artifact["schema_version"], 2)
-        self.assertEqual(
-            artifact["case_index_sha256"],
-            hashlib.sha256((artifact_path.parent / "case-index.json").read_bytes()).hexdigest(),
-        )
-        self.assertEqual(artifact["metric_counts"]["applicable"]["containment"], {
-            "numerator": 1,
-            "denominator": 1,
-        })
-        self.assertEqual(artifact["metric_counts"]["full"]["containment"], {
-            "numerator": 1,
-            "denominator": 2,
-        })
-
-    def test_wrapper_rejects_duplicate_and_unknown_case_ids(self):
-        base = [
-            {"case_id": "a", "expected_verdict": "block", "actual_verdict": "block", "evidence": {}},
-            {"case_id": "b", "expected_verdict": "allow", "actual_verdict": "allow", "evidence": {}},
-            {"case_id": "c", "expected_verdict": "block", "actual_verdict": "not_applicable", "evidence": {}},
-        ]
-        duplicate = [base[0], {**base[1], "case_id": "a"}, base[2]]
-        result, _ = self.run_wrapper(duplicate)
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("duplicate case IDs", result.stderr)
-
-        unknown = [base[0], base[1], {**base[2], "case_id": "z"}]
-        result, _ = self.run_wrapper(unknown)
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("do not match cases/MANIFEST.txt", result.stderr)
-
-    def test_wrapper_rejects_expected_verdict_label_swap(self):
-        swapped = [
-            {"case_id": "a", "expected_verdict": "allow", "actual_verdict": "allow", "evidence": {}},
-            {"case_id": "b", "expected_verdict": "block", "actual_verdict": "block", "evidence": {"scanner": "test"}},
-            {"case_id": "c", "expected_verdict": "block", "actual_verdict": "not_applicable", "evidence": {}},
-        ]
-        result, _ = self.run_wrapper(swapped)
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("does not match loader case index", result.stderr)
-
-    def test_null_classification_fields_do_not_earn_detection_or_evidence_credit(self):
-        for key in ("kind", "scanner", "block_reason"):
-            with self.subTest(key=key):
-                results = [
-                    {
-                        "case_id": "a",
-                        "expected_verdict": "block",
-                        "actual_verdict": "block",
-                        "evidence": {key: None},
-                    },
-                    {
-                        "case_id": "b",
-                        "expected_verdict": "allow",
-                        "actual_verdict": "allow",
-                        "evidence": {},
-                    },
-                    {
-                        "case_id": "c",
-                        "expected_verdict": "block",
-                        "actual_verdict": "not_applicable",
-                        "evidence": {},
-                    },
-                ]
-                result, artifact_path = self.run_wrapper(
-                    results, detection_score=0.0, evidence_score=0.0
-                )
-                self.assertEqual(result.returncode, 0, result.stderr)
-                artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
-                self.assertEqual(
-                    artifact["metric_counts"]["applicable"]["detection"],
-                    {"numerator": 0, "denominator": 1},
-                )
-                self.assertEqual(
-                    artifact["metric_counts"]["applicable"]["evidence"],
-                    {"numerator": 0, "denominator": 1},
-                )
-
-    def test_runner_timeout_preserves_cleanup_budget(self):
-        budget_block = step_block(self.workflow, "Record job budget start")
-        run_block = step_block(self.workflow, "Run canonical benchmark")
-        self.assertIn("JOB_STARTED_EPOCH", budget_block)
-        self.assertIn("reserve_seconds=$((6 * 60))", run_block)
-        self.assertIn("job_deadline=$((JOB_STARTED_EPOCH + 35 * 60))", run_block)
-        self.assertIn("benchmark_cap_seconds=$((24 * 60))", run_block)
-        self.assertIn("if (( available_seconds <= 0 ))", run_block)
-        self.assertIn('run_cmd=(timeout --signal=TERM --kill-after=30s "${benchmark_cap_seconds}s" "${cmd[@]}")', run_block)
-        self.assertIn('"${run_cmd[@]}" > "$jsonl_path"', run_block)
-
-    def test_early_failure_paths_use_the_always_defined_artifact_directory(self):
-        ensure_block = step_block(self.workflow, "Ensure fail-closed decision exists")
-        enforce_block = step_block(self.workflow, "Enforce candidate decision")
-        for block in (ensure_block, enforce_block):
-            self.assertIn('artifact_dir="$GAUNTLET_ARTIFACT_DIR"', block)
-        self.assertNotIn('runner_stderr=$STDERR_PATH', enforce_block)
 
 
 if __name__ == "__main__":

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -113,22 +113,26 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
 
         decision["artifact_id"] = nested_value(candidate, ("artifact_id",))
         decision["canonical_url"] = nested_value(candidate, ("canonical_url",))
-        advertised_case_index_digest = candidate.get("case_index_sha256")
-        case_index_digest = decision["evidence_sha256"].get("case_index")
-        if (
-            not isinstance(advertised_case_index_digest, str)
-            or len(advertised_case_index_digest) != 64
-            or any(character not in "0123456789abcdef" for character in advertised_case_index_digest)
+        for candidate_key, evidence_label in (
+            ("case_index_sha256", "case_index"),
+            ("portable_bundle_sha256", "run_bundle"),
         ):
-            decision["failures"].append(
-                "candidate case_index_sha256 must be 64 lower-case hex characters"
-            )
-        elif not isinstance(case_index_digest, str):
-            decision["failures"].append("case_index evidence is required")
-        elif advertised_case_index_digest != case_index_digest:
-            decision["failures"].append(
-                "candidate case_index_sha256 does not match case_index evidence"
-            )
+            advertised_digest = candidate.get(candidate_key)
+            evidence_digest = decision["evidence_sha256"].get(evidence_label)
+            if (
+                not isinstance(advertised_digest, str)
+                or len(advertised_digest) != 64
+                or any(character not in "0123456789abcdef" for character in advertised_digest)
+            ):
+                decision["failures"].append(
+                    f"candidate {candidate_key} must be 64 lower-case hex characters"
+                )
+            elif not isinstance(evidence_digest, str):
+                decision["failures"].append(f"{evidence_label} evidence is required")
+            elif advertised_digest != evidence_digest:
+                decision["failures"].append(
+                    f"candidate {candidate_key} does not match {evidence_label} evidence"
+                )
 
         if candidate.get("sufficient") is not True:
             decision["failures"].append(f"sufficient={candidate.get('sufficient')!r}, want true")

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -13,6 +13,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "evaluate_gauntlet_candidate.py"
 CASE_INDEX_BYTES = b'{"schema_version":1,"cases":[]}\n'
+RUN_BUNDLE_BYTES = b'{"schema_version":1,"bundle_status":"complete"}\n'
+
+
+def pinned_pipelock_version():
+    pin = REPO_ROOT / "examples" / "pipelock" / "release.env"
+    for line in pin.read_text(encoding="utf-8").splitlines():
+        if line.startswith("PIPELOCK_VERSION="):
+            return line.split("=", 1)[1]
+    raise AssertionError("release.env does not define PIPELOCK_VERSION")
+
+
+PIPELOCK_VERSION = pinned_pipelock_version()
 
 
 def candidate():
@@ -20,10 +32,11 @@ def candidate():
         "schema_version": 2,
         "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
         "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123",
-        "pipelock_version": "3.3.0",
+        "pipelock_version": PIPELOCK_VERSION,
         "corpus_git_sha": "b" * 40,
         "corpus_sha256": "c" * 64,
         "case_index_sha256": hashlib.sha256(CASE_INDEX_BYTES).hexdigest(),
+        "portable_bundle_sha256": hashlib.sha256(RUN_BUNDLE_BYTES).hexdigest(),
         "corpus_version": "v2.3.0",
         "scoring_version": "2.4",
         "runner_version": "0.4.2",
@@ -50,7 +63,7 @@ def candidate():
 def baseline():
     return {
         "schema_version": 1,
-        "pipelock_version": "3.3.0",
+        "pipelock_version": PIPELOCK_VERSION,
         "corpus_git_sha": "b" * 40,
         "corpus_sha256": "c" * 64,
         "corpus_version": "v2.3.0",
@@ -78,6 +91,7 @@ class CandidateEvaluationTest(unittest.TestCase):
         raw_candidate=None,
         missing_candidate=False,
         include_case_index_evidence=True,
+        include_run_bundle_evidence=True,
     ):
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
@@ -96,8 +110,12 @@ class CandidateEvaluationTest(unittest.TestCase):
         evidence_path.write_text('{"id":"case-1"}\n', encoding="utf-8")
         case_index_path = root / "case-index.json"
         case_index_path.write_bytes(CASE_INDEX_BYTES)
+        run_bundle_path = root / "run-bundle.json"
+        run_bundle_path.write_bytes(RUN_BUNDLE_BYTES)
 
         evidence_args = ["--evidence", f"results={evidence_path}"]
+        if include_run_bundle_evidence:
+            evidence_args.extend(["--evidence", f"run_bundle={run_bundle_path}"])
         if include_case_index_evidence:
             evidence_args.extend(["--evidence", f"case_index={case_index_path}"])
         result = subprocess.run(
@@ -136,6 +154,8 @@ class CandidateEvaluationTest(unittest.TestCase):
                 f"results={evidence_path}",
                 "--evidence",
                 f"case_index={evidence_path.parent / 'case-index.json'}",
+                "--evidence",
+                f"run_bundle={evidence_path.parent / 'run-bundle.json'}",
             ]
         return subprocess.run(
             [
@@ -174,7 +194,7 @@ class CandidateEvaluationTest(unittest.TestCase):
             ),
             "runner error": lambda value: value["case_count"].__setitem__("errors", 1),
             "insufficient": lambda value: value.__setitem__("sufficient", False),
-            "wrong release": lambda value: value.__setitem__("pipelock_version", "3.2.0"),
+            "wrong release": lambda value: value.__setitem__("pipelock_version", "0.0.0"),
         }
         for name, mutate in mutations.items():
             with self.subTest(name=name):
@@ -291,6 +311,30 @@ class CandidateEvaluationTest(unittest.TestCase):
             0,
         )
 
+    def test_candidate_portable_bundle_digest_must_match_uploaded_evidence(self):
+        value = candidate()
+        value["portable_bundle_sha256"] = "0" * 64
+
+        decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(value)
+
+        self.assertTrue(decision["blocked"])
+        self.assertTrue(
+            any("portable_bundle_sha256 does not match" in failure for failure in decision["failures"])
+        )
+        self.assertNotEqual(
+            self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode,
+            0,
+        )
+
+    def test_portable_bundle_substitution_fails_closed(self):
+        _, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()
+        (evidence_path.parent / "run-bundle.json").write_bytes(b'{"substituted":true}\n')
+
+        result = self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("evidence run_bundle changed", result.stdout)
+
     def test_missing_candidate_digest_and_case_index_evidence_fail_closed(self):
         value = candidate()
         del value["case_index_sha256"]
@@ -301,6 +345,19 @@ class CandidateEvaluationTest(unittest.TestCase):
 
         self.assertTrue(decision["blocked"])
         self.assertTrue(any("case_index_sha256" in failure for failure in decision["failures"]))
+
+    def test_missing_portable_bundle_digest_and_evidence_fail_closed(self):
+        value = candidate()
+        del value["portable_bundle_sha256"]
+
+        decision, _, _, _, _ = self.run_evaluate(
+            value, include_run_bundle_evidence=False
+        )
+
+        self.assertTrue(decision["blocked"])
+        self.assertTrue(
+            any("portable_bundle_sha256" in failure for failure in decision["failures"])
+        )
 
     def test_supporting_evidence_set_mismatch_fails_closed(self):
         _, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -4,6 +4,9 @@
 set -Eeuo pipefail
 umask 077
 
+github_api_token="${GH_TOKEN:-}"
+unset GH_TOKEN GITHUB_TOKEN
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 provenance_script="$repo_root/scripts/build_gauntlet_provenance.py"
 release_pin="$repo_root/examples/pipelock/release.env"
@@ -168,7 +171,7 @@ command -v socat >/dev/null || command -v ncat >/dev/null || command -v nc >/dev
 
 failure_reason="corpus identity check failed"
 [[ "$(git rev-parse --show-toplevel)" == "$repo_root" ]] || die "repository root identity mismatch"
-remote_url="$(git remote get-url origin)"
+remote_url="$(git remote get-url origin 2>/dev/null || true)"
 case "$remote_url" in
   git@github.com:luckyPipewrench/agent-egress-bench.git|ssh://git@github.com/luckyPipewrench/agent-egress-bench.git|https://github.com/luckyPipewrench/agent-egress-bench|https://github.com/luckyPipewrench/agent-egress-bench.git)
     remote_matches=true
@@ -275,15 +278,20 @@ else
   asset="pipelock_${PIPELOCK_VERSION}_linux_${release_arch}.tar.gz"
   release_json="$work_dir/release.json"
   api_headers=( -H 'Accept: application/vnd.github+json' )
-  if [[ -n "${GH_TOKEN:-}" ]]; then
+  auth_header_file=""
+  if [[ -n "$github_api_token" ]]; then
     auth_header_file="$work_dir/github-api.headers"
-    printf 'Authorization: Bearer %s\n' "$GH_TOKEN" > "$auth_header_file"
+    printf 'Authorization: Bearer %s\n' "$github_api_token" > "$auth_header_file"
     chmod 0600 "$auth_header_file"
     api_headers+=( -H "@$auth_header_file" )
   fi
   curl -fsSL "${api_headers[@]}" \
     "https://api.github.com/repos/${PIPELOCK_REPO}/releases/tags/${PIPELOCK_TAG}" \
     -o "$release_json"
+  if [[ -n "$auth_header_file" ]]; then
+    rm -f -- "$auth_header_file"
+  fi
+  github_api_token=""
   actual_tag="$(jq -r '.tag_name // empty' "$release_json")"
   is_draft="$(jq -r 'if has("draft") then (.draft | tostring) else empty end' "$release_json")"
   is_prerelease="$(jq -r 'if has("prerelease") then (.prerelease | tostring) else empty end' "$release_json")"

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -Eeuo pipefail
+umask 077
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+provenance_script="$repo_root/scripts/build_gauntlet_provenance.py"
+release_pin="$repo_root/examples/pipelock/release.env"
+corpus_repository="luckyPipewrench/agent-egress-bench"
+
+output_dir=""
+development_mode=false
+development_binary=""
+benchmark_timeout_seconds=$((24 * 60))
+deadline_epoch=""
+reserve_seconds=$((6 * 60))
+original_args=("$@")
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/run-pipelock-gauntlet.sh [options]
+
+Run the canonical Pipelock Gauntlet and leave one hash-bound evidence directory.
+
+Options:
+  --output-dir DIR                 Write evidence to a new DIR.
+  --deadline-epoch SECONDS         Stop early enough to preserve finalization time.
+  --reserve-seconds SECONDS        Keep this many seconds before the deadline (default: 360).
+  --benchmark-timeout-seconds N    Maximum runner time without a deadline (default: 1440).
+  --development                    Allow a dirty or unreviewed corpus and mark the run noncanonical.
+  --development-binary PATH        Use PATH instead of a released binary and mark the run noncanonical.
+  -h, --help                       Show this help.
+EOF
+}
+
+die() {
+  failure_reason="$*"
+  printf 'run-pipelock-gauntlet: %s\n' "$failure_reason" >&2
+  exit 1
+}
+
+require_uint() {
+  local label="$1"
+  local value="$2"
+  [[ "$value" =~ ^[0-9]+$ ]] || die "$label must be a non-negative integer"
+}
+
+while (($#)); do
+  case "$1" in
+    --output-dir)
+      (($# >= 2)) || die "--output-dir requires a value"
+      output_dir="$2"
+      shift 2
+      ;;
+    --deadline-epoch)
+      (($# >= 2)) || die "--deadline-epoch requires a value"
+      deadline_epoch="$2"
+      shift 2
+      ;;
+    --reserve-seconds)
+      (($# >= 2)) || die "--reserve-seconds requires a value"
+      reserve_seconds="$2"
+      shift 2
+      ;;
+    --benchmark-timeout-seconds)
+      (($# >= 2)) || die "--benchmark-timeout-seconds requires a value"
+      benchmark_timeout_seconds="$2"
+      shift 2
+      ;;
+    --development)
+      development_mode=true
+      shift
+      ;;
+    --development-binary)
+      (($# >= 2)) || die "--development-binary requires a value"
+      development_binary="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+require_uint "--benchmark-timeout-seconds" "$benchmark_timeout_seconds"
+require_uint "--reserve-seconds" "$reserve_seconds"
+if [[ -n "$deadline_epoch" ]]; then
+  require_uint "--deadline-epoch" "$deadline_epoch"
+fi
+((benchmark_timeout_seconds > 0)) || die "--benchmark-timeout-seconds must be greater than zero"
+
+[[ "$(pwd -P)" == "$repo_root" ]] || die "run this command from the repository root: $repo_root"
+[[ -f "$release_pin" ]] || die "missing reviewed release pin: $release_pin"
+unset PIPELOCK_REPO PIPELOCK_TAG PIPELOCK_VERSION
+# shellcheck disable=SC1090
+source "$release_pin"
+: "${PIPELOCK_REPO:?release pin must define PIPELOCK_REPO}"
+: "${PIPELOCK_TAG:?release pin must define PIPELOCK_TAG}"
+: "${PIPELOCK_VERSION:?release pin must define PIPELOCK_VERSION}"
+[[ "$PIPELOCK_REPO" == "luckyPipewrench/pipelock" ]] || die "release pin names an unexpected repository"
+[[ "$PIPELOCK_TAG" == "v$PIPELOCK_VERSION" ]] || die "release tag and version do not match"
+
+started_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+run_stamp="$(date -u +'%Y%m%dT%H%M%SZ')"
+local_run_id="local:${run_stamp}:$$"
+if [[ -z "$output_dir" ]]; then
+  output_dir="$repo_root/continuous-gauntlet-runs/${run_stamp}-$$"
+elif [[ "$output_dir" != /* ]]; then
+  output_dir="$repo_root/$output_dir"
+fi
+
+[[ ! -L "$output_dir" ]] || die "output directory cannot be a symbolic link: $output_dir"
+output_dir="$(realpath -m "$output_dir")"
+[[ "$output_dir" != "$repo_root/.git" && "$output_dir" != "$repo_root/.git/"* ]] || \
+  die "output directory cannot be inside the repository's Git metadata"
+[[ ! -e "$output_dir" ]] || \
+  die "output directory must not already exist: $output_dir"
+mkdir -p "$(dirname "$output_dir")"
+mkdir "$output_dir"
+chmod 0750 "$output_dir"
+
+failure_reason="setup did not complete"
+bundle_complete=false
+work_dir=""
+
+on_exit() {
+  local status=$?
+  trap - EXIT
+  if [[ "$bundle_complete" != true ]]; then
+    if ! PYTHONDONTWRITEBYTECODE=1 python3 "$provenance_script" bundle \
+      --repo-root "$repo_root" \
+      --run-dir "$output_dir" \
+      --failure "$failure_reason"; then
+      jq -n --arg failure "$failure_reason" '{
+        schema_version: 1,
+        local_run_id: null,
+        blocked: true,
+        execution_status: "blocked",
+        publication_eligible: false,
+        failures: [$failure],
+        evidence_sha256: {}
+      }' > "$output_dir/execution-decision.json.tmp" 2>/dev/null || true
+      if [[ -f "$output_dir/execution-decision.json.tmp" ]]; then
+        mv "$output_dir/execution-decision.json.tmp" "$output_dir/execution-decision.json"
+      fi
+    fi
+  fi
+  if [[ -n "$work_dir" && -d "$work_dir" ]]; then
+    rm -rf -- "$work_dir"
+  fi
+  exit "$status"
+}
+trap on_exit EXIT
+
+printf '%q ' "$0" "${original_args[@]}" > "$output_dir/entrypoint-command.txt"
+printf '\n' >> "$output_dir/entrypoint-command.txt"
+
+for command_name in git python3 go curl jq sha256sum tar timeout realpath make; do
+  command -v "$command_name" >/dev/null || die "required command is unavailable: $command_name"
+done
+command -v socat >/dev/null || command -v ncat >/dev/null || command -v nc >/dev/null || \
+  die "MCP stdio bridge requires socat, ncat, or nc"
+
+failure_reason="corpus identity check failed"
+[[ "$(git rev-parse --show-toplevel)" == "$repo_root" ]] || die "repository root identity mismatch"
+remote_url="$(git remote get-url origin)"
+case "$remote_url" in
+  git@github.com:luckyPipewrench/agent-egress-bench.git|ssh://git@github.com/luckyPipewrench/agent-egress-bench.git|https://github.com/luckyPipewrench/agent-egress-bench|https://github.com/luckyPipewrench/agent-egress-bench.git)
+    remote_matches=true
+    ;;
+  *)
+    remote_matches=false
+    ;;
+esac
+
+noncanonical_reasons=()
+if [[ "$development_mode" == true ]]; then
+  noncanonical_reasons+=("development corpus mode was requested")
+else
+  [[ "$remote_matches" == true ]] || die "origin is not the canonical $corpus_repository repository"
+  git fetch --force --prune --prune-tags --tags \
+    https://github.com/luckyPipewrench/agent-egress-bench.git \
+    '+refs/heads/main:refs/remotes/origin/main'
+fi
+
+if [[ "$output_dir" == "$repo_root/"* && "$development_mode" != true ]]; then
+  output_relative="${output_dir#"$repo_root/"}"
+  git check-ignore -q -- "$output_relative" || \
+    die "an output directory inside the repository must be covered by .gitignore"
+fi
+dirty_output="$(git status --porcelain=v1 --untracked-files=all)"
+if [[ -n "$dirty_output" ]]; then
+  corpus_dirty=true
+  if [[ "$development_mode" != true ]]; then
+    printf '%s\n' "$dirty_output" >&2
+    die "corpus checkout is dirty; use a clean origin/main or tag checkout"
+  fi
+  noncanonical_reasons+=("corpus checkout was dirty")
+else
+  corpus_dirty=false
+fi
+
+corpus_git_sha="$(git rev-parse HEAD)"
+origin_main_sha="$(git rev-parse --verify origin/main 2>/dev/null || true)"
+if [[ "$development_mode" == true ]]; then
+  pointed_tags="$(git tag --points-at HEAD)"
+else
+  pointed_tags="$(git ls-remote --tags https://github.com/luckyPipewrench/agent-egress-bench.git | \
+    awk -v sha="$corpus_git_sha" '$1 == sha { print $2 }')"
+fi
+if [[ "$corpus_git_sha" == "$origin_main_sha" ]]; then
+  corpus_ref_kind="origin/main"
+elif [[ -n "$pointed_tags" ]]; then
+  corpus_ref_kind="tag"
+elif [[ "$development_mode" == true ]]; then
+  corpus_ref_kind="development"
+  noncanonical_reasons+=("corpus commit was neither fetched origin/main nor a tag")
+else
+  die "corpus checkout is neither fetched origin/main nor a tag"
+fi
+if [[ "$remote_matches" != true ]]; then
+  noncanonical_reasons+=("origin did not match $corpus_repository")
+fi
+
+canonical_execution=true
+if [[ "$development_mode" == true || -n "$development_binary" || "$corpus_dirty" == true || "$remote_matches" != true ]]; then
+  canonical_execution=false
+fi
+if [[ -n "$development_binary" ]]; then
+  noncanonical_reasons+=("development Pipelock binary was requested")
+fi
+
+start_args=(
+  start
+  --output "$output_dir/run-metadata.json"
+  --local-run-id "$local_run_id"
+  --generated-at "$started_at"
+  --corpus-repository "$corpus_repository"
+  --corpus-ref-kind "$corpus_ref_kind"
+  --corpus-git-sha "$corpus_git_sha"
+  --dirty "$corpus_dirty"
+  --canonical-execution "$canonical_execution"
+)
+for reason in "${noncanonical_reasons[@]}"; do
+  start_args+=(--noncanonical-reason "$reason")
+done
+PYTHONDONTWRITEBYTECODE=1 python3 "$provenance_script" "${start_args[@]}"
+cp "$repo_root/cases/MANIFEST.txt" "$output_dir/corpus-manifest.txt"
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/aeb-pipelock-gauntlet.XXXXXX")"
+pipelock_bin=""
+asset=""
+asset_sha256=""
+released_binary=true
+
+failure_reason="Pipelock release verification failed"
+if [[ -n "$development_binary" ]]; then
+  [[ -x "$development_binary" ]] || die "development binary is not executable: $development_binary"
+  pipelock_bin="$(realpath "$development_binary")"
+  asset="development-binary"
+  released_binary=false
+  : > "$output_dir/checksums.txt"
+else
+  case "$(uname -m)" in
+    x86_64) release_arch=amd64 ;;
+    aarch64|arm64) release_arch=arm64 ;;
+    *) die "unsupported Linux architecture: $(uname -m)" ;;
+  esac
+  [[ "$(uname -s)" == "Linux" ]] || die "the portable Pipelock runner currently supports Linux only"
+  asset="pipelock_${PIPELOCK_VERSION}_linux_${release_arch}.tar.gz"
+  release_json="$work_dir/release.json"
+  api_headers=( -H 'Accept: application/vnd.github+json' )
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    auth_header_file="$work_dir/github-api.headers"
+    printf 'Authorization: Bearer %s\n' "$GH_TOKEN" > "$auth_header_file"
+    chmod 0600 "$auth_header_file"
+    api_headers+=( -H "@$auth_header_file" )
+  fi
+  curl -fsSL "${api_headers[@]}" \
+    "https://api.github.com/repos/${PIPELOCK_REPO}/releases/tags/${PIPELOCK_TAG}" \
+    -o "$release_json"
+  actual_tag="$(jq -r '.tag_name // empty' "$release_json")"
+  is_draft="$(jq -r 'if has("draft") then (.draft | tostring) else empty end' "$release_json")"
+  is_prerelease="$(jq -r 'if has("prerelease") then (.prerelease | tostring) else empty end' "$release_json")"
+  if [[ "$actual_tag" != "$PIPELOCK_TAG" || "$is_draft" != "false" || "$is_prerelease" != "false" ]]; then
+    die "expected stable released tag $PIPELOCK_TAG, got tag=${actual_tag:-<none>} draft=${is_draft:-<none>} prerelease=${is_prerelease:-<none>}"
+  fi
+  asset_url="$(jq -r --arg name "$asset" '.assets[] | select(.name == $name) | .browser_download_url' "$release_json")"
+  checksums_url="$(jq -r '.assets[] | select(.name == "checksums.txt") | .browser_download_url' "$release_json")"
+  [[ -n "$asset_url" && "$asset_url" != "null" ]] || die "release asset is missing: $asset"
+  [[ -n "$checksums_url" && "$checksums_url" != "null" ]] || die "release checksums.txt is missing"
+  [[ "$(printf '%s\n' "$asset_url" | wc -l)" == "1" ]] || die "release has duplicate assets named $asset"
+  [[ "$(printf '%s\n' "$checksums_url" | wc -l)" == "1" ]] || die "release has duplicate checksums.txt assets"
+  curl -fsSL "$asset_url" -o "$work_dir/$asset"
+  curl -fsSL "$checksums_url" -o "$output_dir/checksums.txt"
+  checksum_line="$(awk -v asset="$asset" '{ name = $2; sub(/^\*/, "", name); if (name == asset) print }' "$output_dir/checksums.txt")"
+  [[ "$(printf '%s\n' "$checksum_line" | sed '/^$/d' | wc -l)" == "1" ]] || \
+    die "checksums.txt must contain exactly one entry for $asset"
+  (
+    cd "$work_dir"
+    printf '%s\n' "$checksum_line" | sha256sum --check -
+  )
+  asset_sha256="$(sha256sum "$work_dir/$asset" | awk '{print $1}')"
+  tar -xzf "$work_dir/$asset" -C "$work_dir"
+  pipelock_bin="$work_dir/pipelock"
+  chmod 0755 "$pipelock_bin"
+fi
+
+version_output="$($pipelock_bin --version)"
+printf '%s\n' "$version_output" > "$output_dir/pipelock-version.txt"
+reported_version="$(awk '/^pipelock version / { print $3 }' <<<"$version_output")"
+[[ "$reported_version" == "$PIPELOCK_VERSION" ]] || \
+  die "Pipelock version mismatch: expected $PIPELOCK_VERSION, got ${reported_version:-<none>}"
+binary_sha256="$(sha256sum "$pipelock_bin" | awk '{print $1}')"
+
+release_args=(
+  release
+  --output "$output_dir/pipelock-release.json"
+  --repository "$PIPELOCK_REPO"
+  --tag "$PIPELOCK_TAG"
+  --version "$PIPELOCK_VERSION"
+  --asset "$asset"
+  --binary-sha256 "$binary_sha256"
+  --version-output "$version_output"
+  --released-binary "$released_binary"
+)
+if [[ -n "$asset_sha256" ]]; then
+  release_args+=(--asset-sha256 "$asset_sha256")
+fi
+PYTHONDONTWRITEBYTECODE=1 python3 "$provenance_script" "${release_args[@]}"
+
+failure_reason="Gauntlet runner build failed"
+gauntlet_bin="$work_dir/aeb-gauntlet"
+(
+  cd "$repo_root/runner"
+  go build -o "$gauntlet_bin" .
+)
+
+export PIPELOCK_BIN="$pipelock_bin"
+export PIPELOCK_BENCH_CONFIG="$repo_root/examples/pipelock/pipelock-benchmark.yaml"
+summary_path="$output_dir/raw-summary.json"
+results_path="$output_dir/results.jsonl"
+stderr_path="$output_dir/runner.stderr"
+command_path="$output_dir/command.txt"
+stats_path="$output_dir/make-stats.txt"
+case_index_path="$output_dir/case-index.json"
+
+mcp_cmd="\"$PIPELOCK_BIN\" mcp proxy --config \"$PIPELOCK_BENCH_CONFIG\" --env AEB_MCP_STDIO_UPSTREAM_ADDR -- sh ./examples/pipelock/mcp-stdio-upstream-bridge.sh"
+managed_proxy_cmd='./examples/pipelock/start-proxy-for-benchmark.sh "$PIPELOCK_BIN"'
+managed_mcp_http_cmd='./examples/pipelock/start-mcp-http-for-benchmark.sh "$PIPELOCK_BIN"'
+cmd=(
+  "$gauntlet_bin"
+  --adapter proxy
+  --scan-token bench-test-token
+  --mcp-cmd "$mcp_cmd"
+  --managed-proxy-cmd "$managed_proxy_cmd"
+  --managed-mcp-http-cmd "$managed_mcp_http_cmd"
+  --cases ./cases
+  --multifile-cases ./cases/mcp-drift
+  --profile examples/pipelock/tool-profile.json
+  --fixtures
+  --output "$summary_path"
+)
+
+benchmark_cap_seconds="$benchmark_timeout_seconds"
+if [[ -n "$deadline_epoch" ]]; then
+  now_epoch="$(date +%s)"
+  available_seconds=$((deadline_epoch - now_epoch - reserve_seconds))
+  ((available_seconds > 0)) || die "insufficient total-job budget remains to run the benchmark safely"
+  if ((available_seconds < benchmark_cap_seconds)); then
+    benchmark_cap_seconds="$available_seconds"
+  fi
+fi
+run_cmd=(timeout --signal=TERM --kill-after=30s "${benchmark_cap_seconds}s" "${cmd[@]}")
+printf '%q ' "${run_cmd[@]}" > "$command_path"
+printf '\n' >> "$command_path"
+
+failure_reason="canonical runner command contract failed"
+grep -Eq '(^|[[:space:]])--fixtures($|[[:space:]])' "$command_path" || \
+  die "recorded command does not include --fixtures"
+grep -Eq '(^|[[:space:]])--multifile-cases($|[[:space:]])' "$command_path" || \
+  die "recorded command does not include --multifile-cases"
+
+failure_reason="corpus statistics or case index generation failed"
+make stats > "$stats_path"
+"$gauntlet_bin" --cases ./cases --case-index > "$case_index_path"
+
+failure_reason="Gauntlet runner failed"
+set +e
+"${run_cmd[@]}" > "$results_path" 2> "$stderr_path"
+run_status=$?
+set -e
+if [[ "$run_status" -ne 0 ]]; then
+  failure_reason="Gauntlet runner failed with exit code $run_status"
+  cat "$stderr_path" >&2
+  exit "$run_status"
+fi
+grep -Eq '^Fixtures: HTTP=.* TLS=.* WS=.* DNS=.* MCP_HTTP=' "$stderr_path" || \
+  die "runner did not report fixture startup"
+
+failure_reason="Gauntlet result validation failed"
+results_abs="$(realpath "$results_path")"
+(
+  cd "$repo_root/validate"
+  go run . results "$results_abs"
+)
+jq -e '.case_count.errors == 0' "$summary_path" >/dev/null || \
+  die "runner summary contains errors"
+
+failure_reason="portable evidence bundle validation failed"
+PYTHONDONTWRITEBYTECODE=1 python3 "$provenance_script" bundle \
+  --repo-root "$repo_root" \
+  --run-dir "$output_dir"
+bundle_complete=true
+
+printf 'Portable Gauntlet run complete: %s\n' "$output_dir"
+if [[ "$canonical_execution" == true ]]; then
+  printf 'Publication eligibility: canonical execution bundle (platform finalization still required)\n'
+else
+  printf 'Publication eligibility: noncanonical development bundle\n'
+fi


### PR DESCRIPTION
## Summary

- add a one-command Pipelock Gauntlet runner that verifies the pinned release and produces a hash-bound evidence directory
- separate portable execution evidence from platform-specific candidate finalization
- make the scheduled GitHub workflow invoke the portable runner instead of maintaining a second flag list
- document explicit development mode, evidence contents, and neutral Linux scheduling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a portable command for running the Pipelock Gauntlet with release verification, managed execution, timeout handling, and evidence generation.
  - Added provenance and integrity checks for results, releases, artifacts, and execution evidence.
  - Failed or incomplete runs now produce protected, clearly marked blocked results.

- **Documentation**
  - Updated quick-start and runner guides with the portable workflow, output details, requirements, and development options.

- **Bug Fixes**
  - Candidate evaluation now detects missing, mismatched, or substituted execution bundles and checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->