### PR TITLE
feat: add owner-friendly Gauntlet run summaries

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -155,15 +155,6 @@ jobs:
             echo "DECISION_PATH=$decision_path"
             echo "ARTIFACT_JSON=$candidate_path"
           } >> "$GITHUB_ENV"
-          {
-            echo '## Continuous Gauntlet candidate'
-            echo
-            echo 'This run did not publish or replace a public result.'
-            echo
-            jq -r '"- Promotion status: `\(.promotion_status)`\n- Blocked: `\(.blocked)`\n- Candidate SHA-256: `\(.candidate_sha256)`"' "$decision_path"
-            jq -r '.review_notes[]? | "- Review: " + .' "$decision_path"
-            jq -r '.failures[]? | "- Failure: " + .' "$decision_path"
-          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload provenance artifact
         if: ${{ !cancelled() }}
@@ -195,12 +186,15 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          set -euo pipefail
+          set -uo pipefail
           test -n "${DECISION_PATH:-}" || { echo "candidate decision was not produced" >&2; exit 1; }
+          test -n "${ARTIFACT_JSON:-}" || { echo "candidate artifact was not produced" >&2; exit 1; }
           artifact_dir="$GAUNTLET_ARTIFACT_DIR"
+          decision_exit=0
           python3 scripts/evaluate_gauntlet_candidate.py enforce "$DECISION_PATH" \
             --candidate "$ARTIFACT_JSON" \
             --baseline ci/gauntlet-baseline.json \
+            --result "$artifact_dir/enforcement-result.json" \
             --evidence "raw_summary=$artifact_dir/raw-summary.json" \
             --evidence "results=$artifact_dir/results.jsonl" \
             --evidence "runner_stderr=$artifact_dir/runner.stderr" \
@@ -214,4 +208,51 @@ jobs:
             --evidence "pipelock_version_output=$artifact_dir/pipelock-version.txt" \
             --evidence "corpus_manifest=$artifact_dir/corpus-manifest.txt" \
             --evidence "execution_decision=$artifact_dir/execution-decision.json" \
-            --evidence "run_bundle=$artifact_dir/run-bundle.json"
+            --evidence "run_bundle=$artifact_dir/run-bundle.json" || decision_exit=$?
+          exit "$decision_exit"
+
+      - name: Render owner-facing run summary
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_dir="$GAUNTLET_ARTIFACT_DIR"
+          mkdir -p "$artifact_dir"
+          candidate_path="${ARTIFACT_JSON:-$artifact_dir/continuous-gauntlet-pipelock.json}"
+          decision_path="${DECISION_PATH:-$artifact_dir/promotion-decision.json}"
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          summary_path="$artifact_dir/owner-summary.md"
+          summary_exit=0
+          if [[ -f scripts/render_gauntlet_run_summary.py ]]; then
+            python3 scripts/render_gauntlet_run_summary.py \
+              --candidate "$candidate_path" \
+              --decision "$decision_path" \
+              --baseline ci/gauntlet-baseline.json \
+              --enforcement-result "$artifact_dir/enforcement-result.json" \
+              --repository "$GITHUB_REPOSITORY" \
+              --run-url "$run_url" > "$summary_path" || summary_exit=$?
+            if [[ ! -s "$summary_path" ]]; then
+              summary_exit=1
+            fi
+          else
+            summary_exit=1
+          fi
+          if (( summary_exit != 0 )) && [[ ! -s "$summary_path" ]]; then
+            {
+              echo '## Continuous Gauntlet: BLOCKED — ACTION REQUIRED'
+              echo
+              echo 'The owner summary could not be rendered after an earlier workflow failure. The public record is unchanged.'
+            } > "$summary_path"
+          fi
+          cat "$summary_path" >> "$GITHUB_STEP_SUMMARY"
+          exit "$summary_exit"
+
+      - name: Upload owner review artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: continuous-gauntlet-owner-review
+          path: |
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/enforcement-result.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/owner-summary.md
+          retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ check-gauntlet-site:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/evaluate_gauntlet_candidate_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/build_gauntlet_provenance_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/continuous_gauntlet_workflow_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/render_gauntlet_run_summary_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/promote_gauntlet_candidate_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/promote_gauntlet_workflow_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/gauntlet_site_index_test.py

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/validate.yaml"><img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/validate.yaml/badge.svg" alt="Validate Cases"></a>
   <a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/security.yaml"><img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/security.yaml/badge.svg" alt="Security"></a>
   <a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml"><img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml/badge.svg" alt="Pipelock Scan"></a>
+  <a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/continuous-gauntlet.yaml"><img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/continuous-gauntlet.yaml/badge.svg" alt="Continuous Gauntlet"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/luckyPipewrench/agent-egress-bench"><img src="https://api.scorecard.dev/projects/github.com/luckyPipewrench/agent-egress-bench/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://goreportcard.com/report/github.com/luckyPipewrench/agent-egress-bench"><img src="https://goreportcard.com/badge/github.com/luckyPipewrench/agent-egress-bench" alt="Go Report Card"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>

--- a/docs/CONTINUOUS-RESULTS.md
+++ b/docs/CONTINUOUS-RESULTS.md
@@ -9,6 +9,10 @@ The Pipelock reference lane separates execution, review, and publication.
 
 The scheduled workflow cannot write repository contents or open a pull request. A raw run never moves the committed pointer by itself. Candidate Actions artifacts are retained for 14 days, so a maintainer must prepare the promotion before that download window closes.
 
+Daily runs do not create pull requests. The workflow summary says **PASS — NO ACTION REQUIRED** when the candidate matches the approved scope. Owner action is needed only when it says **REVIEW REQUIRED** for a scope or policy change, or **BLOCKED** for an incomplete or failed run.
+
+Clean runs finish green. Review-required and blocked runs finish red so the Actions badge and normal failed-workflow notifications surface the action; the first line of the run summary distinguishes a review from a broken run. Email delivery still depends on the owner's GitHub notification settings.
+
 ## Append-only layout
 
 Each approved candidate is stored at a digest-addressed path:

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -2,6 +2,7 @@
 """Structural tests for the fail-safe continuous Gauntlet workflow."""
 
 import importlib.util
+import hashlib
 import json
 import os
 import re
@@ -64,6 +65,18 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("--fixtures", self.entrypoint)
         self.assertIn("--multifile-cases", self.entrypoint)
 
+    def test_zero_argument_entrypoint_avoids_old_bash_empty_array_expansion(self):
+        self.assertIn("original_arg_count=$#", self.entrypoint)
+        self.assertIn("original_arg_index < original_arg_count", self.entrypoint)
+        self.assertIn('${original_args[$original_arg_index]}', self.entrypoint)
+        self.assertNotRegex(self.entrypoint, r"\$\{original_args\[[@*]\]")
+
+    def test_canonical_entrypoint_avoids_old_bash_empty_reason_array_expansion(self):
+        self.assertIn("noncanonical_reason_count=0", self.entrypoint)
+        self.assertIn("reason_index < noncanonical_reason_count", self.entrypoint)
+        self.assertIn('${noncanonical_reasons[$reason_index]}', self.entrypoint)
+        self.assertNotRegex(self.entrypoint, r"\$\{noncanonical_reasons\[[@*]\]")
+
     def test_reviewed_release_pin_is_not_duplicated_in_consumers(self):
         release_pin = RELEASE_PIN.read_text(encoding="utf-8")
         self.assertRegex(release_pin, r"(?m)^PIPELOCK_TAG=v[^\s]+$")
@@ -86,26 +99,59 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
 
     def test_collection_upload_and_enforcement_order_is_fail_safe(self):
         ensure = self.workflow.index("      - name: Ensure fail-closed decision exists")
+        summary = self.workflow.index("      - name: Render owner-facing run summary")
+        review_upload = self.workflow.index("      - name: Upload owner review artifact")
         upload = self.workflow.index("      - name: Upload provenance artifact")
         enforce = self.workflow.index("      - name: Enforce candidate decision")
         self.assertLess(ensure, upload)
+        self.assertLess(ensure, summary)
         self.assertLess(upload, enforce)
+        self.assertLess(enforce, summary)
+        self.assertLess(summary, review_upload)
 
         ensure_block = step_block(self.workflow, "Ensure fail-closed decision exists")
         upload_block = step_block(self.workflow, "Upload provenance artifact")
+        review_upload_block = step_block(self.workflow, "Upload owner review artifact")
         enforce_block = step_block(self.workflow, "Enforce candidate decision")
         evaluate_block = step_block(self.workflow, "Evaluate candidate without publishing")
-        for block in (ensure_block, upload_block, enforce_block):
+        for block in (ensure_block, upload_block, enforce_block, review_upload_block):
             self.assertIn("if: ${{ !cancelled() }}", block)
         self.assertIn("promotion-decision.json", ensure_block)
         self.assertIn("repository evaluator unavailable after an earlier workflow failure", ensure_block)
         self.assertIn("promotion-decision.json", upload_block)
         self.assertIn("execution-decision.json", upload_block)
         self.assertIn("run-bundle.json", upload_block)
+        self.assertIn("enforcement-result.json", review_upload_block)
+        self.assertIn("owner-summary.md", review_upload_block)
         self.assertIn("evaluate_gauntlet_candidate.py enforce", enforce_block)
+        self.assertIn('test -n "${ARTIFACT_JSON:-}"', enforce_block)
         for evidence in EVIDENCE_LABELS:
             for block in (evaluate_block, ensure_block, enforce_block):
                 self.assertIn(f'--evidence "{evidence}=', block)
+
+    def test_owner_summary_uses_renderer_after_fail_closed_decision(self):
+        block = step_block(self.workflow, "Render owner-facing run summary")
+        self.assertIn("if: ${{ !cancelled() }}", block)
+        self.assertIn("scripts/render_gauntlet_run_summary.py", block)
+        self.assertIn('--candidate "$candidate_path"', block)
+        self.assertIn('--decision "$decision_path"', block)
+        self.assertIn("--baseline ci/gauntlet-baseline.json", block)
+        self.assertIn('--repository "$GITHUB_REPOSITORY"', block)
+        self.assertIn('--run-url "$run_url"', block)
+        self.assertIn('--enforcement-result "$artifact_dir/enforcement-result.json"', block)
+        self.assertIn("BLOCKED — ACTION REQUIRED", block)
+        self.assertIn("summary could not be rendered", block)
+        self.assertIn("public record is unchanged", block)
+        self.assertIn('> "$summary_path" || summary_exit=$?', block)
+        self.assertIn('} > "$summary_path"', block)
+        self.assertIn('cat "$summary_path" >> "$GITHUB_STEP_SUMMARY"', block)
+        self.assertIn('exit "$summary_exit"', block)
+        ensure_block = step_block(self.workflow, "Ensure fail-closed decision exists")
+        self.assertNotIn("GITHUB_STEP_SUMMARY", ensure_block)
+
+        enforce_block = step_block(self.workflow, "Enforce candidate decision")
+        self.assertIn('--result "$artifact_dir/enforcement-result.json"', enforce_block)
+        self.assertIn('exit "$decision_exit"', enforce_block)
 
     def test_platform_finalization_supplies_a_real_github_url(self):
         block = step_block(self.workflow, "Finalize GitHub provenance artifact")
@@ -207,6 +253,121 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             )
             self.assertTrue(decision["blocked"])
             self.assertIn("evaluator unavailable", decision["failures"][0])
