### PR TITLE
fix: correct Pipelock budget applicability

### DIFF
--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -113,6 +113,20 @@ back to `ncat` or `nc`; a machine running this example needs one of those
 programs. The continuous Gauntlet verifies that one is available before it
 runs.
 
+### Budget capability scope
+
+The checked-in profile deliberately sets `budget_enforcement` to `false`.
+The current benchmark capability requires authenticated per-subject accounting,
+but the canonical MCP stdio invocation above is one authenticated session.
+Caller-supplied tool arguments such as `subject_id` are payload data, not a
+trusted identity boundary. Pipelock can enforce a session-wide tool-call limit
+on this transport, but this adapter cannot honestly claim the benchmark's
+per-subject capability until it supplies a trusted multi-subject mapping. The
+benchmark config keeps that different session-wide limiter unlimited so it
+cannot decide unrelated cases. The current budget cases therefore score as
+`not_applicable` for this profile instead of as containment failures or
+accidental passes.
+
 The portable entry point above is the normal Pipelock operator surface. The long form below is retained for runner development and to make the managed-command contract inspectable:
 
 ```bash

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -116,7 +116,7 @@ runs.
 ### Budget capability scope
 
 The checked-in profile deliberately sets `budget_enforcement` to `false`.
-The current benchmark capability requires authenticated per-subject accounting,
+The current benchmark capability requires per-subject accounting with authenticated identities,
 but the canonical MCP stdio invocation above is one authenticated session.
 Caller-supplied tool arguments such as `subject_id` are payload data, not a
 trusted identity boundary. Pipelock can enforce a session-wide tool-call limit

--- a/examples/pipelock/pipelock-benchmark.yaml
+++ b/examples/pipelock/pipelock-benchmark.yaml
@@ -3,7 +3,10 @@ mode: balanced
 agents:
   _default:
     budget:
-      max_tool_calls_per_session: 3
+      # The current corpus capability is authenticated per-subject accounting,
+      # which this single-session stdio adapter does not claim. Keep the
+      # session-wide limiter unlimited so it cannot decide unrelated cases.
+      max_tool_calls_per_session: 0
       window_minutes: 1440
       dow_action: block
 

--- a/examples/pipelock/tool-profile.json
+++ b/examples/pipelock/tool-profile.json
@@ -20,7 +20,6 @@
     "shell_obfuscation",
     "crypto_dlp",
     "hostname_exfil",
-    "denial_of_wallet",
     "a2a_card_poison",
     "a2a_scan",
     "benign"
@@ -62,7 +61,7 @@
     "crypto_dlp_scanning": true,
     "hostname_exfil_scanning": true,
     "dns_rebinding_fixture": false,
-    "budget_enforcement": true
+    "budget_enforcement": false
   },
   "receipt_evidence": {
     "evidence_dir": ".receipt-evidence",

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -279,3 +279,46 @@ func TestCheckApplicability(t *testing.T) {
 		})
 	}
 }
+
+func TestPipelockBudgetCasesAreNotApplicable(t *testing.T) {
+	profile, err := loadProfile("../examples/pipelock/tool-profile.json")
+	if err != nil {
+		t.Fatalf("loadProfile: %v", err)
+	}
+	cases, err := loadCases("../cases")
+	if err != nil {
+		t.Fatalf("loadCases: %v", err)
+	}
+
+	wantIDs := map[string]bool{
+		"mcp-chain-dow-budget-exceeded-010":             true,
+		"mcp-chain-dow-under-budget-011":                true,
+		"mcp-chain-dow-interleaved-budget-exceeded-012": true,
+	}
+	seen := make(map[string]bool)
+	for _, c := range cases {
+		budgetCase := false
+		for _, requirement := range c.Requires {
+			if requirement == "budget_enforcement" {
+				budgetCase = true
+				break
+			}
+		}
+		if !budgetCase {
+			continue
+		}
+		seen[c.ID] = true
+		reason, applicable := checkApplicability(c, profile)
+		if applicable || reason != NAMissingRequires {
+			t.Errorf("case %s applicability = (%q, %t), want (%q, false)", c.ID, reason, applicable, NAMissingRequires)
+		}
+	}
+	if len(seen) != len(wantIDs) {
+		t.Fatalf("budget case IDs = %v, want %v", seen, wantIDs)
+	}
+	for id := range wantIDs {
+		if !seen[id] {
+			t.Errorf("missing budget case %s", id)
+		}
+	}
+}

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -15,6 +15,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml"
 ENTRYPOINT = REPO_ROOT / "scripts" / "run-pipelock-gauntlet.sh"
 RELEASE_PIN = REPO_ROOT / "examples" / "pipelock" / "release.env"
+PIPELOCK_PROFILE = REPO_ROOT / "examples" / "pipelock" / "tool-profile.json"
+PIPELOCK_README = REPO_ROOT / "examples" / "pipelock" / "README.md"
+PIPELOCK_CONFIG = REPO_ROOT / "examples" / "pipelock" / "pipelock-benchmark.yaml"
 MAKEFILE = REPO_ROOT / "Makefile"
 
 
@@ -69,6 +72,17 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertNotIn(version, self.workflow)
         self.assertNotIn(version, self.entrypoint)
         self.assertIn('source "$release_pin"', self.entrypoint)
+
+    def test_stdio_profile_does_not_claim_unexercised_subject_budget(self):
+        profile = json.loads(PIPELOCK_PROFILE.read_text(encoding="utf-8"))
+        self.assertIs(profile["supports"]["budget_enforcement"], False)
+        self.assertNotIn("denial_of_wallet", profile["claims"])
+        readme = " ".join(PIPELOCK_README.read_text(encoding="utf-8").split())
+        self.assertIn("Budget capability scope", readme)
+        self.assertIn("one authenticated session", readme)
+        self.assertIn("not a trusted identity boundary", readme)
+        config = PIPELOCK_CONFIG.read_text(encoding="utf-8")
+        self.assertRegex(config, r"(?m)^\s+max_tool_calls_per_session: 0$")
 
     def test_collection_upload_and_enforcement_order_is_fail_safe(self):
         ensure = self.workflow.index("      - name: Ensure fail-closed decision exists")


### PR DESCRIPTION
## Summary

Correct the Pipelock reference profile to match the benchmark's per-subject `budget_enforcement` contract. The canonical MCP stdio adapter has one trusted session and cannot treat caller-supplied `subject_id` arguments as a trusted identity boundary, so the three budget cases now report N/A instead of accidental passes or a false containment miss.

Keep the different session-wide benchmark limiter unlimited so it cannot decide unrelated MCP cases, remove the unexercised denial-of-wallet claim, and document and test the resulting scope.

This intentionally leaves the baseline change to a canonical merged-main run and the reviewed `accept_policy_change` promotion flow instead of hand-editing pre-merge numbers. Merge after #127 so that promotion uses the self-starting required-check workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the Pipelock adapter’s budget capability scope and authentication limitations.
  - Clarified that budget-related cases are not applicable when trusted per-subject accounting is unavailable.

- **Configuration**
  - Disabled budget enforcement and removed the denial-of-wallet claim.
  - Set the default per-session tool-call limit to unlimited.

- **Tests**
  - Added validation ensuring the profile, documentation, and benchmark configuration remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->