### PR TITLE
fix: make Gauntlet promotion checks self-starting

### DIFF
--- a/.github/workflows/pipelock.yaml
+++ b/.github/workflows/pipelock.yaml
@@ -1,8 +1,8 @@
 name: Pipelock Security Scan
 
 on:
-  # Promotion pull requests are created with GITHUB_TOKEN, so GitHub parks
-  # their pull_request runs for manual approval. The promotion workflow
+  # Promotion pull requests are created with GITHUB_TOKEN, which intentionally
+  # does not emit a pull_request workflow run. The promotion workflow explicitly
   # dispatches this trusted workflow against the generated branch instead.
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/pipelock.yaml
+++ b/.github/workflows/pipelock.yaml
@@ -1,6 +1,10 @@
 name: Pipelock Security Scan
 
 on:
+  # Promotion pull requests are created with GITHUB_TOKEN, so GitHub parks
+  # their pull_request runs for manual approval. The promotion workflow
+  # dispatches this trusted workflow against the generated branch instead.
+  workflow_dispatch:
   pull_request:
     branches: [main]
 
@@ -16,9 +20,12 @@ jobs:
           fetch-depth: 0
 
       - name: Pipelock Scan
+        id: pipelock
         uses: luckyPipewrench/pipelock@9d2e37d296359c38e599525a0424cdc189a812e1 # v3.0.0
         with:
-          scan-diff: 'true'
+          # The action's built-in diff scan is pull_request-specific. A
+          # workflow_dispatch run performs the equivalent scan below.
+          scan-diff: ${{ github.event_name == 'pull_request' }}
           fail-on-findings: 'true'
           test-vectors: 'false'
           exclude-paths: |
@@ -27,3 +34,27 @@ jobs:
             scripts/
             runner/go.sum
             control-evidence/v0/conformance/*/*/*.dsse.json
+
+      - name: Scan dispatched branch diff
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CONFIG_PATH: ${{ steps.pipelock.outputs['config-path'] }}
+        run: |
+          set -euo pipefail
+          diff_file="$(mktemp)"
+          trap 'rm -f "$diff_file"' EXIT
+          git diff --no-ext-diff --no-textconv \
+            "origin/$DEFAULT_BRANCH...HEAD" > "$diff_file"
+          scan_args=(
+            --exclude cases/
+            --exclude README.md
+            --exclude scripts/
+            --exclude runner/go.sum
+            --exclude 'control-evidence/v0/conformance/*/*/*.dsse.json'
+          )
+          if [[ -n "$CONFIG_PATH" && -f "$CONFIG_PATH" ]]; then
+            scan_args+=(--config "$CONFIG_PATH")
+          fi
+          pipelock git scan-diff "${scan_args[@]}" < "$diff_file"

--- a/.github/workflows/promote-gauntlet-result.yaml
+++ b/.github/workflows/promote-gauntlet-result.yaml
@@ -140,6 +140,7 @@ jobs:
             --baseline ci/gauntlet-baseline.json
 
       - name: Create reviewed promotion pull request
+        id: promotion
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -160,33 +161,28 @@ jobs:
             ci/gauntlet-baseline.json \
             gauntlet-site/latest-verified.json
           # Evidence extensions can overlap local-output ignore rules. Force-add
-          # only the validated immutable record, then prove its complete file
-          # set reached the index before committing.
+          # only the validated immutable record, then reject missing or extra
+          # staged record files before committing.
           git add -f -- "$record_dir"
-          expected_files="$RUNNER_TEMP/gauntlet-record-expected-files.txt"
-          staged_files="$RUNNER_TEMP/gauntlet-record-staged-files.txt"
-          {
-            printf '%s\n' record-manifest.json
-            jq -r '.files | keys[]' "$record_dir/record-manifest.json"
-          } | LC_ALL=C sort > "$expected_files"
-          git ls-files -- "$record_dir" \
-            | sed "s#^$record_dir/##" \
-            | LC_ALL=C sort > "$staged_files"
-          diff -u "$expected_files" "$staged_files"
+          python3 scripts/verify_staged_gauntlet_record.py \
+            --record-dir "$record_dir"
           # Raw evidence is copied byte-for-byte and may legitimately preserve
           # command-line whitespace. Lint only the generated control files.
           git diff --cached --check -- \
             ci/gauntlet-baseline.json \
             gauntlet-site/latest-verified.json
