### PR TITLE
feat(runner): render a buyer-readable report from an existing run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: preflight check-claim-language stats stats-update check-stats cases-manifest check-gauntlet-site test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-g2-authentication test-pipelock-example validate-cases
+.PHONY: preflight check-claim-language stats stats-update check-stats cases-manifest check-gauntlet-site test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-g2-authentication test-pipelock-example validate-cases validate
 
 TMPDIR := $(HOME)/.cache/pipelock-tmp
 GOCACHE := $(HOME)/.cache/go-build
@@ -24,6 +24,12 @@ check-claim-language:
 test-validate:
 	@mkdir -p "$(TMPDIR)" "$(GOCACHE)"
 	@cd validate && go test -race -count=1 ./...
+
+# `validate` is an alias for validate-cases. It must stay .PHONY: a directory
+# named validate/ holds the validator source, so without the .PHONY entry Make
+# considers the target already satisfied and exits 0 having run nothing. A gate
+# that always passes is worse than no gate, because callers trust it.
+validate: validate-cases
 
 validate-cases:
 	@mkdir -p "$(TMPDIR)" "$(GOCACHE)"

--- a/docs/RESULTS-USE.md
+++ b/docs/RESULTS-USE.md
@@ -51,7 +51,7 @@ Publish these next to any score, or the number is not reproducible.
 | Containment, detection, evidence, and false-positive rate, reported separately | There is no composite score in this corpus. |
 | The non-claims that apply | See below. |
 
-The runner writes most of these into the summary JSON already. Reproduction instructions belong
+The runner writes these into the summary JSON. The corpus-derived facts come from the run itself; repository and commit, adapter owner, and the target configuration are operator declarations, supplied with `--method-repository`, `--method-commit`, `--adapter-owner`, and `--target-config`. A fact you do not declare is omitted rather than guessed, and the buyer report names it as absent. Reproduction instructions belong
 beside a public result too, so a reader can run it rather than believe it.
 
 ## Non-claims

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -34,7 +34,7 @@ force a tool through the wrong shape just to get a numeric result.
 
 One JSON object per case, written to stdout (one per line, JSONL):
 
-> `--stats` is the one exception to this contract. It reports the loaded corpus rather than running it, so it writes a human-readable Markdown snapshot to stdout and exits without producing JSONL or a summary. It requires `--cases` and ignores the tool-profile and adapter flags. `make stats`, `make stats-update` and `make check-stats` are its only intended callers.
+> `--stats` and `--report` are the exceptions to this contract. It reports the loaded corpus rather than running it, so it writes a human-readable Markdown snapshot to stdout and exits without producing JSONL or a summary. It requires `--cases` and ignores the tool-profile and adapter flags. `make stats`, `make stats-update` and `make check-stats` are its only intended callers. `--report` likewise runs no cases: it reads an artifact directory an earlier run left behind and writes Markdown to the path given by `--report-output`, or to stdout when that is `-`.
 
 ```json
 {
@@ -239,6 +239,37 @@ After all cases, the runner should print a summary line to stderr:
 ```
 results: 22 passed, 3 failed, 10 not_applicable, 0 errors (35 total)
 ```
+
+## Buyer-readable report
+
+The Go runner can render a Markdown report from an artifact directory left by an existing run. Report mode does not execute cases or recalculate scores. It reads the retained facts and shows missing or malformed inputs in place.
+
+From the repository root:
+
+```bash
+(cd runner && go run . \
+  --report ../continuous-gauntlet-artifacts \
+  --report-output ../continuous-gauntlet-artifacts/run-report.md)
+```
+
+Use `--report-output -` to write the report to standard output.
+
+The renderer reads these artifacts when present:
+
+| Artifact | Report content |
+|---|---|
+| `raw-summary.json` | Method versions, target product and version, profile digest, declared capabilities, scope counts, and the four metric vectors |
+| `results.jsonl` | Every not-applicable case ID and its recorded reason |
+| `run-metadata.json` | Repository and exact method commit |
+| `run-bundle.json` | Bundle status, publication eligibility, retained material digests, and candidate bindings |
+| `execution-decision.json` | Execution status, failures, review notes, and publication eligibility |
+| `entrypoint-command.txt` and `command.txt` | The retained reproduction commands |
+
+The report checks every digest declared by the run bundle, checks the candidate bindings against the summary and run metadata, and checks the execution decision against the bundle. It reports these checks separately from the four metrics.
+
+Missing facts render as `Absent from run artifacts`. Wrong types and contradictory bindings render as invalid. A malformed JSON or JSONL input leaves the rest of the report readable and marks the affected section. A partial, blocked, errored, or publication-ineligible run still produces a report with that state visible.
+
+The summary carries `target_config_ref`, `target_config_sha256`, and `adapter_owner` when the operator declares them with `--target-config` and `--adapter-owner`, and `adapter_id` for the adapter that was selected. Adapter identity comes from that recorded field rather than from the runner command line. Anything the operator does not declare is omitted from the summary and the report names it absent, so an undeclared fact never reads as a blank the renderer failed to fill.
 
 ## Validating Output
 

--- a/runner/main.go
+++ b/runner/main.go
@@ -34,6 +34,12 @@ func main() {
 	multiFileCases := flag.String("multifile-cases", "", "directory of multi-file MCP-drift cases (each subdirectory has case.yaml + before.json + after.json + expected.json). Driver replays before then after through a single MCP session and observes the verdict on the second tools/list response.")
 	stats := flag.Bool("stats", false, "print loader-backed corpus statistics (requires --cases; ignores runner profile flags)")
 	caseIndex := flag.Bool("case-index", false, "print loader-normalized case IDs and expected verdicts as JSON (requires --cases; ignores runner profile flags)")
+	reportDir := flag.String("report", "", "render a buyer-readable Markdown report from an existing Gauntlet artifact directory")
+	reportOutput := flag.String("report-output", "gauntlet-report.md", "report output path, or - for stdout (used with --report)")
+	methodRepository := flag.String("method-repository", "", "repository this corpus came from, recorded in the summary so a reader can reproduce the run")
+	methodCommit := flag.String("method-commit", "", "exact commit of the corpus under test, recorded in the summary")
+	adapterOwner := flag.String("adapter-owner", "", "who authored the adapter driving the target; a vendor-authored adapter is normal, leaving it unstated is not")
+	targetConfig := flag.String("target-config", "", "path to the target's configuration file; its path and digest are recorded so the score can be repeated")
 
 	// --debug / -v: emit verbose per-case diagnostics to stderr. Both
 	// flag names point at the same variable so either can be used.
@@ -42,6 +48,13 @@ func main() {
 	flag.BoolVar(&debug, "v", false, "alias for --debug")
 
 	flag.Parse()
+	if *reportDir != "" {
+		if err := generateBuyerReport(*reportDir, *reportOutput); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 	if *stats {
 		if *casesDir == "" {
 			flag.Usage()
@@ -80,7 +93,23 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := runWithGatewayPluginOptions(*casesDir, *profilePath, *outputPath, *timeout, *adapterName, *proxyAddr, *scanAddr, *scanToken, *mcpCmd, *mcpHTTPURL, *managedProxyCmd, *managedMCPHTTPCmd, *gatewayPluginPath, *fixtures, *emitReceiptProfile, *receiptVerifierFile, *multiFileCases, debug, *toolVersion); err != nil {
+	prov := RunProvenance{
+		MethodRepository: *methodRepository,
+		MethodCommit:     *methodCommit,
+		AdapterID:        *adapterName,
+		AdapterOwner:     *adapterOwner,
+	}
+	if *targetConfig != "" {
+		sha, hashErr := computeProfileSHA256(*targetConfig)
+		if hashErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: hashing target config: %v\n", hashErr)
+			os.Exit(1)
+		}
+		prov.TargetConfigRef = *targetConfig
+		prov.TargetConfigSHA = sha
+	}
+
+	if err := runWithGatewayPluginOptions(*casesDir, *profilePath, *outputPath, *timeout, *adapterName, *proxyAddr, *scanAddr, *scanToken, *mcpCmd, *mcpHTTPURL, *managedProxyCmd, *managedMCPHTTPCmd, *gatewayPluginPath, *fixtures, *emitReceiptProfile, *receiptVerifierFile, *multiFileCases, debug, *toolVersion, prov); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -91,10 +120,10 @@ func run(casesDir, profilePath, outputPath string, timeout time.Duration, adapte
 }
 
 func runWithOptions(casesDir, profilePath, outputPath string, timeout time.Duration, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd, mcpHTTPURL, managedProxyCmd, managedMCPHTTPCmd string, useFixtures bool, emitReceiptProfile, receiptVerifierFile, multiFileCases string, debug bool, toolVersion string) error {
-	return runWithGatewayPluginOptions(casesDir, profilePath, outputPath, timeout, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd, mcpHTTPURL, managedProxyCmd, managedMCPHTTPCmd, "", useFixtures, emitReceiptProfile, receiptVerifierFile, multiFileCases, debug, toolVersion)
+	return runWithGatewayPluginOptions(casesDir, profilePath, outputPath, timeout, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd, mcpHTTPURL, managedProxyCmd, managedMCPHTTPCmd, "", useFixtures, emitReceiptProfile, receiptVerifierFile, multiFileCases, debug, toolVersion, RunProvenance{AdapterID: adapterName})
 }
 
-func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeout time.Duration, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd, mcpHTTPURL, managedProxyCmd, managedMCPHTTPCmd, gatewayPluginPath string, useFixtures bool, emitReceiptProfile, receiptVerifierFile, multiFileCases string, debug bool, toolVersion string) error {
+func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeout time.Duration, adapterName, proxyAddr, scanAddr, scanToken, mcpCmd, mcpHTTPURL, managedProxyCmd, managedMCPHTTPCmd, gatewayPluginPath string, useFixtures bool, emitReceiptProfile, receiptVerifierFile, multiFileCases string, debug bool, toolVersion string, prov RunProvenance) error {
 	profile, err := loadProfile(profilePath)
 	if err != nil {
 		return err
@@ -324,7 +353,7 @@ func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeo
 	}
 
 	// Build and write summary.
-	summary, err := buildSummary(profile, cases, applicableResults, naReasons, casesDir, multiFileCases, casesByID, profilePath)
+	summary, err := buildSummary(profile, cases, applicableResults, naReasons, casesDir, multiFileCases, casesByID, profilePath, prov)
 	if err != nil {
 		return err
 	}

--- a/runner/redact.go
+++ b/runner/redact.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// The buyer report is built to be published. The runner command it retains is
+// the most useful thing in it for reproduction and the most dangerous, because
+// a real invocation carries --scan-token, proxy URLs with userinfo, and inline
+// environment assignments. Rendering it verbatim copies whatever the operator
+// typed into a document meant for outsiders.
+//
+// Redaction here is deliberately conservative about what it claims: it removes
+// credential-shaped values with confidence, and the report says plainly that
+// local paths and hostnames may remain, so a publisher still reads the command
+// before posting it. A denylist cannot promise more than that, and promising
+// more is how a leak ships.
+
+var (
+	// A credential value may be single-quoted, double-quoted, or bare. The
+	// quoted alternatives come first: matching \S+ alone stops at the first
+	// space, which redacts up to the quote and leaves the rest of the secret
+	// sitting in the report.
+	credentialValue = `(?:'[^']*'|"[^"]*"|\S+)`
+
+	credentialFlagName = `--[A-Za-z0-9._-]*(?:token|secret|password|passwd|credential|apikey|api-key|auth|bearer)[A-Za-z0-9._-]*`
+
+	// Flag values whose name suggests a credential, in --flag=value and
+	// --flag value form.
+	redactFlagAssign = regexp.MustCompile(`(?i)(` + credentialFlagName + `=)(` + credentialValue + `)`)
+	redactFlagSpaced = regexp.MustCompile(`(?i)(` + credentialFlagName + `\s+)(` + credentialValue + `)`)
+
+	// Inline environment assignments, VAR=value, with a credential-shaped name.
+	redactEnvAssign = regexp.MustCompile(`(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|APIKEY|API_KEY|AUTH|BEARER)[A-Z0-9_]*=)(` + credentialValue + `)`)
+
+	// Userinfo in a URL: scheme://user:pass@host.
+	redactURLUserinfo = regexp.MustCompile(`([A-Za-z][A-Za-z0-9+.-]*://)[^/\s:@]+(?::[^/\s@]*)?@`)
+)
+
+const redactedValue = "REDACTED"
+
+// redactReportCommand removes credential-shaped values from a retained command
+// line. It preserves the structure so the reader can still see which flags ran.
+func redactReportCommand(command string) string {
+	if command == "" {
+		return command
+	}
+	out := redactFlagAssign.ReplaceAllString(command, "${1}"+redactedValue)
+	out = redactFlagSpaced.ReplaceAllString(out, "${1}"+redactedValue)
+	out = redactEnvAssign.ReplaceAllString(out, "${1}"+redactedValue)
+	out = redactURLUserinfo.ReplaceAllString(out, "${1}"+redactedValue+"@")
+	return out
+}
+
+// reportCommandContainsLocalDetail reports whether a redacted command still
+// carries an absolute path or a host-looking token. The report uses this to
+// tell the publisher when a manual read is genuinely warranted rather than
+// printing the same warning on every run.
+func reportCommandContainsLocalDetail(command string) bool {
+	for _, field := range strings.Fields(command) {
+		if strings.HasPrefix(field, "/") || strings.HasPrefix(field, "~/") {
+			return true
+		}
+		if strings.Contains(field, "://") {
+			return true
+		}
+	}
+	return false
+}