+
+    def test_owner_summary_shell_emits_content_even_when_renderer_blocks(self):
+        block = step_block(self.workflow, "Render owner-facing run summary")
+        marker = "        run: |\n"
+        source = block[block.index(marker) + len(marker):]
+        source = "\n".join(
+            line[10:] if line.startswith("          ") else line
+            for line in source.splitlines()
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate_path = root / "continuous-gauntlet-pipelock.json"
+            decision_path = root / "promotion-decision.json"
+            baseline_path = REPO_ROOT / "ci" / "gauntlet-baseline.json"
+            enforcement_path = root / "enforcement-result.json"
+            candidate = {
+                "schema_version": 2,
+                "pipelock_version": "3.3.0",
+                "generated_at": "2026-08-05T12:00:00Z",
+                "corpus_version": "v2.3.0",
+                "corpus_git_sha": "a" * 40,
+                "case_count": {
+                    "total": 214,
+                    "applicable": 210,
+                    "not_applicable": 4,
+                    "not_applicable_reasons": {"missing_requires": 4},
+                    "errors": 0,
+                },
+                "scores": {
+                    "applicable": {"containment": 1, "false_positive_rate": 0},
+                    "full": {"containment": 0.9811320754716981},
+                },
+                "sufficient": True,
+            }
+            decision = {
+                "schema_version": 1,
+                "blocked": False,
+                "promotion_status": "under_review",
+                "failures": [],
+                "review_notes": [],
+            }
+            candidate_path.write_text(json.dumps(candidate), encoding="utf-8")
+            decision_path.write_text(json.dumps(decision), encoding="utf-8")
+            enforcement_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "verdict": "pass",
+                        "promotion_status": "under_review",
+                        "failures": [],
+                        "candidate_sha256": hashlib.sha256(candidate_path.read_bytes()).hexdigest(),
+                        "decision_sha256": hashlib.sha256(decision_path.read_bytes()).hexdigest(),
+                        "baseline_sha256": hashlib.sha256(baseline_path.read_bytes()).hexdigest(),
+                    }
+                ),
+                encoding="utf-8",
+            )
+            candidate_path.write_bytes(b"\xff")
+            step_summary = root / "step-summary"
+            env = {
+                **os.environ,
+                "GAUNTLET_ARTIFACT_DIR": str(root),
+                "ARTIFACT_JSON": str(candidate_path),
+                "DECISION_PATH": str(decision_path),
+                "GITHUB_REPOSITORY": "luckyPipewrench/agent-egress-bench",
+                "GITHUB_RUN_ID": "123",
+                "GITHUB_STEP_SUMMARY": str(step_summary),
+            }
+            result = subprocess.run(
+                ["bash", "-c", source],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            summary = step_summary.read_text(encoding="utf-8")
+            self.assertIn("BLOCKED — ACTION REQUIRED", summary)
+            self.assertIn("cannot read candidate", summary)
+
+    def test_owner_summary_shell_writes_fallback_when_renderer_is_unavailable(self):
+        block = step_block(self.workflow, "Render owner-facing run summary")
+        marker = "        run: |\n"
+        source = block[block.index(marker) + len(marker):]
+        source = "\n".join(
+            line[10:] if line.startswith("          ") else line
+            for line in source.splitlines()
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            step_summary = root / "step-summary"
+            env = {
+                **os.environ,
+                "GAUNTLET_ARTIFACT_DIR": str(root / "artifacts"),
+                "GITHUB_REPOSITORY": "luckyPipewrench/agent-egress-bench",
+                "GITHUB_RUN_ID": "123",
+                "GITHUB_STEP_SUMMARY": str(step_summary),
+            }
+            result = subprocess.run(
+                ["bash", "-c", source],
+                cwd=root,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            summary = step_summary.read_text(encoding="utf-8")
+            self.assertIn("BLOCKED — ACTION REQUIRED", summary)
+            self.assertIn("could not be rendered", summary)
+            self.assertEqual(
+                summary,
+                (root / "artifacts" / "owner-summary.md").read_text(encoding="utf-8"),
+            )
 
     def test_stats_creates_its_declared_cache_directories(self):
         makefile = MAKEFILE.read_text(encoding="utf-8")

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -281,12 +281,50 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
     return decision
 
 
-def enforce(decision_path, candidate_path, baseline_path, evidence_paths=None):
+def enforcement_result(decision_path, candidate_path, baseline_path, verdict, promotion_status, failures):
+    result = {
+        "schema_version": 1,
+        "verdict": verdict,
+        "promotion_status": promotion_status,
+        "failures": failures,
+        "decision_sha256": None,
+        "candidate_sha256": None,
+        "baseline_sha256": None,
+    }
+    for field, path in (
+        ("decision_sha256", decision_path),
+        ("candidate_sha256", candidate_path),
+        ("baseline_sha256", baseline_path),
+    ):
+        try:
+            result[field] = file_sha256(path)
+        except OSError:
+            pass
+    return result
+
+
+def write_enforcement_result(result_path, result):
+    try:
+        atomic_json_write(result_path, result)
+    except OSError as exc:
+        print(f"::error::cannot write enforcement result: {exc}")
+        return False
+    return True
+
+
+def enforce(decision_path, candidate_path, baseline_path, result_path, evidence_paths=None):
     evidence_paths = evidence_paths or {}
     try:
         decision = load_object(decision_path)
-    except (OSError, json.JSONDecodeError, ValueError) as exc:
-        print(f"candidate decision: BLOCKED: {exc}")
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        failure = f"cannot read candidate decision: {exc}"
+        write_enforcement_result(
+            result_path,
+            enforcement_result(
+                decision_path, candidate_path, baseline_path, "blocked", "blocked", [failure]
+            ),
+        )
+        print(f"candidate decision: BLOCKED: {failure}")
         return 1
     integrity_failures = []
     recomputed = evaluate(candidate_path, baseline_path, evidence_paths)
@@ -320,14 +358,50 @@ def enforce(decision_path, candidate_path, baseline_path, evidence_paths=None):
 
     if decision.get("blocked") is not False or integrity_failures:
         failures = decision.get("failures")
-        if not isinstance(failures, list) or not failures:
+        if not isinstance(failures, list):
+            failures = []
+        if decision.get("blocked") is not False and not failures:
             failures = ["decision is blocked without a recorded reason"]
         failures = [*failures, *integrity_failures]
         for failure in failures:
             print(f"::error::{failure}")
+        result = enforcement_result(
+            decision_path, candidate_path, baseline_path, "blocked", "blocked", failures
+        )
+        if not write_enforcement_result(result_path, result):
+            return 1
         print(f"candidate decision: BLOCKED ({len(failures)} failure(s))")
         return 1
-    print("candidate decision: ACCEPTED FOR HUMAN REVIEW (not published)")
+    if decision.get("promotion_status") == "scope_changed_requires_review":
+        result = enforcement_result(
+            decision_path,
+            candidate_path,
+            baseline_path,
+            "review_required",
+            "scope_changed_requires_review",
+            [],
+        )
+        if not write_enforcement_result(result_path, result):
+            return 1
+        print("::warning::candidate scope changed and requires owner review; public record unchanged")
+        print("candidate decision: REVIEW REQUIRED (not published)")
+        return 2
+    if decision.get("promotion_status") != "under_review":
+        failure = "candidate decision has an unrecognized promotion status"
+        write_enforcement_result(
+            result_path,
+            enforcement_result(
+                decision_path, candidate_path, baseline_path, "blocked", "blocked", [failure]
+            ),
+        )
+        print(f"::error::{failure}")
+        return 1
+    result = enforcement_result(
+        decision_path, candidate_path, baseline_path, "pass", "under_review", []
+    )
+    if not write_enforcement_result(result_path, result):
+        return 1
+    print("candidate decision: PASS (no action required; not published)")
     return 0
 
 
@@ -345,6 +419,7 @@ def parse_args():
     enforce_parser.add_argument("decision", type=Path)
     enforce_parser.add_argument("--candidate", type=Path, required=True)
     enforce_parser.add_argument("--baseline", type=Path, required=True)
+    enforce_parser.add_argument("--result", type=Path, required=True)
     enforce_parser.add_argument("--evidence", action="append", default=[], metavar="NAME=PATH")
     return parser.parse_args()
 
@@ -369,7 +444,7 @@ def main():
         print(f"candidate decision: BLOCKED: {exc}")
         return 1
     if args.command == "enforce":
-        return enforce(args.decision, args.candidate, args.baseline, evidence_paths)
+        return enforce(args.decision, args.candidate, args.baseline, args.result, evidence_paths)
 
     decision = evaluate(args.candidate, args.baseline, evidence_paths)
     atomic_json_write(args.decision, decision)

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -167,6 +167,8 @@ class CandidateEvaluationTest(unittest.TestCase):
                 str(candidate_path),
                 "--baseline",
                 str(baseline_path),
+                "--result",
+                str(decision_path.parent / "enforcement-result.json"),
                 *evidence_args,
             ],
             cwd=REPO_ROOT,
@@ -208,7 +210,7 @@ class CandidateEvaluationTest(unittest.TestCase):
                     self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode, 0
                 )
 
-    def test_scope_change_requires_review_but_does_not_disable_the_lane(self):
+    def test_scope_change_returns_distinct_owner_review_status(self):
         value = candidate()
         value["case_count"] = {
             "total": 214,
@@ -221,10 +223,14 @@ class CandidateEvaluationTest(unittest.TestCase):
         self.assertFalse(decision["blocked"])
         self.assertEqual(decision["promotion_status"], "scope_changed_requires_review")
         self.assertTrue(any("case_count.total moved" in note for note in decision["review_notes"]))
-        self.assertEqual(
-            self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode,
-            0,
+        enforced = self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path)
+        self.assertEqual(enforced.returncode, 2)
+        self.assertIn("REVIEW REQUIRED", enforced.stdout)
+        result = json.loads(
+            (decision_path.parent / "enforcement-result.json").read_text(encoding="utf-8")
         )
+        self.assertEqual(result["verdict"], "review_required")
+        self.assertEqual(result["promotion_status"], "scope_changed_requires_review")
 
     def test_malformed_candidate_still_produces_a_blocked_decision(self):
         decision, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate(raw_candidate="{")
@@ -286,6 +292,12 @@ class CandidateEvaluationTest(unittest.TestCase):
         result = self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("evidence results changed", result.stdout)
+        enforcement = json.loads(
+            (decision_path.parent / "enforcement-result.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(enforcement["verdict"], "blocked")
+        self.assertTrue(any("evidence results changed" in failure for failure in enforcement["failures"]))
+        self.assertFalse(any("without a recorded reason" in failure for failure in enforcement["failures"]))
 
     def test_case_index_substitution_fails_closed(self):
         _, decision_path, candidate_path, baseline_path, evidence_path = self.run_evaluate()

--- a/scripts/render_gauntlet_run_summary.py
+++ b/scripts/render_gauntlet_run_summary.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Render a fail-closed, owner-facing Continuous Gauntlet summary."""
+
+import argparse
+import hashlib
+import html
+import json
+import math
+import re
+from pathlib import Path
+
+
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+RUN_URL_RE = re.compile(r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/actions/runs/[1-9][0-9]*$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+REVIEW_STATUS = "scope_changed_requires_review"
+PASS_STATUS = "under_review"
+
+
+def markdown_text(value):
+    """Render untrusted values as literal, one-line Markdown text."""
+    if not isinstance(value, str):
+        return "(unavailable)"
+    escaped = value.replace("\\", "\\\\").replace("`", "\\`").replace("\r", " ").replace("\n", " ")
+    for character in ("[", "]", "(", ")"):
+        escaped = escaped.replace(character, "\\" + character)
+    return html.escape(escaped, quote=False)
+
+
+def code_text(value):
+    """Render a literal one-line value inside a Markdown code span."""
+    if not isinstance(value, str):
+        return "(unavailable)"
+    return html.escape(value.replace("`", "'").replace("\r", " ").replace("\n", " "), quote=False)
+
+
+def load_object(path, label, failures):
+    try:
+        with path.open(encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        failures.append(f"cannot read {label}: {exc}")
+        return None
+    if not isinstance(value, dict):
+        failures.append(f"{label} must be a JSON object")
+        return None
+    return value
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def required_string(document, path, failures):
+    value = document
+    for key in path:
+        if not isinstance(value, dict):
+            failures.append("missing field: " + ".".join(path))
+            return None
+        value = value.get(key)
+    if not isinstance(value, str) or not value:
+        failures.append("invalid field: " + ".".join(path))
+        return None
+    return value
+
+
+def count(document, key, failures):
+    value = document.get("case_count", {}).get(key) if isinstance(document.get("case_count"), dict) else None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        failures.append(f"invalid field: case_count.{key}")
+        return None
+    return value
+
+
+def score(document, scope, metric, failures):
+    scores = document.get("scores")
+    value = scores.get(scope, {}).get(metric) if isinstance(scores, dict) and isinstance(scores.get(scope), dict) else None
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or not 0 <= value <= 1:
+        failures.append(f"invalid field: scores.{scope}.{metric}")
+        return None
+    return float(value)
+
+
+def percent(value):
+    return f"{value * 100:.1f}%"
+
+
+def append_failure(failures, message):
+    if message not in failures:
+        failures.append(message)
+
+
+def verify_enforcement_digests(enforcement, paths, failures):
+    for field, (label, path) in paths.items():
+        recorded = enforcement.get(field)
+        if not isinstance(recorded, str) or not SHA256_RE.fullmatch(recorded):
+            append_failure(failures, f"enforcement result {field} is invalid")
+            continue
+        try:
+            current = file_sha256(path)
+        except OSError as exc:
+            append_failure(failures, f"cannot hash {label}: {exc}")
+            continue
+        if current != recorded:
+            append_failure(failures, f"{label} changed after enforcement")
+
+
+def build_summary(candidate_path, decision_path, baseline_path, enforcement_path, repository, run_url):
+    failures = []
+    repository_valid = bool(REPOSITORY_RE.fullmatch(repository))
+    run_url_valid = bool(RUN_URL_RE.fullmatch(run_url))
+    if not repository_valid:
+        failures.append("repository context is invalid")
+    if not run_url_valid:
+        failures.append("current run URL is invalid")
+
+    candidate = load_object(candidate_path, "candidate", failures)
+    decision = load_object(decision_path, "decision", failures)
+    baseline = load_object(baseline_path, "approved baseline", failures)
+    enforcement = load_object(enforcement_path, "enforcement result", failures)
+
+    verdict = None
+    enforced_status = None
+    enforcement_failures = []
+    if enforcement is not None:
+        if enforcement.get("schema_version") != 1:
+            failures.append("enforcement result schema_version must be 1")
+        verdict = enforcement.get("verdict")
+        enforced_status = enforcement.get("promotion_status")
+        if verdict not in {"pass", "review_required", "blocked"}:
+            failures.append("enforcement result verdict is invalid")
+        values = enforcement.get("failures")
+        if not isinstance(values, list) or any(not isinstance(item, str) or not item for item in values):
+            failures.append("enforcement result failures must be non-empty strings")
+        else:
+            enforcement_failures.extend(values)
+        verify_enforcement_digests(
+            enforcement,
+            {
+                "decision_sha256": ("decision", decision_path),
+                "candidate_sha256": ("candidate", candidate_path),
+                "baseline_sha256": ("approved baseline", baseline_path),
+            },
+            failures,
+        )
+
+    details = {}
+    if candidate is not None:
+        if candidate.get("schema_version") != 2:
+            failures.append("candidate schema_version must be 2")
+        for key in ("pipelock_version", "generated_at", "corpus_version", "corpus_git_sha"):
+            details[key] = required_string(candidate, (key,), failures)
+        for key in ("total", "applicable", "not_applicable", "errors"):
+            details[key] = count(candidate, key, failures)
+        if candidate.get("sufficient") is not True:
+            failures.append("candidate sufficient must be true")
+        if details["errors"] not in (None, 0):
+            failures.append("candidate case_count.errors must be 0")
+        reasons = candidate.get("case_count", {}).get("not_applicable_reasons") if isinstance(candidate.get("case_count"), dict) else None
+        if not isinstance(reasons, dict) or any(not isinstance(reason, str) or not reason or isinstance(value, bool) or not isinstance(value, int) or value < 0 for reason, value in reasons.items()):
+            failures.append("invalid field: case_count.not_applicable_reasons")
+        elif details["not_applicable"] is not None and sum(reasons.values()) != details["not_applicable"]:
+            failures.append("candidate N/A reasons do not match case_count.not_applicable")
+        if all(details[key] is not None for key in ("total", "applicable", "not_applicable")) and details["applicable"] + details["not_applicable"] != details["total"]:
+            failures.append("candidate case counts do not partition total")
+        details["applicable_containment"] = score(candidate, "applicable", "containment", failures)
+        details["full_containment"] = score(candidate, "full", "containment", failures)
+        details["false_positive_rate"] = score(candidate, "applicable", "false_positive_rate", failures)
+
+    decision_failures = []
+    review_notes = []
+    status = None
+    if decision is not None:
+        if decision.get("schema_version") != 1:
+            failures.append("decision schema_version must be 1")
+        if not isinstance(decision.get("blocked"), bool):
+            failures.append("decision blocked must be a boolean")
+        status = decision.get("promotion_status")
+        if not isinstance(status, str) or not status:
+            failures.append("decision promotion_status is invalid")
+        for source, destination in (("failures", decision_failures), ("review_notes", review_notes)):
+            values = decision.get(source)
+            if not isinstance(values, list) or any(not isinstance(item, str) for item in values):
+                failures.append(f"decision {source} must be a list of strings")
+            else:
+                destination.extend(values)
+
+    if baseline is not None:
+        if baseline.get("schema_version") != 1:
+            failures.append("approved baseline schema_version must be 1")
+        for key in ("pipelock_version", "corpus_version", "corpus_git_sha"):
+            required_string(baseline, (key,), failures)
+
+    for failure in decision_failures:
+        append_failure(failures, "decision: " + failure)
+    for failure in enforcement_failures:
+        append_failure(failures, "enforcement: " + failure)
+
+    if verdict == "blocked":
+        if not enforcement_failures:
+            append_failure(failures, "enforcement blocked without a recorded reason")
+        state = "BLOCKED — ACTION REQUIRED"
+    elif (
+        not failures
+        and verdict == "review_required"
+        and enforced_status == REVIEW_STATUS
+        and status == REVIEW_STATUS
+        and decision is not None
+        and decision.get("blocked") is False
+    ):
+        state = "REVIEW REQUIRED — PUBLIC RECORD UNCHANGED"
+    elif (
+        not failures
+        and verdict == "pass"
+        and enforced_status == PASS_STATUS
+        and status == PASS_STATUS
+        and decision is not None
+        and decision.get("blocked") is False
+    ):
+        state = "PASS — NO ACTION REQUIRED"
+    else:
+        if not failures:
+            failures.append(
+                "decision status disagrees with enforcement result: "
+                f"promotion_status={status!r}, verdict={verdict!r}, "
+                f"enforced_status={enforced_status!r}"
+            )
+        state = "BLOCKED — ACTION REQUIRED"
+
+    latest_url = f"https://github.com/{repository}/blob/main/gauntlet-site/latest-verified.json" if repository_valid else None
+    promote_url = f"https://github.com/{repository}/actions/workflows/promote-gauntlet-result.yaml" if repository_valid else None
+    lines = [f"## Continuous Gauntlet: {state}", ""]
+    if state == "PASS — NO ACTION REQUIRED":
+        lines.extend(["The candidate is complete and matches the approved scope. No PR was created; permanent publication was not requested.", ""])
+    elif state.startswith("REVIEW REQUIRED"):
+        lines.extend(["The candidate is complete, but its approved scope changed. The public record is unchanged. Review the reasons below, then use the manual promotion workflow if a new checkpoint is wanted.", ""])
+    else:
+        lines.extend(["The candidate, decision, or enforcement result is incomplete, blocked, or malformed. The public record is unchanged. Fix or inspect the failures below before considering promotion.", ""])
+
+    lines.extend(["### Run details", ""])
+    if candidate is not None:
+        lines.append(f"- Pipelock: `{code_text(details.get('pipelock_version'))}`")
+        lines.append(f"- Generated: `{code_text(details.get('generated_at'))}`")
+        if all(details.get(key) is not None for key in ("total", "applicable", "not_applicable", "errors")):
+            lines.append(f"- Cases: {details['total']} total; {details['applicable']} applicable; {details['not_applicable']} N/A; {details['errors']} errors")
+        if details.get("applicable_containment") is not None:
+            lines.append(f"- Applicable containment: {percent(details['applicable_containment'])}")
+        if details.get("full_containment") is not None:
+            lines.append(f"- Full containment: {percent(details['full_containment'])}")
+        if details.get("false_positive_rate") is not None:
+            lines.append(f"- Applicable false-positive rate: {percent(details['false_positive_rate'])}")
+        sha = details.get("corpus_git_sha")
+        short_sha = sha[:12] if isinstance(sha, str) else "(unavailable)"
+        lines.append(f"- Corpus: `{code_text(details.get('corpus_version'))}` at `{code_text(short_sha)}`")
+        if state == "PASS — NO ACTION REQUIRED":
+            lines.append("- Approved scope: unchanged")
+    else:
+        lines.append("- Candidate details are unavailable.")
+
+    if review_notes:
+        lines.extend(["", "### Review notes", ""])
+        lines.extend(f"- {markdown_text(note)}" for note in review_notes)
+    if failures:
+        lines.extend(["", "### Failures", ""])
+        lines.extend(f"- {markdown_text(failure)}" for failure in failures)
+    lines.extend(["", "### Links", ""])
+    lines.append(f"- [Current workflow run]({run_url})" if run_url_valid else "- Current workflow run: (unavailable)")
+    lines.append(f"- [Current verified pointer]({latest_url})" if latest_url else "- Current verified pointer: (unavailable)")
+    lines.append(f"- [Prepare a promotion]({promote_url})" if promote_url else "- Prepare a promotion: (unavailable)")
+    lines.append("")
+    return "\n".join(lines), state
+
+
+def render(candidate_path, decision_path, baseline_path, enforcement_path, repository, run_url):
+    return build_summary(
+        candidate_path, decision_path, baseline_path, enforcement_path, repository, run_url
+    )[0]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--decision", type=Path, required=True)
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--enforcement-result", type=Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--run-url", required=True)
+    args = parser.parse_args()
+    output, state = build_summary(
+        args.candidate,
+        args.decision,
+        args.baseline,
+        args.enforcement_result,
+        args.repository,
+        args.run_url,
+    )
+    print(output)
+    return 1 if state == "BLOCKED — ACTION REQUIRED" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_gauntlet_run_summary_test.py
+++ b/scripts/render_gauntlet_run_summary_test.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Tests for the fail-closed owner-facing Gauntlet summary."""
+
+import importlib.util
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "render_gauntlet_run_summary.py"
+spec = importlib.util.spec_from_file_location("render_gauntlet_run_summary", SCRIPT)
+renderer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(renderer)
+
+REPOSITORY = "luckyPipewrench/agent-egress-bench"
+RUN_URL = "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/123"
+
+
+def candidate():
+    return {
+        "schema_version": 2,
+        "pipelock_version": "3.3.0",
+        "generated_at": "2026-08-05T12:00:00Z",
+        "corpus_version": "v2.3.0",
+        "corpus_git_sha": "a" * 40,
+        "case_count": {"total": 214, "applicable": 210, "not_applicable": 4, "not_applicable_reasons": {"missing_requires": 4}, "errors": 0},
+        "scores": {
+            "applicable": {"containment": 1, "false_positive_rate": 0},
+            "full": {"containment": 0.9811320754716981},
+        },
+        "sufficient": True,
+    }
+
+
+def baseline():
+    return {
+        "schema_version": 1,
+        "pipelock_version": "3.3.0",
+        "corpus_version": "v2.3.0",
+        "corpus_git_sha": "a" * 40,
+    }
+
+
+def decision(status="under_review", blocked=False, failures=None, review_notes=None):
+    return {
+        "schema_version": 1,
+        "blocked": blocked,
+        "promotion_status": status,
+        "failures": failures or [],
+        "review_notes": review_notes or [],
+    }
+
+
+class RenderGauntletRunSummaryTest(unittest.TestCase):
+    def render(self, candidate_value=None, decision_value=None, baseline_value=None, raw_candidate=None, raw_candidate_bytes=None, missing_candidate=False, missing_decision=False, enforcement_exit=0, enforcement_status=None, enforcement_failures=None):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        candidate_path = root / "candidate.json"
+        decision_path = root / "decision.json"
+        baseline_path = root / "baseline.json"
+        if not missing_candidate:
+            if raw_candidate_bytes is not None:
+                candidate_path.write_bytes(raw_candidate_bytes)
+            else:
+                candidate_path.write_text(raw_candidate if raw_candidate is not None else json.dumps(candidate_value or candidate()), encoding="utf-8")
+        if not missing_decision:
+            decision_path.write_text(json.dumps(decision_value or decision()), encoding="utf-8")
+        baseline_path.write_text(json.dumps(baseline_value or baseline()), encoding="utf-8")
+        enforcement_path = root / "enforcement-result.json"
+        if enforcement_exit == 0:
+            verdict = "pass"
+            default_status = "under_review"
+            default_failures = []
+        elif enforcement_exit == 2:
+            verdict = "review_required"
+            default_status = "scope_changed_requires_review"
+            default_failures = []
+        else:
+            verdict = "blocked"
+            default_status = "blocked"
+            default_failures = ["enforcement failed"]
+        digests = {}
+        for field, path in (
+            ("candidate_sha256", candidate_path),
+            ("decision_sha256", decision_path),
+            ("baseline_sha256", baseline_path),
+        ):
+            digests[field] = hashlib.sha256(path.read_bytes()).hexdigest() if path.is_file() else None
+        enforcement_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "verdict": verdict,
+                    "promotion_status": enforcement_status or default_status,
+                    "failures": default_failures if enforcement_failures is None else enforcement_failures,
+                    **digests,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return renderer.render(candidate_path, decision_path, baseline_path, enforcement_path, REPOSITORY, RUN_URL)
+
+    def test_pass_needs_no_owner_action(self):
+        output = self.render()
+        self.assertIn("PASS — NO ACTION REQUIRED", output)
+        self.assertIn("No PR was created; permanent publication was not requested.", output)
+        self.assertIn("214 total; 210 applicable; 4 N/A; 0 errors", output)
+        self.assertIn("Applicable containment: 100.0%", output)
+        self.assertIn("Full containment: 98.1%", output)
+        self.assertIn("Applicable false-positive rate: 0.0%", output)
+
+    def test_scope_change_requires_review_without_publication(self):
+        output = self.render(
+            decision_value=decision("scope_changed_requires_review", review_notes=["case_count.total moved 213 -> 214"]),
+            enforcement_exit=2,
+        )
+        self.assertIn("REVIEW REQUIRED — PUBLIC RECORD UNCHANGED", output)
+        self.assertIn("case_count.total moved 213 -&gt; 214", output)
+        self.assertIn("Prepare a promotion", output)
+
+    def test_blocked_decision_is_action_required(self):
+        output = self.render(decision_value=decision("blocked", True, ["case_count.errors=1, want 0"]), enforcement_exit=1)
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("case_count.errors=1, want 0", output)
+        self.assertIn("The public record is unchanged.", output)
+
+    def test_missing_candidate_never_passes(self):
+        output = self.render(missing_candidate=True, enforcement_exit=1)
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("cannot read candidate", output)
+
+    def test_malformed_json_never_passes(self):
+        output = self.render(raw_candidate="{", enforcement_exit=1)
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("cannot read candidate", output)
+
+    def test_invalid_utf8_never_suppresses_the_blocked_summary(self):
+        output = self.render(raw_candidate_bytes=b"\xff", enforcement_exit=1)
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("cannot read candidate", output)
+
+    def test_missing_decision_and_null_score_never_pass(self):
+        output = self.render(missing_decision=True, enforcement_exit=1)
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("cannot read decision", output)
+        broken = candidate()
+        broken["scores"]["applicable"]["containment"] = None
+        output = self.render(candidate_value=broken, enforcement_exit=1)
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("invalid field: scores.applicable.containment", output)
+
+    def test_untrusted_text_is_escaped_and_stays_single_line(self):
+        output = self.render(decision_value=decision("blocked", True, ["bad <script>\n## forged heading [link](https://bad.example)"], ["`review` <tag>"]), enforcement_exit=1)
+        self.assertIn("bad &lt;script&gt; ## forged heading \\[link\\]\\(https://bad.example\\)", output)
+        self.assertIn("\\`review\\` &lt;tag&gt;", output)
+        self.assertNotIn("\n## forged heading", output)
+
+    def test_invalid_link_context_is_blocked_without_rendering_a_link(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        candidate_path = root / "candidate.json"
+        decision_path = root / "decision.json"
+        baseline_path = root / "baseline.json"
+        enforcement_path = root / "enforcement-result.json"
+        candidate_path.write_text(json.dumps(candidate()), encoding="utf-8")
+        decision_path.write_text(json.dumps(decision()), encoding="utf-8")
+        baseline_path.write_text(json.dumps(baseline()), encoding="utf-8")
+        enforcement_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "verdict": "pass",
+                    "promotion_status": "under_review",
+                    "failures": [],
+                    "candidate_sha256": hashlib.sha256(candidate_path.read_bytes()).hexdigest(),
+                    "decision_sha256": hashlib.sha256(decision_path.read_bytes()).hexdigest(),
+                    "baseline_sha256": hashlib.sha256(baseline_path.read_bytes()).hexdigest(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        output = renderer.render(candidate_path, decision_path, baseline_path, enforcement_path, REPOSITORY, "https://bad.example/](https://evil.example)")
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("Current workflow run: (unavailable)", output)
+        self.assertNotIn("evil.example", output)
+
+    def test_status_and_enforcement_result_must_agree(self):
+        output = self.render(
+            decision_value=decision("scope_changed_requires_review"),
+            enforcement_exit=0,
+            enforcement_status="under_review",
+        )
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("decision status disagrees with enforcement result", output)
+
+        output = self.render(
+            decision_value=decision("under_review"),
+            enforcement_exit=2,
+            enforcement_status="scope_changed_requires_review",
+        )
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("decision status disagrees with enforcement result", output)
+
+    def test_enforcement_integrity_failure_is_visible(self):
+        output = self.render(
+            decision_value=decision(),
+            enforcement_exit=1,
+            enforcement_failures=["evidence results changed after the decision was created"],
+        )
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("enforcement: evidence results changed", output)
+
+    def test_enforcement_digest_binding_rejects_post_enforcement_changes(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        candidate_path = root / "candidate.json"
+        decision_path = root / "decision.json"
+        baseline_path = root / "baseline.json"
+        enforcement_path = root / "enforcement-result.json"
+        candidate_path.write_text(json.dumps(candidate()), encoding="utf-8")
+        decision_path.write_text(json.dumps(decision()), encoding="utf-8")
+        baseline_path.write_text(json.dumps(baseline()), encoding="utf-8")
+        enforcement_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "verdict": "pass",
+                    "promotion_status": "under_review",
+                    "failures": [],
+                    "candidate_sha256": hashlib.sha256(candidate_path.read_bytes()).hexdigest(),
+                    "decision_sha256": hashlib.sha256(decision_path.read_bytes()).hexdigest(),
+                    "baseline_sha256": hashlib.sha256(baseline_path.read_bytes()).hexdigest(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        candidate_path.write_text("{}", encoding="utf-8")
+        output = renderer.render(candidate_path, decision_path, baseline_path, enforcement_path, REPOSITORY, RUN_URL)
+        self.assertIn("BLOCKED — ACTION REQUIRED", output)
+        self.assertIn("candidate changed after enforcement", output)
+
+    def test_structural_guards_fail_closed(self):
+        cases = []
+
+        wrong_schema = candidate()
+        wrong_schema["schema_version"] = 1
+        cases.append(("candidate schema", {"candidate_value": wrong_schema}, "candidate schema_version"))
+
+        insufficient = candidate()
+        insufficient["sufficient"] = False
+        cases.append(("insufficient", {"candidate_value": insufficient}, "candidate sufficient"))
+
+        runner_error = candidate()
+        runner_error["case_count"]["errors"] = 1
+        cases.append(("runner error", {"candidate_value": runner_error}, "case_count.errors"))
+
+        bad_reasons = candidate()
+        bad_reasons["case_count"]["not_applicable_reasons"] = {"missing_requires": 3}
+        cases.append(("N/A reasons", {"candidate_value": bad_reasons}, "N/A reasons"))
+
+        bad_decision = decision()
+        bad_decision["schema_version"] = 2
+        cases.append(("decision schema", {"decision_value": bad_decision}, "decision schema_version"))
+
+        bad_lists = decision()
+        bad_lists["review_notes"] = "not-a-list"
+        cases.append(("decision lists", {"decision_value": bad_lists}, "review_notes must be a list"))
+
+        bad_baseline = baseline()
+        bad_baseline["schema_version"] = 2
+        cases.append(("baseline schema", {"baseline_value": bad_baseline}, "baseline schema_version"))
+
+        for name, arguments, expected in cases:
+            with self.subTest(name=name):
+                output = self.render(**arguments)
+                self.assertIn("BLOCKED — ACTION REQUIRED", output)
+                self.assertIn(expected, output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -18,6 +18,7 @@ development_binary=""
 benchmark_timeout_seconds=$((24 * 60))
 deadline_epoch=""
 reserve_seconds=$((6 * 60))
+original_arg_count=$#
 original_args=("$@")
 
 usage() {
@@ -160,8 +161,13 @@ on_exit() {
 }
 trap on_exit EXIT
 
-printf '%q ' "$0" "${original_args[@]}" > "$output_dir/entrypoint-command.txt"
-printf '\n' >> "$output_dir/entrypoint-command.txt"
+{
+  printf '%q' "$0"
+  for ((original_arg_index = 0; original_arg_index < original_arg_count; original_arg_index++)); do
+    printf ' %q' "${original_args[$original_arg_index]}"
+  done
+  printf '\n'
+} > "$output_dir/entrypoint-command.txt"
 
 for command_name in git python3 go curl jq sha256sum tar timeout realpath make; do
   command -v "$command_name" >/dev/null || die "required command is unavailable: $command_name"
@@ -181,9 +187,14 @@ case "$remote_url" in
     ;;
 esac
 
+noncanonical_reason_count=0
 noncanonical_reasons=()
+add_noncanonical_reason() {
+  noncanonical_reasons[$noncanonical_reason_count]="$1"
+  noncanonical_reason_count=$((noncanonical_reason_count + 1))
+}
 if [[ "$development_mode" == true ]]; then
-  noncanonical_reasons+=("development corpus mode was requested")
+  add_noncanonical_reason "development corpus mode was requested"
 else
   [[ "$remote_matches" == true ]] || die "origin is not the canonical $corpus_repository repository"
   git fetch --force --prune --prune-tags --tags \
@@ -203,7 +214,7 @@ if [[ -n "$dirty_output" ]]; then
     printf '%s\n' "$dirty_output" >&2
     die "corpus checkout is dirty; use a clean origin/main or tag checkout"
   fi
-  noncanonical_reasons+=("corpus checkout was dirty")
+  add_noncanonical_reason "corpus checkout was dirty"
 else
   corpus_dirty=false
 fi
@@ -222,12 +233,12 @@ elif [[ -n "$pointed_tags" ]]; then
   corpus_ref_kind="tag"
 elif [[ "$development_mode" == true ]]; then
   corpus_ref_kind="development"
-  noncanonical_reasons+=("corpus commit was neither fetched origin/main nor a tag")
+  add_noncanonical_reason "corpus commit was neither fetched origin/main nor a tag"
 else
   die "corpus checkout is neither fetched origin/main nor a tag"
 fi
 if [[ "$remote_matches" != true ]]; then
-  noncanonical_reasons+=("origin did not match $corpus_repository")
+  add_noncanonical_reason "origin did not match $corpus_repository"
 fi
 
 canonical_execution=true
@@ -235,7 +246,7 @@ if [[ "$development_mode" == true || -n "$development_binary" || "$corpus_dirty"
   canonical_execution=false
 fi
 if [[ -n "$development_binary" ]]; then
-  noncanonical_reasons+=("development Pipelock binary was requested")
+  add_noncanonical_reason "development Pipelock binary was requested"
 fi
 
 start_args=(
@@ -249,7 +260,9 @@ start_args=(
   --dirty "$corpus_dirty"
   --canonical-execution "$canonical_execution"
 )
-for reason in "${noncanonical_reasons[@]}"; do
+failure_reason="run metadata generation failed"
+for ((reason_index = 0; reason_index < noncanonical_reason_count; reason_index++)); do
+  reason="${noncanonical_reasons[$reason_index]}"
   start_args+=(--noncanonical-reason "$reason")
 done
 PYTHONDONTWRITEBYTECODE=1 python3 "$provenance_script" "${start_args[@]}"


### PR DESCRIPTION
## Summary

- classify scheduled checks as PASS, REVIEW REQUIRED, or BLOCKED in Actions summaries
- keep clean daily runs green while surfacing scope changes and failures as action-required runs
- add a workflow badge and document the no-automatic-PR or publication behavior

The workflow still uploads evidence before enforcement and never writes repository contents or moves the verified public record.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added owner-facing summaries for continuous evaluation runs, including pass, review-required, and blocked outcomes.
  - Added validation for result integrity and tampering, with clear failure reporting.
  - Added a workflow status badge to the README.

- **Bug Fixes**
  - Improved handling of incomplete, invalid, or failed evaluation results.
  - Distinguished review-required outcomes from blocked failures.

- **Documentation**
  - Documented workflow statuses, required actions, and notification behavior.

- **Tests**
  - Expanded coverage for summary rendering, validation, fallback behavior, and workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->