+          if git diff --cached --quiet; then
+            echo "candidate is already promoted on $DEFAULT_BRANCH"
+            echo "needs_validation=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git commit -m "results: promote Gauntlet run $RUN_ID"
-          if remote_sha="$(git ls-remote --exit-code --heads origin "refs/heads/$branch" | awk '{print $1}')"; then
+          if git ls-remote --exit-code --heads origin "refs/heads/$branch" >/dev/null; then
             git fetch origin "refs/heads/$branch:refs/remotes/origin/$branch"
-            local_tree="$(git rev-parse 'HEAD^{tree}')"
-            remote_tree="$(git rev-parse "refs/remotes/origin/$branch^{tree}")"
-            [[ "$local_tree" == "$remote_tree" ]] || {
-              echo "existing promotion branch has different content: $branch at $remote_sha" >&2
-              exit 1
-            }
+            python3 scripts/verify_existing_gauntlet_promotion.py \
+              --default-ref "origin/$DEFAULT_BRANCH" \
+              --remote-ref "refs/remotes/origin/$branch" \
+              --record-dir "$record_dir"
           else
             git push origin "HEAD:refs/heads/$branch"
           fi
@@ -211,16 +207,23 @@ jobs:
               --title "results: promote Gauntlet run $RUN_ID" \
               --body-file "$PR_BODY"
           fi
+          echo "needs_validation=true" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch required validations
+        if: steps.promotion.outputs.needs_validation == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           branch="gauntlet-result-$RUN_ID"
+          dispatch_failed=0
           for workflow in validate.yaml security.yaml pipelock.yaml; do
-            gh workflow run "$workflow" \
+            if ! gh workflow run "$workflow" \
               --repo "$GITHUB_REPOSITORY" \
-              --ref "$branch"
+              --ref "$branch"; then
+              echo "failed to dispatch required workflow: $workflow" >&2
+              dispatch_failed=1
+            fi
           done
+          exit "$dispatch_failed"

--- a/.github/workflows/promote-gauntlet-result.yaml
+++ b/.github/workflows/promote-gauntlet-result.yaml
@@ -158,8 +158,21 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -- \
             ci/gauntlet-baseline.json \
-            gauntlet-site/latest-verified.json \
-            "$record_dir"
+            gauntlet-site/latest-verified.json
+          # Evidence extensions can overlap local-output ignore rules. Force-add
+          # only the validated immutable record, then prove its complete file
+          # set reached the index before committing.
+          git add -f -- "$record_dir"
+          expected_files="$RUNNER_TEMP/gauntlet-record-expected-files.txt"
+          staged_files="$RUNNER_TEMP/gauntlet-record-staged-files.txt"
+          {
+            printf '%s\n' record-manifest.json
+            jq -r '.files | keys[]' "$record_dir/record-manifest.json"
+          } | LC_ALL=C sort > "$expected_files"
+          git ls-files -- "$record_dir" \
+            | sed "s#^$record_dir/##" \
+            | LC_ALL=C sort > "$staged_files"
+          diff -u "$expected_files" "$staged_files"
           # Raw evidence is copied byte-for-byte and may legitimately preserve
           # command-line whitespace. Lint only the generated control files.
           git diff --cached --check -- \
@@ -199,13 +212,15 @@ jobs:
               --body-file "$PR_BODY"
           fi
 
-      - name: Dispatch required validation
+      - name: Dispatch required validations
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           branch="gauntlet-result-$RUN_ID"
-          gh workflow run validate.yaml \
-            --repo "$GITHUB_REPOSITORY" \
-            --ref "$branch"
+          for workflow in validate.yaml security.yaml pipelock.yaml; do
+            gh workflow run "$workflow" \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref "$branch"
+          done

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,6 +1,7 @@
 name: Security
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -50,7 +50,7 @@ jobs:
           case "$GITHUB_EVENT_NAME" in
             pull_request) immutable_base="$PR_BASE_SHA" ;;
             push) immutable_base="$PUSH_BEFORE_SHA" ;;
