### PR TITLE
feat: add reviewed Gauntlet result promotion

### DIFF
--- a/.github/workflows/promote-gauntlet-result.yaml
+++ b/.github/workflows/promote-gauntlet-result.yaml
@@ -34,8 +34,6 @@ jobs:
       RUN_ID: ${{ inputs.run_id }}
       ACCEPT_POLICY_CHANGE: ${{ inputs.accept_policy_change }}
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-      ARTIFACT_DIR: ${{ runner.temp }}/continuous-gauntlet-candidate
-      PR_BODY: ${{ runner.temp }}/gauntlet-result-promotion.md
     steps:
       - name: Check out trusted default branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -48,6 +46,13 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
+
+      - name: Initialize temporary paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf 'ARTIFACT_DIR=%s\n' "$RUNNER_TEMP/continuous-gauntlet-candidate" >> "$GITHUB_ENV"
+          printf 'PR_BODY=%s\n' "$RUNNER_TEMP/gauntlet-result-promotion.md" >> "$GITHUB_ENV"
 
       - name: Verify source workflow run
         shell: bash
@@ -65,14 +70,14 @@ jobs:
           }
           run_json="$RUNNER_TEMP/source-run.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" > "$run_json"
-          jq -e --arg repo "$GITHUB_REPOSITORY" '
+          jq -e --arg repo "$GITHUB_REPOSITORY" --arg branch "$DEFAULT_BRANCH" '
             .status == "completed" and
             .path == ".github/workflows/continuous-gauntlet.yaml" and
             .head_repository.full_name == $repo and
-            .head_branch == "main" and
+            .head_branch == $branch and
             (.event == "schedule" or .event == "workflow_dispatch")
           ' "$run_json" >/dev/null || {
-            echo "source run is not a completed trusted Continuous Gauntlet run on main" >&2
+            echo "source run is not a completed trusted Continuous Gauntlet run on the default branch" >&2
             exit 1
           }
           conclusion="$(jq -r '.conclusion' "$run_json")"
@@ -88,8 +93,8 @@ jobs:
             }
           fi
           head_sha="$(jq -r '.head_sha' "$run_json")"
-          git merge-base --is-ancestor "$head_sha" origin/main || {
-            echo "source run head is not in current main history" >&2
+          git merge-base --is-ancestor "$head_sha" "origin/$DEFAULT_BRANCH" || {
+            echo "source run head is not in current default-branch history" >&2
             exit 1
           }
 
@@ -109,8 +114,8 @@ jobs:
             echo "candidate corpus_git_sha is invalid" >&2
             exit 1
           }
-          git merge-base --is-ancestor "$corpus_sha" origin/main || {
-            echo "candidate corpus commit is not in current main history" >&2
+          git merge-base --is-ancestor "$corpus_sha" "origin/$DEFAULT_BRANCH" || {
+            echo "candidate corpus commit is not in current default-branch history" >&2
             exit 1
           }
 
@@ -168,13 +173,18 @@ jobs:
           else
             git push origin "HEAD:refs/heads/$branch"
           fi
-          existing_pr="$(gh pr list \
+          existing_pr_json="$(gh pr list \
             --repo "$GITHUB_REPOSITORY" \
             --state open \
             --head "$branch" \
-            --json url \
-            --jq '.[0].url // empty')"
+            --json url,baseRefName \
+            --jq '.[0] // {}')"
+          existing_pr="$(jq -r '.url // empty' <<<"$existing_pr_json")"
           if [[ -n "$existing_pr" ]]; then
+            [[ "$(jq -r '.baseRefName' <<<"$existing_pr_json")" == "$DEFAULT_BRANCH" ]] || {
+              echo "existing promotion pull request targets the wrong base branch" >&2
+              exit 1
+            }
             echo "promotion pull request already exists: $existing_pr"
           else
             gh pr create \

--- a/.github/workflows/promote-gauntlet-result.yaml
+++ b/.github/workflows/promote-gauntlet-result.yaml
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Prepare Gauntlet result promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Completed Continuous Gauntlet Actions run ID"
+        required: true
+        type: string
+      accept_policy_change:
+        description: "Prepare a review PR for an explicit score or pinned-version change"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  # Every promotion updates the same baseline and pointer. Serialize different
+  # run IDs too, otherwise two individually valid PR preparations can race.
+  group: gauntlet-result-promotion
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      RUN_ID: ${{ inputs.run_id }}
+      ACCEPT_POLICY_CHANGE: ${{ inputs.accept_policy_change }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      ARTIFACT_DIR: ${{ runner.temp }}/continuous-gauntlet-candidate
+      PR_BODY: ${{ runner.temp }}/gauntlet-result-promotion.md
+    steps:
+      - name: Check out trusted default branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify source workflow run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == "refs/heads/$DEFAULT_BRANCH" ]] || {
+            echo "promotion must be dispatched from the default branch" >&2
+            exit 1
+          }
+          [[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "run_id must be a positive integer" >&2
+            exit 1
+          }
+          run_json="$RUNNER_TEMP/source-run.json"
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" > "$run_json"
+          jq -e --arg repo "$GITHUB_REPOSITORY" '
+            .status == "completed" and
+            .path == ".github/workflows/continuous-gauntlet.yaml" and
+            .head_repository.full_name == $repo and
+            .head_branch == "main" and
+            (.event == "schedule" or .event == "workflow_dispatch")
+          ' "$run_json" >/dev/null || {
+            echo "source run is not a completed trusted Continuous Gauntlet run on main" >&2
+            exit 1
+          }
+          conclusion="$(jq -r '.conclusion' "$run_json")"
+          if [[ "$ACCEPT_POLICY_CHANGE" == "true" ]]; then
+            [[ "$conclusion" == "success" || "$conclusion" == "failure" ]] || {
+              echo "policy-change review requires a completed success or enforcement failure" >&2
+              exit 1
+            }
+          else
+            [[ "$conclusion" == "success" ]] || {
+              echo "a failed source run requires accept_policy_change=true and PR review" >&2
+              exit 1
+            }
+          fi
+          head_sha="$(jq -r '.head_sha' "$run_json")"
+          git merge-base --is-ancestor "$head_sha" origin/main || {
+            echo "source run head is not in current main history" >&2
+            exit 1
+          }
+
+      - name: Download candidate evidence
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$ARTIFACT_DIR"
+          gh run download "$RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name continuous-gauntlet-pipelock \
+            --dir "$ARTIFACT_DIR"
+          corpus_sha="$(jq -r '.corpus_git_sha' "$ARTIFACT_DIR/continuous-gauntlet-pipelock.json")"
+          [[ "$corpus_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "candidate corpus_git_sha is invalid" >&2
+            exit 1
+          }
+          git merge-base --is-ancestor "$corpus_sha" origin/main || {
+            echo "candidate corpus commit is not in current main history" >&2
+            exit 1
+          }
+
+      - name: Prepare append-only record
+        shell: bash
+        run: |
+          set -euo pipefail
+          policy_args=()
+          if [[ "$ACCEPT_POLICY_CHANGE" == "true" ]]; then
+            policy_args+=(--accept-policy-change)
+          fi
+          python3 scripts/promote_gauntlet_candidate.py \
+            --artifact-dir "$ARTIFACT_DIR" \
+            --baseline ci/gauntlet-baseline.json \
+            --store-root gauntlet-site/results \
+            --latest gauntlet-site/latest-verified.json \
+            --summary "$PR_BODY" \
+            --expected-run-id "$RUN_ID" \
+            "${policy_args[@]}"
+          python3 scripts/validate_gauntlet_records.py \
+            --site-root gauntlet-site \
+            --baseline ci/gauntlet-baseline.json
+
+      - name: Create reviewed promotion pull request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          candidate_sha="$(jq -r '.candidate_sha256' gauntlet-site/latest-verified.json)"
+          [[ "$candidate_sha" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "latest pointer returned an invalid candidate digest" >&2
+            exit 1
+          }
+          branch="gauntlet-result-$RUN_ID"
+          record_dir="gauntlet-site/results/pipelock/$candidate_sha"
+          git switch -c "$branch"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- \
+            ci/gauntlet-baseline.json \
+            gauntlet-site/latest-verified.json \
+            "$record_dir"
+          git diff --cached --check
+          git commit -m "results: promote Gauntlet run $RUN_ID"
+          if remote_sha="$(git ls-remote --exit-code --heads origin "refs/heads/$branch" | awk '{print $1}')"; then
+            git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch"
+            local_tree="$(git rev-parse 'HEAD^{tree}')"
+            remote_tree="$(git rev-parse "refs/remotes/origin/$branch^{tree}")"
+            [[ "$local_tree" == "$remote_tree" ]] || {
+              echo "existing promotion branch has different content: $branch at $remote_sha" >&2
+              exit 1
+            }
+          else
+            git push origin "HEAD:refs/heads/$branch"
+          fi
+          existing_pr="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --head "$branch" \
+            --json url \
+            --jq '.[0].url // empty')"
+          if [[ -n "$existing_pr" ]]; then
+            echo "promotion pull request already exists: $existing_pr"
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base "$DEFAULT_BRANCH" \
+              --head "$branch" \
+              --title "results: promote Gauntlet run $RUN_ID" \
+              --body-file "$PR_BODY"
+          fi
+
+      - name: Dispatch required validation
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch="gauntlet-result-$RUN_ID"
+          gh workflow run validate.yaml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$branch"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,6 +1,10 @@
 name: Validate Cases
 
 on:
+  # Promotion branches are created with GITHUB_TOKEN, which intentionally does
+  # not emit a pull_request workflow run. The promotion workflow explicitly
+  # dispatches this trusted workflow against the resulting branch instead.
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
@@ -36,6 +38,22 @@ jobs:
 
       - name: Run local preflight gate
         run: make preflight
+
+      - name: Enforce append-only Gauntlet history
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          case "$GITHUB_EVENT_NAME" in
+            pull_request) immutable_base="$PR_BASE_SHA" ;;
+            push) immutable_base="$PUSH_BEFORE_SHA" ;;
+            workflow_dispatch) immutable_base="origin/$DEFAULT_BRANCH" ;;
+            *) echo "unsupported validation event: $GITHUB_EVENT_NAME" >&2; exit 1 ;;
+          esac
+          python3 scripts/validate_gauntlet_records.py --immutable-base "$immutable_base"
 
   # `runner` is a required status check. Keep the job so the requirement stays
   # satisfiable; the preflight target above already covers these tests, so this

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,12 @@ check-gauntlet-site:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/evaluate_gauntlet_candidate_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/build_gauntlet_provenance_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/continuous_gauntlet_workflow_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/promote_gauntlet_candidate_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/promote_gauntlet_workflow_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/gauntlet_site_index_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/validate_gauntlet_records_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/validate_gauntlet_records.py
 	@node gauntlet-site/scope-render_test.js
+	@node gauntlet-site/latest-result_test.js
 	@test -f "$(GAUNTLET_SCOPE_ARTIFACT)" || { echo "check-gauntlet-site: FAIL - missing provenance artifact: $(GAUNTLET_SCOPE_ARTIFACT)"; exit 1; }
 	@python3 scripts/validate_gauntlet_scope.py "$(GAUNTLET_SCOPE_ARTIFACT)"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ It requires Linux, Go 1.25 or newer, Python 3, Git, curl, jq, tar, GNU timeout, 
 
 The raw directory intentionally has no made-up public URL. GitHub Actions or another retaining platform adds its real artifact ID and HTTPS location later, without modifying the evidence bytes. Creating a schedule and publishing a result are separate operator decisions.
 
+The repository's scheduled Pipelock lane is read-only and produces review candidates, not automatic public claims. Approved candidates are retained as digest-addressed, hash-linked evidence directories, and a reviewed pull request advances the `latest-verified` pointer. The included reference renderer verifies and displays score, scope, N/A reasons, false-positive rate, and the canonical run URL together; it is not currently the live pipelab.org leaderboard. See [Continuous Gauntlet Results](docs/CONTINUOUS-RESULTS.md) for the repository review and publication contract.
+
 For other tools, the runner writes per-case JSONL results to stdout (one object per case, see [docs/RUNNER.md](docs/RUNNER.md)) and a Gauntlet summary JSON to the path passed via `--output` (containment, false-positive rate, detection, evidence, per-category, see [docs/gauntlet.md](docs/gauntlet.md)). `--emit-receipt-profile` additionally writes a byte-reproducible receipt-scoring profile (see [docs/RECEIPT-SCORING.md](docs/RECEIPT-SCORING.md)).
 
 > A minimal legacy shell example for fetch-only cases lives at [`examples/pipelock/harness.sh`](examples/pipelock/harness.sh). It covers a single transport (`/fetch?url=...` GET) and is kept for illustration only — it is not the Gauntlet and will misreport every body, header, WebSocket, MCP, and response-content case. Use the Go runner for any real benchmark.

--- a/docs/CONTINUOUS-RESULTS.md
+++ b/docs/CONTINUOUS-RESULTS.md
@@ -1,0 +1,50 @@
+# Continuous Gauntlet Results
+
+The Pipelock reference lane separates execution, review, and publication.
+
+1. The read-only `Continuous Gauntlet` workflow runs the portable benchmark and retains a candidate evidence bundle.
+2. A maintainer chooses a completed run in the `Prepare Gauntlet result promotion` workflow.
+3. The promotion workflow downloads that exact bundle, recomputes its decision, and opens a pull request.
+4. Merging the pull request is the repository publication approval. It adds an immutable record and advances `latest-verified`.
+
+The scheduled workflow cannot write repository contents or open a pull request. A raw run never moves the committed pointer by itself. Candidate Actions artifacts are retained for 14 days, so a maintainer must prepare the promotion before that download window closes.
+
+## Append-only layout
+
+Each approved candidate is stored at a digest-addressed path:
+
+```text
+gauntlet-site/results/pipelock/<candidate-sha256>/
+```
+
+The directory retains the exact finalized candidate, raw summary, per-case results, stderr, command, case index, corpus manifest, release identity, execution decision, source promotion decision, reviewed promotion decision, and a manifest that hashes every retained file.
+
+`gauntlet-site/latest-verified.json` contains no score. It only identifies the selected immutable record and its digest. The repository includes a reference renderer that fetches the record manifest and candidate, verifies both SHA-256 digests in the browser, and renders containment together with applicable/total scope, N/A reasons, false-positive rate, and the original canonical run URL. The reference renderer is not currently the live pipelab.org leaderboard. If the committed pointer exists but its manifest or record is missing, malformed, or digest-mismatched, the renderer fails closed instead of silently showing the legacy result.
+
+Each record manifest hash-links its predecessor, and the selected pointer binds the head of that chain. Required validation rejects deletion, mutation, cycles, or unlinked records. The promotion command also refuses:
+
+- a missing, partial, or publication-ineligible execution;
+- evidence changed after the source decision;
+- a source run from a different repository or workflow;
+- a noncanonical pointer path;
+- overwrite of an existing record;
+- movement of `latest-verified` to an equal or older run;
+- structural failures such as errors, insufficient scope, or malformed provenance.
+
+## Reviewable policy changes
+
+A normal successful run can prepare a promotion pull request directly. A run that changed a score floor, false-positive ceiling, pinned Pipelock version, corpus identity, runner identity, or applicable/N/A scope remains blocked until the maintainer explicitly selects `accept_policy_change` in the manual promotion workflow.
+
+That option does not turn a failed execution into a pass. It only permits the workflow to propose the exact score, version, identity, or scope change in a pull request. The candidate must still be complete, sufficient, error-free, origin-bound, and hash-consistent. The pull request body lists the old-policy failures and the full new scope. Reviewers can merge or reject the proposal without changing the selected repository record.
+
+Promotion branches are created with GitHub's workflow token, so the promotion workflow explicitly dispatches the repository's required validation workflow against the branch. A second prepared promotion may conflict with the first at the baseline and pointer. It must be regenerated from the newly merged baseline rather than bypassing the up-to-date branch requirement.
+
+## Independent operators
+
+The portable command is not tied to GitHub Actions:
+
+```bash
+./scripts/run-pipelock-gauntlet.sh
+```
+
+An independent lab can repeat that command with its own scheduler and retain the same portable bundle. Its platform supplies its own real artifact ID and HTTPS URL during finalization. Its publication policy remains independent from this repository's self-operated Pipelock lane. Matching the Pipelock release, corpus commit and digest, runner version, fixtures, and applicable/N/A denominator makes the two results directly reconcilable without pretending they share an operator.

--- a/docs/CONTINUOUS-RESULTS.md
+++ b/docs/CONTINUOUS-RESULTS.md
@@ -21,7 +21,7 @@ The directory retains the exact finalized candidate, raw summary, per-case resul
 
 `gauntlet-site/latest-verified.json` contains no score. It only identifies the selected immutable record and its digest. The repository includes a reference renderer that fetches the record manifest and candidate, verifies both SHA-256 digests in the browser, and renders containment together with applicable/total scope, N/A reasons, false-positive rate, and the original canonical run URL. The reference renderer is not currently the live pipelab.org leaderboard. If the committed pointer exists but its manifest or record is missing, malformed, or digest-mismatched, the renderer fails closed instead of silently showing the legacy result.
 
