### PR TITLE
fix(review): prevent empty deep reviews

### DIFF
--- a/scripts/pr-review.py
+++ b/scripts/pr-review.py
@@ -35,11 +35,13 @@ DEFAULT_MODEL_FAST = "gpt-5.6-luna"
 DEFAULT_MODEL_DEEP = "gpt-5.6-terra"
 DEFAULT_TEMPERATURE = 0.2
 DEFAULT_MAX_COMPLETION_TOKENS = 8192
-DEEP_MAX_COMPLETION_TOKENS = 25000
+# max_completion_tokens is shared by reasoning and visible output. At xhigh
+# effort, 25000 was consumed by reasoning alone and produced an empty review.
+DEEP_MAX_COMPLETION_TOKENS = 64000
 DEFAULT_LLM_TIMEOUT_SECONDS = 120
 DEEP_LLM_TIMEOUT_SECONDS = 300
 FAST_REASONING_EFFORT = "low"
-DEEP_REASONING_EFFORT = "medium"
+DEEP_REASONING_EFFORT = "xhigh"
 
 
 class LLMReviewError(RuntimeError):

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -48,9 +48,7 @@ class PayloadTest(unittest.TestCase):
             reasoning_effort=pr_review.DEEP_REASONING_EFFORT,
         )
         self.assertEqual(payload["reasoning_effort"], "xhigh")
-        self.assertEqual(
-            payload["max_completion_tokens"], pr_review.DEEP_MAX_COMPLETION_TOKENS
-        )
+        self.assertEqual(payload["max_completion_tokens"], 64000)
 
     def test_legacy_model_keeps_temperature_without_reasoning_effort(self) -> None:
         payload = pr_review.build_llm_payload("gpt-4.1", "diff")

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -40,14 +40,14 @@ class PayloadTest(unittest.TestCase):
             payload["max_completion_tokens"], pr_review.DEFAULT_MAX_COMPLETION_TOKENS
         )
 
-    def test_deep_payload_uses_medium_reasoning_effort(self) -> None:
+    def test_deep_payload_uses_xhigh_reasoning_effort(self) -> None:
         payload = pr_review.build_llm_payload(
             "gpt-5.6-terra",
             "diff",
             max_completion_tokens=pr_review.DEEP_MAX_COMPLETION_TOKENS,
             reasoning_effort=pr_review.DEEP_REASONING_EFFORT,
         )
-        self.assertEqual(payload["reasoning_effort"], "medium")
+        self.assertEqual(payload["reasoning_effort"], "xhigh")
         self.assertEqual(
             payload["max_completion_tokens"], pr_review.DEEP_MAX_COMPLETION_TOKENS
         )
@@ -104,7 +104,7 @@ class ModelRoutingTest(unittest.TestCase):
         self.assertEqual(default_payload["model"], pr_review.DEFAULT_MODEL_FAST)
         self.assertEqual(default_payload["reasoning_effort"], "low")
         self.assertEqual(deep_payload["model"], pr_review.DEFAULT_MODEL_DEEP)
-        self.assertEqual(deep_payload["reasoning_effort"], "medium")
+        self.assertEqual(deep_payload["reasoning_effort"], "xhigh")
 
     def test_empty_overrides_fall_back_to_python_defaults(self) -> None:
         with mock.patch.dict(


### PR DESCRIPTION
Deep reviews use xhigh reasoning, but the existing 25,000-token shared ceiling can be consumed entirely by reasoning, leaving no visible review. Raise the shared ceiling to 64,000 and pin the deep reasoning settings in the runner tests. Default reviews are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deep review requests can now provide more comprehensive analysis with increased completion capacity and enhanced reasoning.
  * Fast review behavior remains unchanged.

* **Tests**
  * Updated validation to reflect the enhanced deep review settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->