-            workflow_dispatch) immutable_base="origin/$DEFAULT_BRANCH" ;;
+            workflow_dispatch) immutable_base="$(git merge-base "origin/$DEFAULT_BRANCH" HEAD)" ;;
             *) echo "unsupported validation event: $GITHUB_EVENT_NAME" >&2; exit 1 ;;
           esac
           python3 scripts/validate_gauntlet_records.py --immutable-base "$immutable_base"

--- a/docs/CONTINUOUS-RESULTS.md
+++ b/docs/CONTINUOUS-RESULTS.md
@@ -37,7 +37,7 @@ A normal successful run can prepare a promotion pull request directly. A run tha
 
 That option does not turn a failed execution into a pass. It only permits the workflow to propose the exact score, version, identity, or scope change in a pull request. The candidate must still be complete, sufficient, error-free, origin-bound, and hash-consistent. The pull request body lists the old-policy failures and the full new scope. Reviewers can merge or reject the proposal without changing the selected repository record.
 
-Promotion branches are created with GitHub's workflow token, so the promotion workflow explicitly dispatches the repository's required validation workflow against the branch. A second prepared promotion may conflict with the first at the baseline and pointer. It must be regenerated from the newly merged baseline rather than bypassing the up-to-date branch requirement.
+Promotion branches are created with GitHub's workflow token, so the promotion workflow explicitly dispatches the repository's required validation workflows against the branch. Re-running a candidate that is already selected on `main` exits successfully without creating another branch or dispatching unnecessary checks. A second unmerged promotion may conflict with the first at the baseline and pointer. It must be regenerated from the newly merged baseline rather than bypassing the up-to-date branch requirement.
 
 ## Independent operators
 

--- a/scripts/promote_gauntlet_workflow_test.py
+++ b/scripts/promote_gauntlet_workflow_test.py
@@ -114,6 +114,11 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("existing promotion pull request targets the wrong base branch", create)
         self.assertIn("baseRefName", create)
         self.assertIn("Raw evidence is copied byte-for-byte", create)
+        self.assertIn('git add -f -- "$record_dir"', create)
+        self.assertIn("gauntlet-record-expected-files.txt", create)
+        self.assertIn("gauntlet-record-staged-files.txt", create)
+        self.assertIn("git ls-files --", create)
+        self.assertIn('diff -u "$expected_files" "$staged_files"', create)
         self.assertIn("git diff --cached --check --", create)
         self.assertIn("ci/gauntlet-baseline.json", create)
         self.assertIn("gauntlet-site/latest-verified.json", create)
@@ -124,16 +129,41 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         self.assertNotIn("--force", self.workflow)
 
     def test_generated_pr_branch_gets_required_validation_dispatch(self):