-Each record manifest hash-links its predecessor, and the selected pointer binds the head of that chain. Required validation rejects deletion, mutation, cycles, or unlinked records. The promotion command also refuses:
+Each record manifest hash-links its predecessor, and the selected pointer binds the head of that chain. Required validation checks the current chain and compares every previously committed record byte-for-byte with the pull request base, rejecting deletion, mutation, cycles, or unlinked records. The promotion command also refuses:
 
 - a missing, partial, or publication-ineligible execution;
 - evidence changed after the source decision;

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -162,7 +162,7 @@ For the reviewed Pipelock release, run the portable entry point from a clean Lin
 
 The entry point pins and verifies the released binary, supplies the required managed commands, enables the local fixtures, includes the multi-file MCP drift corpus, validates the result rows, and leaves a hash-bound evidence directory. It rejects a recorded command with the fixture or multi-file flags missing. Without fixtures, cases can fail because no local server exists rather than because policy blocked them, and the false-positive rate becomes meaningless. A plain listening proxy also scores response-interception cases incorrectly because it does not receive the runner's TLS fixture configuration.
 
-The raw portable directory is the common execution layer. It has a local run ID but no invented public URL. GitHub Actions or another retaining platform supplies a real artifact ID and canonical HTTPS URL during a separate finalization step. The [Pipelock reference-runner guide](../examples/pipelock/README.md) documents every evidence file, explicit development mode, the underlying long-form command, and a Linux scheduling example.
+The raw portable directory is the common execution layer. It has a local run ID but no invented public URL. GitHub Actions or another retaining platform supplies a real artifact ID and canonical HTTPS URL during a separate finalization step. The [Pipelock reference-runner guide](../examples/pipelock/README.md) documents every evidence file, explicit development mode, the underlying long-form command, and a Linux scheduling example. The [continuous-results contract](CONTINUOUS-RESULTS.md) documents the separate append-only review and publication step.
 
 For other tools and adapter development, use the Go runner directly. Per-case JSONL results are written to stdout and the summary JSON file is written to the path specified by `--output`. See [RUNNER.md](RUNNER.md) for the full runner contract and verdict mapping rules.
 
@@ -170,9 +170,11 @@ For other tools and adapter development, use the Go runner directly. Per-case JS
 
 Vendors run the Gauntlet locally against their own tool. Results may be submitted to a public leaderboard or published independently.
 
-Submitted results start as **self-reported**. A maintainer may verify results by re-running the Gauntlet against the same tool version. Verified results are marked accordingly on the leaderboard.
+Submitted results start as **self-reported**. A maintainer may verify results by re-running the Gauntlet against the same tool version. Verified results are marked accordingly on the leaderboard. The repository's Pipelock reference lane is explicitly first-party: it publishes only human-reviewed, append-only records and does not claim independent certification.
 
-Gauntlet leaderboard results are not stored in this repository. This repo contains attack cases, scoring methodology, and optional maintainer-published receipt profiles under `profiles/`. Each vendor owns its results and is expected to document reproduction steps.
+Third-party leaderboard submissions are not stored in this repository. This repo contains attack cases, scoring methodology, and optional maintainer-published receipt profiles under `profiles/`. Each vendor owns its results and is expected to document reproduction steps.
+
+The maintainer-operated Pipelock reference lane is the narrow exception. Its first-party results live under `gauntlet-site/results/pipelock/` as immutable evidence records selected by a reviewed `latest-verified` pointer. This is disclosed self-operated regression evidence, not a ranking or independent certification. Independent lab results remain under the independent operator's control.
 
 ## Dispute Resolution
 
@@ -200,7 +202,7 @@ Neutrality is maintained through design constraints:
 
 - **Cases test observable behavior.** Every case asks "was this traffic blocked?" not "did the tool use this internal technique?" No case requires a specific implementation approach.
 - **Pipelock runner is reference, not privileged.** The Pipelock runner in `examples/pipelock/` is a working example. It has no special status. Any vendor can add a runner in `examples/`.
-- **Gauntlet leaderboard results live outside this repo.** Optional receipt profiles may live in `profiles/` as self-reported, reproducible evidence artifacts, not rankings or certifications.
+- **Third-party leaderboard results live outside this repo.** The append-only Pipelock reference history is disclosed first-party regression evidence, not a ranking or certification. Optional receipt profiles may live in `profiles/` as self-reported, reproducible evidence artifacts.
 - **Methodology published before results.** The scoring rules, case corpus, and governance policy are public before any tool publishes Gauntlet results. No retroactive tuning.
 
 Contributions from any vendor, researcher, or individual are welcome. See [GOVERNANCE.md](GOVERNANCE.md) for the full policy and [ADOPTION.md](ADOPTION.md) for how to build a runner and publish results.

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -70,13 +70,11 @@ CRON_TZ=UTC
 
 That timer does not update the repository, delete old runs, upload evidence, or publish a result. The machine operator must choose update, retention, and publication policies separately. Run the command manually once and inspect `execution-decision.json` and `run-bundle.json` before connecting it to any timer.
 
-### Reviewed GitHub publication
+### Publication is separate from this example
 
-The repository's daily GitHub workflow finalizes the portable bundle with the real Actions run ID and URL, evaluates it against the reviewed baseline, and retains it for review. It has read-only repository permissions and cannot publish.
+This directory is only a reference execution adapter. It does not grant Pipelock a benchmark endorsement, vendor submission path, ranking, or certification. Other tools use the same runner contract and control their own result publication.
 
-A maintainer can select a completed run in the `Prepare Gauntlet result promotion` workflow. That separate manual workflow revalidates the source run and every evidence digest, then opens one pull request containing an immutable evidence record, the next reviewed baseline, and the `latest-verified` pointer update. Merging that pull request approves the repository record. A rejected candidate leaves the currently selected repository record untouched. The live pipelab.org leaderboard is a separate publication surface.
-
-If a score or pinned Pipelock version moved, the source candidate remains blocked. Selecting `accept_policy_change` only allows the workflow to put the exact move in front of reviewers. It cannot override incomplete execution, errors, insufficient scope, wrong origin, or tampered evidence. The complete contract is in [`../../docs/CONTINUOUS-RESULTS.md`](../../docs/CONTINUOUS-RESULTS.md).
+The repository maintainer's separately governed, first-party regression record is documented in [`../../docs/CONTINUOUS-RESULTS.md`](../../docs/CONTINUOUS-RESULTS.md). It is disclosed operational evidence for this reference adapter, not a status available through `examples/` and not the live pipelab.org leaderboard.
 
 ## Advanced runner invocation
 

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -70,6 +70,14 @@ CRON_TZ=UTC
 
 That timer does not update the repository, delete old runs, upload evidence, or publish a result. The machine operator must choose update, retention, and publication policies separately. Run the command manually once and inspect `execution-decision.json` and `run-bundle.json` before connecting it to any timer.
 
+### Reviewed GitHub publication
+
+The repository's daily GitHub workflow finalizes the portable bundle with the real Actions run ID and URL, evaluates it against the reviewed baseline, and retains it for review. It has read-only repository permissions and cannot publish.
+
+A maintainer can select a completed run in the `Prepare Gauntlet result promotion` workflow. That separate manual workflow revalidates the source run and every evidence digest, then opens one pull request containing an immutable evidence record, the next reviewed baseline, and the `latest-verified` pointer update. Merging that pull request approves the repository record. A rejected candidate leaves the currently selected repository record untouched. The live pipelab.org leaderboard is a separate publication surface.
+
+If a score or pinned Pipelock version moved, the source candidate remains blocked. Selecting `accept_policy_change` only allows the workflow to put the exact move in front of reviewers. It cannot override incomplete execution, errors, insufficient scope, wrong origin, or tampered evidence. The complete contract is in [`../../docs/CONTINUOUS-RESULTS.md`](../../docs/CONTINUOUS-RESULTS.md).
+
 ## Advanced runner invocation
 
 The runner can either target already-running endpoints (`--proxy-addr`,

--- a/gauntlet-site/index.html
+++ b/gauntlet-site/index.html
@@ -60,7 +60,7 @@ pre { background: var(--bg); border: 1px solid var(--border); border-radius: 0.3
 }
 </style>
 </head>
-<body data-results-url="./gauntlet-results.json" data-corpus-version="v2.0.0" data-scoring-version="2.0">
+<body data-latest-url="./latest-verified.json" data-results-url="./gauntlet-results.json" data-corpus-version="v2.3.0" data-scoring-version="2.4">
 
 <h1>Pipelock Gauntlet</h1>
 <p class="subtitle">Agent egress security benchmark. Tests the security tool, not the agent.</p>
@@ -77,10 +77,13 @@ go build -o aeb-gauntlet .
   <p style="margin-top:0.75rem">To submit results, open a <a href="https://github.com/luckyPipewrench/agent-egress-bench/discussions">discussion</a>.</p>
 </div>
 
+<script src="./scope-render.js"></script>
+<script src="./latest-result.js"></script>
 <script>
 (function() {
   'use strict';
   var container = document.getElementById('results');
+  var latestUrl = document.body.getAttribute('data-latest-url') || './latest-verified.json';
   var resultsUrl = document.body.getAttribute('data-results-url') || './gauntlet-results.json';
   var curCorpus = document.body.getAttribute('data-corpus-version');
   var curScoring = document.body.getAttribute('data-scoring-version');
@@ -160,7 +163,7 @@ go build -o aeb-gauntlet .
     return wrap;
   }
 
-  function renderTool(r) {
+  function renderTool(r, verified) {
     var card = el('div', 'tool-card');
     var hdr = el('div', 'tool-header');
     hdr.appendChild(txt('span', r.tool || 'Unknown', 'tool-name'));
@@ -168,8 +171,7 @@ go build -o aeb-gauntlet .
     var meta = el('div', 'tool-meta');
     meta.appendChild(txt('span', r.tool_version || '', 'tool-version'));
 
-    var verification = r.verification || 'self-reported';
-    meta.appendChild(makeBadge(verification, verification === 'verified' ? 'verified' : 'self-reported'));
+    if (!verified) meta.appendChild(makeBadge('self-reported', 'self-reported'));
     meta.appendChild(makeBadge(r.sufficient ? 'sufficient' : 'insufficient', r.sufficient ? 'sufficient' : 'insufficient'));
 
     var stale = r.corpus_version !== curCorpus || r.scoring_version !== curScoring;
@@ -179,7 +181,11 @@ go build -o aeb-gauntlet .
     card.appendChild(hdr);
 
     var cc = r.case_count || {};
-    card.appendChild(txt('div', 'Scored on ' + (cc.applicable || 0) + ' / ' + (cc.total || 0) + ' cases (' + (cc.not_applicable || 0) + ' N/A, ' + (cc.errors || 0) + ' errors)', 'denominator'));
+    if (verified) {
+      card.appendChild(window.renderGauntletScope(r));
+    } else {
+      card.appendChild(txt('div', 'Scored on ' + (cc.applicable || 0) + ' / ' + (cc.total || 0) + ' cases (' + (cc.not_applicable || 0) + ' N/A, ' + (cc.errors || 0) + ' errors)', 'denominator'));
+    }
 
     var scores = r.scores || {};
     var full = scores.full || scores;
@@ -206,7 +212,7 @@ go build -o aeb-gauntlet .
     var prov = el('div', 'provenance');
     var fields = [
       ['corpus', r.corpus_version], ['scoring', r.scoring_version],
-      ['runner', r.runner_version], ['date', r.date ? r.date.split('T')[0] : '?']
+      ['runner', r.runner_version], ['date', (r.generated_at || r.date) ? (r.generated_at || r.date).split('T')[0] : '?']
     ];
     fields.forEach(function(f) {
       var s = el('span');
@@ -217,7 +223,7 @@ go build -o aeb-gauntlet .
     return card;
   }
 
-  function render(results) {
+  function render(results, verified) {
     while (container.firstChild) container.removeChild(container.firstChild);
     if (!results || results.length === 0) {
       container.appendChild(txt('div', 'No results yet. Be the first to run the Gauntlet.', 'empty-state'));
@@ -231,16 +237,25 @@ go build -o aeb-gauntlet .
       };
       return s(b) - s(a);
     });
-    results.forEach(function(r) { container.appendChild(renderTool(r)); });
+    results.forEach(function(r) { container.appendChild(renderTool(r, verified)); });
   }
 
-  fetch(resultsUrl).then(function(resp) {
-    if (!resp.ok) throw new Error('HTTP ' + resp.status);
-    return resp.json();
-  }).then(function(data) {
-    render(Array.isArray(data) ? data : [data]);
+  function loadLegacyResult() {
+    return fetch(resultsUrl).then(function(resp) {
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      return resp.json();
+    }).then(function(data) {
+      render(Array.isArray(data) ? data : [data], false);
+    });
+  }
+
+  window.loadLatestVerifiedResult(latestUrl, window.fetch.bind(window), window.crypto).then(function(data) {
+    render([data], true);
   }).catch(function(err) {
-    container.appendChild(txt('div', 'No results available. ' + err.message, 'empty-state'));
+    if (err.status === 404 && err.resource === 'pointer') return loadLegacyResult();
+    throw err;
+  }).catch(function(err) {
+    container.appendChild(txt('div', 'Verified result unavailable. ' + err.message, 'empty-state'));
   });
 })();
 </script>

--- a/gauntlet-site/latest-result.js
+++ b/gauntlet-site/latest-result.js
@@ -1,0 +1,131 @@
+/* Load and hash-check the append-only record selected by latest-verified. */
+(function(root) {
+  'use strict';
+
+  var SHA256 = /^[0-9a-f]{64}$/;
+
+  function nonEmptyString(value, label) {
+    if (typeof value !== 'string' || !value.trim()) {
+      throw new Error(label + ' must be a non-empty string');
+    }
+    return value;
+  }
+
+  function validatePointer(pointer) {
+    if (!pointer || typeof pointer !== 'object' || Array.isArray(pointer)) {
+      throw new Error('latest-verified pointer must be an object');
+    }
+    if (pointer.schema_version !== 1 || pointer.status !== 'verified') {
+      throw new Error('latest-verified pointer must be schema v1 with verified status');
+    }
+    var digest = nonEmptyString(pointer.candidate_sha256, 'candidate_sha256');
+    if (!SHA256.test(digest)) throw new Error('candidate_sha256 must be lower-case SHA-256');
+    var manifestDigest = nonEmptyString(pointer.record_manifest_sha256, 'record_manifest_sha256');
+    if (!SHA256.test(manifestDigest)) {
+      throw new Error('record_manifest_sha256 must be lower-case SHA-256');
+    }
+    var expectedRecord = './results/pipelock/' + digest + '/continuous-gauntlet-pipelock.json';
+    var expectedManifest = './results/pipelock/' + digest + '/record-manifest.json';
+    if (pointer.record_path !== expectedRecord) {
+      throw new Error('latest-verified record_path is not canonical');
+    }
+    if (pointer.record_manifest_path !== expectedManifest) {
+      throw new Error('latest-verified record_manifest_path is not canonical');
+    }
+    nonEmptyString(pointer.artifact_id, 'artifact_id');
+    nonEmptyString(pointer.canonical_url, 'canonical_url');
+    nonEmptyString(pointer.tool, 'tool');
+    nonEmptyString(pointer.tool_version, 'tool_version');
+    nonEmptyString(pointer.generated_at, 'generated_at');
+    return pointer;
+  }
+
+  async function responseBytes(response, label, resource) {
+    if (!response.ok) {
+      var error = new Error(label + ' returned HTTP ' + response.status);
+      error.status = response.status;
+      error.resource = resource;
+      throw error;
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
+  function decodeUTF8(bytes, label) {
+    try {
+      return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    } catch (error) {
+      throw new Error(label + ' is not valid UTF-8');
+    }
+  }
+
+  async function sha256Hex(bytes, cryptoImpl) {
+    if (!cryptoImpl || !cryptoImpl.subtle) throw new Error('Web Crypto is unavailable');
+    var digest = await cryptoImpl.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest)).map(function(value) {
+      return value.toString(16).padStart(2, '0');
+    }).join('');
+  }
+
+  async function loadLatestVerifiedResult(pointerURL, fetchImpl, cryptoImpl) {
+    var pointerBytes = await responseBytes(
+      await fetchImpl(pointerURL), 'latest-verified pointer', 'pointer'
+    );
+    var pointerText = decodeUTF8(pointerBytes, 'latest-verified pointer');
+    var pointer;
+    try {
+      pointer = validatePointer(JSON.parse(pointerText));
+    } catch (error) {
+      if (error instanceof SyntaxError) throw new Error('latest-verified pointer is not valid JSON');
+      throw error;
+    }
+    var manifestBytes = await responseBytes(
+      await fetchImpl(pointer.record_manifest_path),
+      'append-only record manifest',
+      'manifest'
+    );
+    var manifestDigest = await sha256Hex(manifestBytes, cryptoImpl);
+    if (manifestDigest !== pointer.record_manifest_sha256) {
+      throw new Error('append-only record manifest digest does not match latest-verified');
+    }
+    var manifest;
+    try {
+      manifest = JSON.parse(decodeUTF8(manifestBytes, 'append-only record manifest'));
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error('append-only record manifest is not valid JSON');
+      }
+      throw error;
+    }
+    if (!manifest || manifest.schema_version !== 1 ||
+        manifest.candidate_sha256 !== pointer.candidate_sha256 ||
+        !manifest.files ||
+        manifest.files['continuous-gauntlet-pipelock.json'] !== pointer.candidate_sha256) {
+      throw new Error('append-only record manifest does not bind the selected candidate');
+    }
+
+    var artifactBytes = await responseBytes(
+      await fetchImpl(pointer.record_path),
+      'append-only result record',
+      'record'
+    );
+    var actualDigest = await sha256Hex(artifactBytes, cryptoImpl);
+    if (actualDigest !== pointer.candidate_sha256) {
+      throw new Error('append-only result digest does not match latest-verified');
+    }
+    var artifact;
+    try {
+      artifact = JSON.parse(decodeUTF8(artifactBytes, 'append-only result record'));
+    } catch (error) {
+      throw new Error('append-only result record is not valid JSON');
+    }
+    ['artifact_id', 'canonical_url', 'tool', 'tool_version', 'generated_at'].forEach(function(key) {
+      if (artifact[key] !== pointer[key]) {
+        throw new Error('latest-verified and result record disagree on ' + key);
+      }
+    });
+    return artifact;
+  }
+
+  root.validateLatestVerifiedPointer = validatePointer;
+  root.loadLatestVerifiedResult = loadLatestVerifiedResult;
+})(window);

--- a/gauntlet-site/latest-result.js
+++ b/gauntlet-site/latest-result.js
@@ -122,6 +122,9 @@
       if (artifact[key] !== pointer[key]) {
         throw new Error('latest-verified and result record disagree on ' + key);
       }
+      if (artifact[key] !== manifest[key]) {
+        throw new Error('record manifest and result record disagree on ' + key);
+      }
     });
     return artifact;
   }

