### PR TITLE
runner: restore the closed v3 supports contract

### DIFF
--- a/control-evidence/v0/verifier/schemas/tool-profile.schema.json
+++ b/control-evidence/v0/verifier/schemas/tool-profile.schema.json
@@ -62,8 +62,47 @@
     },
     "supports": {
       "type": "object",
-      "description": "Declared capability surface. Keys are optional: an omitted key means the capability is unsupported, which is what omission already conveys, so requiring every key only invalidated profiles written before a key existed. additionalProperties stays true so a profile may carry a capability this schema version does not yet name.",
-      "additionalProperties": true,
+      "description": "Transport mechanisms and runtime features the tool supports.",
+      "required": [
+        "fetch_proxy",
+        "http_proxy",
+        "mcp_stdio",
+        "mcp_http",
+        "websocket",
+        "a2a",
+        "tls_interception",
+        "url_dlp_scanning",
+        "request_body_dlp_scanning",
+        "header_dlp_scanning",
+        "response_prompt_injection_scanning",
+        "mcp_input_dlp_scanning",
+        "mcp_input_prompt_injection_scanning",
+        "mcp_tool_policy",
+        "mcp_tool_result_prompt_injection_scanning",
+        "mcp_tool_poison_scanning",
+        "mcp_tool_baseline",
+        "mcp_chain_memory",
+        "mcp_cross_server_chain_memory",
+        "mcp_data_class_labels",
+        "a2a_dlp_scanning",
+        "a2a_prompt_injection_scanning",
+        "a2a_card_prompt_injection_scanning",
+        "a2a_card_drift_scanning",
+        "a2a_ssrf_scanning",
+        "websocket_dlp_scanning",
+        "websocket_prompt_injection_scanning",
+        "ssrf_scanning",
+        "ssrf_bypass_scanning",
+        "domain_blocklist",
+        "entropy_scanning",
+        "encoding_evasion_scanning",
+        "shell_analysis",
+        "crypto_dlp_scanning",
+        "hostname_exfil_scanning",
+        "dns_rebinding_fixture",
+        "budget_enforcement"
+      ],
+      "additionalProperties": false,
       "properties": {
         "fetch_proxy": {
           "type": "boolean",
@@ -248,11 +287,7 @@
           "description": "JSON Pointer to the receipt detail object or JSON-encoded detail string within each JSONL row."
         },
         "detail_encoding": {
-          "enum": [
-            "object",
-            "json_string",
-            "object_or_json_string"
-          ],
+          "enum": ["object", "json_string", "object_or_json_string"],
           "description": "How to decode the value at detail_json_pointer."
         },
         "record_case_id_json_pointer": {

--- a/runner/case.go
+++ b/runner/case.go
@@ -10,6 +10,28 @@ import (
 
 const activeSchemaVersion = 3
 
+// requiredSupportsKeys is the complete, closed v3 supports vocabulary. A
+// profile is a scored input, so omitted keys must never silently become false
+// and an unknown key must never disappear from applicability decisions.
+var requiredSupportsKeys = map[string]struct{}{
+	"fetch_proxy": {}, "http_proxy": {}, "mcp_stdio": {}, "mcp_http": {},
+	"websocket": {}, "a2a": {}, "tls_interception": {},
+	"url_dlp_scanning": {}, "request_body_dlp_scanning": {},
+	"header_dlp_scanning": {}, "response_prompt_injection_scanning": {},
+	"mcp_input_dlp_scanning": {}, "mcp_input_prompt_injection_scanning": {},
+	"mcp_tool_policy": {}, "mcp_tool_result_prompt_injection_scanning": {},
+	"mcp_tool_poison_scanning": {}, "mcp_tool_baseline": {},
+	"mcp_chain_memory": {}, "mcp_cross_server_chain_memory": {},
+	"mcp_data_class_labels": {}, "a2a_dlp_scanning": {},
+	"a2a_prompt_injection_scanning": {}, "a2a_card_prompt_injection_scanning": {},
+	"a2a_card_drift_scanning": {}, "a2a_ssrf_scanning": {},
+	"websocket_dlp_scanning": {}, "websocket_prompt_injection_scanning": {},
+	"ssrf_scanning": {}, "ssrf_bypass_scanning": {}, "domain_blocklist": {},
+	"entropy_scanning": {}, "encoding_evasion_scanning": {}, "shell_analysis": {},
+	"crypto_dlp_scanning": {}, "hostname_exfil_scanning": {},
+	"dns_rebinding_fixture": {}, "budget_enforcement": {},
+}
+
 // Case represents a single benchmark case loaded from JSON.
 type Case struct {
 	SchemaVersion   int                    `json:"schema_version"`
@@ -170,8 +192,8 @@ func loadProfile(path string) (Profile, error) {
 }
 
 // validateProfileForRun checks the fields whose absence would otherwise turn
-// into zero values before a run begins. Supports remains open at schema v3:
-// profile extensions are records and must not be rejected by a newer runner.
+// into zero values before a run begins. Supports is closed at schema v3 so a
+// typo cannot quietly disable an exercised surface.
 func validateProfileForRun(p Profile) error {
 	if p.Tool == "" {
 		return fmt.Errorf("missing required field tool")
@@ -187,6 +209,16 @@ func validateProfileForRun(p Profile) error {
 	}
 	if p.Supports == nil {
 		return fmt.Errorf("missing required field supports")
+	}
+	for key := range p.Supports {
+		if _, known := requiredSupportsKeys[key]; !known {
+			return fmt.Errorf("unknown supports key: %q", key)
+		}
+	}
+	for key := range requiredSupportsKeys {
+		if _, present := p.Supports[key]; !present {
+			return fmt.Errorf("missing required supports key: %q", key)
+		}
 	}
 	return nil
 }

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -88,33 +93,12 @@ func TestLoadCasesEmpty(t *testing.T) {
 
 func TestLoadProfile(t *testing.T) {
 	dir := t.TempDir()
-	profileJSON := `{
-		"schema_version": 3,
-		"tool": "test-tool",
-		"tool_version": "1.0.0",
-		"runner_version": "v1",
-		"claims": ["url_dlp"],
-		"supports": {
-			"fetch_proxy": true,
-			"http_proxy": true,
-			"mcp_stdio": false,
-			"mcp_http": false,
-			"websocket": false,
-			"a2a": false,
-			"tls_interception": false,
-			"request_body_dlp_scanning": false,
-			"header_dlp_scanning": false,
-			"response_prompt_injection_scanning": false,
-			"mcp_tool_baseline": false,
-			"mcp_chain_memory": false,
-			"websocket_dlp_scanning": false,
-			"a2a_dlp_scanning": false,
-			"shell_analysis": false,
-			"dns_rebinding_fixture": false
-		}
-	}`
 	path := filepath.Join(dir, "profile.json")
-	if err := os.WriteFile(path, []byte(profileJSON), 0o600); err != nil {
+	data, err := os.ReadFile(filepath.Join("..", "examples", "runner-template", "tool-profile-template.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -122,10 +106,10 @@ func TestLoadProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadProfile: %v", err)
 	}
-	if p.Tool != "test-tool" {
-		t.Errorf("expected tool test-tool, got %s", p.Tool)
+	if p.Tool != "YOUR_TOOL_NAME" {
+		t.Errorf("expected tool YOUR_TOOL_NAME, got %s", p.Tool)
 	}
-	if len(p.Claims) != 1 || p.Claims[0] != "url_dlp" {
+	if len(p.Claims) != 0 {
 		t.Errorf("unexpected claims: %v", p.Claims)
 	}
 }
@@ -142,61 +126,192 @@ func TestLoadProfileRejectsMissingRunField(t *testing.T) {
 	}
 }
 
-func TestLoadProfilePreservesSupportsExtensionAtV3(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "profile.json")
-	profileJSON := `{"schema_version":3,"tool":"test-tool","tool_version":"1.0.0","runner_version":"v1","claims":[],"supports":{"future_delivery_mode":true}}`
-	if err := os.WriteFile(path, []byte(profileJSON), 0o600); err != nil {
+func validV3Profile(t *testing.T) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "examples", "runner-template", "tool-profile-template.json"))
+	if err != nil {
 		t.Fatal(err)
 	}
-	profile, err := loadProfile(path)
-	if err != nil {
-		t.Fatalf("loadProfile rejected a v3 supports extension: %v", err)
+	var profile map[string]any
+	if err := json.Unmarshal(data, &profile); err != nil {
+		t.Fatal(err)
 	}
-	if got, ok := profile.Supports["future_delivery_mode"]; !ok || !got {
-		t.Fatalf("supports extension = (%t, present=%t), want (true, true)", got, ok)
+	return profile
+}
+
+func writeV3Profile(t *testing.T, path string, mutate func(map[string]any)) {
+	t.Helper()
+	profile := validV3Profile(t)
+	mutate(profile["supports"].(map[string]any))
+	data, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 
-func TestLoadProfileDefaultsOmittedSupportsKeyToFalse(t *testing.T) {
+// These replace permissive tests added on this branch. An omitted capability
+// does not mean unsupported in v3: it is an invalid scored profile because a
+// typo otherwise silently removes cases from execution.
+func TestLoadProfileRejectsMissingSupportsKey(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "profile.json")
-	data, err := os.ReadFile("../examples/pipelock/tool-profile.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	trimmed := strings.Replace(string(data), `"mcp_http": true,`, ``, 1)
-	if err := os.WriteFile(path, []byte(trimmed), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	profile, err := loadProfile(path)
-	if err != nil {
-		t.Fatalf("loadProfile error = %v, want an omitted key to be accepted as unsupported", err)
-	}
-	if _, present := profile.Supports["mcp_http"]; present {
-		t.Fatal("loadProfile rewrote an omitted supports key into the recorded profile")
-	}
-	if reason, applicable := checkApplicability(Case{Transport: "mcp_http"}, profile); applicable || reason != NAUnsupportedTransport {
-		t.Fatalf("omitted mcp_http applicability = (%q, %t), want (%q, false)", reason, applicable, NAUnsupportedTransport)
+	writeV3Profile(t, path, func(supports map[string]any) { delete(supports, "mcp_http") })
+	if _, err := loadProfile(path); err == nil || !strings.Contains(err.Error(), `missing required supports key: "mcp_http"`) {
+		t.Fatalf("loadProfile error = %v, want missing mcp_http", err)
 	}
 }
 
-func TestToolProfileSchemaAllowsSupportsExtensionsAtV3(t *testing.T) {
-	data, err := os.ReadFile(filepath.Join("..", "schemas", "tool-profile.schema.json"))
+func TestLoadProfileRejectsUnknownSupportsKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.json")
+	writeV3Profile(t, path, func(supports map[string]any) { supports["mcp_htttp"] = true })
+	if _, err := loadProfile(path); err == nil || !strings.Contains(err.Error(), `unknown supports key: "mcp_htttp"`) {
+		t.Fatalf("loadProfile error = %v, want unknown mcp_htttp", err)
+	}
+}
+
+func TestLoadProfileRejectsEmptySupports(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.json")
+	writeV3Profile(t, path, func(supports map[string]any) {
+		for key := range supports {
+			delete(supports, key)
+		}
+	})
+	if _, err := loadProfile(path); err == nil || !strings.Contains(err.Error(), "missing required supports key") {
+		t.Fatalf("loadProfile error = %v, want missing required supports key", err)
+	}
+}
+
+type supportsSchema struct {
+	Properties           map[string]json.RawMessage `json:"properties"`
+	Required             []string                   `json:"required"`
+	AdditionalProperties bool                       `json:"additionalProperties"`
+}
+
+func supportsVocabularyFromSchema(t *testing.T, path string) (map[string]struct{}, []byte) {
+	t.Helper()
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var schema struct {
-		Properties map[string]struct {
-			AdditionalProperties any `json:"additionalProperties"`
-		} `json:"properties"`
+		Properties map[string]json.RawMessage `json:"properties"`
 	}
 	if err := json.Unmarshal(data, &schema); err != nil {
 		t.Fatal(err)
 	}
-	if got, ok := schema.Properties["supports"].AdditionalProperties.(bool); !ok || !got {
-		t.Fatalf("supports.additionalProperties = %#v, want true", schema.Properties["supports"].AdditionalProperties)
+	var supports supportsSchema
+	if err := json.Unmarshal(schema.Properties["supports"], &supports); err != nil {
+		t.Fatal(err)
+	}
+	if supports.AdditionalProperties {
+		t.Fatalf("%s permits unknown supports keys", path)
+	}
+	vocabulary := make(map[string]struct{}, len(supports.Properties))
+	for key := range supports.Properties {
+		vocabulary[key] = struct{}{}
+	}
+	assertSameVocabulary(t, path+" properties", vocabulary, path+" required", stringsToSet(supports.Required))
+	return vocabulary, data
+}
+
+func supportsVocabularyFromValidator(t *testing.T) map[string]struct{} {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filepath.Join("..", "validate", "main.go"), nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok || len(value.Names) != 1 || value.Names[0].Name != "validSupportsKeys" || len(value.Values) != 1 {
+				continue
+			}
+			literal, ok := value.Values[0].(*ast.CompositeLit)
+			if !ok {
+				t.Fatal("validate validSupportsKeys is not a composite literal")
+			}
+			vocabulary := make(map[string]struct{}, len(literal.Elts))
+			for _, element := range literal.Elts {
+				pair, ok := element.(*ast.KeyValueExpr)
+				if !ok {
+					t.Fatal("validate validSupportsKeys contains a non-keyed entry")
+				}
+				key, ok := pair.Key.(*ast.BasicLit)
+				if !ok || key.Kind != token.STRING {
+					t.Fatal("validate validSupportsKeys contains a non-string key")
+				}
+				name, err := strconv.Unquote(key.Value)
+				if err != nil {
+					t.Fatal(err)
+				}
+				vocabulary[name] = struct{}{}
+			}
+			return vocabulary
+		}
+	}
+	t.Fatal("validate validSupportsKeys declaration not found")
+	return nil
+}
+
+func stringsToSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
+}
+
+func assertSameVocabulary(t *testing.T, leftName string, left map[string]struct{}, rightName string, right map[string]struct{}) {
+	t.Helper()
+	if len(left) != len(right) {
+		t.Fatalf("%s has %d keys; %s has %d", leftName, len(left), rightName, len(right))
+	}
+	for key := range left {
+		if _, found := right[key]; !found {
+			t.Fatalf("%s contains %q but %s does not", leftName, key, rightName)
+		}
+	}
+}
+
+// TestToolProfileSupportsVocabularyParity keeps all five v3 contract copies in
+// lockstep: the runner's preflight, the Go validator, schema properties and
+// required list, plus the embedded verifier mirror. The branch used to test a
+// permissive runner and schema against a strict validator; this test makes that
+// disagreement fail before a profile can hide cases by typo or omission.
+func TestToolProfileSupportsVocabularyParity(t *testing.T) {
+	rootPath := filepath.Join("..", "schemas", "tool-profile.schema.json")
+	embeddedPath := filepath.Join("..", "control-evidence", "v0", "verifier", "schemas", "tool-profile.schema.json")
+	rootVocabulary, rootBytes := supportsVocabularyFromSchema(t, rootPath)
+	embeddedVocabulary, embeddedBytes := supportsVocabularyFromSchema(t, embeddedPath)
+	if !bytes.Equal(rootBytes, embeddedBytes) {
+		t.Fatal("tool-profile schema and embedded verifier mirror differ")
+	}
+	assertSameVocabulary(t, "runner required set", requiredSupportsKeys, "validator vocabulary", supportsVocabularyFromValidator(t))
+	assertSameVocabulary(t, "runner required set", requiredSupportsKeys, "schema properties", rootVocabulary)
+	assertSameVocabulary(t, "runner required set", requiredSupportsKeys, "embedded schema properties", embeddedVocabulary)
+}
+
+// Every active tool-profile artifact must pass runner preflight. The profiles/
+// receipt records use their own historical reader and are covered by the
+// committed-profile validation tests in receipt_profile_test.go.
+func TestShippedToolProfilesSatisfyV3Contract(t *testing.T) {
+	for _, path := range []string{
+		filepath.Join("..", "examples", "pipelock", "tool-profile.json"),
+		filepath.Join("..", "examples", "runner-template", "tool-profile-template.json"),
+	} {
+		if _, err := loadProfile(path); err != nil {
+			t.Errorf("%s violates the v3 tool-profile contract: %v", path, err)
+		}
 	}
 }
 

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -187,9 +187,14 @@ func TestLoadProfileRejectsEmptySupports(t *testing.T) {
 }
 
 type supportsSchema struct {
-	Properties           map[string]json.RawMessage `json:"properties"`
-	Required             []string                   `json:"required"`
-	AdditionalProperties bool                       `json:"additionalProperties"`
+	Properties map[string]json.RawMessage `json:"properties"`
+	Required   []string                   `json:"required"`
+	// Pointer, so an ABSENT keyword is distinguishable from an explicit false.
+	// A plain bool decodes an absent keyword as false, which would read as
+	// "unknown keys are forbidden" while JSON Schema treats the absent case as
+	// permissive. Deleting the line would then silently reopen the contract
+	// with this guard still passing.
+	AdditionalProperties *bool `json:"additionalProperties"`
 }
 
 func supportsVocabularyFromSchema(t *testing.T, path string) (map[string]struct{}, []byte) {
@@ -208,7 +213,10 @@ func supportsVocabularyFromSchema(t *testing.T, path string) (map[string]struct{
 	if err := json.Unmarshal(schema.Properties["supports"], &supports); err != nil {
 		t.Fatal(err)
 	}
-	if supports.AdditionalProperties {
+	if supports.AdditionalProperties == nil {
+		t.Fatalf("%s omits additionalProperties on supports; JSON Schema treats that as permissive, so it must be stated explicitly", path)
+	}
+	if *supports.AdditionalProperties {
 		t.Fatalf("%s permits unknown supports keys", path)
 	}
 	vocabulary := make(map[string]struct{}, len(supports.Properties))

--- a/runner/multifile_test.go
+++ b/runner/multifile_test.go
@@ -467,28 +467,30 @@ func TestRunIntegratesMultiFileCases(t *testing.T) {
 	profilePath := filepath.Join(tmpDir, "profile.json")
 	receiptPath := filepath.Join(tmpDir, "receipt-profile.json")
 
-	if err := os.WriteFile(profilePath, []byte(`{
-		"schema_version": 3,
-		"tool": "test-tool",
-		"tool_version": "0.0.0",
-		"runner_version": "test",
-		"claims": ["mcp_tool_poison", "mcp_chain"],
-		"supports": {
-			"mcp_stdio": true,
-			"mcp_tool_poison_scanning": true,
-			"mcp_tool_baseline": true,
-			"mcp_chain_memory": true,
-			"mcp_cross_server_chain_memory": true,
-			"mcp_data_class_labels": true
-		}
-	}`), 0o600); err != nil {
+	profile := validV3Profile(t)
+	profile["tool"] = "test-tool"
+	profile["tool_version"] = "0.0.0"
+	profile["runner_version"] = "test"
+	profile["claims"] = []string{"mcp_tool_poison", "mcp_chain"}
+	supports := profile["supports"].(map[string]any)
+	for _, key := range []string{
+		"mcp_stdio", "mcp_tool_poison_scanning", "mcp_tool_baseline",
+		"mcp_chain_memory", "mcp_cross_server_chain_memory", "mcp_data_class_labels",
+	} {
+		supports[key] = true
+	}
+	profileData, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("marshal profile: %v", err)
+	}
+	if err := os.WriteFile(profilePath, profileData, 0o600); err != nil {
 		t.Fatalf("write profile: %v", err)
 	}
 
 	casesDir := filepath.Join("..", "cases")
 	multiFileDir := filepath.Join("..", "cases", "mcp-drift")
 
-	err := run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, receiptPath, "", multiFileDir, false)
+	err = run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, receiptPath, "", multiFileDir, false)
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}

--- a/schemas/tool-profile.schema.json
+++ b/schemas/tool-profile.schema.json
@@ -62,8 +62,47 @@
     },
     "supports": {
       "type": "object",
-      "description": "Declared capability surface. Keys are optional: an omitted key means the capability is unsupported, which is what omission already conveys, so requiring every key only invalidated profiles written before a key existed. additionalProperties stays true so a profile may carry a capability this schema version does not yet name.",
-      "additionalProperties": true,
+      "description": "Transport mechanisms and runtime features the tool supports.",
+      "required": [
+        "fetch_proxy",
+        "http_proxy",
+        "mcp_stdio",
+        "mcp_http",
+        "websocket",
+        "a2a",
+        "tls_interception",
+        "url_dlp_scanning",
+        "request_body_dlp_scanning",
+        "header_dlp_scanning",
+        "response_prompt_injection_scanning",
+        "mcp_input_dlp_scanning",
+        "mcp_input_prompt_injection_scanning",
+        "mcp_tool_policy",
+        "mcp_tool_result_prompt_injection_scanning",
+        "mcp_tool_poison_scanning",
+        "mcp_tool_baseline",
+        "mcp_chain_memory",
+        "mcp_cross_server_chain_memory",
+        "mcp_data_class_labels",
+        "a2a_dlp_scanning",
+        "a2a_prompt_injection_scanning",
+        "a2a_card_prompt_injection_scanning",
+        "a2a_card_drift_scanning",
+        "a2a_ssrf_scanning",
+        "websocket_dlp_scanning",
+        "websocket_prompt_injection_scanning",
+        "ssrf_scanning",
+        "ssrf_bypass_scanning",
+        "domain_blocklist",
+        "entropy_scanning",
+        "encoding_evasion_scanning",
+        "shell_analysis",
+        "crypto_dlp_scanning",
+        "hostname_exfil_scanning",
+        "dns_rebinding_fixture",
+        "budget_enforcement"
+      ],
+      "additionalProperties": false,
       "properties": {
         "fetch_proxy": {
           "type": "boolean",
@@ -248,11 +287,7 @@
           "description": "JSON Pointer to the receipt detail object or JSON-encoded detail string within each JSONL row."
         },
         "detail_encoding": {
-          "enum": [
-            "object",
-            "json_string",
-            "object_or_json_string"
-          ],
+          "enum": ["object", "json_string", "object_or_json_string"],
           "description": "How to decode the value at detail_json_pointer."
         },
         "record_case_id_json_pointer": {

--- a/validate/main_test.go
+++ b/validate/main_test.go
@@ -1573,7 +1573,7 @@ func TestProfileValidation_MissingFields(t *testing.T) {
 
 func TestProfileValidation_InvalidSupportsKey(t *testing.T) {
 	sup := allSupportsKeys()
-	sup["fake_key"] = true
+	sup["mcp_htttp"] = true
 	p := Profile{
 		SchemaVersion: 3, Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
 		Claims:   []string{"url_dlp"},
@@ -1582,12 +1582,12 @@ func TestProfileValidation_InvalidSupportsKey(t *testing.T) {
 	errors := validateProfile(p)
 	found := false
 	for _, e := range errors {
-		if strings.Contains(e, "invalid supports key") {
+		if strings.Contains(e, `invalid supports key: "mcp_htttp"`) {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatal("expected invalid supports key error")
+		t.Fatal("expected mcp_htttp invalid supports key error")
 	}
 }
 
@@ -1689,6 +1689,15 @@ func TestProfileValidation_MissingSupportsKeys(t *testing.T) {
 		SchemaVersion: 3, Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
 		Claims:   []string{"url_dlp"},
 		Supports: map[string]interface{}{"fetch_proxy": true},
+	}
+	errors := validateProfile(p)
+	assertContainsError(t, errors, `missing required supports key: "mcp_http"`)
+}
+
+func TestProfileValidation_EmptySupportsRejectsEveryRequiredKey(t *testing.T) {
+	p := Profile{
+		SchemaVersion: 3, Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
+		Claims: []string{"url_dlp"}, Supports: map[string]interface{}{},
 	}
 	errors := validateProfile(p)
 	assertContainsError(t, errors, "missing required supports key")


### PR DESCRIPTION
Restores the v3 `supports` contract that #140 relaxed. This is a straight repair of a regression that merged: nothing new is designed here.

## What went wrong

Schema v3, as published by #139, requires every known `supports` key and sets `additionalProperties: false`. A change during #140's review relaxed both, at an unchanged schema version, on the premise that existing v3 profiles carried extension keys and would break. That premise was false: `additionalProperties: false` meant such profiles were never valid, so nothing could break.

The result was three disagreeing contracts under one version. The runner accepted `{}` and arbitrary keys, checking only that `supports` was non-nil. The schemas followed the runner. The authoritative Go validator still required the complete closed set. Both test suites passed, because each blessed a different side.

The practical effect is the reason this matters rather than being a tidiness question. A profile declaring `"mcp_htttp": true` was accepted, the real `mcp_http` read as absent and therefore unsupported, and its cases silently stopped executing. `"supports": {}` was a valid profile that declared nothing at all.

Closed vocabulary is what makes that typo detectable. When omission is illegal, a misspelling produces two signals: an unknown key and a missing required key. When omission is legal, the misspelling produces neither, because the real key simply looks deliberately omitted.

## What this restores

The v3 contract exactly as merged `main` defined it before #140: all keys required, `additionalProperties: false`, in both the canonical schema and the verifier's embedded mirror, which are byte-identical.

Runner preflight now rejects a missing key and an unknown key, naming the offending key in each case, so the runner and the validator agree rather than each enforcing half a contract.

## The part that prevents a recurrence

A parity test asserts one vocabulary across all five surfaces: the runner's required set, the validator's vocabulary, the schema `properties`, the schema `required` list, and the embedded mirror.

Drift between copies of this contract is the recurring defect, not any single copy being wrong. Several distinct symptoms traced back to two surfaces disagreeing about the same list. The test fails if any one of the five moves without the others.

Shipped profiles under `examples/` and `profiles/` are validated during preflight, so an artifact the repository publishes cannot violate the contract it documents.

## Verification

Guards were checked by disabling only the guard under test and confirming its specific test fails, then restoring. Removing a key, adding a misspelled key, and an empty map each fail in both the runner and the validator. Removing one entry from the schema `required` list fails the parity test.

Tests that asserted the permissive behaviour encoded the regression and were changed rather than deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile validation now requires every defined capability to be explicitly declared.
  * Unknown, misspelled, or omitted capability keys are rejected with clear validation errors.
  * Validation is consistent across the runner and both profile schema versions.
* **Tests**
  * Added coverage for missing, empty, unknown, and misspelled capability declarations.
  * Updated integration tests to use complete, valid capability profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->