### PR TITLE
fix: scope Gauntlet promotion token permissions

### DIFF
--- a/.github/workflows/promote-gauntlet-result.yaml
+++ b/.github/workflows/promote-gauntlet-result.yaml
@@ -15,10 +15,7 @@ on:
         default: false
         type: boolean
 
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   # Every promotion updates the same baseline and pointer. Serialize different
@@ -28,6 +25,10 @@ concurrency:
 
 jobs:
   prepare:
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/scripts/promote_gauntlet_workflow_test.py
+++ b/scripts/promote_gauntlet_workflow_test.py
@@ -39,9 +39,13 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("accept_policy_change:", trigger)
 
     def test_write_permissions_are_isolated_from_scheduled_lane(self):
+        self.assertRegex(self.workflow, r"(?m)^permissions: \{\}$")
         self.assertRegex(
             self.workflow,
-            r"(?m)^permissions:\n  actions: write\n  contents: write\n  pull-requests: write$",
+            r"(?m)^  prepare:\n    permissions:\n"
+            r"      actions: write\n"
+            r"      contents: write\n"
+            r"      pull-requests: write$",
         )
         scheduled = (REPO_ROOT / ".github" / "workflows" / "continuous-gauntlet.yaml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
Scope the Gauntlet promotion workflow's write permissions to the prepare job. This clears the Scorecard Token-Permissions alerts without changing the permissions needed to create promotion PRs and dispatch validation workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted default workflow permissions and limited write access to the specific job that requires it.
* **Tests**
  * Updated workflow validation to confirm the new permission boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->