--- a/gauntlet-site/latest-result_test.js
+++ b/gauntlet-site/latest-result_test.js
@@ -19,6 +19,11 @@ const artifactText = JSON.stringify(artifact) + '\n';
 const digest = nodeCrypto.createHash('sha256').update(artifactText).digest('hex');
 const manifest = {
   schema_version: 1,
+  tool: artifact.tool,
+  tool_version: artifact.tool_version,
+  artifact_id: artifact.artifact_id,
+  canonical_url: artifact.canonical_url,
+  generated_at: artifact.generated_at,
   candidate_sha256: digest,
   previous_candidate_sha256: null,
   previous_record_manifest_sha256: null,
@@ -111,6 +116,22 @@ function fetcher(pointerValue = pointer, recordText = artifactText, recordManife
       crypto
     ),
     /disagree on artifact_id/
+  );
+
+  const manifestIdentityMismatch = { ...manifest, tool_version: '9.9.9' };
+  const manifestIdentityMismatchText = JSON.stringify(manifestIdentityMismatch) + '\n';
+  const manifestIdentityMismatchPointer = {
+    ...pointer,
+    record_manifest_sha256: nodeCrypto.createHash('sha256')
+      .update(manifestIdentityMismatchText).digest('hex'),
+  };
+  await assert.rejects(
+    window.loadLatestVerifiedResult(
+      './latest-verified.json',
+      fetcher(manifestIdentityMismatchPointer, artifactText, manifestIdentityMismatchText),
+      crypto
+    ),
+    /record manifest and result record disagree on tool_version/
   );
 
   const missing = async () => response('', 404);