-        validate = (REPO_ROOT / ".github" / "workflows" / "validate.yaml").read_text(
-            encoding="utf-8"
+        workflow_dir = REPO_ROOT / ".github" / "workflows"
+        required_workflows = ("validate.yaml", "security.yaml", "pipelock.yaml")
+        loaded = {
+            name: (workflow_dir / name).read_text(encoding="utf-8")
+            for name in required_workflows
+        }
+        dispatch = step_block(self.workflow, "Dispatch required validations")
+        for name, workflow in loaded.items():
+            with self.subTest(workflow=name):
+                self.assertRegex(workflow, r"(?m)^  workflow_dispatch:$")
+        self.assertIn(
+            "for workflow in validate.yaml security.yaml pipelock.yaml; do",
+            dispatch,
         )
-        dispatch = step_block(self.workflow, "Dispatch required validation")
-        self.assertRegex(validate, r"(?m)^  workflow_dispatch:$")
-        self.assertIn("gh workflow run validate.yaml", dispatch)
+        self.assertIn('gh workflow run "$workflow"', dispatch)
         self.assertIn('--ref "$branch"', dispatch)
         self.assertIn("GH_TOKEN:", dispatch)
-        self.assertIn("--immutable-base", validate)
-        self.assertIn("fetch-depth: 0", validate)
+        self.assertIn("--immutable-base", loaded["validate.yaml"])
+        self.assertIn("fetch-depth: 0", loaded["validate.yaml"])
+
+    def test_dispatched_pipelock_scan_checks_branch_diff(self):
+        pipelock = (REPO_ROOT / ".github" / "workflows" / "pipelock.yaml").read_text(
+            encoding="utf-8"
+        )
+        dispatched_scan = step_block(pipelock, "Scan dispatched branch diff")
+        self.assertIn("if: github.event_name == 'workflow_dispatch'", dispatched_scan)
+        self.assertIn('"origin/$DEFAULT_BRANCH...HEAD"', dispatched_scan)
+        self.assertIn("git diff --no-ext-diff --no-textconv", dispatched_scan)
+        self.assertIn('> "$diff_file"', dispatched_scan)
+        self.assertIn(
+            'pipelock git scan-diff "${scan_args[@]}" < "$diff_file"',
+            dispatched_scan,
+        )
+        self.assertIn("CONFIG_PATH:", dispatched_scan)
+        self.assertIn("--exclude cases/", dispatched_scan)
 
     def test_every_shell_step_parses(self):
         for name in (
@@ -142,7 +172,7 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
             "Download candidate evidence",
             "Prepare append-only record",
             "Create reviewed promotion pull request",
-            "Dispatch required validation",
+            "Dispatch required validations",
         ):
             with self.subTest(name=name):
                 block = step_block(self.workflow, name)

--- a/scripts/promote_gauntlet_workflow_test.py
+++ b/scripts/promote_gauntlet_workflow_test.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 """Structural tests for the reviewed Gauntlet promotion workflow."""
 
+import json
 import re
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
+
+from scripts import verify_staged_gauntlet_record as staged_record
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "promote-gauntlet-result.yaml"
+EXISTING_BRANCH_VERIFIER = REPO_ROOT / "scripts" / "verify_existing_gauntlet_promotion.py"
+RECORD_VALIDATOR = REPO_ROOT / "scripts" / "validate_gauntlet_records.py"
 
 
 def step_block(workflow, name):
@@ -109,16 +115,19 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         self.assertIn('branch="gauntlet-result-$RUN_ID"', create)
         self.assertIn('git push origin "HEAD:refs/heads/$branch"', create)
         self.assertIn("gh pr create", create)
-        self.assertIn("existing promotion branch has different content", create)
+        self.assertIn("scripts/verify_existing_gauntlet_promotion.py", create)
+        self.assertIn('--default-ref "origin/$DEFAULT_BRANCH"', create)
+        self.assertIn('--remote-ref "refs/remotes/origin/$branch"', create)
         self.assertIn("promotion pull request already exists", create)
         self.assertIn("existing promotion pull request targets the wrong base branch", create)
         self.assertIn("baseRefName", create)
         self.assertIn("Raw evidence is copied byte-for-byte", create)
         self.assertIn('git add -f -- "$record_dir"', create)
-        self.assertIn("gauntlet-record-expected-files.txt", create)
-        self.assertIn("gauntlet-record-staged-files.txt", create)
-        self.assertIn("git ls-files --", create)
-        self.assertIn('diff -u "$expected_files" "$staged_files"', create)
+        self.assertIn("scripts/verify_staged_gauntlet_record.py", create)
+        self.assertIn("id: promotion", create)
+        self.assertIn("git diff --cached --quiet", create)
+        self.assertIn('needs_validation=false" >> "$GITHUB_OUTPUT"', create)
+        self.assertIn('needs_validation=true" >> "$GITHUB_OUTPUT"', create)
         self.assertIn("git diff --cached --check --", create)
         self.assertIn("ci/gauntlet-baseline.json", create)
         self.assertIn("gauntlet-site/latest-verified.json", create)
@@ -136,6 +145,10 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
             for name in required_workflows
         }
         dispatch = step_block(self.workflow, "Dispatch required validations")