--- a/runner/redact_test.go
+++ b/runner/redact_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The retained command is the highest-value line in a published report and the
+// one most likely to carry a credential, because a real invocation passes
+// --scan-token and proxy URLs on the command line.
+//
+// EVERY credential-shaped value below is assembled at run time from parts.
+// Written out whole they are real secret patterns committed to a public
+// repository, and secret scanners are right to flag them: an earlier revision
+// of this file split only some of them and a scanner caught the one left
+// intact. There is no such thing as a fake secret that only looks fake to the
+// scanner you happened to run, so the rule here is all of them or none.
+func secretish(parts ...string) string { return strings.Join(parts, "") }
+
+func TestRedactReportCommand(t *testing.T) {
+	var (
+		apiToken       = secretish("sk", "-live-", "abc123")
+		awsLikeKey     = secretish("AKIA", "IOSFODNN7", "EXAMPLE")
+		envTokenVar    = secretish("AEB_SCAN_", "TOKEN")
+		envPasswordVar = secretish("PROXY_PASS", "WORD")
+		envTokenValue  = secretish("hunt", "er2")
+		envPasswdValue = secretish("sword", "fish")
+		urlPassword    = secretish("s3c", "r3t")
+		bearerToken    = secretish("abc.", "def.", "ghi")
+		bearerValue    = secretish("Bear", "er ") + bearerToken
+	)
+
+	tests := []struct {
+		name     string
+		command  string
+		mustHide []string
+		mustKeep []string
+	}{
+		{
+			name:     "spaced credential flag",
+			command:  "./runner --adapter proxy --scan-token " + apiToken + " --cases ./cases",
+			mustHide: []string{apiToken},
+			mustKeep: []string{"--scan-token", "--adapter", "proxy", "./cases"},
+		},
+		{
+			name:     "assigned credential flag",
+			command:  "./runner --api-key=" + awsLikeKey + " --cases ./cases",
+			mustHide: []string{awsLikeKey},
+			mustKeep: []string{"--api-key=", "./cases"},
+		},
+		{
+			name:     "inline environment secret",
+			command:  envTokenVar + "=" + envTokenValue + " " + envPasswordVar + "=" + envPasswdValue + " ./runner --cases ./cases",
+			mustHide: []string{envTokenValue, envPasswdValue},
+			mustKeep: []string{envTokenVar + "=", envPasswordVar + "=", "./runner"},
+		},
+		{
+			name:     "url userinfo",
+			command:  "./runner --mcp-http-url https://alice:" + urlPassword + "@mcp.internal:8443/rpc",
+			mustHide: []string{urlPassword, "alice:"},
+			mustKeep: []string{"https://", "mcp.internal:8443/rpc"},
+		},
+		{
+			// Assert the token itself is gone, not just the whole quoted value.
+			// A redaction that stopped at the first space satisfied the
+			// whole-value check while leaving the token in the report.
+			name:     "quoted bearer authorization flag",
+			command:  "./runner --authorization '" + bearerValue + "' --cases ./cases",
+			mustHide: []string{bearerValue, bearerToken},
+			mustKeep: []string{"--authorization", "./cases"},
+		},
+		{
+			name:     "quoted environment secret",
+			command:  envTokenVar + `="` + envTokenValue + ` trailing" ./runner --cases ./cases`,
+			mustHide: []string{envTokenValue, "trailing"},
+			mustKeep: []string{envTokenVar + "=", "./runner"},
+		},
+		{
+			name:     "nothing to redact is left alone",
+			command:  "./runner --adapter dryrun --cases ./cases --profile ./profile.json",
+			mustKeep: []string{"--adapter dryrun", "--cases ./cases", "--profile ./profile.json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactReportCommand(tt.command)
+			for _, secret := range tt.mustHide {
+				if strings.Contains(got, secret) {
+					t.Errorf("redacted command still contains %q:\n%s", secret, got)
+				}
+			}
+			for _, keep := range tt.mustKeep {
+				if !strings.Contains(got, keep) {
+					t.Errorf("redacted command lost %q, which a reader needs to reproduce the run:\n%s", keep, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRedactReportCommandEmpty(t *testing.T) {
+	if got := redactReportCommand(""); got != "" {
+		t.Errorf("redactReportCommand(\"\") = %q, want empty", got)
+	}
+}
+
+// The report only warns about a manual read when there is something local left
+// to read, so the warning stays meaningful instead of decorating every run.
+func TestReportCommandContainsLocalDetail(t *testing.T) {
+	tests := []struct {
+		command string
+		want    bool
+	}{
+		{"./runner --cases ./cases", false},
+		{"./runner --profile /home/operator/private/profile.json", true},
+		{"./runner --mcp-http-url https://mcp.internal:8443/rpc", true},
+		{"./runner --cases ~/corpus", true},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := reportCommandContainsLocalDetail(tt.command); got != tt.want {
+			t.Errorf("reportCommandContainsLocalDetail(%q) = %v, want %v", tt.command, got, tt.want)
+		}
+	}
+}

--- a/runner/report.go
+++ b/runner/report.go
@@ -1,0 +1,837 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const absentFact = "Absent from run artifacts"
+
+// reportSelfConsistentPrefix opens every successful validation string. The
+// eligibility predicate matches on it, so the producers and the consumer share
+// one constant: when these were separate literals a rename left the predicate
+// testing for a string nothing produced, and eligibility silently never
+// resolved.
+const reportSelfConsistentPrefix = "Self-consistent:"
+
+var reportRestrictedClaims = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)leaderboards?`),
+	regexp.MustCompile(`(?i)certif(?:ied|ication|ications|ies|y)`),
+	regexp.MustCompile(`(?i)proofstamp`),
+	regexp.MustCompile(`(?i)neutral benchmark`),
+	regexp.MustCompile(`(?i)proven secure`),
+	regexp.MustCompile(`(?i)no bypass(?:es)?\b`),
+	regexp.MustCompile(`(?i)unbypassable`),
+	regexp.MustCompile(`(?i)insurance discount`),
+	regexp.MustCompile(`(?i)\bFIPS\b`),
+	regexp.MustCompile(`(?i)all prox(?:y|ies)[- ]based`),
+}
+
+type reportDocument struct {
+	name   string
+	data   map[string]interface{}
+	status string
+}
+
+type reportNA struct {
+	caseID string
+	reason string
+}
+
+type buyerReport struct {
+	dir        string
+	summary    reportDocument
+	metadata   reportDocument
+	bundle     reportDocument
+	decision   reportDocument
+	results    []reportNA
+	resultErr  string
+	rowCounts  reportRowCounts
+	command    string
+	entrypoint string
+}
+
+func generateBuyerReport(dir, outputPath string) error {
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		return err
+	}
+	var out bytes.Buffer
+	report.renderMarkdown(&out)
+	if outputPath == "-" {
+		_, err = os.Stdout.Write(out.Bytes())
+		return err
+	}
+	if err := os.WriteFile(outputPath, out.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("writing report to %s: %w", outputPath, err)
+	}
+	return nil
+}
+
+func loadBuyerReport(dir string) (*buyerReport, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading report artifact directory: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("report input is not a directory: %s", dir)
+	}
+	r := &buyerReport{dir: dir}
+	r.summary = loadReportDocument(dir, "raw-summary.json")
+	r.metadata = loadReportDocument(dir, "run-metadata.json")
+	r.bundle = loadReportDocument(dir, "run-bundle.json")
+	r.decision = loadReportDocument(dir, "execution-decision.json")
+	r.results, r.rowCounts, r.resultErr = loadNotApplicable(filepath.Join(dir, "results.jsonl"))
+	r.command = loadReportText(dir, "command.txt")
+	r.entrypoint = loadReportText(dir, "entrypoint-command.txt")
+	return r, nil
+}
+
+func loadReportDocument(dir, name string) reportDocument {
+	doc := reportDocument{name: name}
+	data, err := os.ReadFile(filepath.Join(dir, name))
+	if os.IsNotExist(err) {
+		doc.status = absentFact
+		return doc
+	}
+	if err != nil {
+		doc.status = "Unreadable run artifact"
+		return doc
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&doc.data); err != nil {
+		doc.status = "Malformed JSON: " + safeReportText(err.Error())
+		return doc
+	}
+	if doc.data == nil {
+		doc.status = "Invalid in run artifacts: expected a JSON object"
+		return doc
+	}
+	if err := ensureJSONEOF(dec); err != nil {
+		doc.data = nil
+		doc.status = "Malformed JSON: " + safeReportText(err.Error())
+		return doc
+	}
+	doc.status = "Readable"
+	return doc
+}
+
+func ensureJSONEOF(dec *json.Decoder) error {
+	var extra interface{}
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func loadReportText(dir, name string) string {
+	data, err := os.ReadFile(filepath.Join(dir, name))
+	if os.IsNotExist(err) {
+		return absentFact
+	}
+	if err != nil {
+		return "Unreadable run artifact"
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "" {
+		return "Invalid in run artifacts: empty file"
+	}
+	return safeReportText(value)
+}
+
+// reportRowCounts is what results.jsonl actually contains, as opposed to what
+// the summary declares about it. Comparing the two is the only way the report
+// can tell a reader the scope arithmetic holds.
+type reportRowCounts struct {
+	total         int
+	applicable    int
+	notApplicable int
+	errors        int
+}
+
+func loadNotApplicable(path string) ([]reportNA, reportRowCounts, string) {
+	var counts reportRowCounts
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, counts, absentFact
+	}
+	if err != nil {
+		return nil, counts, "Unreadable run artifact"
+	}
+	defer f.Close()
+
+	var out []reportNA
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		var row map[string]interface{}
+		dec := json.NewDecoder(strings.NewReader(scanner.Text()))
+		dec.UseNumber()
+		if err := dec.Decode(&row); err != nil {
+			return out, counts, fmt.Sprintf("Malformed JSONL at line %d", line)
+		}
+		// One object per line, and nothing after it. Trailing JSON on a row is
+		// malformed input, not a row with extra decoration to ignore.
+		if err := ensureJSONEOF(dec); err != nil {
+			return out, counts, fmt.Sprintf("Malformed JSONL at line %d", line)
+		}
+		counts.total++
+		actual, _ := row["actual_verdict"].(string)
+		switch actual {
+		case "not_applicable":
+			counts.notApplicable++
+		case "error":
+			counts.errors++
+			counts.applicable++
+		case "allow", "block", "skip", "warn":
+			counts.applicable++
+		default:
+			// Counting an unrecognized verdict as applicable would let a row
+			// reading "banana" inflate the denominator of every rate while the
+			// arithmetic still reconciled.
+			return out, counts, fmt.Sprintf("Malformed JSONL at line %d", line)
+		}
+		if actual != "not_applicable" {
+			continue
+		}
+		caseID, ok := row["case_id"].(string)
+		if !ok || strings.TrimSpace(caseID) == "" {
+			caseID = "Invalid in run artifacts"
+		}
+		reason := absentFact
+		if notes, ok := row["notes"].(string); ok {
+			const prefix = "not applicable: "
+			if strings.HasPrefix(notes, prefix) && strings.TrimSpace(strings.TrimPrefix(notes, prefix)) != "" {
+				reason = strings.TrimSpace(strings.TrimPrefix(notes, prefix))
+			}
+		}
+		out = append(out, reportNA{safeReportText(caseID), safeReportText(reason)})
+	}
+	if err := scanner.Err(); err != nil {
+		return out, counts, "Unreadable run artifact"
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].caseID < out[j].caseID })
+	return out, counts, "Readable"
+}
+
+func safeReportText(value string) string {
+	for _, pattern := range reportRestrictedClaims {
+		if pattern.MatchString(value) {
+			return "Artifact value withheld by claim-language gate"
+		}
+	}
+	value = strings.ReplaceAll(value, "\x00", "")
+	return value
+}
+
+func nestedValue(data map[string]interface{}, path ...string) (interface{}, bool) {
+	var current interface{} = data
+	for _, key := range path {
+		object, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		current, ok = object[key]
+		if !ok || current == nil {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+// firstReportFact returns the first candidate that is actually present. A fact
+// the operator never declared reads as an explicit absence rather than an empty
+// line, because a blank in a reproduction section is indistinguishable from a
+// rendering bug.
+func firstReportFact(candidates ...string) string {
+	for _, c := range candidates {
+		if c != "" && c != absentFact {
+			return c
+		}
+	}
+	return absentFact
+}
+
+func reportString(doc reportDocument, path ...string) string {
+	if doc.data == nil {
+		return absentFact
+	}
+	value, ok := nestedValue(doc.data, path...)
+	if !ok {
+		return absentFact
+	}
+	s, ok := value.(string)
+	if !ok || strings.TrimSpace(s) == "" {
+		return "Invalid in run artifacts"
+	}
+	return safeReportText(s)
+}
+
+func reportBool(doc reportDocument, path ...string) string {
+	if doc.data == nil {
+		return absentFact
+	}
+	value, ok := nestedValue(doc.data, path...)
+	if !ok {
+		return absentFact
+	}
+	b, ok := value.(bool)
+	if !ok {
+		return "Invalid in run artifacts"
+	}
+	return strconv.FormatBool(b)
+}
+
+func reportNumber(doc reportDocument, path ...string) string {
+	if doc.data == nil {
+		return absentFact
+	}
+	value, ok := nestedValue(doc.data, path...)
+	if !ok {
+		return absentFact
+	}
+	switch number := value.(type) {
+	case json.Number:
+		if _, err := number.Float64(); err != nil {
+			return "Invalid in run artifacts"
+		}
+		return number.String()
+	default:
+		return "Invalid in run artifacts"
+	}
+}
+
+func reportPercent(doc reportDocument, path ...string) string {
+	if doc.data == nil {
+		return absentFact
+	}
+	value, ok := nestedValue(doc.data, path...)
+	if !ok {
+		return absentFact
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return "Invalid in run artifacts"
+	}
+	f, err := number.Float64()
+	if err != nil || f < 0 || f > 1 {
+		return "Invalid in run artifacts"
+	}
+	return strconv.FormatFloat(f*100, 'f', 2, 64) + "%"
+}
+
+func reportStringList(doc reportDocument, path ...string) []string {
+	if doc.data == nil {
+		return []string{absentFact}
+	}
+	value, ok := nestedValue(doc.data, path...)
+	if !ok {
+		return []string{absentFact}
+	}
+	items, ok := value.([]interface{})
+	if !ok {
+		return []string{"Invalid in run artifacts"}
+	}
+	if len(items) == 0 {
+		return []string{"None declared"}
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok || strings.TrimSpace(s) == "" {
+			out = append(out, "Invalid in run artifacts")
+			continue
+		}
+		out = append(out, safeReportText(s))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func markdownInline(value string) string {
+	replacer := strings.NewReplacer("\\", "\\\\", "`", "\\`", "*", "\\*", "_", "\\_", "[", "\\[", "]", "\\]", "<", "&lt;", ">", "&gt;", "\n", " ")
+	return replacer.Replace(value)
+}
+
+func (r *buyerReport) renderMarkdown(w io.Writer) {
+	line := func(format string, args ...interface{}) { _, _ = fmt.Fprintf(w, format+"\n", args...) }
+	bullet := func(label, value string) { line("- %s: %s", label, markdownInline(value)) }
+	list := func(items []string) {
+		for _, item := range items {
+			line("  - %s", markdownInline(item))
+		}
+	}
+
+	line("# Agent Egress Bench Run Report")
+	line("")
+	line("This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.")
+	line("")
+	line("## Artifact input status")
+	line("")
+	bullet("raw-summary.json", r.summary.status)
+	bullet("results.jsonl", r.resultErr)
+	bullet("run-metadata.json", r.metadata.status)
+	bullet("run-bundle.json", r.bundle.status)
+	bullet("execution-decision.json", r.decision.status)
+	line("")
+	line("## Method identity")
+	line("")
+	bullet("Repository", firstReportFact(
+		reportString(r.summary, "method_repository"),
+		reportString(r.metadata, "corpus_repository")))
+	bullet("Exact commit", firstReportFact(
+		reportString(r.summary, "method_commit"),
+		reportString(r.metadata, "corpus_git_sha")))
+	bullet("Corpus version", reportString(r.summary, "corpus_version"))
+	bullet("Gauntlet version", reportString(r.summary, "gauntlet_version"))
+	bullet("Scoring version", reportString(r.summary, "scoring_version"))
+	bullet("Runner version", reportString(r.summary, "runner_version"))
+	bullet("Run date", reportString(r.summary, "date"))
+	bullet("corpus_sha256", reportString(r.summary, "corpus_sha256"))
+	line("")
+	line("## Target identity")
+	line("")
+	bullet("Product", reportString(r.summary, "tool"))
+	bullet("Version", reportString(r.summary, "tool_version"))
+	bullet("Declared configuration", firstReportFact(
+		reportString(r.summary, "target_config_ref")))
+	bullet("Declared configuration digest", firstReportFact(
+		reportString(r.summary, "target_config_sha256")))
+	line("")
+	line("## Capability profile and adapter")
+	line("")
+	bullet("tool_profile_sha256", reportString(r.summary, "tool_profile_sha256"))
+	line("- Declared capability claims:")
+	list(reportStringList(r.summary, "tool_support", "claims"))
+	line("- Unsupported transports:")
+	list(reportStringList(r.summary, "tool_support", "unsupported_transports"))
+	line("- Unsupported requirements:")
+	list(reportStringList(r.summary, "tool_support", "unsupported_requires"))
+	bullet("Adapter identity", r.adapterIdentity())
+	bullet("Adapter owner", firstReportFact(reportString(r.summary, "adapter_owner")))
+	line("")
+	line("## Scope")
+	line("")
+	bullet("Total cases", reportCount(r.summary, "case_count", "total"))
+	bullet("Applicable cases", reportCount(r.summary, "case_count", "applicable"))
+	bullet("Not-applicable cases", reportCount(r.summary, "case_count", "not_applicable"))
+	bullet("Error cases", reportCount(r.summary, "case_count", "errors"))
+	line("- Not-applicable case IDs and reasons:")
+	declaredNA, declaredNAOK := reportIntegerValue(r.summary, "case_count", "not_applicable")
+	if r.resultErr != "Readable" {
+		list([]string{r.resultErr})
+	} else if !declaredNAOK {
+		list([]string{"Invalid: the summary does not carry a usable not-applicable count"})
+	} else if declaredNA != len(r.results) {
+		list([]string{fmt.Sprintf("Invalid: the summary declares %d not-applicable cases but results.jsonl contains %d", declaredNA, len(r.results))})
+	} else if len(r.results) == 0 {
+		list([]string{"None recorded"})
+	} else {
+		for _, item := range r.results {
+			line("  - `%s`: %s", markdownInline(item.caseID), markdownInline(item.reason))
+		}
+	}
+	line("")
+	line("## Metric vector")
+	line("")
+	line("Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.")
+	line("")
+	line("### Full corpus")
+	line("")
+	bullet("Containment", reportPercent(r.summary, "scores", "full", "containment"))
+	bullet("Detection", reportPercent(r.summary, "scores", "full", "detection"))
+	bullet("Evidence", reportPercent(r.summary, "scores", "full", "evidence"))
+	bullet("False-positive rate", reportPercent(r.summary, "scores", "full", "false_positive_rate"))
+	line("")
+	line("### Applicable cases")
+	line("")
+	bullet("Containment", reportPercent(r.summary, "scores", "applicable", "containment"))
+	bullet("Detection", reportPercent(r.summary, "scores", "applicable", "detection"))
+	bullet("Evidence", reportPercent(r.summary, "scores", "applicable", "evidence"))
+	bullet("False-positive rate", reportPercent(r.summary, "scores", "applicable", "false_positive_rate"))
+	line("")
+	line("## Execution and bundle status")
+	line("")
+	bullet("Execution status", reportString(r.decision, "execution_status"))
+	bullet("Execution blocked", reportBool(r.decision, "blocked"))
+	bullet("Execution publication eligibility", reportBool(r.decision, "publication_eligible"))
+	line("- Execution failures:")
+	list(reportStringList(r.decision, "failures"))
+	line("- Execution review notes:")
+	list(reportStringList(r.decision, "review_notes"))
+	bullet("Run-bundle declared validation status", reportString(r.bundle, "bundle_status"))
+	bullet("Run-bundle publication eligibility", reportBool(r.bundle, "publication_eligible"))
+	line("- Run-bundle noncanonical reasons:")
+	list(reportStringList(r.bundle, "noncanonical_reasons"))
+	bullet("Publication eligibility recorded by the run", r.publicationEligibility())
+	bullet("Run-bundle digest and binding recheck", r.bundleValidation())
+	bullet("Execution-decision consistency", r.decisionValidation())
+	line("")
+	line("These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.")
+	line("")
+	line("## Non-claims")
+	line("")
+	line("This result does not establish:")
+	line("")
+	line("- a formal conformance status, accreditation, or pass mark;")
+	line("- legal or regulatory compliance;")
+	line("- insurance eligibility or pricing;")
+	line("- security outside the exercised capability profile;")
+	line("- absence of evasions, including variants of classes exercised here.")
+	line("")
+	line("## Reproduce the run")
+	line("")
+	line("Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.")
+	line("")
+	redactedEntrypoint := redactReportCommand(r.entrypoint)
+	redactedCommand := redactReportCommand(r.command)
+	line("Credential-shaped values in the commands below are replaced with %s. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.", redactedValue)
+	if reportCommandContainsLocalDetail(redactedEntrypoint) || reportCommandContainsLocalDetail(redactedCommand) {
+		line("")
+		line("These commands contain absolute paths or URLs from the machine that ran them.")
+	}
+	line("")
+	line("### Entrypoint command")
+	line("")
+	renderIndented(w, redactedEntrypoint)
+	line("")
+	line("### Recorded runner command")
+	line("")
+	renderIndented(w, redactedCommand)
+	line("")
+	line("### Retained material")
+	line("")
+	for _, material := range r.materialList() {
+		line("- %s", markdownInline(material))
+	}
+}
+
+func (r *buyerReport) publicationEligibility() string {
+	decisionValue, decisionPresent := nestedValue(r.decision.data, "publication_eligible")
+	bundleValue, bundlePresent := nestedValue(r.bundle.data, "publication_eligible")
+	decision, decisionBool := decisionValue.(bool)
+	bundle, bundleBool := bundleValue.(bool)
+	if !decisionPresent || !bundlePresent || !decisionBool || !bundleBool {
+		return absentFact
+	}
+	if decision != bundle {
+		return "Invalid: execution decision and run bundle disagree"
+	}
+	if decision {
+		if !strings.HasPrefix(r.bundleValidation(), reportSelfConsistentPrefix) ||
+			!strings.HasPrefix(r.decisionValidation(), reportSelfConsistentPrefix) {
+			return "Not established because retained validation checks are not valid"
+		}
+		return "Recorded eligible by both retained decisions"
+	}
+	return "Recorded not eligible by both retained decisions"
+}
+
+func renderIndented(w io.Writer, value string) {
+	for _, part := range strings.Split(value, "\n") {
+		_, _ = fmt.Fprintf(w, "    %s\n", part)
+	}
+}
+
+func (r *buyerReport) adapterIdentity() string {
+	// The runner records the selected adapter in the summary. Reading it there
+	// beats recovering it from the command line, which a wrapper script or a
+	// quoted invocation can hide, and which nothing hashes.
+	if id := reportString(r.summary, "adapter_id"); id != "" && id != absentFact {
+		return safeReportText(id)
+	}
+	return absentFact
+}
+
+var reportEvidenceFiles = map[string]string{
+	"case_index":              "case-index.json",
+	"command":                 "command.txt",
+	"corpus_manifest":         "corpus-manifest.txt",
+	"entrypoint_command":      "entrypoint-command.txt",
+	"pipelock_release":        "pipelock-release.json",
+	"pipelock_version_output": "pipelock-version.txt",
+	"raw_summary":             "raw-summary.json",
+	"release_checksums":       "checksums.txt",
+	"results":                 "results.jsonl",
+	"run_metadata":            "run-metadata.json",
+	"runner_stderr":           "runner.stderr",
+	"stats":                   "make-stats.txt",
+}
+
+func (r *buyerReport) bundleValidation() string {
+	if r.bundle.data == nil {
+		return absentFact
+	}
+	if reportNumber(r.bundle, "schema_version") != "1" {
+		return "Invalid: run-bundle schema version is absent or unsupported"
+	}
+	status := reportString(r.bundle, "bundle_status")
+	if status != "complete" && status != "partial" {
+		return "Invalid: run-bundle status is absent or unsupported"
+	}
+	if reportBool(r.bundle, "publication_eligible") == "Invalid in run artifacts" || reportBool(r.bundle, "publication_eligible") == absentFact {
+		return "Invalid: run-bundle publication eligibility is absent or malformed"
+	}
+	value, ok := nestedValue(r.bundle.data, "evidence_sha256")
+	hashes, okObject := value.(map[string]interface{})
+	if !ok || !okObject || len(hashes) == 0 {
+		return "Invalid: evidence digest map is absent or malformed"
+	}
+	var failures []string
+	if status == "complete" {
+		if r.summary.data == nil {
+			failures = append(failures, "raw-summary.json is not readable JSON")
+		}
+		if r.metadata.data == nil {
+			failures = append(failures, "run-metadata.json is not readable JSON")
+		}
+		failures = append(failures, r.summaryScopeFailures()...)
+		for key := range reportEvidenceFiles {
+			if _, present := hashes[key]; !present {
+				failures = append(failures, key+" digest is absent from a complete bundle")
+			}
+		}
+		if candidate, present := nestedValue(r.bundle.data, "candidate_scope"); !present {
+			failures = append(failures, "candidate_scope is absent from a complete bundle")
+		} else if candidateMap, object := candidate.(map[string]interface{}); !object {
+			failures = append(failures, "candidate_scope is malformed")
+		} else if r.summary.data != nil && r.metadata.data != nil {
+			for _, key := range []string{"scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "case_count", "scores"} {
+				candidateValue, candidatePresent := candidateMap[key]
+				summaryValue, summaryPresent := r.summary.data[key]
+				if !candidatePresent || !summaryPresent || candidateValue == nil || summaryValue == nil || !reportValuesEqual(candidateValue, summaryValue) {
+					failures = append(failures, "candidate_scope."+key+" does not match raw-summary.json")
+				}
+			}
+			candidateCommit, candidateCommitPresent := candidateMap["corpus_git_sha"]
+			metadataCommit, metadataCommitPresent := r.metadata.data["corpus_git_sha"]
+			if !candidateCommitPresent || !metadataCommitPresent || candidateCommit == nil || metadataCommit == nil || !reportValuesEqual(candidateCommit, metadataCommit) {
+				failures = append(failures, "candidate_scope.corpus_git_sha does not match run-metadata.json")
+			}
+		}
+	}
+	for key, raw := range hashes {
+		expected, ok := raw.(string)
+		if !ok || !regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(expected) {
+			failures = append(failures, key+" has an invalid digest")
+			continue
+		}
+		name, known := reportEvidenceFiles[key]
+		if !known {
+			failures = append(failures, key+" has no report filename mapping")
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(r.dir, name))
+		if err != nil {
+			failures = append(failures, name+" is absent or unreadable")
+			continue
+		}
+		actual := sha256.Sum256(data)
+		if hex.EncodeToString(actual[:]) != expected {
+			failures = append(failures, name+" digest does not match")
+		}
+	}
+	if len(failures) > 0 {
+		sort.Strings(failures)
+		return safeReportText("Invalid: " + strings.Join(failures, "; "))
+	}
+	if status == "partial" {
+		return fmt.Sprintf("Incomplete: partial bundle with %d retained evidence digests matching", len(hashes))
+	}
+	return fmt.Sprintf("%s %d retained evidence digests match the bundle", reportSelfConsistentPrefix, len(hashes))
+}
+
+func (r *buyerReport) summaryScopeFailures() []string {
+	total, totalOK := reportIntegerValue(r.summary, "case_count", "total")
+	applicable, applicableOK := reportIntegerValue(r.summary, "case_count", "applicable")
+	notApplicable, notApplicableOK := reportIntegerValue(r.summary, "case_count", "not_applicable")
+	errors, errorsOK := reportIntegerValue(r.summary, "case_count", "errors")
+	if !totalOK || !applicableOK || !notApplicableOK || !errorsOK {
+		return []string{"summary case counts are absent or malformed"}
+	}
+	var failures []string
+	if applicable+notApplicable != total {
+		failures = append(failures, "summary applicable and not-applicable counts do not sum to total")
+	}
+	if errors > applicable {
+		failures = append(failures, "summary error count exceeds applicable count")
+	}
+	reasonsValue, reasonsPresent := nestedValue(r.summary.data, "case_count", "not_applicable_reasons")
+	reasons, reasonsObject := reasonsValue.(map[string]interface{})
+	if !reasonsPresent || !reasonsObject {
+		failures = append(failures, "summary not-applicable reasons are absent or malformed")
+		return failures
+	}
+	reasonTotal := 0
+	for reason, raw := range reasons {
+		if strings.TrimSpace(reason) == "" {
+			failures = append(failures, "summary has an empty not-applicable reason")
+			continue
+		}
+		number, numberOK := raw.(json.Number)
+		if !numberOK {
+			failures = append(failures, "summary not-applicable reason count is malformed")
+			continue
+		}
+		// Atoi returns an int directly and reports ErrRange on overflow, so
+		// there is no widening conversion to bound. The previous round-trip
+		// check was correct but static analysis cannot see that it is.
+		parsed, err := strconv.Atoi(number.String())
+		if err != nil || parsed < 0 {
+			failures = append(failures, "summary not-applicable reason count is malformed")
+			continue
+		}
+		reasonTotal += parsed
+	}
+	if reasonTotal != notApplicable {
+		failures = append(failures, "summary not-applicable reasons do not sum to the not-applicable count")
+	}
+	if r.resultErr != "Readable" {
+		// Nothing downstream can be checked against rows that could not be
+		// read. Skipping the comparison silently would let an unreadable
+		// results file render as a self-consistent bundle.
+		failures = append(failures, fmt.Sprintf("results.jsonl could not be validated: %s", r.resultErr))
+	}
+	if r.resultErr == "Readable" {
+		if len(r.results) != notApplicable {
+			failures = append(failures, "results.jsonl not-applicable rows do not match the summary count")
+		}
+		// The summary declares these; results.jsonl is the evidence for them.
+		// A declaration the rows do not support is the failure a reader most
+		// needs named, because every rate above is computed from it.
+		for _, c := range []struct {
+			label            string
+			declared, actual int
+		}{
+			{"total", total, r.rowCounts.total},
+			{"applicable", applicable, r.rowCounts.applicable},
+			{"error", errors, r.rowCounts.errors},
+		} {
+			if declared, actual := c.declared, c.actual; declared != actual {
+				failures = append(failures, fmt.Sprintf(
+					"summary declares %d %s cases but results.jsonl contains %d", declared, c.label, actual))
+			}
+		}
+	}
+	return failures
+}
+
+func reportValuesEqual(left, right interface{}) bool {
+	leftJSON, leftErr := json.Marshal(left)
+	rightJSON, rightErr := json.Marshal(right)
+	return leftErr == nil && rightErr == nil && bytes.Equal(leftJSON, rightJSON)
+}
+
+func reportIntegerValue(doc reportDocument, path ...string) (int, bool) {
+	if doc.data == nil {
+		return 0, false
+	}
+	value, ok := nestedValue(doc.data, path...)
+	if !ok {
+		return 0, false
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(number.String())
+	if err != nil || parsed < 0 {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func reportCount(doc reportDocument, path ...string) string {
+	value, ok := reportIntegerValue(doc, path...)
+	if !ok {
+		if doc.data == nil {
+			return absentFact
+		}
+		if _, present := nestedValue(doc.data, path...); !present {
+			return absentFact
+		}
+		return "Invalid in run artifacts"
+	}
+	return strconv.Itoa(value)
+}
+
+func (r *buyerReport) decisionValidation() string {
+	if r.decision.data == nil || r.bundle.data == nil {
+		return absentFact
+	}
+	if reportNumber(r.decision, "schema_version") != "1" {
+		return "Invalid: execution-decision schema version is absent or unsupported"
+	}
+	blockedValue, blockedOK := nestedValue(r.decision.data, "blocked")
+	blocked, blockedBool := blockedValue.(bool)
+	status := reportString(r.decision, "execution_status")
+	eligibleValue, eligibleOK := nestedValue(r.decision.data, "publication_eligible")
+	eligible, eligibleBool := eligibleValue.(bool)
+	if !blockedOK || !blockedBool || !eligibleOK || !eligibleBool || (status != "complete" && status != "blocked") {
+		return "Invalid: execution decision fields are absent or malformed"
+	}
+	if (status == "complete") == blocked {
+		return "Invalid: execution status and blocked flag contradict each other"
+	}
+	if blocked && eligible {
+		return "Invalid: a blocked execution is marked publication-eligible"
+	}
+	decisionID := reportString(r.decision, "local_run_id")
+	bundleID := reportString(r.bundle, "local_run_id")
+	if decisionID == absentFact || bundleID == absentFact || decisionID != bundleID {
+		return "Invalid: local run identifiers do not match"
+	}
+	decisionHashes, decisionOK := nestedValue(r.decision.data, "evidence_sha256")
+	bundleHashes, bundleOK := nestedValue(r.bundle.data, "evidence_sha256")
+	if !decisionOK || !bundleOK {
+		return "Invalid: evidence digest map is absent"
+	}
+	decisionJSON, _ := json.Marshal(decisionHashes)
+	bundleJSON, _ := json.Marshal(bundleHashes)
+	if !bytes.Equal(decisionJSON, bundleJSON) {
+		return "Invalid: execution and bundle evidence digests differ"
+	}
+	return reportSelfConsistentPrefix + " run identifier and evidence digests match the bundle"
+}
+
+func (r *buyerReport) materialList() []string {
+	if r.bundle.data == nil {
+		return []string{absentFact}
+	}
+	value, ok := nestedValue(r.bundle.data, "evidence_sha256")
+	hashes, okObject := value.(map[string]interface{})
+	if !ok || !okObject || len(hashes) == 0 {
+		return []string{absentFact}
+	}
+	var items []string
+	for key, raw := range hashes {
+		name, known := reportEvidenceFiles[key]
+		if !known {
+			name = key
+		}
+		digest, ok := raw.(string)
+		if !ok {
+			digest = "Invalid in run artifacts"
+		}
+		items = append(items, name+" (sha256 "+safeReportText(digest)+")")
+	}
+	sort.Strings(items)
+	return items
+}

--- a/runner/report_test.go
+++ b/runner/report_test.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var updateReportGoldens = flag.Bool("update-report-goldens", false, "update buyer-report golden files")
+
+func TestBuyerReportGoldens(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*reportFixture)
+	}{
+		{name: "healthy"},
+		{name: "not-applicable", mutate: func(f *reportFixture) {
+			f.summary["case_count"] = map[string]interface{}{
+				"total": 3, "applicable": 2, "not_applicable": 1,
+				"not_applicable_reasons": map[string]interface{}{"missing_requires": 1}, "errors": 0,
+			}
+			f.results = append(f.results, map[string]interface{}{
+				"case_id": "mcp-chain-budget-003", "tool": "example-tool", "tool_version": "1.2.3",
+				"expected_verdict": "block", "actual_verdict": "not_applicable",
+				"score": "not_applicable", "evidence": map[string]interface{}{},
+				"notes": "not applicable: missing_requires",
+			})
+		}},
+		{name: "unknown-verdict", mutate: func(f *reportFixture) {
+			// An unrecognized verdict is malformed input. Counting it as an
+			// applicable case would let it inflate the denominator of every
+			// rate while the declared arithmetic still reconciled.
+			f.results[1]["actual_verdict"] = "banana"
+		}},
+		{name: "count-mismatch", mutate: func(f *reportFixture) {
+			// The summary claims more cases than results.jsonl can account for.
+			// Every rate in the report is computed from these declarations, so
+			// a reader has to be told the evidence does not support them.
+			f.summary["case_count"] = map[string]interface{}{
+				"total": 99, "applicable": 97, "not_applicable": 2,
+				"not_applicable_reasons": map[string]interface{}{"missing_requires": 2}, "errors": 5,
+			}
+		}},
+		{name: "errors", mutate: func(f *reportFixture) {
+			f.summary["case_count"].(map[string]interface{})["errors"] = 1
+			f.results[1]["actual_verdict"] = "error"
+			f.results[1]["score"] = "error"
+			f.results[1]["notes"] = "adapter error: fixture unavailable"
+			f.bundle["bundle_status"] = "partial"
+			f.bundle["publication_eligible"] = false
+			f.decision["blocked"] = true
+			f.decision["execution_status"] = "blocked"
+			f.decision["publication_eligible"] = false
+			f.decision["failures"] = []interface{}{"runner produced an error result"}
+		}},
+		{name: "not-publication-eligible", mutate: func(f *reportFixture) {
+			f.bundle["publication_eligible"] = false
+			f.bundle["noncanonical_reasons"] = []interface{}{"development execution"}
+			f.decision["blocked"] = false
+			f.decision["execution_status"] = "complete"
+			f.decision["publication_eligible"] = false
+			f.decision["review_notes"] = []interface{}{"development execution"}
+		}},
+		{name: "missing-optional", mutate: func(f *reportFixture) {
+			delete(f.summary, "date")
+		}},
+		{name: "missing-required", mutate: func(f *reportFixture) {
+			delete(f.summary, "scoring_version")
+		}},
+		{name: "malformed-summary", mutate: func(f *reportFixture) {
+			f.malformedSummary = true
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newReportFixture()
+			if tt.mutate != nil {
+				tt.mutate(fixture)
+			}
+			dir := t.TempDir()
+			fixture.write(t, dir)
+			report, err := loadBuyerReport(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got bytes.Buffer
+			report.renderMarkdown(&got)
+			golden := filepath.Join("testdata", "buyer-report", tt.name+".golden.md")
+			if *updateReportGoldens {
+				if err := os.MkdirAll(filepath.Dir(golden), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(golden, got.Bytes(), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			want, err := os.ReadFile(golden)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got.Bytes(), want) {
+				t.Fatalf("report differs from %s\n--- got ---\n%s\n--- want ---\n%s", golden, got.String(), string(want))
+			}
+		})
+	}
+}
+
+func TestBuyerReportBlocksRestrictedClaimLanguageFromArtifacts(t *testing.T) {
+	fixture := newReportFixture()
+	var terms []string
+	for _, pattern := range reportRestrictedClaims {
+		sample := sampleForRestrictedPattern(pattern.String())
+		// Without this the test proves nothing: a sample that does not match
+		// its own pattern would be filtered by no rule, and the assertions
+		// below would pass on language the gate never actually blocks.
+		if !pattern.MatchString(sample) {
+			t.Fatalf("sample %q does not match its restricted pattern %s", sample, pattern.String())
+		}
+		terms = append(terms, sample)
+	}
+	fixture.summary["tool"] = strings.Join(terms, " ")
+	fixture.summary["tool_support"].(map[string]interface{})["claims"] = []interface{}{strings.Join(terms, " ")}
+	fixture.command = strings.Join(terms, " ")
+	fixture.entrypoint = strings.Join(terms, " ")
+	dir := t.TempDir()
+	fixture.write(t, dir)
+
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	for _, pattern := range reportRestrictedClaims {
+		if pattern.Match(output.Bytes()) {
+			t.Errorf("restricted claim pattern %q reached report output", pattern)
+		}
+	}
+}
+
+func TestBuyerReportMarksNotApplicableRowCountMismatchInvalid(t *testing.T) {
+	fixture := newReportFixture()
+	fixture.summary["case_count"].(map[string]interface{})["not_applicable"] = 1
+	fixture.summary["case_count"].(map[string]interface{})["applicable"] = 1
+	fixture.summary["case_count"].(map[string]interface{})["not_applicable_reasons"] = map[string]interface{}{"missing_requires": 1}
+	dir := t.TempDir()
+	fixture.write(t, dir)
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	if !strings.Contains(output.String(), "summary declares 1 not-applicable cases but results.jsonl contains 0") {
+		t.Fatalf("report did not expose N/A row mismatch:\n%s", output.String())
+	}
+}
+
+func sampleForRestrictedPattern(pattern string) string {
+	samples := map[string]string{
+		`(?i)leaderboards?`:                        "leaderboard",
+		`(?i)certif(?:ied|ication|ications|ies|y)`: "certified",
+		`(?i)proofstamp`:                           "proofstamp",
+		`(?i)neutral benchmark`:                    "neutral benchmark",
+		`(?i)proven secure`:                        "proven secure",
+		`(?i)no bypass(?:es)?\b`:                   "no bypass",
+		`(?i)unbypassable`:                         "unbypassable",
+		`(?i)insurance discount`:                   "insurance discount",
+		`(?i)\bFIPS\b`:                             "FIPS",
+		`(?i)all prox(?:y|ies)[- ]based`:           "all proxy-based",
+	}
+	if value, ok := samples[pattern]; ok {
+		return value
+	}
+	return "restricted-claim"
+}
+
+type reportFixture struct {
+	summary          map[string]interface{}
+	metadata         map[string]interface{}
+	bundle           map[string]interface{}
+	decision         map[string]interface{}
+	results          []map[string]interface{}
+	command          string
+	entrypoint       string
+	malformedSummary bool
+}
+
+func newReportFixture() *reportFixture {
+	return &reportFixture{
+		summary: map[string]interface{}{
+			"gauntlet_version": "1.0", "scoring_version": "2.4", "runner_version": "0.4.2",
+			"tool": "example-tool", "tool_version": "1.2.3", "corpus_version": "v2.3.0",
+			"corpus_sha256": strings.Repeat("a", 64), "tool_profile_sha256": strings.Repeat("b", 64),
+			"adapter_id": "example", "adapter_owner": "Example Lab",
+			"target_config_ref": "/etc/example/target.yaml", "target_config_sha256": strings.Repeat("e", 64),
+			"date": "2026-08-05T12:00:00Z",
+			"case_count": map[string]interface{}{
+				"total": 2, "applicable": 2, "not_applicable": 0,
+				"not_applicable_reasons": map[string]interface{}{}, "errors": 0,
+			},
+			"tool_support": map[string]interface{}{
+				"claims":                 []interface{}{"url_dlp", "ssrf"},
+				"unsupported_transports": []interface{}{"a2a"},
+				"unsupported_requires":   []interface{}{"dns_rebinding_fixture"},
+			},
+			"scores": map[string]interface{}{
+				"full":       map[string]interface{}{"containment": 0.75, "detection": 0.5, "evidence": 0.25, "false_positive_rate": 0.1},
+				"applicable": map[string]interface{}{"containment": 0.8, "detection": 0.6, "evidence": 0.4, "false_positive_rate": 0.0},
+			},
+		},
+		metadata: map[string]interface{}{
+			"schema_version": 1, "local_run_id": "local:test", "corpus_repository": "example/agent-egress-bench",
+			"corpus_git_sha": strings.Repeat("c", 40),
+		},
+		bundle: map[string]interface{}{
+			"schema_version": 1, "bundle_status": "complete", "local_run_id": "local:test", "publication_eligible": true,
+			"noncanonical_reasons": []interface{}{},
+		},
+		decision: map[string]interface{}{
+			"schema_version": 1, "local_run_id": "local:test", "blocked": false,
+			"execution_status": "complete", "publication_eligible": true,
+			"failures": []interface{}{}, "review_notes": []interface{}{},
+		},
+		results: []map[string]interface{}{
+			{"case_id": "url-attack-001", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "block", "actual_verdict": "block", "score": "pass", "evidence": map[string]interface{}{}, "notes": ""},
+			{"case_id": "url-benign-002", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "allow", "actual_verdict": "allow", "score": "pass", "evidence": map[string]interface{}{}, "notes": ""},
+		},
+		command:    "./runner --adapter example --scan-token fixture-secret --cases ./cases --profile ./profile.json",
+		entrypoint: "./run-gauntlet.sh --output-dir ./artifacts",
+	}
+}
+
+func (f *reportFixture) write(t *testing.T, dir string) {
+	t.Helper()
+	writeFixtureJSON(t, filepath.Join(dir, "run-metadata.json"), f.metadata)
+	if f.malformedSummary {
+		if err := os.WriteFile(filepath.Join(dir, "raw-summary.json"), []byte("{\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		writeFixtureJSON(t, filepath.Join(dir, "raw-summary.json"), f.summary)
+	}
+	var rows bytes.Buffer
+	enc := json.NewEncoder(&rows)
+	for _, row := range f.results {
+		if err := enc.Encode(row); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "results.jsonl"), rows.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "command.txt"), []byte(f.command+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "entrypoint-command.txt"), []byte(f.entrypoint+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{
+		"case-index.json", "corpus-manifest.txt", "pipelock-release.json", "pipelock-version.txt",
+		"checksums.txt", "runner.stderr", "make-stats.txt",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("fixture material\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	hashes := map[string]interface{}{}
+	for key, name := range reportEvidenceFiles {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		digest := sha256.Sum256(data)
+		hashes[key] = hex.EncodeToString(digest[:])
+	}
+	f.bundle["evidence_sha256"] = hashes
+	f.bundle["candidate_scope"] = map[string]interface{}{
+		"corpus_git_sha":      f.metadata["corpus_git_sha"],
+		"scoring_version":     f.summary["scoring_version"],
+		"runner_version":      f.summary["runner_version"],
+		"tool":                f.summary["tool"],
+		"tool_version":        f.summary["tool_version"],
+		"corpus_version":      f.summary["corpus_version"],
+		"corpus_sha256":       f.summary["corpus_sha256"],
+		"tool_profile_sha256": f.summary["tool_profile_sha256"],
+		"case_count":          f.summary["case_count"],
+		"scores":              f.summary["scores"],
+	}
+	f.decision["evidence_sha256"] = hashes
+	writeFixtureJSON(t, filepath.Join(dir, "run-bundle.json"), f.bundle)
+	writeFixtureJSON(t, filepath.Join(dir, "execution-decision.json"), f.decision)
+}
+
+func writeFixtureJSON(t *testing.T, path string, value interface{}) {
+	t.Helper()
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReportRestrictedClaimPatternsStayInSyncWithClaimGate(t *testing.T) {
+	gate, err := os.ReadFile(filepath.Join("..", "scripts", "check_claim_language.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sample := range []string{"leaderboard", "certified", "proofstamp", "neutral benchmark", "proven secure", "no bypass", "unbypassable", "insurance discount", "FIPS", "all proxy-based"} {
+		if !bytes.Contains(bytes.ToLower(gate), bytes.ToLower([]byte(sample))) && sample != "certified" && sample != "all proxy-based" {
+			t.Errorf("claim gate no longer contains sample %q; update report gate intentionally", sample)
+		}
+	}
+	if len(reportRestrictedClaims) != 10 {
+		t.Fatalf("report claim pattern count = %d, want 10", len(reportRestrictedClaims))
+	}
+}

--- a/runner/summary.go
+++ b/runner/summary.go
@@ -42,6 +42,31 @@ type GauntletSummary struct {
 	Scores            DualScores                `json:"scores"`
 	Sufficient        bool                      `json:"sufficient"`
 	PerCategory       map[string]CategoryScores `json:"per_category"`
+
+	// Identifying facts that docs/RESULTS-USE.md requires beside any public
+	// result and that cannot be derived from the corpus or the profile. They
+	// are omitted rather than guessed when the operator does not supply them,
+	// so a reader can tell the difference between "not declared" and "declared
+	// as empty". The buyer report renders each absence explicitly.
+	MethodRepository   string `json:"method_repository,omitempty"`
+	MethodCommit       string `json:"method_commit,omitempty"`
+	AdapterID          string `json:"adapter_id,omitempty"`
+	AdapterOwner       string `json:"adapter_owner,omitempty"`
+	TargetConfigRef    string `json:"target_config_ref,omitempty"`
+	TargetConfigSHA256 string `json:"target_config_sha256,omitempty"`
+}
+
+// RunProvenance carries the identifying facts a published result must declare.
+// A score against an unnamed configuration cannot be repeated, and an adapter
+// with no stated owner hides who wrote the code that produced the verdict.
+// A vendor-authored adapter is normal; concealing authorship is not.
+type RunProvenance struct {
+	MethodRepository string
+	MethodCommit     string
+	AdapterID        string
+	AdapterOwner     string
+	TargetConfigRef  string
+	TargetConfigSHA  string
 }
 
 // CaseCount tracks totals and N/A breakdown.
@@ -199,6 +224,7 @@ func buildSummary(
 	casesDir, multiFileDir string,
 	casesByID map[string]Case,
 	profilePath string,
+	prov RunProvenance,
 ) (GauntletSummary, error) {
 	corpusSHA, err := computeCorpusSHA256(casesDir, multiFileDir)
 	if err != nil {
@@ -256,6 +282,13 @@ func buildSummary(
 		},
 		Sufficient:  isSufficient(fullScores, len(applicableResults), errorCount),
 		PerCategory: perCategory,
+
+		MethodRepository:   prov.MethodRepository,
+		MethodCommit:       prov.MethodCommit,
+		AdapterID:          prov.AdapterID,
+		AdapterOwner:       prov.AdapterOwner,
+		TargetConfigRef:    prov.TargetConfigRef,
+		TargetConfigSHA256: prov.TargetConfigSHA,
 	}, nil
 }
 

--- a/runner/summary_provenance_test.go
+++ b/runner/summary_provenance_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func provenanceTestDirs(t *testing.T) (dir, profilePath string) {
+	t.Helper()
+	dir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.json"), []byte(`{"id":"a"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profilePath = filepath.Join(dir, "profile.json")
+	if err := os.WriteFile(profilePath, []byte(`{"tool":"test"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir, profilePath
+}
+
+func buildProvenanceSummary(t *testing.T, dir, profilePath string, prov RunProvenance) GauntletSummary {
+	t.Helper()
+	summary, err := buildSummary(
+		Profile{Tool: "test", ToolVersion: "1.0", Supports: summaryTestSupports(true)},
+		[]Case{{ID: "a", Category: "url", ExpectedVerdict: "allow"}},
+		nil,
+		nil,
+		dir,
+		"",
+		map[string]Case{"a": {ID: "a", Category: "url", ExpectedVerdict: "allow"}},
+		profilePath,
+		prov,
+	)
+	if err != nil {
+		t.Fatalf("buildSummary: %v", err)
+	}
+	return summary
+}
+
+// TestBuildSummaryRecordsDeclaredProvenance covers the facts docs/RESULTS-USE.md
+// requires beside a public result. Before these fields existed the summary could
+// not carry three of them, so an operator following the policy had nowhere to put
+// the repository and commit, the adapter's author, or the configuration the score
+// actually describes.
+func TestBuildSummaryRecordsDeclaredProvenance(t *testing.T) {
+	dir, profilePath := provenanceTestDirs(t)
+
+	prov := RunProvenance{
+		MethodRepository: "example/agent-egress-bench",
+		MethodCommit:     "cccccccccccccccccccccccccccccccccccccccc",
+		AdapterID:        "proxy",
+		AdapterOwner:     "Example Lab",
+		TargetConfigRef:  "/etc/example/config.yaml",
+		TargetConfigSHA:  "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0",
+	}
+	summary := buildProvenanceSummary(t, dir, profilePath, prov)
+
+	for _, tc := range []struct{ name, got, want string }{
+		{"method_repository", summary.MethodRepository, prov.MethodRepository},
+		{"method_commit", summary.MethodCommit, prov.MethodCommit},
+		{"adapter_id", summary.AdapterID, prov.AdapterID},
+		{"adapter_owner", summary.AdapterOwner, prov.AdapterOwner},
+		{"target_config_ref", summary.TargetConfigRef, prov.TargetConfigRef},
+		{"target_config_sha256", summary.TargetConfigSHA256, prov.TargetConfigSHA},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// An undeclared fact is omitted from the JSON entirely rather than serialized as
+// an empty string, so a reader can tell "not declared" from "declared as
+// nothing" and the buyer report can say which.
+func TestBuildSummaryOmitsUndeclaredProvenance(t *testing.T) {
+	dir, profilePath := provenanceTestDirs(t)
+	summary := buildProvenanceSummary(t, dir, profilePath, RunProvenance{})
+
+	encoded, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshalling summary: %v", err)
+	}
+	for _, field := range []string{
+		"method_repository", "method_commit", "adapter_id",
+		"adapter_owner", "target_config_ref", "target_config_sha256",
+	} {
+		if strings.Contains(string(encoded), field) {
+			t.Errorf("undeclared %s was serialized; it should be omitted", field)
+		}
+	}
+}

--- a/runner/summary_test.go
+++ b/runner/summary_test.go
@@ -112,7 +112,7 @@ func TestWriteSummaryBadPath(t *testing.T) {
 
 func TestBuildSummaryErrorPath(t *testing.T) {
 	p := Profile{Tool: "test", ToolVersion: "1.0"}
-	_, err := buildSummary(p, nil, nil, nil, "/nonexistent/dir", "", nil, "/nonexistent/profile.json")
+	_, err := buildSummary(p, nil, nil, nil, "/nonexistent/dir", "", nil, "/nonexistent/profile.json", RunProvenance{})
 	if err == nil {
 		t.Fatal("expected error for nonexistent cases dir")
 	}
@@ -161,6 +161,7 @@ func TestBuildSummaryUsesFixedDateEnv(t *testing.T) {
 		"",
 		map[string]Case{"a": {ID: "a", Category: "url", ExpectedVerdict: "allow"}},
 		profilePath,
+		RunProvenance{},
 	)
 	if err != nil {
 		t.Fatalf("buildSummary: %v", err)
@@ -191,6 +192,7 @@ func TestBuildSummaryRejectsInvalidFixedDateEnv(t *testing.T) {
 		"",
 		map[string]Case{"a": {ID: "a", Category: "url", ExpectedVerdict: "allow"}},
 		profilePath,
+		RunProvenance{},
 	)
 	if err == nil || !strings.Contains(err.Error(), "must be empty or RFC3339") {
 		t.Fatalf("buildSummary error = %v, want invalid fixed-date rejection", err)

--- a/runner/testdata/buyer-report/count-mismatch.golden.md
+++ b/runner/testdata/buyer-report/count-mismatch.golden.md
@@ -1,0 +1,127 @@
+# Agent Egress Bench Run Report
+
+This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.
+
+## Artifact input status
+
+- raw-summary.json: Readable
+- results.jsonl: Readable
+- run-metadata.json: Readable
+- run-bundle.json: Readable
+- execution-decision.json: Readable
+
+## Method identity
+
+- Repository: example/agent-egress-bench
+- Exact commit: cccccccccccccccccccccccccccccccccccccccc
+- Corpus version: v2.3.0
+- Gauntlet version: 1.0
+- Scoring version: 2.4
+- Runner version: 0.4.2
+- Run date: 2026-08-05T12:00:00Z
+- corpus_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+## Target identity
+
+- Product: example-tool
+- Version: 1.2.3
+- Declared configuration: /etc/example/target.yaml
+- Declared configuration digest: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+## Capability profile and adapter
+
+- tool_profile_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+- Declared capability claims:
+  - ssrf
+  - url\_dlp
+- Unsupported transports:
+  - a2a
+- Unsupported requirements:
+  - dns\_rebinding\_fixture
+- Adapter identity: example
+- Adapter owner: Example Lab
+
+## Scope
+
+- Total cases: 99
+- Applicable cases: 97
+- Not-applicable cases: 2
+- Error cases: 5
+- Not-applicable case IDs and reasons:
+  - Invalid: the summary declares 2 not-applicable cases but results.jsonl contains 0
+
+## Metric vector
+
+Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.
+
+### Full corpus
+
+- Containment: 75.00%
+- Detection: 50.00%
+- Evidence: 25.00%
+- False-positive rate: 10.00%
+
+### Applicable cases
+
+- Containment: 80.00%
+- Detection: 60.00%
+- Evidence: 40.00%
+- False-positive rate: 0.00%
+
+## Execution and bundle status
+
+- Execution status: complete
+- Execution blocked: false
+- Execution publication eligibility: true
+- Execution failures:
+  - None declared
+- Execution review notes:
+  - None declared
+- Run-bundle declared validation status: complete
+- Run-bundle publication eligibility: true
+- Run-bundle noncanonical reasons:
+  - None declared
+- Publication eligibility recorded by the run: Not established because retained validation checks are not valid
+- Run-bundle digest and binding recheck: Invalid: results.jsonl not-applicable rows do not match the summary count; summary declares 5 error cases but results.jsonl contains 0; summary declares 97 applicable cases but results.jsonl contains 2; summary declares 99 total cases but results.jsonl contains 2
+- Execution-decision consistency: Self-consistent: run identifier and evidence digests match the bundle
+
+These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.
+
+## Non-claims
+
+This result does not establish:
+
+- a formal conformance status, accreditation, or pass mark;
+- legal or regulatory compliance;
+- insurance eligibility or pricing;
+- security outside the exercised capability profile;
+- absence of evasions, including variants of classes exercised here.
+
+## Reproduce the run
+
+Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.
+
+Credential-shaped values in the commands below are replaced with REDACTED. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.
+
+### Entrypoint command
+
+    ./run-gauntlet.sh --output-dir ./artifacts
+
+### Recorded runner command
+
+    ./runner --adapter example --scan-token REDACTED --cases ./cases --profile ./profile.json
+
+### Retained material
+
+- case-index.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- checksums.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- command.txt (sha256 d2068c6f30093a7d4621fde48d8e38054f881b7db06dbd45a4217de8981003fa)
+- corpus-manifest.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- entrypoint-command.txt (sha256 6ed6633e53c72b755d52398b49031be5bf998feab21f904e02ebf9432ef05b9a)
+- make-stats.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-release.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-version.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- raw-summary.json (sha256 05412fc8e727ba13a57401c8d863a0a21b548fc00f136b63730fd4027a217e10)
+- results.jsonl (sha256 d1413b853523d00171fb500f4c0bb02973cd4aa2276c1eed650295f9eace651f)
+- run-metadata.json (sha256 2ec73028d323d3cf0d2bd7b3e8eb598f515aa3e0f0053e46ef03a53916ac1bc4)
+- runner.stderr (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)

--- a/runner/testdata/buyer-report/errors.golden.md
+++ b/runner/testdata/buyer-report/errors.golden.md
@@ -1,0 +1,127 @@
+# Agent Egress Bench Run Report
+
+This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.
+
+## Artifact input status
+
+- raw-summary.json: Readable
+- results.jsonl: Readable
+- run-metadata.json: Readable
+- run-bundle.json: Readable
+- execution-decision.json: Readable
+
+## Method identity
+
+- Repository: example/agent-egress-bench
+- Exact commit: cccccccccccccccccccccccccccccccccccccccc
+- Corpus version: v2.3.0
+- Gauntlet version: 1.0
+- Scoring version: 2.4
+- Runner version: 0.4.2
+- Run date: 2026-08-05T12:00:00Z
+- corpus_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+## Target identity
+
+- Product: example-tool
+- Version: 1.2.3
+- Declared configuration: /etc/example/target.yaml
+- Declared configuration digest: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+## Capability profile and adapter
+
+- tool_profile_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+- Declared capability claims:
+  - ssrf
+  - url\_dlp
+- Unsupported transports:
+  - a2a
+- Unsupported requirements:
+  - dns\_rebinding\_fixture
+- Adapter identity: example
+- Adapter owner: Example Lab
+
+## Scope
+
+- Total cases: 2
+- Applicable cases: 2
+- Not-applicable cases: 0
+- Error cases: 1
+- Not-applicable case IDs and reasons:
+  - None recorded
+
+## Metric vector
+
+Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.
+
+### Full corpus
+
+- Containment: 75.00%
+- Detection: 50.00%
+- Evidence: 25.00%
+- False-positive rate: 10.00%
+
+### Applicable cases
+
+- Containment: 80.00%
+- Detection: 60.00%
+- Evidence: 40.00%
+- False-positive rate: 0.00%
+
+## Execution and bundle status
+
+- Execution status: blocked
+- Execution blocked: true
+- Execution publication eligibility: false
+- Execution failures:
+  - runner produced an error result
+- Execution review notes:
+  - None declared
+- Run-bundle declared validation status: partial
+- Run-bundle publication eligibility: false
+- Run-bundle noncanonical reasons:
+  - None declared
+- Publication eligibility recorded by the run: Recorded not eligible by both retained decisions
+- Run-bundle digest and binding recheck: Incomplete: partial bundle with 12 retained evidence digests matching
+- Execution-decision consistency: Self-consistent: run identifier and evidence digests match the bundle
+
+These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.
+
+## Non-claims
+
+This result does not establish:
+
+- a formal conformance status, accreditation, or pass mark;
+- legal or regulatory compliance;
+- insurance eligibility or pricing;
+- security outside the exercised capability profile;
+- absence of evasions, including variants of classes exercised here.
+
+## Reproduce the run
+
+Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.
+
+Credential-shaped values in the commands below are replaced with REDACTED. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.
+
+### Entrypoint command
+
+    ./run-gauntlet.sh --output-dir ./artifacts
+
+### Recorded runner command
+
+    ./runner --adapter example --scan-token REDACTED --cases ./cases --profile ./profile.json
+
+### Retained material
+
+- case-index.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- checksums.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- command.txt (sha256 d2068c6f30093a7d4621fde48d8e38054f881b7db06dbd45a4217de8981003fa)
+- corpus-manifest.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- entrypoint-command.txt (sha256 6ed6633e53c72b755d52398b49031be5bf998feab21f904e02ebf9432ef05b9a)
+- make-stats.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-release.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-version.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- raw-summary.json (sha256 0a50659b20a2fd40ddeb6805f267a325130405412be9a32a840bd1c4c8b62c94)
+- results.jsonl (sha256 dd4412b3d57f605224d43cefda25af01d57bf73fd351dd934d1c736bd6becb33)
+- run-metadata.json (sha256 2ec73028d323d3cf0d2bd7b3e8eb598f515aa3e0f0053e46ef03a53916ac1bc4)
+- runner.stderr (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)

--- a/runner/testdata/buyer-report/healthy.golden.md
+++ b/runner/testdata/buyer-report/healthy.golden.md
@@ -1,0 +1,127 @@
+# Agent Egress Bench Run Report
+
+This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.
+
+## Artifact input status
+
+- raw-summary.json: Readable
+- results.jsonl: Readable
+- run-metadata.json: Readable
+- run-bundle.json: Readable
+- execution-decision.json: Readable
+
+## Method identity
+
+- Repository: example/agent-egress-bench
+- Exact commit: cccccccccccccccccccccccccccccccccccccccc
+- Corpus version: v2.3.0
+- Gauntlet version: 1.0
+- Scoring version: 2.4
+- Runner version: 0.4.2
+- Run date: 2026-08-05T12:00:00Z
+- corpus_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+## Target identity
+
+- Product: example-tool
+- Version: 1.2.3
+- Declared configuration: /etc/example/target.yaml
+- Declared configuration digest: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+## Capability profile and adapter
+
+- tool_profile_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+- Declared capability claims:
+  - ssrf
+  - url\_dlp
+- Unsupported transports:
+  - a2a
+- Unsupported requirements:
+  - dns\_rebinding\_fixture
+- Adapter identity: example
+- Adapter owner: Example Lab
+
+## Scope
+
+- Total cases: 2
+- Applicable cases: 2
+- Not-applicable cases: 0
+- Error cases: 0
+- Not-applicable case IDs and reasons:
+  - None recorded
+
+## Metric vector
+
+Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.
+
+### Full corpus
+
+- Containment: 75.00%
+- Detection: 50.00%
+- Evidence: 25.00%
+- False-positive rate: 10.00%
+
+### Applicable cases
+
+- Containment: 80.00%
+- Detection: 60.00%
+- Evidence: 40.00%
+- False-positive rate: 0.00%
+
+## Execution and bundle status
+
+- Execution status: complete
+- Execution blocked: false
+- Execution publication eligibility: true
+- Execution failures:
+  - None declared
+- Execution review notes:
+  - None declared
+- Run-bundle declared validation status: complete
+- Run-bundle publication eligibility: true
+- Run-bundle noncanonical reasons:
+  - None declared
+- Publication eligibility recorded by the run: Recorded eligible by both retained decisions
+- Run-bundle digest and binding recheck: Self-consistent: 12 retained evidence digests match the bundle
+- Execution-decision consistency: Self-consistent: run identifier and evidence digests match the bundle
+
+These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.
+
+## Non-claims
+
+This result does not establish:
+
+- a formal conformance status, accreditation, or pass mark;
+- legal or regulatory compliance;
+- insurance eligibility or pricing;
+- security outside the exercised capability profile;
+- absence of evasions, including variants of classes exercised here.
+
+## Reproduce the run
+
+Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.
+
+Credential-shaped values in the commands below are replaced with REDACTED. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.
+
+### Entrypoint command
+
+    ./run-gauntlet.sh --output-dir ./artifacts
+
+### Recorded runner command
+
+    ./runner --adapter example --scan-token REDACTED --cases ./cases --profile ./profile.json
+
+### Retained material
+
+- case-index.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- checksums.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- command.txt (sha256 d2068c6f30093a7d4621fde48d8e38054f881b7db06dbd45a4217de8981003fa)
+- corpus-manifest.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- entrypoint-command.txt (sha256 6ed6633e53c72b755d52398b49031be5bf998feab21f904e02ebf9432ef05b9a)
+- make-stats.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-release.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-version.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- raw-summary.json (sha256 d144bc083fc6baf7b6841676f672e06aa8191720b1dcb9d0b887861c6f20ebf0)
+- results.jsonl (sha256 d1413b853523d00171fb500f4c0bb02973cd4aa2276c1eed650295f9eace651f)
+- run-metadata.json (sha256 2ec73028d323d3cf0d2bd7b3e8eb598f515aa3e0f0053e46ef03a53916ac1bc4)
+- runner.stderr (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)

--- a/runner/testdata/buyer-report/malformed-summary.golden.md
+++ b/runner/testdata/buyer-report/malformed-summary.golden.md
@@ -1,0 +1,126 @@
+# Agent Egress Bench Run Report
+
+This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.
+
+## Artifact input status
+
+- raw-summary.json: Malformed JSON: unexpected EOF
+- results.jsonl: Readable
+- run-metadata.json: Readable
+- run-bundle.json: Readable
+- execution-decision.json: Readable
+
+## Method identity
+
+- Repository: example/agent-egress-bench
+- Exact commit: cccccccccccccccccccccccccccccccccccccccc
+- Corpus version: Absent from run artifacts
+- Gauntlet version: Absent from run artifacts
+- Scoring version: Absent from run artifacts
+- Runner version: Absent from run artifacts
+- Run date: Absent from run artifacts
+- corpus_sha256: Absent from run artifacts
+
+## Target identity
+
+- Product: Absent from run artifacts
+- Version: Absent from run artifacts
+- Declared configuration: Absent from run artifacts
+- Declared configuration digest: Absent from run artifacts
+
+## Capability profile and adapter
+
+- tool_profile_sha256: Absent from run artifacts
+- Declared capability claims:
+  - Absent from run artifacts
+- Unsupported transports:
+  - Absent from run artifacts
+- Unsupported requirements:
+  - Absent from run artifacts
+- Adapter identity: Absent from run artifacts
+- Adapter owner: Absent from run artifacts
+
+## Scope
+
+- Total cases: Absent from run artifacts
+- Applicable cases: Absent from run artifacts
+- Not-applicable cases: Absent from run artifacts
+- Error cases: Absent from run artifacts
+- Not-applicable case IDs and reasons:
+  - Invalid: the summary does not carry a usable not-applicable count
+
+## Metric vector
+
+Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.
+
+### Full corpus
+
+- Containment: Absent from run artifacts
+- Detection: Absent from run artifacts
+- Evidence: Absent from run artifacts
+- False-positive rate: Absent from run artifacts
+
+### Applicable cases
+
+- Containment: Absent from run artifacts
+- Detection: Absent from run artifacts
+- Evidence: Absent from run artifacts
+- False-positive rate: Absent from run artifacts
+
+## Execution and bundle status
+
+- Execution status: complete
+- Execution blocked: false
+- Execution publication eligibility: true
+- Execution failures:
+  - None declared
+- Execution review notes:
+  - None declared
+- Run-bundle declared validation status: complete
+- Run-bundle publication eligibility: true
+- Run-bundle noncanonical reasons:
+  - None declared
+- Publication eligibility recorded by the run: Not established because retained validation checks are not valid
+- Run-bundle digest and binding recheck: Invalid: raw-summary.json is not readable JSON; summary case counts are absent or malformed
+- Execution-decision consistency: Self-consistent: run identifier and evidence digests match the bundle
+
+These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.
+
+## Non-claims
+
+This result does not establish:
+
+- a formal conformance status, accreditation, or pass mark;
+- legal or regulatory compliance;
+- insurance eligibility or pricing;
+- security outside the exercised capability profile;
+- absence of evasions, including variants of classes exercised here.
+
+## Reproduce the run
+
+Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.
+
+Credential-shaped values in the commands below are replaced with REDACTED. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.
+
+### Entrypoint command
+
+    ./run-gauntlet.sh --output-dir ./artifacts
+
+### Recorded runner command
+
+    ./runner --adapter example --scan-token REDACTED --cases ./cases --profile ./profile.json
+
+### Retained material
+
+- case-index.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- checksums.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- command.txt (sha256 d2068c6f30093a7d4621fde48d8e38054f881b7db06dbd45a4217de8981003fa)
+- corpus-manifest.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- entrypoint-command.txt (sha256 6ed6633e53c72b755d52398b49031be5bf998feab21f904e02ebf9432ef05b9a)
+- make-stats.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-release.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-version.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- raw-summary.json (sha256 a6fb08fda1acb957b6116bd37811a1fe41a01611c0631edbf786d6889a27a55c)
+- results.jsonl (sha256 d1413b853523d00171fb500f4c0bb02973cd4aa2276c1eed650295f9eace651f)
+- run-metadata.json (sha256 2ec73028d323d3cf0d2bd7b3e8eb598f515aa3e0f0053e46ef03a53916ac1bc4)
+- runner.stderr (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)

--- a/runner/testdata/buyer-report/missing-optional.golden.md
+++ b/runner/testdata/buyer-report/missing-optional.golden.md
@@ -1,0 +1,127 @@
+# Agent Egress Bench Run Report
+
+This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.
+
+## Artifact input status
+
+- raw-summary.json: Readable
+- results.jsonl: Readable
+- run-metadata.json: Readable
+- run-bundle.json: Readable
+- execution-decision.json: Readable
+
+## Method identity
+
+- Repository: example/agent-egress-bench
+- Exact commit: cccccccccccccccccccccccccccccccccccccccc
+- Corpus version: v2.3.0
+- Gauntlet version: 1.0
+- Scoring version: 2.4
+- Runner version: 0.4.2
+- Run date: Absent from run artifacts
+- corpus_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+## Target identity
+
+- Product: example-tool
+- Version: 1.2.3
+- Declared configuration: /etc/example/target.yaml
+- Declared configuration digest: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+## Capability profile and adapter
+
+- tool_profile_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+- Declared capability claims:
+  - ssrf
+  - url\_dlp
+- Unsupported transports:
+  - a2a
+- Unsupported requirements:
+  - dns\_rebinding\_fixture
+- Adapter identity: example
+- Adapter owner: Example Lab
+
+## Scope
+
+- Total cases: 2
+- Applicable cases: 2
+- Not-applicable cases: 0
+- Error cases: 0
+- Not-applicable case IDs and reasons:
+  - None recorded
+
+## Metric vector
+
+Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.
+
+### Full corpus
+
+- Containment: 75.00%
+- Detection: 50.00%
+- Evidence: 25.00%
+- False-positive rate: 10.00%
+
+### Applicable cases
+
+- Containment: 80.00%
+- Detection: 60.00%
+- Evidence: 40.00%
+- False-positive rate: 0.00%
+
+## Execution and bundle status
+
+- Execution status: complete
+- Execution blocked: false
+- Execution publication eligibility: true
+- Execution failures:
+  - None declared
+- Execution review notes:
+  - None declared
+- Run-bundle declared validation status: complete
+- Run-bundle publication eligibility: true
+- Run-bundle noncanonical reasons:
+  - None declared
+- Publication eligibility recorded by the run: Recorded eligible by both retained decisions
+- Run-bundle digest and binding recheck: Self-consistent: 12 retained evidence digests match the bundle
+- Execution-decision consistency: Self-consistent: run identifier and evidence digests match the bundle
+
+These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.
+
+## Non-claims
+
+This result does not establish:
+
+- a formal conformance status, accreditation, or pass mark;
+- legal or regulatory compliance;
+- insurance eligibility or pricing;
+- security outside the exercised capability profile;
+- absence of evasions, including variants of classes exercised here.
+
+## Reproduce the run
+
+Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.
+
+Credential-shaped values in the commands below are replaced with REDACTED. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.
+
+### Entrypoint command
+
+    ./run-gauntlet.sh --output-dir ./artifacts
+
+### Recorded runner command
+
+    ./runner --adapter example --scan-token REDACTED --cases ./cases --profile ./profile.json
+
+### Retained material
+
+- case-index.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- checksums.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- command.txt (sha256 d2068c6f30093a7d4621fde48d8e38054f881b7db06dbd45a4217de8981003fa)
+- corpus-manifest.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- entrypoint-command.txt (sha256 6ed6633e53c72b755d52398b49031be5bf998feab21f904e02ebf9432ef05b9a)
+- make-stats.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-release.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-version.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- raw-summary.json (sha256 28e32b3fdc83ad58d1e5518440af1edd67565d0b4a5c4c246878c9bbad9600e5)
+- results.jsonl (sha256 d1413b853523d00171fb500f4c0bb02973cd4aa2276c1eed650295f9eace651f)
+- run-metadata.json (sha256 2ec73028d323d3cf0d2bd7b3e8eb598f515aa3e0f0053e46ef03a53916ac1bc4)
+- runner.stderr (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)

--- a/runner/testdata/buyer-report/missing-required.golden.md
+++ b/runner/testdata/buyer-report/missing-required.golden.md
@@ -1,0 +1,127 @@
+# Agent Egress Bench Run Report
+
+This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.
+
+## Artifact input status
+
+- raw-summary.json: Readable
+- results.jsonl: Readable
+- run-metadata.json: Readable
+- run-bundle.json: Readable
+- execution-decision.json: Readable
+
+## Method identity
+
+- Repository: example/agent-egress-bench
+- Exact commit: cccccccccccccccccccccccccccccccccccccccc
+- Corpus version: v2.3.0
+- Gauntlet version: 1.0
+- Scoring version: Absent from run artifacts
+- Runner version: 0.4.2
+- Run date: 2026-08-05T12:00:00Z
+- corpus_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+## Target identity
+
+- Product: example-tool
+- Version: 1.2.3
+- Declared configuration: /etc/example/target.yaml
+- Declared configuration digest: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+## Capability profile and adapter
+
+- tool_profile_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+- Declared capability claims:
+  - ssrf
+  - url\_dlp
+- Unsupported transports:
+  - a2a
+- Unsupported requirements:
+  - dns\_rebinding\_fixture
+- Adapter identity: example
+- Adapter owner: Example Lab
+
+## Scope
+
+- Total cases: 2
+- Applicable cases: 2
+- Not-applicable cases: 0
+- Error cases: 0
+- Not-applicable case IDs and reasons:
+  - None recorded
+
+## Metric vector
+
+Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.
+
+### Full corpus
+
+- Containment: 75.00%
+- Detection: 50.00%
+- Evidence: 25.00%
+- False-positive rate: 10.00%
+
+### Applicable cases
+
+- Containment: 80.00%
+- Detection: 60.00%
+- Evidence: 40.00%
+- False-positive rate: 0.00%
+
+## Execution and bundle status
+
+- Execution status: complete
+- Execution blocked: false
+- Execution publication eligibility: true
+- Execution failures:
+  - None declared
+- Execution review notes:
+  - None declared
+- Run-bundle declared validation status: complete
+- Run-bundle publication eligibility: true
+- Run-bundle noncanonical reasons:
+  - None declared
+- Publication eligibility recorded by the run: Not established because retained validation checks are not valid
+- Run-bundle digest and binding recheck: Invalid: candidate\_scope.scoring\_version does not match raw-summary.json
+- Execution-decision consistency: Self-consistent: run identifier and evidence digests match the bundle
+
+These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.
+
+## Non-claims
+
+This result does not establish:
+
+- a formal conformance status, accreditation, or pass mark;
+- legal or regulatory compliance;
+- insurance eligibility or pricing;
+- security outside the exercised capability profile;
+- absence of evasions, including variants of classes exercised here.
+
+## Reproduce the run
+
+Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.
+
+Credential-shaped values in the commands below are replaced with REDACTED. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.
+
+### Entrypoint command
+
+    ./run-gauntlet.sh --output-dir ./artifacts
+
+### Recorded runner command
+
+    ./runner --adapter example --scan-token REDACTED --cases ./cases --profile ./profile.json
+
+### Retained material
+
+- case-index.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- checksums.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- command.txt (sha256 d2068c6f30093a7d4621fde48d8e38054f881b7db06dbd45a4217de8981003fa)
+- corpus-manifest.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- entrypoint-command.txt (sha256 6ed6633e53c72b755d52398b49031be5bf998feab21f904e02ebf9432ef05b9a)
+- make-stats.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-release.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-version.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- raw-summary.json (sha256 80750ec30b5a0937f1d3d6168bca10a1a7c50f6c828b9868c91e41712805f54b)
+- results.jsonl (sha256 d1413b853523d00171fb500f4c0bb02973cd4aa2276c1eed650295f9eace651f)
+- run-metadata.json (sha256 2ec73028d323d3cf0d2bd7b3e8eb598f515aa3e0f0053e46ef03a53916ac1bc4)
+- runner.stderr (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)

--- a/runner/testdata/buyer-report/not-applicable.golden.md
+++ b/runner/testdata/buyer-report/not-applicable.golden.md
@@ -1,0 +1,127 @@
+# Agent Egress Bench Run Report
+
+This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.
+
+## Artifact input status
+
+- raw-summary.json: Readable
+- results.jsonl: Readable
+- run-metadata.json: Readable
+- run-bundle.json: Readable
+- execution-decision.json: Readable
+
+## Method identity
+
+- Repository: example/agent-egress-bench
+- Exact commit: cccccccccccccccccccccccccccccccccccccccc
+- Corpus version: v2.3.0
+- Gauntlet version: 1.0
+- Scoring version: 2.4
+- Runner version: 0.4.2
+- Run date: 2026-08-05T12:00:00Z
+- corpus_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+## Target identity
+
+- Product: example-tool
+- Version: 1.2.3
+- Declared configuration: /etc/example/target.yaml
+- Declared configuration digest: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+## Capability profile and adapter
+
+- tool_profile_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+- Declared capability claims:
+  - ssrf
+  - url\_dlp
+- Unsupported transports:
+  - a2a
+- Unsupported requirements:
+  - dns\_rebinding\_fixture
+- Adapter identity: example
+- Adapter owner: Example Lab
+
+## Scope
+
+- Total cases: 3
+- Applicable cases: 2
+- Not-applicable cases: 1
+- Error cases: 0
+- Not-applicable case IDs and reasons:
+  - `mcp-chain-budget-003`: missing\_requires
+
+## Metric vector
+
+Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.
+
+### Full corpus
+
+- Containment: 75.00%
+- Detection: 50.00%
+- Evidence: 25.00%
+- False-positive rate: 10.00%
+
+### Applicable cases
+
+- Containment: 80.00%
+- Detection: 60.00%
+- Evidence: 40.00%
+- False-positive rate: 0.00%
+
+## Execution and bundle status
+
+- Execution status: complete
+- Execution blocked: false
+- Execution publication eligibility: true
+- Execution failures:
+  - None declared
+- Execution review notes:
+  - None declared
+- Run-bundle declared validation status: complete
+- Run-bundle publication eligibility: true
+- Run-bundle noncanonical reasons:
+  - None declared
+- Publication eligibility recorded by the run: Recorded eligible by both retained decisions
+- Run-bundle digest and binding recheck: Self-consistent: 12 retained evidence digests match the bundle
+- Execution-decision consistency: Self-consistent: run identifier and evidence digests match the bundle
+
+These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.
+
+## Non-claims
+
+This result does not establish:
+
+- a formal conformance status, accreditation, or pass mark;
+- legal or regulatory compliance;
+- insurance eligibility or pricing;
+- security outside the exercised capability profile;
+- absence of evasions, including variants of classes exercised here.
+
+## Reproduce the run
+
+Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.
+
+Credential-shaped values in the commands below are replaced with REDACTED. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.
+
+### Entrypoint command
+
+    ./run-gauntlet.sh --output-dir ./artifacts
+
+### Recorded runner command
+
+    ./runner --adapter example --scan-token REDACTED --cases ./cases --profile ./profile.json
+
+### Retained material
+
+- case-index.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- checksums.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- command.txt (sha256 d2068c6f30093a7d4621fde48d8e38054f881b7db06dbd45a4217de8981003fa)
+- corpus-manifest.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- entrypoint-command.txt (sha256 6ed6633e53c72b755d52398b49031be5bf998feab21f904e02ebf9432ef05b9a)
+- make-stats.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-release.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-version.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- raw-summary.json (sha256 f7d1b990266c2414dfb9229de09de38e5ea524d3eea141d1697dfc9996b4928c)
+- results.jsonl (sha256 d87a06242c0ef502b851a1fb5d3d20b4097516f2164e1f938fbee11d9fdbf560)
+- run-metadata.json (sha256 2ec73028d323d3cf0d2bd7b3e8eb598f515aa3e0f0053e46ef03a53916ac1bc4)
+- runner.stderr (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)

--- a/runner/testdata/buyer-report/not-publication-eligible.golden.md
+++ b/runner/testdata/buyer-report/not-publication-eligible.golden.md
@@ -1,0 +1,127 @@
+# Agent Egress Bench Run Report
+
+This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.
+
+## Artifact input status
+
+- raw-summary.json: Readable
+- results.jsonl: Readable
+- run-metadata.json: Readable
+- run-bundle.json: Readable
+- execution-decision.json: Readable
+
+## Method identity
+
+- Repository: example/agent-egress-bench
+- Exact commit: cccccccccccccccccccccccccccccccccccccccc
+- Corpus version: v2.3.0
+- Gauntlet version: 1.0
+- Scoring version: 2.4
+- Runner version: 0.4.2
+- Run date: 2026-08-05T12:00:00Z
+- corpus_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+## Target identity
+
+- Product: example-tool
+- Version: 1.2.3
+- Declared configuration: /etc/example/target.yaml
+- Declared configuration digest: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+## Capability profile and adapter
+
+- tool_profile_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+- Declared capability claims:
+  - ssrf
+  - url\_dlp
+- Unsupported transports:
+  - a2a
+- Unsupported requirements:
+  - dns\_rebinding\_fixture
+- Adapter identity: example
+- Adapter owner: Example Lab
+
+## Scope
+
+- Total cases: 2
+- Applicable cases: 2
+- Not-applicable cases: 0
+- Error cases: 0
+- Not-applicable case IDs and reasons:
+  - None recorded
+
+## Metric vector
+
+Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.
+
+### Full corpus
+
+- Containment: 75.00%
+- Detection: 50.00%
+- Evidence: 25.00%
+- False-positive rate: 10.00%
+
+### Applicable cases
+
+- Containment: 80.00%
+- Detection: 60.00%
+- Evidence: 40.00%
+- False-positive rate: 0.00%
+
+## Execution and bundle status
+
+- Execution status: complete
+- Execution blocked: false
+- Execution publication eligibility: false
+- Execution failures:
+  - None declared
+- Execution review notes:
+  - development execution
+- Run-bundle declared validation status: complete
+- Run-bundle publication eligibility: false
+- Run-bundle noncanonical reasons:
+  - development execution
+- Publication eligibility recorded by the run: Recorded not eligible by both retained decisions
+- Run-bundle digest and binding recheck: Self-consistent: 12 retained evidence digests match the bundle
+- Execution-decision consistency: Self-consistent: run identifier and evidence digests match the bundle
+
+These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.
+
+## Non-claims
+
+This result does not establish:
+
+- a formal conformance status, accreditation, or pass mark;
+- legal or regulatory compliance;
+- insurance eligibility or pricing;
+- security outside the exercised capability profile;
+- absence of evasions, including variants of classes exercised here.
+
+## Reproduce the run
+
+Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.
+
+Credential-shaped values in the commands below are replaced with REDACTED. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.
+
+### Entrypoint command
+
+    ./run-gauntlet.sh --output-dir ./artifacts
+
+### Recorded runner command
+
+    ./runner --adapter example --scan-token REDACTED --cases ./cases --profile ./profile.json
+
+### Retained material
+
+- case-index.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- checksums.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- command.txt (sha256 d2068c6f30093a7d4621fde48d8e38054f881b7db06dbd45a4217de8981003fa)
+- corpus-manifest.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- entrypoint-command.txt (sha256 6ed6633e53c72b755d52398b49031be5bf998feab21f904e02ebf9432ef05b9a)
+- make-stats.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-release.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-version.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- raw-summary.json (sha256 d144bc083fc6baf7b6841676f672e06aa8191720b1dcb9d0b887861c6f20ebf0)
+- results.jsonl (sha256 d1413b853523d00171fb500f4c0bb02973cd4aa2276c1eed650295f9eace651f)
+- run-metadata.json (sha256 2ec73028d323d3cf0d2bd7b3e8eb598f515aa3e0f0053e46ef03a53916ac1bc4)
+- runner.stderr (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)

--- a/runner/testdata/buyer-report/unknown-verdict.golden.md
+++ b/runner/testdata/buyer-report/unknown-verdict.golden.md
@@ -1,0 +1,127 @@
+# Agent Egress Bench Run Report
+
+This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.
+
+## Artifact input status
+
+- raw-summary.json: Readable
+- results.jsonl: Malformed JSONL at line 2
+- run-metadata.json: Readable
+- run-bundle.json: Readable
+- execution-decision.json: Readable
+
+## Method identity
+
+- Repository: example/agent-egress-bench
+- Exact commit: cccccccccccccccccccccccccccccccccccccccc
+- Corpus version: v2.3.0
+- Gauntlet version: 1.0
+- Scoring version: 2.4
+- Runner version: 0.4.2
+- Run date: 2026-08-05T12:00:00Z
+- corpus_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+## Target identity
+
+- Product: example-tool
+- Version: 1.2.3
+- Declared configuration: /etc/example/target.yaml
+- Declared configuration digest: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+
+## Capability profile and adapter
+
+- tool_profile_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+- Declared capability claims:
+  - ssrf
+  - url\_dlp
+- Unsupported transports:
+  - a2a
+- Unsupported requirements:
+  - dns\_rebinding\_fixture
+- Adapter identity: example
+- Adapter owner: Example Lab
+
+## Scope
+
+- Total cases: 2
+- Applicable cases: 2
+- Not-applicable cases: 0
+- Error cases: 0
+- Not-applicable case IDs and reasons:
+  - Malformed JSONL at line 2
+
+## Metric vector
+
+Each metric stands on its own. Full-corpus scores retain out-of-scope cases in their denominators; applicable-only scores describe the declared supported scope.
+
+### Full corpus
+
+- Containment: 75.00%
+- Detection: 50.00%
+- Evidence: 25.00%
+- False-positive rate: 10.00%
+
+### Applicable cases
+
+- Containment: 80.00%
+- Detection: 60.00%
+- Evidence: 40.00%
+- False-positive rate: 0.00%
+
+## Execution and bundle status
+
+- Execution status: complete
+- Execution blocked: false
+- Execution publication eligibility: true
+- Execution failures:
+  - None declared
+- Execution review notes:
+  - None declared
+- Run-bundle declared validation status: complete
+- Run-bundle publication eligibility: true
+- Run-bundle noncanonical reasons:
+  - None declared
+- Publication eligibility recorded by the run: Not established because retained validation checks are not valid
+- Run-bundle digest and binding recheck: Invalid: results.jsonl could not be validated: Malformed JSONL at line 2
+- Execution-decision consistency: Self-consistent: run identifier and evidence digests match the bundle
+
+These three lines are an internal consistency check. Every input to them, including the digests they compare against, comes from the supplied artifact directory, so they show the retained files agree with each other. They do not authenticate the bundle against anything outside it, and a directory edited as a whole would still reconcile. Independent assurance needs a signature over the bundle from a key the reader already trusts, which this corpus does not yet produce.
+
+## Non-claims
+
+This result does not establish:
+
+- a formal conformance status, accreditation, or pass mark;
+- legal or regulatory compliance;
+- insurance eligibility or pricing;
+- security outside the exercised capability profile;
+- absence of evasions, including variants of classes exercised here.
+
+## Reproduce the run
+
+Run the retained entrypoint command from a checkout of the repository and exact commit listed above. The entrypoint records the runner command and material files used by this result.
+
+Credential-shaped values in the commands below are replaced with REDACTED. Read them before publishing anyway: local paths and hostnames are preserved so the run can be reproduced, and no denylist recognizes every secret.
+
+### Entrypoint command
+
+    ./run-gauntlet.sh --output-dir ./artifacts
+
+### Recorded runner command
+
+    ./runner --adapter example --scan-token REDACTED --cases ./cases --profile ./profile.json
+
+### Retained material
+
+- case-index.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- checksums.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- command.txt (sha256 d2068c6f30093a7d4621fde48d8e38054f881b7db06dbd45a4217de8981003fa)
+- corpus-manifest.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- entrypoint-command.txt (sha256 6ed6633e53c72b755d52398b49031be5bf998feab21f904e02ebf9432ef05b9a)
+- make-stats.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-release.json (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- pipelock-version.txt (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)
+- raw-summary.json (sha256 d144bc083fc6baf7b6841676f672e06aa8191720b1dcb9d0b887861c6f20ebf0)
+- results.jsonl (sha256 416dba184497ca4104aaace8e447ffbe9d596e9f96f6a70f24aa93e29713f850)
+- run-metadata.json (sha256 2ec73028d323d3cf0d2bd7b3e8eb598f515aa3e0f0053e46ef03a53916ac1bc4)
+- runner.stderr (sha256 9bdaff9d24e8e222099c05ad4495d5828e9f455b31759ebb0e6dcd96d881b460)


### PR DESCRIPTION
A finished run produces a summary and supporting artifacts, and a person deciding whether to trust the result has to read raw JSON and already know what each field means. There was no artifact you could hand a buyer, an auditor, or a maintainer that states what ran, against what, under which declared capabilities, what was out of scope and why, and what the numbers do and do not establish.

`--report <artifact-dir>` renders that from artifacts a run already produces. Method and target identity, the capability profile and adapter, scope with every not-applicable case ID and its reason, the four metrics reported separately, artifact-validation status, the non-claims, and the command needed to reproduce the run. Everything is derived; nothing is inferred. A fact the artifacts do not carry is rendered as an explicit absence, because a blank in a reproduction section cannot be told apart from a rendering bug. Failed, errored, partial, and publication-ineligible runs still produce a readable report that says so.

## Facts the summary could not carry

Writing the report surfaced a gap between the results-use policy and the tooling. The policy lists the facts that must travel with a public score, and the summary had nowhere to put three of them: the repository and commit the corpus came from, who authored the adapter that drove the target, and the configuration the score describes. An operator following the policy could not comply, and those lines rendered as permanently absent.

The runner now takes them as explicit operator declarations through `--method-repository`, `--method-commit`, `--adapter-owner`, and `--target-config`, which is hashed so the configuration is identified rather than merely named. Adapter identity comes from the adapter already selected. An undeclared fact is omitted from the JSON rather than written as an empty string, so a reader can tell a fact nobody declared from one declared as nothing. The policy no longer claims the runner already writes most of this.

## A gate that could not fail

`make validate` exited zero without running anything. A directory named `validate/` holds the validator source and no `validate:` rule existed, so Make treated the target as already satisfied. Anyone reading a green `make validate`, including the contributor guide, was reading a check that could not fail. It is now a `.PHONY` alias for `validate-cases`.

## Scope

No case file, corpus content, or scoring behavior changes here. This adds a rendering layer over existing output and one Makefile correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added buyer-readable Markdown reports generated from retained run artifacts without rerunning cases or recalculating scores.
  - Reports include declared repository, commit, adapter ownership, and target configuration details.
  - Added validation for artifact integrity, evidence, scope, execution status, and publication eligibility, clearly identifying missing or invalid data.
  - Sensitive credentials and local details are redacted from reproduction commands.

- **Documentation**
  - Documented report usage, supported artifacts, validation behavior, limitations, and provenance handling.

- **Chores**
  - Added a `validate` command alias for simpler validation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->