--- a/gauntlet-site/latest-result_test.js
+++ b/gauntlet-site/latest-result_test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const nodeCrypto = require('node:crypto');
+const crypto = nodeCrypto.webcrypto;
+
+global.window = {};
+require('./latest-result.js');
+
+const artifact = {
+  schema_version: 2,
+  artifact_id: 'github-actions:luckyPipewrench/agent-egress-bench:123',
+  canonical_url: 'https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123',
+  tool: 'pipelock',
+  tool_version: '3.3.0',
+  generated_at: '2026-08-05T00:10:08Z',
+};
+const artifactText = JSON.stringify(artifact) + '\n';
+const digest = nodeCrypto.createHash('sha256').update(artifactText).digest('hex');
+const manifest = {
+  schema_version: 1,
+  candidate_sha256: digest,
+  previous_candidate_sha256: null,
+  previous_record_manifest_sha256: null,
+  files: { 'continuous-gauntlet-pipelock.json': digest },
+};
+const manifestText = JSON.stringify(manifest) + '\n';
+const manifestDigest = nodeCrypto.createHash('sha256').update(manifestText).digest('hex');
+const pointer = {
+  schema_version: 1,
+  status: 'verified',
+  tool: artifact.tool,
+  tool_version: artifact.tool_version,
+  generated_at: artifact.generated_at,
+  artifact_id: artifact.artifact_id,
+  canonical_url: artifact.canonical_url,
+  candidate_sha256: digest,
+  record_manifest_sha256: manifestDigest,
+  record_path: './results/pipelock/' + digest + '/continuous-gauntlet-pipelock.json',
+  record_manifest_path: './results/pipelock/' + digest + '/record-manifest.json',
+};
+
+function response(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    arrayBuffer: async () => {
+      const bytes = Buffer.from(body);
+      return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    },
+  };
+}
+
+function fetcher(pointerValue = pointer, recordText = artifactText, recordManifestText = manifestText) {
+  return async (url) => {
+    if (url === './latest-verified.json') return response(JSON.stringify(pointerValue));
+    if (url === pointerValue.record_manifest_path) return response(recordManifestText);
+    if (url === pointerValue.record_path) return response(recordText);
+    return response('', 404);
+  };
+}
+
+(async () => {
+  const loaded = await window.loadLatestVerifiedResult(
+    './latest-verified.json', fetcher(), crypto
+  );
+  assert.deepEqual(loaded, artifact);
+
+  const unsafe = { ...pointer, record_path: 'https://attacker.example/result.json' };
+  await assert.rejects(
+    window.loadLatestVerifiedResult('./latest-verified.json', fetcher(unsafe), crypto),
+    /record_path is not canonical/
+  );
+
+  await assert.rejects(
+    window.loadLatestVerifiedResult(
+      './latest-verified.json', fetcher(pointer, artifactText + ' '), crypto
+    ),
+    /digest does not match/
+  );
+
+  await assert.rejects(
+    window.loadLatestVerifiedResult(
+      './latest-verified.json', fetcher(pointer, artifactText, manifestText + ' '), crypto
+    ),
+    /record manifest digest does not match/
+  );
+
+  const mismatch = { ...artifact, artifact_id: artifact.artifact_id + ':other' };
+  const mismatchText = JSON.stringify(mismatch) + '\n';
+  const mismatchDigest = nodeCrypto.createHash('sha256').update(mismatchText).digest('hex');
+  const mismatchManifest = {
+    ...manifest,
+    candidate_sha256: mismatchDigest,
+    files: { 'continuous-gauntlet-pipelock.json': mismatchDigest },
+  };
+  const mismatchManifestText = JSON.stringify(mismatchManifest) + '\n';
+  const mismatchManifestDigest = nodeCrypto.createHash('sha256')
+    .update(mismatchManifestText).digest('hex');
+  const mismatchPointer = {
+    ...pointer,
+    candidate_sha256: mismatchDigest,
+    record_manifest_sha256: mismatchManifestDigest,
+    record_path: './results/pipelock/' + mismatchDigest + '/continuous-gauntlet-pipelock.json',
+    record_manifest_path: './results/pipelock/' + mismatchDigest + '/record-manifest.json',
+  };
+  await assert.rejects(
+    window.loadLatestVerifiedResult(
+      './latest-verified.json',
+      fetcher(mismatchPointer, mismatchText, mismatchManifestText),
+      crypto
+    ),
+    /disagree on artifact_id/
+  );
+
+  const missing = async () => response('', 404);
+  const missingError = await window.loadLatestVerifiedResult(
+    './latest-verified.json', missing, crypto
+  ).then(() => null, (error) => error);
+  assert.equal(missingError.status, 404);
+  assert.equal(missingError.resource, 'pointer');
+
+  const missingRecord = async (url) => {
+    if (url === './latest-verified.json') return response(JSON.stringify(pointer));
+    if (url === pointer.record_manifest_path) return response(manifestText);
+    return response('', 404);
+  };
+  const recordError = await window.loadLatestVerifiedResult(
+    './latest-verified.json', missingRecord, crypto
+  ).then(() => null, (error) => error);
+  assert.equal(recordError.status, 404);
+  assert.equal(recordError.resource, 'record');
+
+  console.log('latest verified result loader tests: OK');
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/gauntlet_site_index_test.py
+++ b/scripts/gauntlet_site_index_test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Structural tests for pointer-first Gauntlet result rendering."""
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEX = REPO_ROOT / "gauntlet-site" / "index.html"
+
+
+class GauntletSiteIndexTest(unittest.TestCase):
+    def setUp(self):
+        self.html = INDEX.read_text(encoding="utf-8")
+
+    def test_verified_pointer_loads_before_legacy_result(self):
+        latest = self.html.index("window.loadLatestVerifiedResult(")
+        legacy = self.html.index("function loadLegacyResult()")
+        self.assertLess(legacy, latest)
+        self.assertIn(
+            "if (err.status === 404 && err.resource === 'pointer') return loadLegacyResult();",
+            self.html,
+        )
+        self.assertNotIn("catch(function() { return loadLegacyResult();", self.html)
+
+    def test_verified_scope_is_rendered_as_one_validated_block(self):
+        self.assertIn("card.appendChild(window.renderGauntletScope(r));", self.html)
+        self.assertIn('<script src="./scope-render.js"></script>', self.html)
+        self.assertIn('<script src="./latest-result.js"></script>', self.html)
+
+    def test_current_scope_identity_matches_repository_versions(self):
+        self.assertIn('data-corpus-version="v2.3.0"', self.html)
+        self.assertIn('data-scoring-version="2.4"', self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/promote_gauntlet_candidate.py
+++ b/scripts/promote_gauntlet_candidate.py
@@ -24,6 +24,9 @@ BASELINE_SNAPSHOT_FILENAME = "reviewed-baseline.json"
 SOURCE_BASELINE_FILENAME = "source-baseline.json"
 RECORD_MANIFEST_FILENAME = "record-manifest.json"
 LATEST_POINTER_FILENAME = "latest-verified.json"
+SOURCE_PROMOTION_DECISION_FILENAME = "source-promotion-decision.json"
+DEFAULT_ARTIFACT_PREFIX = "github-actions:luckyPipewrench/agent-egress-bench:"
+DEFAULT_URL_PREFIX = "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/"
 SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
 REVIEWABLE_SCORE_FAILURE = re.compile(
     r"^scores\.(?:full|applicable)\.[a-z_]+=.+, "
@@ -98,13 +101,23 @@ def validate_candidate_origin(candidate, artifact_prefix, url_prefix, expected_r
     if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
         raise ValueError("canonical_url must be an absolute HTTPS URL")
     run_id = artifact_id.removeprefix(artifact_prefix)
-    if not run_id.isdigit() or run_id.startswith("0"):
+    if not run_id.isascii() or not run_id.isdigit() or run_id.startswith("0"):
         raise ValueError("artifact_id must end in a positive decimal run ID")
     expected_url = url_prefix + run_id
     if canonical_url != expected_url:
         raise ValueError("artifact_id and canonical_url run IDs do not match")
     if expected_run_id is not None and run_id != expected_run_id:
         raise ValueError("candidate run ID does not match the requested source run")
+
+
+def validate_reference_candidate(candidate):
+    if candidate.get("schema_version") != 2:
+        raise ValueError("candidate schema_version must be 2")
+    if candidate.get("tool") != "pipelock":
+        raise ValueError("reference promotion candidate tool must be pipelock")
+    tool_version = require_non_empty_string(candidate, "tool_version")
+    if tool_version != require_non_empty_string(candidate, "pipelock_version"):
+        raise ValueError("candidate tool_version and pipelock_version must match")
 
 
 def reviewable_policy_failure(failure):
@@ -210,6 +223,8 @@ def manifest_for(
 def validate_record(record_dir, candidate_sha256):
     manifest_path = record_dir / RECORD_MANIFEST_FILENAME
     manifest = require_object(manifest_path)
+    if manifest.get("schema_version") != 1:
+        raise ValueError("record manifest schema_version must be 1")
     require_sha256(manifest.get("candidate_sha256"), "record candidate_sha256")
     if manifest["candidate_sha256"] != candidate_sha256:
         raise ValueError("existing record candidate digest does not match its directory")
@@ -235,15 +250,34 @@ def validate_record(record_dir, candidate_sha256):
         require_sha256(expected, f"record files.{filename}")
         if evaluator.file_sha256(record_dir / filename) != expected:
             raise ValueError(f"existing record file changed: {filename}")
+    candidate = require_object(record_dir / CANDIDATE_FILENAME)
+    for field in ("tool", "tool_version", "artifact_id", "canonical_url", "generated_at"):
+        if manifest.get(field) != candidate.get(field):
+            raise ValueError(f"record manifest and candidate disagree on {field}")
     return manifest
+
+
+def canonical_pointer_paths(latest_path, candidate_sha256):
+    site_root = latest_path.resolve().parent
+    record_root = site_root / "results" / "pipelock" / candidate_sha256
+    base = "./" + record_root.relative_to(site_root).as_posix()
+    return (
+        f"{base}/{CANDIDATE_FILENAME}",
+        f"{base}/{RECORD_MANIFEST_FILENAME}",
+    )
+
+
+def validate_site_layout(store_root, latest_path):
+    expected_store_root = latest_path.resolve().parent / "results"
+    if store_root.resolve() != expected_store_root:
+        raise ValueError("store root must be the results directory beside latest-verified")
 
 
 def validate_pointer(pointer, latest_path):
     if pointer.get("schema_version") != 1 or pointer.get("status") != "verified":
         raise ValueError("latest pointer must be a schema-v1 verified pointer")
     candidate_sha256 = require_sha256(pointer.get("candidate_sha256"), "pointer candidate_sha256")
-    expected_record = f"./results/pipelock/{candidate_sha256}/{CANDIDATE_FILENAME}"
-    expected_manifest = f"./results/pipelock/{candidate_sha256}/{RECORD_MANIFEST_FILENAME}"
+    expected_record, expected_manifest = canonical_pointer_paths(latest_path, candidate_sha256)
     if pointer.get("record_path") != expected_record:
         raise ValueError("latest pointer record_path is not canonical")
     if pointer.get("record_manifest_path") != expected_manifest:
@@ -269,6 +303,10 @@ def existing_promotion_is_complete(latest_path, record_dir, candidate_sha256):
     if pointer["candidate_sha256"] != candidate_sha256:
         return False
     manifest = validate_record(record_dir, candidate_sha256)
+    candidate = require_object(record_dir / CANDIDATE_FILENAME)
+    for field in ("tool", "tool_version", "artifact_id", "canonical_url", "generated_at"):
+        if pointer.get(field) != candidate.get(field):
+            raise ValueError(f"latest pointer and record candidate disagree on {field}")
     if evaluator.file_sha256(record_dir / RECORD_MANIFEST_FILENAME) != pointer["record_manifest_sha256"]:
         raise ValueError("latest pointer record manifest digest does not match the record")
     if manifest["candidate_sha256"] != candidate_sha256:
@@ -374,12 +412,12 @@ def promote(args):
         raise ValueError("artifact directory is missing the candidate or source decision")
 
     candidate = require_object(candidate_path)
-    if candidate.get("schema_version") != 2:
-        raise ValueError("candidate schema_version must be 2")
+    validate_reference_candidate(candidate)
     validate_candidate_origin(
         candidate, args.artifact_prefix, args.url_prefix, args.expected_run_id
     )
     candidate_sha256 = evaluator.file_sha256(candidate_path)
+    validate_site_layout(args.store_root, args.latest)
     tool_root = args.store_root.resolve() / "pipelock"
     record_dir = tool_root / candidate_sha256
     latest_path = args.latest.resolve()
@@ -392,7 +430,9 @@ def promote(args):
             raise ValueError("latest-verified record and reviewed baseline are out of sync")
         if args.summary is not None:
             stored_candidate = require_object(record_dir / CANDIDATE_FILENAME)
-            stored_source_decision = require_object(record_dir / "source-promotion-decision.json")
+            stored_source_decision = require_object(
+                record_dir / SOURCE_PROMOTION_DECISION_FILENAME
+            )
             write_summary(
                 args.summary.resolve(),
                 stored_candidate,
@@ -458,7 +498,10 @@ def promote(args):
         temporary_record = Path(tempfile.mkdtemp(prefix=f".{candidate_sha256}.", dir=tool_root))
         try:
             atomic_copy(candidate_path, temporary_record / CANDIDATE_FILENAME)
-            atomic_copy(source_decision_path, temporary_record / "source-promotion-decision.json")
+            atomic_copy(
+                source_decision_path,
+                temporary_record / SOURCE_PROMOTION_DECISION_FILENAME,
+            )
             atomic_copy(args.baseline.resolve(), temporary_record / SOURCE_BASELINE_FILENAME)
             for path in paths.values():
                 atomic_copy(path, temporary_record / path.name)
@@ -484,6 +527,7 @@ def promote(args):
                 shutil.rmtree(temporary_record)
 
     manifest_sha256 = evaluator.file_sha256(record_dir / RECORD_MANIFEST_FILENAME)
+    record_path, record_manifest_path = canonical_pointer_paths(latest_path, candidate_sha256)
     pointer = {
         "schema_version": 1,
         "status": "verified",
@@ -496,8 +540,8 @@ def promote(args):
         "record_manifest_sha256": manifest_sha256,
         "previous_candidate_sha256": previous_candidate_sha256,
         "previous_record_manifest_sha256": previous_record_manifest_sha256,
-        "record_path": f"./results/pipelock/{candidate_sha256}/{CANDIDATE_FILENAME}",
-        "record_manifest_path": f"./results/pipelock/{candidate_sha256}/{RECORD_MANIFEST_FILENAME}",
+        "record_path": record_path,
+        "record_manifest_path": record_manifest_path,
     }
     evaluator.atomic_json_write(args.baseline.resolve(), baseline)
     evaluator.atomic_json_write(latest_path, pointer)
@@ -524,11 +568,11 @@ def parse_args():
     parser.add_argument("--summary", type=Path)
     parser.add_argument(
         "--artifact-prefix",
-        default="github-actions:luckyPipewrench/agent-egress-bench:",
+        default=DEFAULT_ARTIFACT_PREFIX,
     )
     parser.add_argument(
         "--url-prefix",
-        default="https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/",
+        default=DEFAULT_URL_PREFIX,
     )
     parser.add_argument("--expected-run-id")
     parser.add_argument("--accept-policy-change", action="store_true")
@@ -538,7 +582,7 @@ def parse_args():
 def main():
     try:
         promote(parse_args())
-    except (OSError, json.JSONDecodeError, ValueError) as exc:
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
         print(f"promotion: BLOCKED: {exc}")
         return 1
     return 0

--- a/scripts/promote_gauntlet_candidate.py
+++ b/scripts/promote_gauntlet_candidate.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Prepare an append-only Gauntlet result and latest-verified pointer."""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse
+
+import build_gauntlet_provenance as provenance
+import evaluate_gauntlet_candidate as evaluator
+
+
+CANDIDATE_FILENAME = "continuous-gauntlet-pipelock.json"
+SOURCE_DECISION_FILENAME = "promotion-decision.json"
+EXECUTION_DECISION_FILENAME = "execution-decision.json"
+RUN_BUNDLE_FILENAME = "run-bundle.json"
+PUBLISHED_DECISION_FILENAME = "reviewed-promotion-decision.json"
+BASELINE_SNAPSHOT_FILENAME = "reviewed-baseline.json"
+SOURCE_BASELINE_FILENAME = "source-baseline.json"
+RECORD_MANIFEST_FILENAME = "record-manifest.json"
+LATEST_POINTER_FILENAME = "latest-verified.json"
+SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
+REVIEWABLE_SCORE_FAILURE = re.compile(
+    r"^scores\.(?:full|applicable)\.[a-z_]+=.+, "
+    r"(?:below baseline floor|above baseline ceiling) .+$"
+)
+
+EVIDENCE_FILES = {
+    **provenance.RAW_EVIDENCE,
+    "execution_decision": EXECUTION_DECISION_FILENAME,
+    "run_bundle": RUN_BUNDLE_FILENAME,
+}
+
+
+def require_object(path):
+    return evaluator.load_object(path)
+
+
+def require_non_empty_string(document, key):
+    value = document.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def require_sha256(value, label):
+    if not isinstance(value, str) or not SHA256_HEX.fullmatch(value):
+        raise ValueError(f"{label} must be 64 lower-case hex characters")
+    return value
+
+
+def parse_timestamp(value, label):
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise ValueError(f"{label} must be an ISO-8601 timestamp with a timezone") from exc
+    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        raise ValueError(f"{label} must be an ISO-8601 timestamp with a timezone")
+    return timestamp
+
+
+def evidence_paths(artifact_dir):
+    paths = {}
+    for label, filename in EVIDENCE_FILES.items():
+        path = artifact_dir / filename
+        if not path.is_file() or path.is_symlink():
+            raise ValueError(f"required evidence is missing: {label} ({filename})")
+        paths[label] = path
+    return paths
+
+
+def validate_execution_decision(path):
+    decision = require_object(path)
+    if decision.get("execution_status") != "complete":
+        raise ValueError("execution decision is not complete")
+    if decision.get("blocked") is not False:
+        raise ValueError("execution decision is blocked")
+    if decision.get("publication_eligible") is not True:
+        raise ValueError("execution decision is not publication eligible")
+    failures = decision.get("failures")
+    if failures != []:
+        raise ValueError("execution decision failures must be an empty array")
+
+
+def validate_candidate_origin(candidate, artifact_prefix, url_prefix, expected_run_id):
+    artifact_id = require_non_empty_string(candidate, "artifact_id")
+    canonical_url = require_non_empty_string(candidate, "canonical_url")
+    if not artifact_id.startswith(artifact_prefix):
+        raise ValueError(f"artifact_id must start with {artifact_prefix!r}")
+    if not canonical_url.startswith(url_prefix):
+        raise ValueError(f"canonical_url must start with {url_prefix!r}")
+    parsed = urlparse(canonical_url)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
+        raise ValueError("canonical_url must be an absolute HTTPS URL")
+    run_id = artifact_id.removeprefix(artifact_prefix)
+    if not run_id.isdigit() or run_id.startswith("0"):
+        raise ValueError("artifact_id must end in a positive decimal run ID")
+    expected_url = url_prefix + run_id
+    if canonical_url != expected_url:
+        raise ValueError("artifact_id and canonical_url run IDs do not match")
+    if expected_run_id is not None and run_id != expected_run_id:
+        raise ValueError("candidate run ID does not match the requested source run")
+
+
+def reviewable_policy_failure(failure):
+    if not isinstance(failure, str):
+        return False
+    if REVIEWABLE_SCORE_FAILURE.fullmatch(failure):
+        return True
+    return failure.startswith("pipelock_version=") and ", baseline is " in failure
+
+
+def proposed_baseline(candidate, candidate_sha256):
+    generated_at = require_non_empty_string(candidate, "generated_at")
+    recorded_on = parse_timestamp(generated_at, "generated_at").date().isoformat()
+
+    counts = candidate.get("case_count")
+    scores = candidate.get("scores")
+    if not isinstance(counts, dict) or not isinstance(scores, dict):
+        raise ValueError("candidate case_count and scores must be objects")
+    applicable_scores = scores.get("applicable")
+    full_scores = scores.get("full")
+    if not isinstance(applicable_scores, dict) or not isinstance(full_scores, dict):
+        raise ValueError("candidate full and applicable scores must be objects")
+
+    return {
+        "_comment": (
+            "Reviewed baseline for the continuous Gauntlet lane. Exact candidate scores become "
+            "the next run's floors and ceiling only through a promotion PR. Public records remain "
+            "append-only and the latest-verified pointer moves only with that reviewed commit."
+        ),
+        "schema_version": 1,
+        "recorded_on": recorded_on,
+        "verified_candidate_sha256": candidate_sha256,
+        "verified_artifact_id": require_non_empty_string(candidate, "artifact_id"),
+        "pipelock_version": require_non_empty_string(candidate, "pipelock_version"),
+        "corpus_git_sha": require_non_empty_string(candidate, "corpus_git_sha"),
+        "corpus_sha256": require_non_empty_string(candidate, "corpus_sha256"),
+        "corpus_version": require_non_empty_string(candidate, "corpus_version"),
+        "scoring_version": require_non_empty_string(candidate, "scoring_version"),
+        "runner_version": require_non_empty_string(candidate, "runner_version"),
+        "observed_case_count": {
+            "total": counts.get("total"),
+            "applicable": counts.get("applicable"),
+            "not_applicable": counts.get("not_applicable"),
+            "not_applicable_reasons": counts.get("not_applicable_reasons"),
+        },
+        "score_floors": {
+            "full": {"containment": full_scores.get("containment")},
+            "applicable": {
+                "containment": applicable_scores.get("containment"),
+                "detection": applicable_scores.get("detection"),
+                "evidence": applicable_scores.get("evidence"),
+            },
+        },
+        "score_ceilings": {
+            "applicable": {"false_positive_rate": applicable_scores.get("false_positive_rate")}
+        },
+    }
+
+
+def atomic_copy(source, destination):
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=destination.name + ".", dir=destination.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as target, source.open("rb") as current:
+            shutil.copyfileobj(current, target)
+            target.flush()
+            os.fsync(target.fileno())
+        os.replace(temporary_name, destination)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def manifest_for(
+    record_dir,
+    candidate,
+    previous_candidate_sha256,
+    previous_record_manifest_sha256,
+):
+    files = {}
+    for path in sorted(record_dir.iterdir(), key=lambda item: item.name):
+        if path.is_symlink() or not path.is_file():
+            raise ValueError(f"record contains a non-regular entry: {path.name}")
+        if path.name != RECORD_MANIFEST_FILENAME:
+            files[path.name] = evaluator.file_sha256(path)
+    return {
+        "schema_version": 1,
+        "tool": require_non_empty_string(candidate, "tool"),
+        "tool_version": require_non_empty_string(candidate, "tool_version"),
+        "artifact_id": require_non_empty_string(candidate, "artifact_id"),
+        "canonical_url": require_non_empty_string(candidate, "canonical_url"),
+        "generated_at": require_non_empty_string(candidate, "generated_at"),
+        "candidate_sha256": files[CANDIDATE_FILENAME],
+        "previous_candidate_sha256": previous_candidate_sha256,
+        "previous_record_manifest_sha256": previous_record_manifest_sha256,
+        "files": files,
+    }
+
+
+def validate_record(record_dir, candidate_sha256):
+    manifest_path = record_dir / RECORD_MANIFEST_FILENAME
+    manifest = require_object(manifest_path)
+    require_sha256(manifest.get("candidate_sha256"), "record candidate_sha256")
+    if manifest["candidate_sha256"] != candidate_sha256:
+        raise ValueError("existing record candidate digest does not match its directory")
+    previous_candidate = manifest.get("previous_candidate_sha256")
+    previous_manifest = manifest.get("previous_record_manifest_sha256")
+    if previous_candidate is None:
+        if previous_manifest is not None:
+            raise ValueError("first record cannot name a previous record manifest")
+    else:
+        require_sha256(previous_candidate, "record previous_candidate_sha256")
+        require_sha256(previous_manifest, "record previous_record_manifest_sha256")
+    files = manifest.get("files")
+    if not isinstance(files, dict) or not files:
+        raise ValueError("record manifest files must be a non-empty object")
+    entries = list(record_dir.iterdir())
+    if any(path.is_symlink() or not path.is_file() for path in entries):
+        raise ValueError("existing record contains a non-regular entry")
+    expected_names = set(files) | {RECORD_MANIFEST_FILENAME}
+    actual_names = {path.name for path in entries}
+    if actual_names != expected_names:
+        raise ValueError("existing record file set does not match its manifest")
+    for filename, expected in files.items():
+        require_sha256(expected, f"record files.{filename}")
+        if evaluator.file_sha256(record_dir / filename) != expected:
+            raise ValueError(f"existing record file changed: {filename}")
+    return manifest
+
+
+def validate_pointer(pointer, latest_path):
+    if pointer.get("schema_version") != 1 or pointer.get("status") != "verified":
+        raise ValueError("latest pointer must be a schema-v1 verified pointer")
+    candidate_sha256 = require_sha256(pointer.get("candidate_sha256"), "pointer candidate_sha256")
+    expected_record = f"./results/pipelock/{candidate_sha256}/{CANDIDATE_FILENAME}"
+    expected_manifest = f"./results/pipelock/{candidate_sha256}/{RECORD_MANIFEST_FILENAME}"
+    if pointer.get("record_path") != expected_record:
+        raise ValueError("latest pointer record_path is not canonical")
+    if pointer.get("record_manifest_path") != expected_manifest:
+        raise ValueError("latest pointer record_manifest_path is not canonical")
+    require_sha256(pointer.get("record_manifest_sha256"), "pointer record_manifest_sha256")
+    previous_candidate = pointer.get("previous_candidate_sha256")
+    previous_manifest = pointer.get("previous_record_manifest_sha256")
+    if previous_candidate is None:
+        if previous_manifest is not None:
+            raise ValueError("first latest pointer cannot name a previous record manifest")
+    else:
+        require_sha256(previous_candidate, "pointer previous_candidate_sha256")
+        require_sha256(previous_manifest, "pointer previous_record_manifest_sha256")
+    generated_at = require_non_empty_string(pointer, "generated_at")
+    parse_timestamp(generated_at, f"{latest_path} generated_at")
+    return pointer
+
+
+def existing_promotion_is_complete(latest_path, record_dir, candidate_sha256):
+    if not latest_path.is_file() or not record_dir.is_dir():
+        return False
+    pointer = validate_pointer(require_object(latest_path), latest_path)
+    if pointer["candidate_sha256"] != candidate_sha256:
+        return False
+    manifest = validate_record(record_dir, candidate_sha256)
+    if evaluator.file_sha256(record_dir / RECORD_MANIFEST_FILENAME) != pointer["record_manifest_sha256"]:
+        raise ValueError("latest pointer record manifest digest does not match the record")
+    if manifest["candidate_sha256"] != candidate_sha256:
+        raise ValueError("latest pointer and record candidate digests differ")
+    for field in ("previous_candidate_sha256", "previous_record_manifest_sha256"):
+        if manifest.get(field) != pointer.get(field):
+            raise ValueError(f"latest pointer and record manifest disagree on {field}")
+    return True
+
+
+def markdown_code(value):
+    return str(value).replace("`", "'").replace("\r", " ").replace("\n", " ")
+
+
+def nonpassing_case_lines(results_path):
+    lines = []
+    with results_path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"results JSONL line {line_number} is invalid") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"results JSONL line {line_number} must be an object")
+            if row.get("score") not in {"fail", "error"}:
+                continue
+            evidence = row.get("evidence") if isinstance(row.get("evidence"), dict) else {}
+            detail = evidence.get("error_message") or evidence.get("reason") or row.get("notes") or ""
+            timing = evidence.get("budget_block_timing")
+            suffix = f"; {timing}" if timing else ""
+            if detail:
+                suffix += f"; {detail}"
+            lines.append(
+                "- `{}`: expected `{}`, observed `{}`, score `{}`{}".format(
+                    markdown_code(row.get("case_id", "unknown")),
+                    markdown_code(row.get("expected_verdict", "unknown")),
+                    markdown_code(row.get("actual_verdict", "unknown")),
+                    markdown_code(row.get("score", "unknown")),
+                    markdown_code(suffix),
+                )
+            )
+    return lines
+
+
+def write_summary(
+    path, candidate, candidate_sha256, source_decision, policy_change, results_path
+):
+    counts = candidate["case_count"]
+    applicable_scores = candidate["scores"]["applicable"]
+    full_scores = candidate["scores"]["full"]
+    lines = [
+        "## Continuous Gauntlet result promotion",
+        "",
+        (
+            f"- Source run: [{markdown_code(candidate['artifact_id'])}]"
+            f"({candidate['canonical_url']})"
+        ),
+        f"- Candidate SHA-256: `{candidate_sha256}`",
+        f"- Pipelock: `{markdown_code(candidate['pipelock_version'])}`",
+        (
+            f"- Corpus: `{markdown_code(candidate['corpus_version'])}` at "
+            f"`{markdown_code(candidate['corpus_git_sha'])}`"
+        ),
+        (
+            f"- Scope: `{counts['applicable']} / {counts['total']}` applicable, "
+            f"`{counts['not_applicable']}` N/A, `{counts['errors']}` errors"
+        ),
+        f"- Applicable containment: `{applicable_scores['containment']}`",
+        f"- Full-corpus containment: `{full_scores['containment']}`",
+        f"- Applicable false-positive rate: `{applicable_scores['false_positive_rate']}`",
+        f"- Reviewed policy change proposed: `{'yes' if policy_change else 'no'}`",
+        "",
+        (
+            "Merging this PR adds one immutable evidence record, updates the reviewed baseline, "
+            "and advances `latest-verified`. It does not replace or delete earlier records."
+        ),
+    ]
+    failures = source_decision.get("failures", [])
+    notes = source_decision.get("review_notes", [])
+    if failures or notes:
+        lines.extend(["", "### Source decision"])
+        lines.extend(f"- Failure: {markdown_code(value)}" for value in failures)
+        lines.extend(f"- Review: {markdown_code(value)}" for value in notes)
+    case_lines = nonpassing_case_lines(results_path)
+    if case_lines:
+        lines.extend(["", "### Non-passing applicable cases", *case_lines])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def promote(args):
+    artifact_dir = args.artifact_dir.resolve()
+    candidate_path = artifact_dir / CANDIDATE_FILENAME
+    source_decision_path = artifact_dir / SOURCE_DECISION_FILENAME
+    if (
+        not candidate_path.is_file()
+        or candidate_path.is_symlink()
+        or not source_decision_path.is_file()
+        or source_decision_path.is_symlink()
+    ):
+        raise ValueError("artifact directory is missing the candidate or source decision")
+
+    candidate = require_object(candidate_path)
+    if candidate.get("schema_version") != 2:
+        raise ValueError("candidate schema_version must be 2")
+    validate_candidate_origin(
+        candidate, args.artifact_prefix, args.url_prefix, args.expected_run_id
+    )
+    candidate_sha256 = evaluator.file_sha256(candidate_path)
+    tool_root = args.store_root.resolve() / "pipelock"
+    record_dir = tool_root / candidate_sha256
+    latest_path = args.latest.resolve()
+    previous_candidate_sha256 = None
+    previous_record_manifest_sha256 = None
+
+    if existing_promotion_is_complete(latest_path, record_dir, candidate_sha256):
+        baseline_snapshot = record_dir / BASELINE_SNAPSHOT_FILENAME
+        if evaluator.file_sha256(args.baseline.resolve()) != evaluator.file_sha256(baseline_snapshot):
+            raise ValueError("latest-verified record and reviewed baseline are out of sync")
+        if args.summary is not None:
+            stored_candidate = require_object(record_dir / CANDIDATE_FILENAME)
+            stored_source_decision = require_object(record_dir / "source-promotion-decision.json")
+            write_summary(
+                args.summary.resolve(),
+                stored_candidate,
+                candidate_sha256,
+                stored_source_decision,
+                bool(stored_source_decision.get("failures"))
+                or stored_source_decision.get("promotion_status")
+                == "scope_changed_requires_review",
+                record_dir / provenance.RAW_EVIDENCE["results"],
+            )
+        print(f"promotion already complete for {candidate_sha256}")
+        return record_dir
+
+    if latest_path.is_file():
+        previous = validate_pointer(require_object(latest_path), latest_path)
+        previous_candidate_sha256 = previous["candidate_sha256"]
+        previous_record_manifest_sha256 = previous["record_manifest_sha256"]
+        previous_record = tool_root / previous["candidate_sha256"]
+        validate_record(previous_record, previous["candidate_sha256"])
+        if (
+            evaluator.file_sha256(previous_record / RECORD_MANIFEST_FILENAME)
+            != previous["record_manifest_sha256"]
+        ):
+            raise ValueError("existing latest pointer does not match its append-only record")
+        previous_time = parse_timestamp(previous["generated_at"], "previous generated_at")
+        current_time = parse_timestamp(candidate.get("generated_at"), "candidate generated_at")
+        if current_time <= previous_time:
+            raise ValueError("refusing to move latest-verified backward or sideways in time")
+
+    paths = evidence_paths(artifact_dir)
+    validate_execution_decision(paths["execution_decision"])
+
+    source_decision = require_object(source_decision_path)
+    fresh_source_decision = evaluator.evaluate(candidate_path, args.baseline, paths)
+    if source_decision != fresh_source_decision:
+        raise ValueError("source decision does not match a fresh evaluation against the current baseline")
+    failures = fresh_source_decision.get("failures")
+    if not isinstance(failures, list):
+        raise ValueError("source decision failures must be an array")
+    scope_change = fresh_source_decision.get("promotion_status") == "scope_changed_requires_review"
+    policy_change = bool(failures) or scope_change
+    if policy_change and not args.accept_policy_change:
+        raise ValueError(
+            "candidate requires an explicit reviewed policy-change proposal"
+        )
+    if failures:
+        unreviewable = [failure for failure in failures if not reviewable_policy_failure(failure)]
+        if unreviewable:
+            raise ValueError("candidate has non-reviewable failures: " + "; ".join(unreviewable))
+
+    baseline = proposed_baseline(candidate, candidate_sha256)
+    with tempfile.TemporaryDirectory(prefix="gauntlet-promotion-") as temporary:
+        proposed_baseline_path = Path(temporary) / BASELINE_SNAPSHOT_FILENAME
+        evaluator.atomic_json_write(proposed_baseline_path, baseline)
+        reviewed_decision = evaluator.evaluate(candidate_path, proposed_baseline_path, paths)
+        if reviewed_decision.get("blocked") is not False:
+            raise ValueError(
+                "candidate remains blocked against its proposed baseline: "
+                + "; ".join(reviewed_decision.get("failures", []))
+            )
+
+        tool_root.mkdir(parents=True, exist_ok=True)
+        temporary_record = Path(tempfile.mkdtemp(prefix=f".{candidate_sha256}.", dir=tool_root))
+        try:
+            atomic_copy(candidate_path, temporary_record / CANDIDATE_FILENAME)
+            atomic_copy(source_decision_path, temporary_record / "source-promotion-decision.json")
+            atomic_copy(args.baseline.resolve(), temporary_record / SOURCE_BASELINE_FILENAME)
+            for path in paths.values():
+                atomic_copy(path, temporary_record / path.name)
+            evaluator.atomic_json_write(
+                temporary_record / PUBLISHED_DECISION_FILENAME, reviewed_decision
+            )
+            atomic_copy(proposed_baseline_path, temporary_record / BASELINE_SNAPSHOT_FILENAME)
+            record_manifest = manifest_for(
+                temporary_record,
+                candidate,
+                previous_candidate_sha256,
+                previous_record_manifest_sha256,
+            )
+            evaluator.atomic_json_write(
+                temporary_record / RECORD_MANIFEST_FILENAME, record_manifest
+            )
+            if record_dir.exists():
+                validate_record(record_dir, candidate_sha256)
+                raise ValueError("append-only record already exists without a matching latest pointer")
+            os.replace(temporary_record, record_dir)
+        finally:
+            if temporary_record.exists():
+                shutil.rmtree(temporary_record)
+
+    manifest_sha256 = evaluator.file_sha256(record_dir / RECORD_MANIFEST_FILENAME)
+    pointer = {
+        "schema_version": 1,
+        "status": "verified",
+        "tool": "pipelock",
+        "tool_version": require_non_empty_string(candidate, "tool_version"),
+        "generated_at": require_non_empty_string(candidate, "generated_at"),
+        "artifact_id": require_non_empty_string(candidate, "artifact_id"),
+        "canonical_url": require_non_empty_string(candidate, "canonical_url"),
+        "candidate_sha256": candidate_sha256,
+        "record_manifest_sha256": manifest_sha256,
+        "previous_candidate_sha256": previous_candidate_sha256,
+        "previous_record_manifest_sha256": previous_record_manifest_sha256,
+        "record_path": f"./results/pipelock/{candidate_sha256}/{CANDIDATE_FILENAME}",
+        "record_manifest_path": f"./results/pipelock/{candidate_sha256}/{RECORD_MANIFEST_FILENAME}",
+    }
+    evaluator.atomic_json_write(args.baseline.resolve(), baseline)
+    evaluator.atomic_json_write(latest_path, pointer)
+    if args.summary is not None:
+        write_summary(
+            args.summary.resolve(),
+            candidate,
+            candidate_sha256,
+            fresh_source_decision,
+            policy_change,
+            paths["results"],
+        )
+    print(f"prepared append-only record {record_dir}")
+    print(f"advanced latest-verified to {candidate_sha256}")
+    return record_dir
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--store-root", type=Path, default=Path("gauntlet-site/results"))
+    parser.add_argument("--latest", type=Path, default=Path("gauntlet-site") / LATEST_POINTER_FILENAME)
+    parser.add_argument("--summary", type=Path)
+    parser.add_argument(
+        "--artifact-prefix",
+        default="github-actions:luckyPipewrench/agent-egress-bench:",
+    )
+    parser.add_argument(
+        "--url-prefix",
+        default="https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/",
+    )
+    parser.add_argument("--expected-run-id")
+    parser.add_argument("--accept-policy-change", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    try:
+        promote(parse_args())
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"promotion: BLOCKED: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/promote_gauntlet_candidate_test.py
+++ b/scripts/promote_gauntlet_candidate_test.py
@@ -98,7 +98,7 @@ def candidate(run_id="123", generated_at="2026-08-05T00:10:08Z"):
         },
         "scores": {
             "full": {
-                "containment": 0.99,
+                "containment": 157 / 158,
                 "detection": 1.0,
                 "evidence": 1.0,
                 "false_positive_rate": 0.0,
@@ -122,6 +122,7 @@ class PromotionFixture:
         self.store_root = root / "site" / "results"
         self.latest = root / "site" / "latest-verified.json"
         self.baseline_path = root / "baseline.json"
+        self.summary = root / "promotion-summary.md"
         write_json(self.baseline_path, baseline_value or baseline())
 
         self.evidence = {}
@@ -174,7 +175,6 @@ class PromotionFixture:
         write_json(self.artifact_dir / promotion.SOURCE_DECISION_FILENAME, decision)
 
     def command(self, accept_policy_change=False):
-        self.summary = self.root / "promotion-summary.md"
         command = [
             sys.executable,
             str(SCRIPT),
@@ -235,7 +235,8 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
 
     def test_same_promotion_is_idempotent(self):
         fixture = self.fixture()
-        self.assertEqual(fixture.run().returncode, 0)
+        first = fixture.run()
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
         fixture.summary.unlink()
         second = fixture.run()
         self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
@@ -255,6 +256,18 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
             evaluator.load_object(fixture.baseline_path)["score_floors"]["full"]["containment"],
             0.98,
         )
+
+    def test_false_positive_regression_needs_explicit_policy_change(self):
+        value = candidate()
+        value["metric_counts"]["applicable"]["false_positive_rate"]["numerator"] = 1
+        value["scores"]["applicable"]["false_positive_rate"] = 1 / 54
+        fixture = self.fixture(value)
+        blocked = fixture.run()
+        self.assertNotEqual(blocked.returncode, 0)
+        self.assertIn("explicit reviewed policy-change", blocked.stdout)
+        accepted = fixture.run(accept_policy_change=True)
+        self.assertEqual(accepted.returncode, 0, accepted.stdout + accepted.stderr)
+        self.assertIn("above baseline ceiling", fixture.summary.read_text(encoding="utf-8"))
 
     def test_pinned_version_move_needs_explicit_policy_change(self):
         value = candidate()
@@ -324,7 +337,8 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
 
     def test_record_mutation_breaks_idempotent_promotion(self):
         fixture = self.fixture()
-        self.assertEqual(fixture.run().returncode, 0)
+        first = fixture.run()
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
         pointer = evaluator.load_object(fixture.latest)
         record_candidate = (
             fixture.store_root
@@ -337,6 +351,58 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("existing record file changed", result.stdout)
 
+    def test_record_manifest_identity_must_match_candidate(self):
+        fixture = self.fixture()
+        first = fixture.run()
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        pointer = evaluator.load_object(fixture.latest)
+        record = fixture.store_root / "pipelock" / pointer["candidate_sha256"]
+        manifest_path = record / promotion.RECORD_MANIFEST_FILENAME
+        manifest = evaluator.load_object(manifest_path)
+        manifest["tool_version"] = "9.9.9"
+        write_json(manifest_path, manifest)
+        with self.assertRaisesRegex(
+            ValueError, "record manifest and candidate disagree on tool_version"
+        ):
+            promotion.validate_record(record, pointer["candidate_sha256"])
+
+    def test_record_manifest_schema_is_enforced(self):
+        fixture = self.fixture()
+        first = fixture.run()
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        pointer = evaluator.load_object(fixture.latest)
+        record = fixture.store_root / "pipelock" / pointer["candidate_sha256"]
+        manifest_path = record / promotion.RECORD_MANIFEST_FILENAME
+        manifest = evaluator.load_object(manifest_path)
+        manifest["schema_version"] = 2
+        write_json(manifest_path, manifest)
+        with self.assertRaisesRegex(ValueError, "manifest schema_version must be 1"):
+            promotion.validate_record(record, pointer["candidate_sha256"])
+
+    def test_missing_latest_pointer_cannot_recreate_existing_record(self):
+        fixture = self.fixture()
+        first = fixture.run()
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        fixture.latest.unlink()
+        fixture.write_source_decision()
+        second = fixture.run()
+        self.assertNotEqual(second.returncode, 0)
+        self.assertIn(
+            "append-only record already exists without a matching latest pointer",
+            second.stdout,
+        )
+
+    def test_latest_pointer_identity_must_match_candidate(self):
+        fixture = self.fixture()
+        first = fixture.run()
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        pointer = evaluator.load_object(fixture.latest)
+        pointer["artifact_id"] = promotion.DEFAULT_ARTIFACT_PREFIX + "999"
+        write_json(fixture.latest, pointer)
+        second = fixture.run()
+        self.assertNotEqual(second.returncode, 0)
+        self.assertIn("latest pointer and record candidate disagree on artifact_id", second.stdout)
+
     def test_unsafe_artifact_origin_is_rejected(self):
         value = candidate()
         value["canonical_url"] = "https://attacker.example/run/123"
@@ -344,6 +410,28 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
         result = fixture.run()
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("canonical_url must start", result.stdout)
+
+    def test_non_reference_tool_is_rejected(self):
+        value = candidate()
+        value["tool"] = "other-tool"
+        fixture = self.fixture(value)
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate tool must be pipelock", result.stdout)
+
+    def test_unicode_run_id_is_rejected(self):
+        value = candidate(run_id="١٢٣")
+        fixture = self.fixture(value)
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("positive decimal run ID", result.stdout)
+
+    def test_store_root_must_be_beside_latest_pointer(self):
+        fixture = self.fixture()
+        fixture.store_root = fixture.root / "elsewhere" / "results"
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("results directory beside latest-verified", result.stdout)
 
     def test_cross_run_candidate_substitution_is_rejected(self):
         fixture = self.fixture()
@@ -380,7 +468,8 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
 
     def test_latest_pointer_cannot_move_backward(self):
         fixture = self.fixture()
-        self.assertEqual(fixture.run().returncode, 0)
+        first = fixture.run()
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
 
         older = candidate(run_id="124", generated_at="2026-08-04T00:10:08Z")
         second_artifact = fixture.root / "older-artifact"
@@ -418,6 +507,9 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
         first = fixture.run()
         self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
         first_pointer = evaluator.load_object(fixture.latest)
+        first_record = fixture.store_root / "pipelock" / first_pointer["candidate_sha256"]
+        first_manifest_path = first_record / promotion.RECORD_MANIFEST_FILENAME
+        first_manifest_digest = evaluator.file_sha256(first_manifest_path)
 
         newer = candidate(run_id="124", generated_at="2026-08-06T00:10:08Z")
         second_artifact = fixture.root / "newer-artifact"
@@ -460,6 +552,7 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
         self.assertEqual(
             manifest["previous_candidate_sha256"], first_pointer["candidate_sha256"]
         )
+        self.assertEqual(evaluator.file_sha256(first_manifest_path), first_manifest_digest)
         self.assertEqual(len(list((fixture.store_root / "pipelock").iterdir())), 2)
 
 

--- a/scripts/promote_gauntlet_candidate_test.py
+++ b/scripts/promote_gauntlet_candidate_test.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Tests for reviewed append-only Gauntlet result promotion."""
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "promote_gauntlet_candidate.py"
+
+
+def load_module(name):
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+provenance = load_module("build_gauntlet_provenance")
+evaluator = load_module("evaluate_gauntlet_candidate")
+promotion = load_module("promote_gauntlet_candidate")
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def baseline():
+    return {
+        "schema_version": 1,
+        "recorded_on": "2026-08-01",
+        "pipelock_version": "3.3.0",
+        "corpus_git_sha": "b" * 40,
+        "corpus_sha256": "c" * 64,
+        "corpus_version": "v2.3.0",
+        "scoring_version": "2.4",
+        "runner_version": "0.4.2",
+        "observed_case_count": {
+            "total": 213,
+            "applicable": 212,
+            "not_applicable": 1,
+            "not_applicable_reasons": {"missing_requires": 1},
+        },
+        "score_floors": {
+            "full": {"containment": 0.99},
+            "applicable": {"containment": 1.0, "detection": 1.0, "evidence": 1.0},
+        },
+        "score_ceilings": {"applicable": {"false_positive_rate": 0.0}},
+    }
+
+
+def candidate(run_id="123", generated_at="2026-08-05T00:10:08Z"):
+    return {
+        "schema_version": 2,
+        "artifact_id": f"github-actions:luckyPipewrench/agent-egress-bench:{run_id}",
+        "canonical_url": (
+            "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/" + run_id
+        ),
+        "generated_at": generated_at,
+        "tool": "pipelock",
+        "tool_version": "3.3.0",
+        "pipelock_version": "3.3.0",
+        "corpus_git_sha": "b" * 40,
+        "corpus_sha256": "c" * 64,
+        "corpus_manifest_sha256": "d" * 64,
+        "corpus_version": "v2.3.0",
+        "scoring_version": "2.4",
+        "runner_version": "0.4.2",
+        "logical_case_count": 213,
+        "case_count": {
+            "total": 213,
+            "applicable": 212,
+            "not_applicable": 1,
+            "not_applicable_reasons": {"missing_requires": 1},
+            "errors": 0,
+        },
+        "metric_counts": {
+            "full": {
+                "containment": {"numerator": 157, "denominator": 158},
+                "detection": {"numerator": 157, "denominator": 157},
+                "evidence": {"numerator": 157, "denominator": 157},
+                "false_positive_rate": {"numerator": 0, "denominator": 55},
+            },
+            "applicable": {
+                "containment": {"numerator": 158, "denominator": 158},
+                "detection": {"numerator": 157, "denominator": 157},
+                "evidence": {"numerator": 157, "denominator": 157},
+                "false_positive_rate": {"numerator": 0, "denominator": 54},
+            },
+        },
+        "scores": {
+            "full": {
+                "containment": 0.99,
+                "detection": 1.0,
+                "evidence": 1.0,
+                "false_positive_rate": 0.0,
+            },
+            "applicable": {
+                "containment": 1.0,
+                "detection": 1.0,
+                "evidence": 1.0,
+                "false_positive_rate": 0.0,
+            },
+        },
+        "sufficient": True,
+    }
+
+
+class PromotionFixture:
+    def __init__(self, root, candidate_value=None, baseline_value=None):
+        self.root = root
+        self.artifact_dir = root / "artifact"
+        self.artifact_dir.mkdir(parents=True)
+        self.store_root = root / "site" / "results"
+        self.latest = root / "site" / "latest-verified.json"
+        self.baseline_path = root / "baseline.json"
+        write_json(self.baseline_path, baseline_value or baseline())
+
+        self.evidence = {}
+        for label, filename in promotion.EVIDENCE_FILES.items():
+            path = self.artifact_dir / filename
+            if label == "execution_decision":
+                write_json(
+                    path,
+                    {
+                        "schema_version": 1,
+                        "execution_status": "complete",
+                        "blocked": False,
+                        "publication_eligible": True,
+                        "failures": [],
+                    },
+                )
+            elif label == "results":
+                path.write_text(
+                    json.dumps(
+                        {
+                            "case_id": "case-1",
+                            "expected_verdict": "block",
+                            "actual_verdict": "block",
+                            "score": "pass",
+                            "evidence": {},
+                            "notes": "",
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            else:
+                path.write_text(f"{label}\n", encoding="utf-8")
+            self.evidence[label] = path
+
+        value = candidate_value or candidate()
+        value["case_index_sha256"] = hashlib.sha256(
+            self.evidence["case_index"].read_bytes()
+        ).hexdigest()
+        value["portable_bundle_sha256"] = hashlib.sha256(
+            self.evidence["run_bundle"].read_bytes()
+        ).hexdigest()
+        self.candidate_value = value
+        self.candidate_path = self.artifact_dir / promotion.CANDIDATE_FILENAME
+        write_json(self.candidate_path, value)
+        self.write_source_decision()
+
+    def write_source_decision(self):
+        decision = evaluator.evaluate(self.candidate_path, self.baseline_path, self.evidence)
+        write_json(self.artifact_dir / promotion.SOURCE_DECISION_FILENAME, decision)
+
+    def command(self, accept_policy_change=False):
+        self.summary = self.root / "promotion-summary.md"
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            "--artifact-dir",
+            str(self.artifact_dir),
+            "--baseline",
+            str(self.baseline_path),
+            "--store-root",
+            str(self.store_root),
+            "--latest",
+            str(self.latest),
+            "--summary",
+            str(self.summary),
+            "--expected-run-id",
+            self.candidate_value["artifact_id"].rsplit(":", 1)[1],
+        ]
+        if accept_policy_change:
+            command.append("--accept-policy-change")
+        return command
+
+    def run(self, accept_policy_change=False):
+        return subprocess.run(
+            self.command(accept_policy_change),
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+
+class PromoteGauntletCandidateTest(unittest.TestCase):
+    def fixture(self, candidate_value=None, baseline_value=None):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        return PromotionFixture(Path(temporary.name), candidate_value, baseline_value)
+
+    def test_clean_candidate_creates_append_only_record_pointer_and_baseline(self):
+        fixture = self.fixture()
+        original_candidate = fixture.candidate_path.read_bytes()
+        result = fixture.run()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+        pointer = evaluator.load_object(fixture.latest)
+        digest = pointer["candidate_sha256"]
+        record = fixture.store_root / "pipelock" / digest
+        self.assertEqual((record / promotion.CANDIDATE_FILENAME).read_bytes(), original_candidate)
+        self.assertEqual(
+            evaluator.file_sha256(record / promotion.RECORD_MANIFEST_FILENAME),
+            pointer["record_manifest_sha256"],
+        )
+        promoted_baseline = evaluator.load_object(fixture.baseline_path)
+        self.assertEqual(promoted_baseline["verified_candidate_sha256"], digest)
+        reviewed = evaluator.load_object(record / promotion.PUBLISHED_DECISION_FILENAME)
+        self.assertFalse(reviewed["blocked"])
+        summary = fixture.summary.read_text(encoding="utf-8")
+        self.assertIn("Scope: `212 / 213` applicable", summary)
+        self.assertIn("Reviewed policy change proposed: `no`", summary)
+
+    def test_same_promotion_is_idempotent(self):
+        fixture = self.fixture()
+        self.assertEqual(fixture.run().returncode, 0)
+        fixture.summary.unlink()
+        second = fixture.run()
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+        self.assertIn("already complete", second.stdout)
+        self.assertTrue(fixture.summary.is_file())
+
+    def test_score_regression_needs_explicit_policy_change(self):
+        value = candidate()
+        value["scores"]["full"]["containment"] = 0.98
+        fixture = self.fixture(value)
+        blocked = fixture.run()
+        self.assertNotEqual(blocked.returncode, 0)
+        self.assertIn("explicit reviewed policy-change", blocked.stdout)
+        accepted = fixture.run(accept_policy_change=True)
+        self.assertEqual(accepted.returncode, 0, accepted.stdout + accepted.stderr)
+        self.assertEqual(
+            evaluator.load_object(fixture.baseline_path)["score_floors"]["full"]["containment"],
+            0.98,
+        )
+
+    def test_pinned_version_move_needs_explicit_policy_change(self):
+        value = candidate()
+        value["pipelock_version"] = "3.4.0"
+        value["tool_version"] = "3.4.0"
+        fixture = self.fixture(value)
+        self.assertNotEqual(fixture.run().returncode, 0)
+        accepted = fixture.run(accept_policy_change=True)
+        self.assertEqual(accepted.returncode, 0, accepted.stdout + accepted.stderr)
+        self.assertEqual(
+            evaluator.load_object(fixture.baseline_path)["pipelock_version"], "3.4.0"
+        )
+
+    def test_scope_identity_move_needs_explicit_policy_change(self):
+        value = candidate()
+        value["corpus_sha256"] = "a" * 64
+        fixture = self.fixture(value)
+        blocked = fixture.run()
+        self.assertNotEqual(blocked.returncode, 0)
+        self.assertIn("explicit reviewed policy-change", blocked.stdout)
+        accepted = fixture.run(accept_policy_change=True)
+        self.assertEqual(accepted.returncode, 0, accepted.stdout + accepted.stderr)
+        summary = fixture.summary.read_text(encoding="utf-8")
+        self.assertIn("Reviewed policy change proposed: `yes`", summary)
+
+    def test_summary_names_nonpassing_case_and_boundary_timing(self):
+        fixture = self.fixture()
+        fixture.evidence["results"].write_text(
+            json.dumps(
+                {
+                    "case_id": "budget-boundary-1",
+                    "expected_verdict": "block",
+                    "actual_verdict": "allow",
+                    "score": "fail",
+                    "evidence": {
+                        "budget_block_timing": "before_over_budget",
+                        "error_message": "blocked at 4/3",
+                    },
+                    "notes": "",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        fixture.write_source_decision()
+        result = fixture.run()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        summary = fixture.summary.read_text(encoding="utf-8")
+        self.assertIn("`budget-boundary-1`:", summary)
+        self.assertIn("before_over_budget; blocked at 4/3", summary)
+
+    def test_structural_failure_cannot_be_overridden(self):
+        value = candidate()
+        value["sufficient"] = False
+        fixture = self.fixture(value)
+        result = fixture.run(accept_policy_change=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("non-reviewable failures", result.stdout)
+        self.assertFalse(fixture.latest.exists())
+
+    def test_evidence_changed_after_source_decision_is_rejected(self):
+        fixture = self.fixture()
+        fixture.evidence["results"].write_text("tampered\n", encoding="utf-8")
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("source decision does not match", result.stdout)
+
+    def test_record_mutation_breaks_idempotent_promotion(self):
+        fixture = self.fixture()
+        self.assertEqual(fixture.run().returncode, 0)
+        pointer = evaluator.load_object(fixture.latest)
+        record_candidate = (
+            fixture.store_root
+            / "pipelock"
+            / pointer["candidate_sha256"]
+            / promotion.CANDIDATE_FILENAME
+        )
+        record_candidate.write_text("{}\n", encoding="utf-8")
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("existing record file changed", result.stdout)
+
+    def test_unsafe_artifact_origin_is_rejected(self):
+        value = candidate()
+        value["canonical_url"] = "https://attacker.example/run/123"
+        fixture = self.fixture(value)
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("canonical_url must start", result.stdout)
+
+    def test_cross_run_candidate_substitution_is_rejected(self):
+        fixture = self.fixture()
+        command = fixture.command()
+        command[command.index("--expected-run-id") + 1] = "999"
+        result = subprocess.run(
+            command, cwd=REPO_ROOT, text=True, capture_output=True, check=False
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not match the requested source run", result.stdout)
+
+    def test_timezone_free_candidate_time_is_rejected(self):
+        fixture = self.fixture(candidate(generated_at="2026-08-05T00:10:08"))
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("timestamp with a timezone", result.stdout)
+
+    def test_missing_evidence_is_rejected(self):
+        fixture = self.fixture()
+        fixture.evidence["runner_stderr"].unlink()
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("required evidence is missing", result.stdout)
+
+    def test_symlinked_evidence_is_rejected(self):
+        fixture = self.fixture()
+        target = fixture.root / "outside.txt"
+        target.write_text("outside\n", encoding="utf-8")
+        fixture.evidence["runner_stderr"].unlink()
+        fixture.evidence["runner_stderr"].symlink_to(target)
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("required evidence is missing", result.stdout)
+
+    def test_latest_pointer_cannot_move_backward(self):
+        fixture = self.fixture()
+        self.assertEqual(fixture.run().returncode, 0)
+
+        older = candidate(run_id="124", generated_at="2026-08-04T00:10:08Z")
+        second_artifact = fixture.root / "older-artifact"
+        second_artifact.mkdir()
+        for path in fixture.artifact_dir.iterdir():
+            if path.is_file():
+                (second_artifact / path.name).write_bytes(path.read_bytes())
+        older["case_index_sha256"] = hashlib.sha256(
+            (second_artifact / promotion.EVIDENCE_FILES["case_index"]).read_bytes()
+        ).hexdigest()
+        older["portable_bundle_sha256"] = hashlib.sha256(
+            (second_artifact / promotion.EVIDENCE_FILES["run_bundle"]).read_bytes()
+        ).hexdigest()
+        write_json(second_artifact / promotion.CANDIDATE_FILENAME, older)
+        second_paths = {
+            label: second_artifact / filename
+            for label, filename in promotion.EVIDENCE_FILES.items()
+        }
+        source = evaluator.evaluate(
+            second_artifact / promotion.CANDIDATE_FILENAME,
+            fixture.baseline_path,
+            second_paths,
+        )
+        write_json(second_artifact / promotion.SOURCE_DECISION_FILENAME, source)
+        fixture.artifact_dir = second_artifact
+        fixture.candidate_value = older
+        records_before = sorted((fixture.store_root / "pipelock").iterdir())
+        result = fixture.run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("backward or sideways", result.stdout)
+        self.assertEqual(sorted((fixture.store_root / "pipelock").iterdir()), records_before)
+
+    def test_newer_candidate_appends_hash_linked_record_and_advances_pointer(self):
+        fixture = self.fixture()
+        first = fixture.run()
+        self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+        first_pointer = evaluator.load_object(fixture.latest)
+
+        newer = candidate(run_id="124", generated_at="2026-08-06T00:10:08Z")
+        second_artifact = fixture.root / "newer-artifact"
+        second_artifact.mkdir()
+        for path in fixture.artifact_dir.iterdir():
+            if path.is_file():
+                (second_artifact / path.name).write_bytes(path.read_bytes())
+        newer["case_index_sha256"] = hashlib.sha256(
+            (second_artifact / promotion.EVIDENCE_FILES["case_index"]).read_bytes()
+        ).hexdigest()
+        newer["portable_bundle_sha256"] = hashlib.sha256(
+            (second_artifact / promotion.EVIDENCE_FILES["run_bundle"]).read_bytes()
+        ).hexdigest()
+        write_json(second_artifact / promotion.CANDIDATE_FILENAME, newer)
+        second_paths = {
+            label: second_artifact / filename
+            for label, filename in promotion.EVIDENCE_FILES.items()
+        }
+        write_json(
+            second_artifact / promotion.SOURCE_DECISION_FILENAME,
+            evaluator.evaluate(
+                second_artifact / promotion.CANDIDATE_FILENAME,
+                fixture.baseline_path,
+                second_paths,
+            ),
+        )
+        fixture.artifact_dir = second_artifact
+        fixture.candidate_value = newer
+        second = fixture.run()
+        self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+
+        pointer = evaluator.load_object(fixture.latest)
+        self.assertEqual(pointer["previous_candidate_sha256"], first_pointer["candidate_sha256"])
+        self.assertEqual(
+            pointer["previous_record_manifest_sha256"],
+            first_pointer["record_manifest_sha256"],
+        )
+        record = fixture.store_root / "pipelock" / pointer["candidate_sha256"]
+        manifest = evaluator.load_object(record / promotion.RECORD_MANIFEST_FILENAME)
+        self.assertEqual(
+            manifest["previous_candidate_sha256"], first_pointer["candidate_sha256"]
+        )
+        self.assertEqual(len(list((fixture.store_root / "pipelock").iterdir())), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/promote_gauntlet_workflow_test.py
+++ b/scripts/promote_gauntlet_workflow_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Structural tests for the reviewed Gauntlet promotion workflow."""
+
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "promote-gauntlet-result.yaml"
+
+
+def step_block(workflow, name):
+    marker = f"      - name: {name}\n"
+    start = workflow.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing workflow step: {name}")
+    next_step = workflow.find("\n      - name:", start + len(marker))
+    end = next_step if next_step >= 0 else len(workflow)
+    return workflow[start:end]
+
+
+class PromoteGauntletWorkflowTest(unittest.TestCase):
+    def setUp(self):
+        self.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_only_manual_dispatch_can_prepare_a_public_pr(self):
+        trigger = self.workflow.split("permissions:", 1)[0]
+        self.assertIn("workflow_dispatch:", trigger)
+        self.assertNotRegex(trigger, r"(?m)^  (push|schedule|pull_request):")
+        self.assertIn("run_id:", trigger)
+        self.assertIn("accept_policy_change:", trigger)
+
+    def test_write_permissions_are_isolated_from_scheduled_lane(self):
+        self.assertRegex(
+            self.workflow,
+            r"(?m)^permissions:\n  actions: write\n  contents: write\n  pull-requests: write$",
+        )
+        scheduled = (REPO_ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml").read_text(
+            encoding="utf-8"
+        )
+        self.assertRegex(scheduled, r"(?m)^permissions:\n  contents: read$")
+        self.assertNotIn("pull-requests: write", scheduled)
+
+    def test_all_run_ids_share_one_promotion_lock(self):
+        self.assertRegex(
+            self.workflow,
+            r"(?m)^concurrency:\n(?:  #.*\n)*  group: gauntlet-result-promotion\n  cancel-in-progress: false$",
+        )
+        self.assertNotIn("gauntlet-result-promotion-${{ inputs.run_id }}", self.workflow)
+
+    def test_source_run_identity_is_checked_before_download(self):
+        verify = step_block(self.workflow, "Verify source workflow run")
+        download = step_block(self.workflow, "Download candidate evidence")
+        self.assertLess(self.workflow.index(verify), self.workflow.index(download))
+        self.assertIn('.path == ".github/workflows/continuous-gauntlet.yaml"', verify)
+        self.assertIn('.head_repository.full_name == $repo', verify)
+        self.assertIn('.head_branch == "main"', verify)
+        self.assertIn("git merge-base --is-ancestor", verify)
+        self.assertIn('[[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]]', verify)
+
+    def test_failed_run_requires_explicit_policy_review(self):
+        verify = step_block(self.workflow, "Verify source workflow run")
+        prepare = step_block(self.workflow, "Prepare append-only record")
+        self.assertIn('ACCEPT_POLICY_CHANGE" == "true"', verify)
+        self.assertIn("success or enforcement failure", verify)
+        self.assertIn("--accept-policy-change", prepare)
+        self.assertIn('ACCEPT_POLICY_CHANGE" == "true"', prepare)
+
+    def test_artifact_and_promotion_paths_are_fixed(self):
+        download = step_block(self.workflow, "Download candidate evidence")
+        prepare = step_block(self.workflow, "Prepare append-only record")
+        self.assertIn("--name continuous-gauntlet-pipelock", download)
+        self.assertIn("corpus_git_sha", download)
+        self.assertIn("git merge-base --is-ancestor", download)
+        self.assertIn("scripts/promote_gauntlet_candidate.py", prepare)
+        self.assertIn("ci/gauntlet-baseline.json", prepare)
+        self.assertIn("gauntlet-site/results", prepare)
+        self.assertIn("gauntlet-site/latest-verified.json", prepare)
+        self.assertIn('--expected-run-id "$RUN_ID"', prepare)
+        self.assertIn("scripts/validate_gauntlet_records.py", prepare)
+        self.assertNotIn("GH_TOKEN", prepare)
+
+    def test_write_token_is_not_persisted_or_exposed_to_promotion_script(self):
+        checkout = step_block(self.workflow, "Check out trusted default branch")
+        verify = step_block(self.workflow, "Verify source workflow run")
+        download = step_block(self.workflow, "Download candidate evidence")
+        prepare = step_block(self.workflow, "Prepare append-only record")
+        create = step_block(self.workflow, "Create reviewed promotion pull request")
+        self.assertIn("persist-credentials: false", checkout)
+        self.assertIn("GH_TOKEN:", verify)
+        self.assertIn("GH_TOKEN:", download)
+        self.assertNotIn("GH_TOKEN:", prepare)
+        self.assertIn("GH_TOKEN:", create)
+        self.assertIn("gh auth setup-git", create)
+
+    def test_public_write_is_feature_branch_and_pr_only(self):
+        create = step_block(self.workflow, "Create reviewed promotion pull request")
+        self.assertIn('branch="gauntlet-result-$RUN_ID"', create)
+        self.assertIn('git push origin "HEAD:refs/heads/$branch"', create)
+        self.assertIn("gh pr create", create)
+        self.assertIn("existing promotion branch has different content", create)
+        self.assertIn("promotion pull request already exists", create)
+        self.assertIn('--body-file "$PR_BODY"', create)
+        self.assertNotIn("git push origin main", create)
+        self.assertNotIn("gh pr merge", self.workflow)
+        self.assertNotIn("--force", self.workflow)
+
+    def test_generated_pr_branch_gets_required_validation_dispatch(self):
+        validate = (REPO_ROOT / ".github" / "workflows" / "validate.yaml").read_text(
+            encoding="utf-8"
+        )
+        dispatch = step_block(self.workflow, "Dispatch required validation")
+        self.assertRegex(validate, r"(?m)^  workflow_dispatch:$")
+        self.assertIn("gh workflow run validate.yaml", dispatch)
+        self.assertIn('--ref "$branch"', dispatch)
+        self.assertIn("GH_TOKEN:", dispatch)
+
+    def test_every_shell_step_parses(self):
+        for name in (
+            "Verify source workflow run",
+            "Download candidate evidence",
+            "Prepare append-only record",
+            "Create reviewed promotion pull request",
+            "Dispatch required validation",
+        ):
+            with self.subTest(name=name):
+                block = step_block(self.workflow, name)
+                marker = "        run: |\n"
+                source = block[block.index(marker) + len(marker):]
+                source = "\n".join(
+                    line[10:] if line.startswith("          ") else line
+                    for line in source.splitlines()
+                )
+                result = subprocess.run(
+                    ["bash", "-n"],
+                    input=source,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/promote_gauntlet_workflow_test.py
+++ b/scripts/promote_gauntlet_workflow_test.py
@@ -56,9 +56,18 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         self.assertLess(self.workflow.index(verify), self.workflow.index(download))
         self.assertIn('.path == ".github/workflows/continuous-gauntlet.yaml"', verify)
         self.assertIn('.head_repository.full_name == $repo', verify)
-        self.assertIn('.head_branch == "main"', verify)
+        self.assertIn('.head_branch == $branch', verify)
+        self.assertIn('"origin/$DEFAULT_BRANCH"', verify)
         self.assertIn("git merge-base --is-ancestor", verify)
         self.assertIn('[[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]]', verify)
+
+    def test_runner_paths_are_initialized_at_step_scope(self):
+        job_env = self.workflow.split("    steps:", 1)[0]
+        initialize = step_block(self.workflow, "Initialize temporary paths")
+        self.assertNotIn("runner.temp", job_env)
+        self.assertIn("$RUNNER_TEMP/continuous-gauntlet-candidate", initialize)
+        self.assertIn("$RUNNER_TEMP/gauntlet-result-promotion.md", initialize)
+        self.assertIn('>> "$GITHUB_ENV"', initialize)
 
     def test_failed_run_requires_explicit_policy_review(self):
         verify = step_block(self.workflow, "Verify source workflow run")
@@ -102,6 +111,8 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("gh pr create", create)
         self.assertIn("existing promotion branch has different content", create)
         self.assertIn("promotion pull request already exists", create)
+        self.assertIn("existing promotion pull request targets the wrong base branch", create)
+        self.assertIn("baseRefName", create)
         self.assertIn('--body-file "$PR_BODY"', create)
         self.assertNotIn("git push origin main", create)
         self.assertNotIn("gh pr merge", self.workflow)
@@ -116,9 +127,12 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("gh workflow run validate.yaml", dispatch)
         self.assertIn('--ref "$branch"', dispatch)
         self.assertIn("GH_TOKEN:", dispatch)
+        self.assertIn("--immutable-base", validate)
+        self.assertIn("fetch-depth: 0", validate)
 
     def test_every_shell_step_parses(self):
         for name in (
+            "Initialize temporary paths",
             "Verify source workflow run",
             "Download candidate evidence",
             "Prepare append-only record",

--- a/scripts/validate_gauntlet_records.py
+++ b/scripts/validate_gauntlet_records.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Validate every retained Gauntlet record and the latest-verified pointer."""
+
+import argparse
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import build_gauntlet_provenance as provenance
+import evaluate_gauntlet_candidate as evaluator
+import promote_gauntlet_candidate as promotion
+
+
+def reconstruct_candidate(record_dir, candidate, repo_root):
+    corpus_git_sha = promotion.require_non_empty_string(candidate, "corpus_git_sha")
+    if len(corpus_git_sha) != 40 or any(char not in "0123456789abcdef" for char in corpus_git_sha):
+        raise ValueError(f"{record_dir}: corpus_git_sha must be 40 lower-case hex characters")
+    manifest_at_commit = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{corpus_git_sha}:cases/MANIFEST.txt"],
+        check=False,
+        capture_output=True,
+    )
+    if manifest_at_commit.returncode != 0:
+        raise ValueError(f"{record_dir}: corpus_git_sha is not a retained repository commit")
+    retained_manifest = record_dir / provenance.RAW_EVIDENCE["corpus_manifest"]
+    if manifest_at_commit.stdout != retained_manifest.read_bytes():
+        raise ValueError(f"{record_dir}: retained corpus manifest differs from corpus_git_sha")
+    with tempfile.TemporaryDirectory(prefix="gauntlet-record-validation-") as temporary:
+        root = Path(temporary)
+        (root / "cases").mkdir()
+        shutil.copyfile(
+            record_dir / provenance.RAW_EVIDENCE["corpus_manifest"],
+            root / "cases" / "MANIFEST.txt",
+        )
+        rebuilt = root / promotion.CANDIDATE_FILENAME
+        provenance.finalize_command(
+            SimpleNamespace(
+                repo_root=root,
+                bundle=record_dir / promotion.RUN_BUNDLE_FILENAME,
+                artifact_id=candidate["artifact_id"],
+                canonical_url=candidate["canonical_url"],
+                output=rebuilt,
+            )
+        )
+        if rebuilt.read_bytes() != (record_dir / promotion.CANDIDATE_FILENAME).read_bytes():
+            raise ValueError(f"{record_dir}: candidate does not match a fresh evidence reconstruction")
+
+
+def validate_decision(record_dir, candidate_path, baseline_filename, decision_filename):
+    baseline_path = record_dir / baseline_filename
+    decision_path = record_dir / decision_filename
+    paths = {
+        label: record_dir / filename for label, filename in promotion.EVIDENCE_FILES.items()
+    }
+    expected = evaluator.evaluate(candidate_path, baseline_path, paths)
+    actual = evaluator.load_object(decision_path)
+    if actual != expected:
+        raise ValueError(f"{record_dir}: {decision_filename} does not match a fresh evaluation")
+    return actual
+
+
+def validate_record(record_dir, repo_root):
+    digest = promotion.require_sha256(record_dir.name, "record directory name")
+    manifest = promotion.validate_record(record_dir, digest)
+    candidate_path = record_dir / promotion.CANDIDATE_FILENAME
+    candidate = evaluator.load_object(candidate_path)
+    if evaluator.file_sha256(candidate_path) != digest:
+        raise ValueError(f"{record_dir}: candidate digest does not match its directory")
+    promotion.validate_candidate_origin(
+        candidate,
+        "github-actions:luckyPipewrench/agent-egress-bench:",
+        "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/",
+        None,
+    )
+    promotion.validate_execution_decision(record_dir / promotion.EXECUTION_DECISION_FILENAME)
+    reconstruct_candidate(record_dir, candidate, repo_root)
+    validate_decision(
+        record_dir,
+        candidate_path,
+        promotion.SOURCE_BASELINE_FILENAME,
+        "source-promotion-decision.json",
+    )
+    reviewed = validate_decision(
+        record_dir,
+        candidate_path,
+        promotion.BASELINE_SNAPSHOT_FILENAME,
+        promotion.PUBLISHED_DECISION_FILENAME,
+    )
+    if reviewed.get("blocked") is not False:
+        raise ValueError(f"{record_dir}: reviewed promotion decision is blocked")
+    return candidate, manifest
+
+
+def validate(site_root, baseline_path, repo_root):
+    results_root = site_root / "results" / "pipelock"
+    latest_path = site_root / promotion.LATEST_POINTER_FILENAME
+    if not results_root.exists():
+        if latest_path.exists():
+            raise ValueError("latest-verified exists without an append-only result store")
+        print("Gauntlet record validation: OK (no promoted records yet)")
+        return
+    if results_root.is_symlink() or not results_root.is_dir():
+        raise ValueError("Pipelock result store must be a real directory")
+
+    records = {}
+    for entry in sorted(results_root.iterdir(), key=lambda item: item.name):
+        if entry.is_symlink() or not entry.is_dir():
+            raise ValueError(f"unexpected non-directory result-store entry: {entry}")
+        candidate, manifest = validate_record(entry, repo_root)
+        records[entry.name] = (entry, candidate, manifest)
+    if not records:
+        raise ValueError("Pipelock result store is empty")
+    if not latest_path.is_file() or latest_path.is_symlink():
+        raise ValueError("append-only records exist without latest-verified")
+
+    pointer = promotion.validate_pointer(evaluator.load_object(latest_path), latest_path)
+    digest = pointer["candidate_sha256"]
+    if digest not in records:
+        raise ValueError("latest-verified points outside the retained result set")
+    record_dir, candidate, manifest = records[digest]
+    if evaluator.file_sha256(record_dir / promotion.RECORD_MANIFEST_FILENAME) != pointer[
+        "record_manifest_sha256"
+    ]:
+        raise ValueError("latest-verified record manifest digest is wrong")
+    for field in ("artifact_id", "canonical_url", "tool", "tool_version", "generated_at"):
+        if pointer.get(field) != candidate.get(field):
+            raise ValueError(f"latest-verified and selected candidate disagree on {field}")
+    newest_digest = max(
+        records,
+        key=lambda value: promotion.parse_timestamp(
+            records[value][1]["generated_at"], f"{value} generated_at"
+        ),
+    )
+    if digest != newest_digest:
+        raise ValueError("latest-verified does not select the newest retained record")
+    if evaluator.file_sha256(baseline_path) != evaluator.file_sha256(
+        record_dir / promotion.BASELINE_SNAPSHOT_FILENAME
+    ):
+        raise ValueError("reviewed baseline does not match latest-verified")
+    if manifest["candidate_sha256"] != digest:
+        raise ValueError("selected record manifest and pointer candidate digests differ")
+    for field in ("previous_candidate_sha256", "previous_record_manifest_sha256"):
+        if pointer.get(field) != manifest.get(field):
+            raise ValueError(f"latest-verified and selected manifest disagree on {field}")
+
+    visited = set()
+    current_digest = digest
+    expected_manifest_digest = pointer["record_manifest_sha256"]
+    while current_digest is not None:
+        if current_digest in visited:
+            raise ValueError("append-only record chain contains a cycle")
+        if current_digest not in records:
+            raise ValueError("append-only record chain is missing a predecessor")
+        visited.add(current_digest)
+        current_dir, _, current_manifest = records[current_digest]
+        actual_manifest_digest = evaluator.file_sha256(
+            current_dir / promotion.RECORD_MANIFEST_FILENAME
+        )
+        if actual_manifest_digest != expected_manifest_digest:
+            raise ValueError("append-only record chain manifest digest is wrong")
+        current_digest = current_manifest.get("previous_candidate_sha256")
+        expected_manifest_digest = current_manifest.get("previous_record_manifest_sha256")
+    if visited != set(records):
+        raise ValueError("result store contains records outside the append-only chain")
+    print(f"Gauntlet record validation: OK ({len(records)} append-only record(s))")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--site-root", type=Path, default=Path("gauntlet-site"))
+    parser.add_argument("--baseline", type=Path, default=Path("ci/gauntlet-baseline.json"))
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        validate(args.site_root.resolve(), args.baseline.resolve(), args.repo_root.resolve())
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        print(f"Gauntlet record validation: BLOCKED: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_gauntlet_records.py
+++ b/scripts/validate_gauntlet_records.py
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -12,6 +13,9 @@ from types import SimpleNamespace
 import build_gauntlet_provenance as provenance
 import evaluate_gauntlet_candidate as evaluator
 import promote_gauntlet_candidate as promotion
+
+
+RESULTS_PATH = Path("gauntlet-site/results/pipelock")
 
 
 def reconstruct_candidate(record_dir, candidate, repo_root):
@@ -69,10 +73,11 @@ def validate_record(record_dir, repo_root):
     candidate = evaluator.load_object(candidate_path)
     if evaluator.file_sha256(candidate_path) != digest:
         raise ValueError(f"{record_dir}: candidate digest does not match its directory")
+    promotion.validate_reference_candidate(candidate)
     promotion.validate_candidate_origin(
         candidate,
-        "github-actions:luckyPipewrench/agent-egress-bench:",
-        "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/",
+        promotion.DEFAULT_ARTIFACT_PREFIX,
+        promotion.DEFAULT_URL_PREFIX,
         None,
     )
     promotion.validate_execution_decision(record_dir / promotion.EXECUTION_DECISION_FILENAME)
@@ -81,7 +86,7 @@ def validate_record(record_dir, repo_root):
         record_dir,
         candidate_path,
         promotion.SOURCE_BASELINE_FILENAME,
-        "source-promotion-decision.json",
+        promotion.SOURCE_PROMOTION_DECISION_FILENAME,
     )
     reviewed = validate_decision(
         record_dir,
@@ -92,6 +97,60 @@ def validate_record(record_dir, repo_root):
     if reviewed.get("blocked") is not False:
         raise ValueError(f"{record_dir}: reviewed promotion decision is blocked")
     return candidate, manifest
+
+
+def require_predecessor_older(predecessor, successor):
+    predecessor_time = promotion.parse_timestamp(
+        predecessor["generated_at"], "predecessor generated_at"
+    )
+    successor_time = promotion.parse_timestamp(
+        successor["generated_at"], "successor generated_at"
+    )
+    if predecessor_time >= successor_time:
+        raise ValueError("append-only record chain is not strictly chronological")
+
+
+def validate_immutable_history(repo_root, base_ref):
+    ancestor = subprocess.run(
+        ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", base_ref, "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if ancestor.returncode != 0:
+        raise ValueError(f"immutable base is not an ancestor of HEAD: {base_ref}")
+    listing = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "ls-tree",
+            "-r",
+            "-z",
+            "--name-only",
+            base_ref,
+            "--",
+            RESULTS_PATH.as_posix(),
+        ],
+        check=False,
+        capture_output=True,
+    )
+    if listing.returncode != 0:
+        raise ValueError(f"cannot inspect append-only records at immutable base: {base_ref}")
+    for raw_path in listing.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        relative = Path(os.fsdecode(raw_path))
+        current = repo_root / relative
+        if current.is_symlink() or not current.is_file():
+            raise ValueError(f"append-only history deleted a retained file: {relative}")
+        original = subprocess.run(
+            ["git", "-C", str(repo_root), "show", f"{base_ref}:{relative.as_posix()}"],
+            check=False,
+            capture_output=True,
+        )
+        if original.returncode != 0 or original.stdout != current.read_bytes():
+            raise ValueError(f"append-only history modified a retained file: {relative}")
 
 
 def validate(site_root, baseline_path, repo_root):
@@ -149,13 +208,17 @@ def validate(site_root, baseline_path, repo_root):
     visited = set()
     current_digest = digest
     expected_manifest_digest = pointer["record_manifest_sha256"]
+    successor_candidate = None
     while current_digest is not None:
         if current_digest in visited:
             raise ValueError("append-only record chain contains a cycle")
         if current_digest not in records:
             raise ValueError("append-only record chain is missing a predecessor")
         visited.add(current_digest)
-        current_dir, _, current_manifest = records[current_digest]
+        current_dir, current_candidate, current_manifest = records[current_digest]
+        if successor_candidate is not None:
+            require_predecessor_older(current_candidate, successor_candidate)
+        successor_candidate = current_candidate
         actual_manifest_digest = evaluator.file_sha256(
             current_dir / promotion.RECORD_MANIFEST_FILENAME
         )
@@ -173,12 +236,15 @@ def parse_args():
     parser.add_argument("--site-root", type=Path, default=Path("gauntlet-site"))
     parser.add_argument("--baseline", type=Path, default=Path("ci/gauntlet-baseline.json"))
     parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--immutable-base")
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
     try:
+        if args.immutable_base is not None:
+            validate_immutable_history(args.repo_root.resolve(), args.immutable_base)
         validate(args.site_root.resolve(), args.baseline.resolve(), args.repo_root.resolve())
     except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
         print(f"Gauntlet record validation: BLOCKED: {exc}")

--- a/scripts/validate_gauntlet_records_test.py
+++ b/scripts/validate_gauntlet_records_test.py
@@ -54,6 +54,14 @@ class ValidRecordFixture:
             check=True,
         )
         subprocess.run(
+            ["git", "-C", str(self.corpus_root), "config", "commit.gpgsign", "false"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.corpus_root), "config", "core.hooksPath", "/dev/null"],
+            check=True,
+        )
+        subprocess.run(
             ["git", "-C", str(self.corpus_root), "add", "cases/MANIFEST.txt"], check=True
         )
         subprocess.run(
@@ -227,6 +235,61 @@ class ValidRecordFixture:
             )
         )
 
+    def promote_newer(self):
+        run_metadata_path = self.artifact_dir / "run-metadata.json"
+        run_metadata = evaluator.load_object(run_metadata_path)
+        run_metadata["local_run_id"] = "local:test:2"
+        run_metadata["generated_at"] = "2026-08-06T00:10:08Z"
+        write_json(run_metadata_path, run_metadata)
+
+        bundle = provenance.build_complete_bundle(self.corpus_root, self.artifact_dir)
+        write_json(self.artifact_dir / promotion.RUN_BUNDLE_FILENAME, bundle)
+        write_json(
+            self.artifact_dir / promotion.EXECUTION_DECISION_FILENAME,
+            {
+                "schema_version": 1,
+                "local_run_id": bundle["local_run_id"],
+                "blocked": False,
+                "execution_status": "complete",
+                "publication_eligible": True,
+                "failures": [],
+                "review_notes": [],
+                "evidence_sha256": bundle["evidence_sha256"],
+            },
+        )
+        candidate = dict(bundle["candidate_scope"])
+        candidate.update(
+            {
+                "artifact_id": promotion.DEFAULT_ARTIFACT_PREFIX + "124",
+                "canonical_url": promotion.DEFAULT_URL_PREFIX + "124",
+                "portable_bundle_sha256": evaluator.file_sha256(
+                    self.artifact_dir / promotion.RUN_BUNDLE_FILENAME
+                ),
+            }
+        )
+        write_json(self.candidate_path, candidate)
+        evidence = {
+            label: self.artifact_dir / filename
+            for label, filename in promotion.EVIDENCE_FILES.items()
+        }
+        write_json(
+            self.artifact_dir / promotion.SOURCE_DECISION_FILENAME,
+            evaluator.evaluate(self.candidate_path, self.baseline, evidence),
+        )
+        promotion.promote(
+            SimpleNamespace(
+                artifact_dir=self.artifact_dir,
+                baseline=self.baseline,
+                store_root=self.site / "results",
+                latest=self.site / promotion.LATEST_POINTER_FILENAME,
+                summary=None,
+                artifact_prefix=promotion.DEFAULT_ARTIFACT_PREFIX,
+                url_prefix=promotion.DEFAULT_URL_PREFIX,
+                expected_run_id="124",
+                accept_policy_change=False,
+            )
+        )
+
 
 class ValidateGauntletRecordsTest(unittest.TestCase):
     def root(self):
@@ -234,11 +297,53 @@ class ValidateGauntletRecordsTest(unittest.TestCase):
         self.addCleanup(temporary.cleanup)
         return Path(temporary.name)
 
+    def immutable_repo(self):
+        root = self.root()
+        retained = root / validator.RESULTS_PATH / "record-a" / "evidence.json"
+        retained.parent.mkdir(parents=True)
+        retained.write_text('{"value":"original"}\n', encoding="utf-8")
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        for key, value in (
+            ("user.name", "Gauntlet Test"),
+            ("user.email", "test@vendor.example"),
+            ("commit.gpgsign", "false"),
+            ("core.hooksPath", "/dev/null"),
+        ):
+            subprocess.run(
+                ["git", "-C", str(root), "config", key, value], check=True
+            )
+        subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-q", "-m", "fixture"], check=True
+        )
+        base = subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", "HEAD"], text=True
+        ).strip()
+        return root, base, retained
+
     def test_no_promoted_records_is_valid_before_first_publication(self):
         root = self.root()
         baseline = root / "baseline.json"
         baseline.write_text("{}\n", encoding="utf-8")
         validator.validate(root / "site", baseline, REPO_ROOT)
+
+    def test_immutable_history_allows_new_records(self):
+        root, base, _ = self.immutable_repo()
+        added = root / validator.RESULTS_PATH / "record-b" / "evidence.json"
+        added.parent.mkdir(parents=True)
+        added.write_text('{"value":"new"}\n', encoding="utf-8")
+        validator.validate_immutable_history(root, base)
+
+    def test_immutable_history_rejects_modified_or_deleted_files(self):
+        for action in ("modified", "deleted"):
+            with self.subTest(action=action):
+                root, base, retained = self.immutable_repo()
+                if action == "modified":
+                    retained.write_text('{"value":"changed"}\n', encoding="utf-8")
+                else:
+                    retained.unlink()
+                with self.assertRaisesRegex(ValueError, f"{action} a retained file"):
+                    validator.validate_immutable_history(root, base)
 
     def test_complete_promoted_record_reconstructs_from_retained_evidence(self):
         fixture = ValidRecordFixture(self.root())
@@ -281,6 +386,56 @@ class ValidateGauntletRecordsTest(unittest.TestCase):
         write_json(pointer_path, pointer)
         with self.assertRaisesRegex(ValueError, "missing a predecessor"):
             validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
+
+    def test_record_outside_append_only_chain_is_rejected(self):
+        fixture = ValidRecordFixture(self.root())
+        fixture.promote_newer()
+        pointer_path = fixture.site / promotion.LATEST_POINTER_FILENAME
+        pointer = evaluator.load_object(pointer_path)
+        newest = fixture.site / "results" / "pipelock" / pointer["candidate_sha256"]
+        manifest_path = newest / promotion.RECORD_MANIFEST_FILENAME
+        manifest = evaluator.load_object(manifest_path)
+        manifest["previous_candidate_sha256"] = None
+        manifest["previous_record_manifest_sha256"] = None
+        write_json(manifest_path, manifest)
+        pointer["previous_candidate_sha256"] = None
+        pointer["previous_record_manifest_sha256"] = None
+        pointer["record_manifest_sha256"] = evaluator.file_sha256(manifest_path)
+        write_json(pointer_path, pointer)
+        with self.assertRaisesRegex(ValueError, "outside the append-only chain"):
+            validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
+
+    def test_latest_pointer_must_select_newest_record(self):
+        fixture = ValidRecordFixture(self.root())
+        first_pointer = evaluator.load_object(
+            fixture.site / promotion.LATEST_POINTER_FILENAME
+        )
+        first_record = (
+            fixture.site / "results" / "pipelock" / first_pointer["candidate_sha256"]
+        )
+        first_candidate = evaluator.load_object(first_record / promotion.CANDIDATE_FILENAME)
+        fixture.promote_newer()
+
+        pointer = {
+            **first_pointer,
+            **{
+                field: first_candidate[field]
+                for field in ("artifact_id", "canonical_url", "tool", "tool_version", "generated_at")
+            },
+        }
+        write_json(fixture.site / promotion.LATEST_POINTER_FILENAME, pointer)
+        (fixture.baseline).write_bytes(
+            (first_record / promotion.BASELINE_SNAPSHOT_FILENAME).read_bytes()
+        )
+        with self.assertRaisesRegex(ValueError, "does not select the newest"):
+            validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
+
+    def test_append_only_chain_timestamps_must_strictly_decrease(self):
+        with self.assertRaisesRegex(ValueError, "not strictly chronological"):
+            validator.require_predecessor_older(
+                {"generated_at": "2026-08-06T00:10:08Z"},
+                {"generated_at": "2026-08-06T00:10:08Z"},
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/validate_gauntlet_records_test.py
+++ b/scripts/validate_gauntlet_records_test.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Tests for retained Gauntlet record and pointer validation."""
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name):
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+provenance = load_module("build_gauntlet_provenance")
+evaluator = load_module("evaluate_gauntlet_candidate")
+promotion = load_module("promote_gauntlet_candidate")
+validator = load_module("validate_gauntlet_records")
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+class ValidRecordFixture:
+    def __init__(self, root):
+        self.root = root
+        self.artifact_dir = root / "artifact"
+        self.artifact_dir.mkdir()
+        self.corpus_root = root / "corpus"
+        (self.corpus_root / "cases").mkdir(parents=True)
+        manifest = "attack-a\nattack-b\nbenign-a\n"
+        (self.corpus_root / "cases" / "MANIFEST.txt").write_text(manifest, encoding="utf-8")
+        (self.artifact_dir / "corpus-manifest.txt").write_text(manifest, encoding="utf-8")
+        subprocess.run(["git", "init", "-q", str(self.corpus_root)], check=True)
+        subprocess.run(
+            ["git", "-C", str(self.corpus_root), "config", "user.name", "Gauntlet Test"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.corpus_root), "config", "user.email", "test@vendor.example"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.corpus_root), "add", "cases/MANIFEST.txt"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(self.corpus_root), "commit", "-q", "-m", "fixture"],
+            check=True,
+        )
+        corpus_git_sha = subprocess.check_output(
+            ["git", "-C", str(self.corpus_root), "rev-parse", "HEAD"], text=True
+        ).strip()
+
+        rows = [
+            {
+                "case_id": case_id,
+                "tool": "pipelock",
+                "tool_version": "3.3.0",
+                "expected_verdict": expected,
+                "actual_verdict": actual,
+                "score": "pass",
+                "evidence": evidence,
+                "notes": "",
+            }
+            for case_id, expected, actual, evidence in (
+                ("attack-a", "block", "block", {"scanner": "dlp", "pattern": "a"}),
+                ("attack-b", "block", "block", {"scanner": "dlp", "pattern": "b"}),
+                ("benign-a", "allow", "allow", {}),
+            )
+        ]
+        (self.artifact_dir / "results.jsonl").write_text(
+            "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+        )
+        summary = {
+            "gauntlet_version": "1.0",
+            "scoring_version": "2.4",
+            "runner_version": "0.4.2",
+            "tool": "pipelock",
+            "tool_version": "3.3.0",
+            "corpus_version": "v-test",
+            "corpus_sha256": "a" * 64,
+            "tool_profile_sha256": "b" * 64,
+            "case_count": {
+                "total": 3,
+                "applicable": 3,
+                "not_applicable": 0,
+                "not_applicable_reasons": {},
+                "errors": 0,
+            },
+            "scores": {
+                scope: {
+                    "containment": 1.0,
+                    "false_positive_rate": 0.0,
+                    "detection": 1.0,
+                    "evidence": 1.0,
+                }
+                for scope in ("full", "applicable")
+            },
+            "sufficient": True,
+        }
+        write_json(self.artifact_dir / "raw-summary.json", summary)
+        (self.artifact_dir / "runner.stderr").write_text(
+            "Fixtures: HTTP=x TLS=x WS=x DNS=x MCP_HTTP=x\n", encoding="utf-8"
+        )
+        (self.artifact_dir / "command.txt").write_text(
+            "aeb-gauntlet --fixtures --multifile-cases cases/mcp-drift\n", encoding="utf-8"
+        )
+        (self.artifact_dir / "make-stats.txt").write_text(
+            "block: 2\nallow: 1\nwarn: 0\n", encoding="utf-8"
+        )
+        write_json(
+            self.artifact_dir / "case-index.json",
+            {
+                "schema_version": 1,
+                "cases": [
+                    {"case_id": "attack-a", "expected_verdict": "block"},
+                    {"case_id": "attack-b", "expected_verdict": "block"},
+                    {"case_id": "benign-a", "expected_verdict": "allow"},
+                ],
+            },
+        )
+        (self.artifact_dir / "entrypoint-command.txt").write_text(
+            "./scripts/run-pipelock-gauntlet.sh\n", encoding="utf-8"
+        )
+        write_json(
+            self.artifact_dir / "run-metadata.json",
+            {
+                "schema_version": 1,
+                "local_run_id": "local:test:1",
+                "generated_at": "2026-08-05T00:10:08Z",
+                "corpus_repository": "luckyPipewrench/agent-egress-bench",
+                "corpus_ref_kind": "origin/main",
+                "corpus_git_sha": corpus_git_sha,
+                "dirty": False,
+                "canonical_execution": True,
+                "noncanonical_reasons": [],
+            },
+        )
+        write_json(
+            self.artifact_dir / "pipelock-release.json",
+            {
+                "schema_version": 1,
+                "repository": "luckyPipewrench/pipelock",
+                "tag": "v3.3.0",
+                "version": "3.3.0",
+                "asset": "pipelock_3.3.0_linux_amd64.tar.gz",
+                "asset_sha256": "d" * 64,
+                "binary_sha256": "e" * 64,
+                "version_output": "pipelock version 3.3.0",
+                "released_binary": True,
+            },
+        )
+        (self.artifact_dir / "checksums.txt").write_text(
+            "d" * 64 + "  pipelock_3.3.0_linux_amd64.tar.gz\n", encoding="utf-8"
+        )
+        (self.artifact_dir / "pipelock-version.txt").write_text(
+            "pipelock version 3.3.0\n", encoding="utf-8"
+        )
+
+        bundle = provenance.build_complete_bundle(self.corpus_root, self.artifact_dir)
+        write_json(self.artifact_dir / promotion.RUN_BUNDLE_FILENAME, bundle)
+        write_json(
+            self.artifact_dir / promotion.EXECUTION_DECISION_FILENAME,
+            {
+                "schema_version": 1,
+                "local_run_id": bundle["local_run_id"],
+                "blocked": False,
+                "execution_status": "complete",
+                "publication_eligible": True,
+                "failures": [],
+                "review_notes": [],
+                "evidence_sha256": bundle["evidence_sha256"],
+            },
+        )
+        candidate = dict(bundle["candidate_scope"])
+        candidate.update(
+            {
+                "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:123",
+                "canonical_url": (
+                    "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123"
+                ),
+                "portable_bundle_sha256": evaluator.file_sha256(
+                    self.artifact_dir / promotion.RUN_BUNDLE_FILENAME
+                ),
+            }
+        )
+        self.candidate_path = self.artifact_dir / promotion.CANDIDATE_FILENAME
+        write_json(self.candidate_path, candidate)
+        candidate_digest = evaluator.file_sha256(self.candidate_path)
+        self.baseline = root / "baseline.json"
+        write_json(self.baseline, promotion.proposed_baseline(candidate, candidate_digest))
+        evidence = {
+            label: self.artifact_dir / filename
+            for label, filename in promotion.EVIDENCE_FILES.items()
+        }
+        write_json(
+            self.artifact_dir / promotion.SOURCE_DECISION_FILENAME,
+            evaluator.evaluate(self.candidate_path, self.baseline, evidence),
+        )
+        self.site = root / "site"
+        promotion.promote(
+            SimpleNamespace(
+                artifact_dir=self.artifact_dir,
+                baseline=self.baseline,
+                store_root=self.site / "results",
+                latest=self.site / promotion.LATEST_POINTER_FILENAME,
+                summary=None,
+                artifact_prefix="github-actions:luckyPipewrench/agent-egress-bench:",
+                url_prefix=(
+                    "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/"
+                ),
+                expected_run_id="123",
+                accept_policy_change=False,
+            )
+        )
+
+
+class ValidateGauntletRecordsTest(unittest.TestCase):
+    def root(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        return Path(temporary.name)
+
+    def test_no_promoted_records_is_valid_before_first_publication(self):
+        root = self.root()
+        baseline = root / "baseline.json"
+        baseline.write_text("{}\n", encoding="utf-8")
+        validator.validate(root / "site", baseline, REPO_ROOT)
+
+    def test_complete_promoted_record_reconstructs_from_retained_evidence(self):
+        fixture = ValidRecordFixture(self.root())
+        validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
+
+    def test_evidence_tamper_fails_even_if_record_manifest_is_rewritten(self):
+        fixture = ValidRecordFixture(self.root())
+        pointer_path = fixture.site / promotion.LATEST_POINTER_FILENAME
+        pointer = evaluator.load_object(pointer_path)
+        record = fixture.site / "results" / "pipelock" / pointer["candidate_sha256"]
+        (record / "results.jsonl").write_text("tampered\n", encoding="utf-8")
+        manifest_path = record / promotion.RECORD_MANIFEST_FILENAME
+        manifest = evaluator.load_object(manifest_path)
+        manifest["files"]["results.jsonl"] = evaluator.file_sha256(record / "results.jsonl")
+        write_json(manifest_path, manifest)
+        pointer["record_manifest_sha256"] = evaluator.file_sha256(manifest_path)
+        write_json(pointer_path, pointer)
+        with self.assertRaisesRegex(ValueError, "evidence results changed"):
+            validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
+
+    def test_root_baseline_must_match_selected_record(self):
+        fixture = ValidRecordFixture(self.root())
+        fixture.baseline.write_text("{}\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "reviewed baseline does not match"):
+            validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
+
+    def test_missing_predecessor_breaks_append_only_chain(self):
+        fixture = ValidRecordFixture(self.root())
+        pointer_path = fixture.site / promotion.LATEST_POINTER_FILENAME
+        pointer = evaluator.load_object(pointer_path)
+        record = fixture.site / "results" / "pipelock" / pointer["candidate_sha256"]
+        manifest_path = record / promotion.RECORD_MANIFEST_FILENAME
+        manifest = evaluator.load_object(manifest_path)
+        manifest["previous_candidate_sha256"] = "f" * 64
+        manifest["previous_record_manifest_sha256"] = "e" * 64
+        write_json(manifest_path, manifest)
+        pointer["previous_candidate_sha256"] = "f" * 64
+        pointer["previous_record_manifest_sha256"] = "e" * 64
+        pointer["record_manifest_sha256"] = evaluator.file_sha256(manifest_path)
+        write_json(pointer_path, pointer)
+        with self.assertRaisesRegex(ValueError, "missing a predecessor"):
+            validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a manual workflow that verifies completed Gauntlet candidates and opens reviewed promotion pull requests
- retain complete evidence as digest-addressed, hash-linked records
- advance the reviewed baseline and latest-verified pointer only through merge
- add fail-closed record validation and a digest-verifying reference renderer
- document the boundary between repository publication, the live leaderboard, and independent operators


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added verified Gauntlet result loading with integrity, provenance, metadata, and digest validation.
  - Updated the results page to show verified scope information and clearly identify legacy, self-reported results.
  - Added a controlled promotion workflow for reviewing and publishing immutable Gauntlet records.

- **Documentation**
  - Documented continuous-results publication, review, promotion, reproduction, and evidence policies.
  - Clarified the distinction between first-party regression evidence and independent certification.

- **Tests**
  - Added comprehensive coverage for result loading, promotion, record validation, workflow behavior, and legacy fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->