+        self.assertIn(
+            "if: steps.promotion.outputs.needs_validation == 'true'",
+            dispatch,
+        )
         for name, workflow in loaded.items():
             with self.subTest(workflow=name):
                 self.assertRegex(workflow, r"(?m)^  workflow_dispatch:$")
@@ -145,8 +158,14 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         )
         self.assertIn('gh workflow run "$workflow"', dispatch)
         self.assertIn('--ref "$branch"', dispatch)
+        self.assertIn("dispatch_failed=0", dispatch)
+        self.assertIn('exit "$dispatch_failed"', dispatch)
         self.assertIn("GH_TOKEN:", dispatch)
         self.assertIn("--immutable-base", loaded["validate.yaml"])
+        self.assertIn(
+            'git merge-base "origin/$DEFAULT_BRANCH" HEAD',
+            loaded["validate.yaml"],
+        )
         self.assertIn("fetch-depth: 0", loaded["validate.yaml"])
 
     def test_dispatched_pipelock_scan_checks_branch_diff(self):
@@ -190,6 +209,274 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
                     check=False,
                 )
                 self.assertEqual(result.returncode, 0, result.stderr)
+
+
+class VerifyStagedGauntletRecordTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name)
+        subprocess.run(["git", "init", "-q", str(self.repo)], check=True)
+        (self.repo / ".gitignore").write_text("*.jsonl\n", encoding="utf-8")
+        self.record = (
+            self.repo / "gauntlet-site" / "results" / "pipelock" / "candidate"
+        )
+        self.record.mkdir(parents=True)
+        (self.record / "evidence.json").write_text("{}\n", encoding="utf-8")
+        (self.record / "results.jsonl").write_text("{}\n", encoding="utf-8")
+        (self.record / "record-manifest.json").write_text(
+            json.dumps(
+                {
+                    "files": {
+                        "evidence.json": "0" * 64,
+                        "results.jsonl": "1" * 64,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.repo),
+                "add",
+                ".gitignore",
+                str(self.record / "evidence.json"),
+                str(self.record / "record-manifest.json"),
+            ],
+            check=True,
+        )
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_ignored_manifest_file_is_rejected_until_force_staged(self):
+        with self.assertRaisesRegex(ValueError, "staged record file set"):
+            staged_record.verify(self.repo, self.record)
+        subprocess.run(
+            ["git", "-C", str(self.repo), "add", "-f", str(self.record)],
+            check=True,
+        )
+        staged_record.verify(self.repo, self.record)
+
+    def test_unexpected_staged_record_file_is_rejected(self):
+        subprocess.run(
+            ["git", "-C", str(self.repo), "add", "-f", str(self.record)],
+            check=True,
+        )
+        extra = self.record / "extra.txt"
+        extra.write_text("unexpected\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.repo), "add", str(extra)], check=True)
+        with self.assertRaisesRegex(ValueError, "staged record file set"):
+            staged_record.verify(self.repo, self.record)
+
+    def test_malformed_or_non_local_manifest_is_rejected(self):
+        manifest_path = self.record / "record-manifest.json"
+        fixtures = (
+            ([], "manifest must be an object"),
+            ({"files": {}}, "files must be a non-empty object"),
+            ({"files": {"../outside.json": "0" * 64}}, "non-local filename"),
+        )
+        for manifest, message in fixtures:
+            with self.subTest(manifest=manifest):
+                manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+                with self.assertRaisesRegex(ValueError, message):
+                    staged_record.verify(self.repo, self.record)
+
+
+class ExistingPromotionBranchTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.repo)], check=True)
+        for key, value in (
+            ("user.name", "Gauntlet Test"),
+            ("user.email", "gauntlet-test@vendor.example"),
+            ("commit.gpgsign", "false"),
+            ("core.hooksPath", "/dev/null"),
+        ):
+            self._git("config", key, value)
+        (self.repo / "base.txt").write_text("base\n", encoding="utf-8")
+        self._git("add", "base.txt")
+        self._git("commit", "-q", "-m", "base")
+
+        self._git("switch", "-q", "-c", "remote-promotion")
+        self._write_promotion("candidate")
+        self._git("add", "ci", "gauntlet-site")
+        self._git("commit", "-q", "-m", "remote promotion")
+        remote_head = self._git("rev-parse", "HEAD", capture_output=True).stdout.strip()
+        self._git("update-ref", "refs/remotes/origin/gauntlet-result-1", remote_head)
+
+        self._git("switch", "-q", "main")
+        (self.repo / "unrelated.txt").write_text("main advanced\n", encoding="utf-8")
+        self._git("add", "unrelated.txt")
+        self._git("commit", "-q", "-m", "unrelated main change")
+        main_head = self._git("rev-parse", "HEAD", capture_output=True).stdout.strip()
+        self._git("update-ref", "refs/remotes/origin/main", main_head)
+
+        self._git("switch", "-q", "-c", "local-promotion")
+        self._write_promotion("candidate")
+        self._git("add", "ci", "gauntlet-site")
+        self._git("commit", "-q", "-m", "local promotion")
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def _git(self, *args, capture_output=False):
+        return subprocess.run(
+            ["git", "-C", str(self.repo), *args],
+            check=True,
+            capture_output=capture_output,
+            text=True,
+        )
+
+    def _write_promotion(self, value):
+        record = self.repo / "gauntlet-site" / "results" / "pipelock" / "candidate"
+        record.mkdir(parents=True, exist_ok=True)
+        (self.repo / "ci").mkdir(exist_ok=True)
+        (self.repo / "ci" / "gauntlet-baseline.json").write_text(
+            f'{{"value":"{value}"}}\n', encoding="utf-8"
+        )
+        (self.repo / "gauntlet-site" / "latest-verified.json").write_text(
+            f'{{"value":"{value}"}}\n', encoding="utf-8"
+        )
+        (record / "evidence.json").write_text(
+            f'{{"value":"{value}"}}\n', encoding="utf-8"
+        )
+
+    def _verify(self):
+        return subprocess.run(
+            [
+                "python3",
+                str(EXISTING_BRANCH_VERIFIER),
+                "--repo-root",
+                str(self.repo),
+                "--default-ref",
+                "origin/main",
+                "--remote-ref",
+                "refs/remotes/origin/gauntlet-result-1",
+                "--record-dir",
+                str(
+                    self.repo
+                    / "gauntlet-site"
+                    / "results"
+                    / "pipelock"
+                    / "candidate"
+                ),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def _update_remote_promotion(self):
+        remote_head = self._git("rev-parse", "HEAD", capture_output=True).stdout.strip()
+        self._git("update-ref", "refs/remotes/origin/gauntlet-result-1", remote_head)
+        self._git("switch", "-q", "local-promotion")
+
+    def test_unrelated_default_branch_change_does_not_block_reuse(self):
+        result = self._verify()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_unexpected_remote_branch_change_is_rejected(self):
+        self._git("switch", "-q", "remote-promotion")
+        (self.repo / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
+        self._git("add", "unexpected.txt")
+        self._git("commit", "-q", "-m", "unexpected remote change")
+        self._update_remote_promotion()
+        result = self._verify()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("changes unexpected paths", result.stdout)
+
+    def test_different_remote_promotion_content_is_rejected(self):
+        self._git("switch", "-q", "remote-promotion")
+        self._write_promotion("different")
+        self._git("add", "ci", "gauntlet-site")
+        self._git("commit", "-q", "-m", "different promotion")
+        self._update_remote_promotion()
+        result = self._verify()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("different promotion content", result.stdout)
+
+
+class DispatchedImmutableBaseTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temporary.name)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.repo)], check=True)
+        subprocess.run(
+            ["git", "-C", str(self.repo), "config", "user.name", "Gauntlet Test"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.repo),
+                "config",
+                "user.email",
+                "gauntlet-test@vendor.example",
+            ],
+            check=True,
+        )
+        (self.repo / "base.txt").write_text("base\n", encoding="utf-8")
+        self._git("add", "base.txt")
+        self._git("commit", "-q", "-m", "base")
+        self._git("switch", "-q", "-c", "gauntlet-result-1")
+        (self.repo / "result.txt").write_text("result\n", encoding="utf-8")
+        self._git("add", "result.txt")
+        self._git("commit", "-q", "-m", "result")
+        self._git("switch", "-q", "main")
+        (self.repo / "unrelated.txt").write_text("main advanced\n", encoding="utf-8")
+        self._git("add", "unrelated.txt")
+        self._git("commit", "-q", "-m", "unrelated main change")
+        main_head = self._git("rev-parse", "HEAD", capture_output=True).stdout.strip()
+        self._git("update-ref", "refs/remotes/origin/main", main_head)
+        self._git("switch", "-q", "gauntlet-result-1")
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def _git(self, *args, capture_output=False):
+        return subprocess.run(
+            ["git", "-C", str(self.repo), *args],
+            check=True,
+            capture_output=capture_output,
+            text=True,
+        )
+
+    def test_fork_point_remains_valid_after_default_branch_advances(self):
+        moving_tip = self._validate("origin/main")
+        self.assertNotEqual(moving_tip.returncode, 0)
+        self.assertIn("immutable base is not an ancestor", moving_tip.stdout)
+
+        immutable_base = self._git(
+            "merge-base",
+            "origin/main",
+            "HEAD",
+            capture_output=True,
+        ).stdout.strip()
+        fork_point = self._validate(immutable_base)
+        self.assertEqual(fork_point.returncode, 0, fork_point.stdout + fork_point.stderr)
+
+    def _validate(self, immutable_base):
+        return subprocess.run(
+            [
+                "python3",
+                str(RECORD_VALIDATOR),
+                "--repo-root",
+                str(self.repo),
+                "--site-root",
+                str(self.repo / "gauntlet-site"),
+                "--baseline",
+                str(self.repo / "ci" / "gauntlet-baseline.json"),
+                "--immutable-base",
+                immutable_base,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/verify_existing_gauntlet_promotion.py
+++ b/scripts/verify_existing_gauntlet_promotion.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Verify that an existing Gauntlet promotion branch is safe to reuse."""
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+
+
+STATIC_PROMOTION_PATHS = (
+    Path("ci/gauntlet-baseline.json"),
+    Path("gauntlet-site/latest-verified.json"),
+)
+
+
+def git(repo_root, *args, check=True):
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=check,
+        capture_output=True,
+    )
+
+
+def relative_record_dir(repo_root, record_dir):
+    return record_dir.resolve().relative_to(repo_root.resolve())
+
+
+def verify(repo_root, default_ref, remote_ref, local_ref, record_dir):
+    record_relative = relative_record_dir(repo_root, record_dir)
+    merge_base = git(repo_root, "merge-base", default_ref, remote_ref).stdout.strip()
+    if not merge_base:
+        raise ValueError("existing promotion branch has no default-branch merge base")
+
+    changed = git(
+        repo_root,
+        "diff",
+        "--name-only",
+        "-z",
+        os.fsdecode(merge_base),
+        remote_ref,
+    ).stdout.split(b"\0")
+    record_prefix = record_relative.as_posix() + "/"
+    allowed = {path.as_posix() for path in STATIC_PROMOTION_PATHS}
+    unexpected = []
+    for raw_path in changed:
+        if not raw_path:
+            continue
+        path = os.fsdecode(raw_path)
+        if path not in allowed and not path.startswith(record_prefix):
+            unexpected.append(path)
+    if unexpected:
+        raise ValueError(
+            "existing promotion branch changes unexpected paths: "
+            + ", ".join(sorted(unexpected))
+        )
+
+    promotion_paths = [
+        *(path.as_posix() for path in STATIC_PROMOTION_PATHS),
+        record_relative.as_posix(),
+    ]
+    comparison = git(
+        repo_root,
+        "diff",
+        "--quiet",
+        remote_ref,
+        local_ref,
+        "--",
+        *promotion_paths,
+        check=False,
+    )
+    if comparison.returncode == 1:
+        raise ValueError("existing promotion branch has different promotion content")
+    if comparison.returncode != 0:
+        raise subprocess.CalledProcessError(
+            comparison.returncode,
+            comparison.args,
+            output=comparison.stdout,
+            stderr=comparison.stderr,
+        )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--default-ref", required=True)
+    parser.add_argument("--remote-ref", required=True)
+    parser.add_argument("--local-ref", default="HEAD")
+    parser.add_argument("--record-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        verify(
+            args.repo_root,
+            args.default_ref,
+            args.remote_ref,
+            args.local_ref,
+            args.record_dir,
+        )
+    except (OSError, UnicodeError, subprocess.CalledProcessError, ValueError) as exc:
+        print(f"Gauntlet existing-branch validation: BLOCKED: {exc}")
+        return 1
+    print("Gauntlet existing-branch validation: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_staged_gauntlet_record.py
+++ b/scripts/verify_staged_gauntlet_record.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Verify that Git's index contains exactly one complete Gauntlet record."""
+
+import argparse
+import difflib
+import json
+import subprocess
+from pathlib import Path
+
+
+RECORD_MANIFEST_FILENAME = "record-manifest.json"
+
+
+def expected_files(record_dir):
+    manifest_path = record_dir / RECORD_MANIFEST_FILENAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ValueError("record manifest must be an object")
+    files = manifest.get("files")
+    if not isinstance(files, dict) or not files:
+        raise ValueError("record manifest files must be a non-empty object")
+    expected = {RECORD_MANIFEST_FILENAME}
+    for filename in files:
+        if (
+            not isinstance(filename, str)
+            or not filename
+            or filename in {".", ".."}
+            or Path(filename).name != filename
+        ):
+            raise ValueError(f"record manifest contains a non-local filename: {filename!r}")
+        expected.add(filename)
+    return expected
+
+
+def staged_files(repo_root, record_dir):
+    relative = record_dir.resolve().relative_to(repo_root.resolve()).as_posix()
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "-z", "--", relative],
+        check=True,
+        capture_output=True,
+    )
+    prefix = f"{relative}/".encode()
+    staged = set()
+    for path in result.stdout.split(b"\0"):
+        if not path:
+            continue
+        if not path.startswith(prefix):
+            raise ValueError(f"staged path escaped record directory: {path!r}")
+        staged.add(path[len(prefix):].decode())
+    return staged
+
+
+def verify(repo_root, record_dir):
+    expected = expected_files(record_dir)
+    staged = staged_files(repo_root, record_dir)
+    if staged == expected:
+        return
+    difference = "\n".join(
+        difflib.unified_diff(
+            sorted(expected),
+            sorted(staged),
+            fromfile="record-manifest",
+            tofile="git-index",
+            lineterm="",
+        )
+    )
+    raise ValueError(f"staged record file set does not match its manifest:\n{difference}")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--record-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        verify(args.repo_root, args.record_dir)
+    except (OSError, UnicodeError, json.JSONDecodeError, subprocess.CalledProcessError, ValueError) as exc:
+        print(f"Gauntlet staged-record validation: BLOCKED: {exc}")
+        return 1
+    print("Gauntlet staged-record validation: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- force-stage validated immutable evidence records and compare the staged file set with the record manifest
- dispatch every required check workflow for promotion pull requests created by GitHub Actions
- preserve Pipelock diff scanning for explicitly dispatched validation runs

This keeps reviewed result promotion fail-closed without requiring a maintainer to manually start required checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Promotion workflows now perform stricter checks to ensure generated records match their expected manifests before committing.
  - Promotions now trigger validation, security, and code-safety scans automatically.
  - Security and code-safety checks can also be run manually when needed.
  - Code-safety scans for manually triggered promotions now inspect changes against the default branch.

- **Tests**
  - Expanded workflow coverage verifies exact staged files, required validations, and branch-diff scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->