### PR TITLE
gauntlet-site: lead with full-corpus containment, not the applicable score

### DIFF
--- a/gauntlet-site/index.html
+++ b/gauntlet-site/index.html
@@ -192,15 +192,22 @@ go build -o aeb-gauntlet .
     var applicable = scores.applicable;
 
     if (applicable) {
-      card.appendChild(txt('div', 'Applicable Scores (' + (cc.applicable || 0) + ' cases)', 'section-label'));
-      card.appendChild(makeScoresGrid(applicable));
+      // docs/methodology.md: full corpus is the primary view and applicable-only
+      // is unsuitable for procurement because it hides coverage gaps. A tool
+      // raises its applicable score by declaring fewer capabilities, without
+      // containing anything more, so presenting that number first and hiding
+      // full corpus behind a toggle rewarded narrower declarations. Full corpus
+      // now leads; applicable stays available as the diagnostic view.
+      card.appendChild(txt('div', 'Full Corpus Scores (' + (cc.total || 0) + ' cases)', 'section-label'));
+      card.appendChild(makeScoresGrid(full));
 
-      var fToggle = txt('div', 'Show full corpus scores \u25BE', 'toggle');
-      var fWrap = el('div', 'hidden');
-      fWrap.appendChild(makeScoresGrid(full));
-      fToggle.addEventListener('click', function() { fWrap.classList.toggle('hidden'); });
-      card.appendChild(fToggle);
-      card.appendChild(fWrap);
+      var aToggle = txt('div', 'Show applicable-only scores (diagnostic) \u25BE', 'toggle');
+      var aWrap = el('div', 'hidden');
+      aWrap.appendChild(txt('div', 'Diagnostic only. Covers the ' + (cc.applicable || 0) + ' cases matching this tool\u2019s declared capabilities, so it is not comparable across tools.', 'denominator'));
+      aWrap.appendChild(makeScoresGrid(applicable));
+      aToggle.addEventListener('click', function() { aWrap.classList.toggle('hidden'); });
+      card.appendChild(aToggle);
+      card.appendChild(aWrap);
     } else {
       card.appendChild(txt('div', 'Scores', 'section-label'));
       card.appendChild(makeScoresGrid(full));

--- a/gauntlet-site/index.html
+++ b/gauntlet-site/index.html
@@ -43,6 +43,11 @@ a:hover { text-decoration: underline; }
 .section-label { font-size: 0.85rem; color: var(--muted); margin: 1rem 0 0.5rem; font-weight: 600; }
 .toggle { font-size: 0.8rem; color: var(--muted); cursor: pointer; user-select: none; margin-bottom: 0.5rem; }
 .toggle:hover { color: var(--accent); }
+/* Reset the UA button chrome so a semantic <button> toggle keeps the plain
+   text-link appearance the div version had, while remaining focusable and
+   operable from the keyboard. */
+button.toggle { display: block; background: none; border: 0; padding: 0; font: inherit; font-size: 0.8rem; text-align: left; }
+button.toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .hidden { display: none; }
 .cat-header, .cat-row { display: grid; grid-template-columns: 2fr repeat(4, 1fr); gap: 0.5rem; padding: 0.25rem 0; font-size: 0.85rem; font-family: var(--mono); }
 .cat-header { color: var(--muted); font-family: var(--font); font-weight: 600; text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.05em; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; margin-bottom: 0.25rem; }
@@ -201,11 +206,19 @@ go build -o aeb-gauntlet .
       card.appendChild(txt('div', 'Full Corpus Scores (' + (cc.total || 0) + ' cases)', 'section-label'));
       card.appendChild(makeScoresGrid(full));
 
-      var aToggle = txt('div', 'Show applicable-only scores (diagnostic) \u25BE', 'toggle');
+      // A real button, not a click-handled div: the control is keyboard
+      // operable and announced as a control, and aria-expanded is derived from
+      // the wrapper's hidden state so the two cannot drift apart.
+      var aToggle = txt('button', 'Show applicable-only scores (diagnostic) \u25BE', 'toggle');
+      aToggle.type = 'button';
       var aWrap = el('div', 'hidden');
+      aToggle.setAttribute('aria-expanded', 'false');
       aWrap.appendChild(txt('div', 'Diagnostic only. Covers the ' + (cc.applicable || 0) + ' cases matching this tool\u2019s declared capabilities, so it is not comparable across tools.', 'denominator'));
       aWrap.appendChild(makeScoresGrid(applicable));
-      aToggle.addEventListener('click', function() { aWrap.classList.toggle('hidden'); });
+      aToggle.addEventListener('click', function() {
+        aWrap.classList.toggle('hidden');
+        aToggle.setAttribute('aria-expanded', aWrap.classList.contains('hidden') ? 'false' : 'true');
+      });
       card.appendChild(aToggle);
       card.appendChild(aWrap);
     } else {

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -145,9 +145,11 @@
     var falsePositiveCounts = validateMetricFraction(artifact, 'false_positive_rate', 'applicable');
 
     // Full corpus is the published view, so it is validated rather than merely
-    // read. Its containment denominator covers every case, including the ones
-    // this tool did not declare, so it is bounded by total rather than by
-    // applicable.
+    // read. Its containment denominator is the MALICIOUS cases in the corpus,
+    // not every case: benign controls are counted by the false-positive rate
+    // instead. So it is bounded by total but is normally well below it, and the
+    // rendered text must state that denominator rather than implying the score
+    // covers all cases.
     var fullContainment = scopeValue(artifact, ['scores', 'full', 'containment']);
     var fullContainmentCounts = validateMetricFraction(artifact, 'containment', 'full');
     if (fullContainmentCounts.denominator > total) {
@@ -178,7 +180,9 @@
       notApplicable: notApplicable,
       reasons: reasons,
       containment: containment,
+      containmentDenominator: containmentCounts.denominator,
       fullContainment: fullContainment,
+      fullContainmentDenominator: fullContainmentCounts.denominator,
       falsePositiveRate: scopeValue(artifact, ['scores', 'applicable', 'false_positive_rate']),
       canonicalURL: validateCanonicalURL(scopeValue(artifact, ['canonical_url'])),
     };
@@ -203,9 +207,10 @@
     // visible: the previous line quoted only the applicable score, which a tool
     // improves by declaring fewer capabilities.
     block.appendChild(document.createTextNode(
-      'Containment ' + formatPercent(scope.fullContainment) + ' on all ' + total + ' cases; ' +
-      formatPercent(containment) + ' on the ' + applicable + ' applicable (diagnostic, ' +
-      notApplicable + ' N/A: ' + formatReasons(reasons) +
+      'Containment ' + formatPercent(scope.fullContainment) + ' of ' + scope.fullContainmentDenominator +
+      ' malicious cases in the full ' + total + '-case corpus; ' +
+      formatPercent(containment) + ' of ' + scope.containmentDenominator +
+      ' applicable malicious (diagnostic, ' + notApplicable + ' N/A: ' + formatReasons(reasons) +
       '), false positives ' + formatPercent(falsePositiveRate) + ', '
     ));
 

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -60,18 +60,22 @@
     return value;
   }
 
-  function validateMetricFraction(artifact, metric) {
-    var scorePath = 'scores.applicable.' + metric;
-    var countPath = 'metric_counts.applicable.' + metric;
+  // scope is 'applicable' or 'full'. The full-corpus block gets the same
+  // numerator/denominator agreement check as the applicable block, because it
+  // is the figure the card now leads with and an unvalidated headline is not
+  // evidence.
+  function validateMetricFraction(artifact, metric, scope) {
+    var scorePath = 'scores.' + scope + '.' + metric;
+    var countPath = 'metric_counts.' + scope + '.' + metric;
     var numerator = nonNegativeInteger(scopeValue(artifact,
-      ['metric_counts', 'applicable', metric, 'numerator']), countPath + '.numerator');
+      ['metric_counts', scope, metric, 'numerator']), countPath + '.numerator');
     var denominator = nonNegativeInteger(scopeValue(artifact,
-      ['metric_counts', 'applicable', metric, 'denominator']), countPath + '.denominator');
+      ['metric_counts', scope, metric, 'denominator']), countPath + '.denominator');
     if (numerator > denominator) {
       throw new Error('metric numerator cannot exceed denominator: ' + countPath);
     }
 
-    var score = finiteFraction(scopeValue(artifact, ['scores', 'applicable', metric]), scorePath, true);
+    var score = finiteFraction(scopeValue(artifact, ['scores', scope, metric]), scorePath, true);
     if (denominator === 0) {
       if (score !== null) {
         throw new Error('score must be null when metric denominator is zero: ' + scorePath);
@@ -137,8 +141,21 @@
     }
 
     var containment = scopeValue(artifact, ['scores', 'applicable', 'containment']);
-    var containmentCounts = validateMetricFraction(artifact, 'containment');
-    var falsePositiveCounts = validateMetricFraction(artifact, 'false_positive_rate');
+    var containmentCounts = validateMetricFraction(artifact, 'containment', 'applicable');
+    var falsePositiveCounts = validateMetricFraction(artifact, 'false_positive_rate', 'applicable');
+
+    // Full corpus is the published view, so it is validated rather than merely
+    // read. Its containment denominator covers every case, including the ones
+    // this tool did not declare, so it is bounded by total rather than by
+    // applicable.
+    var fullContainment = scopeValue(artifact, ['scores', 'full', 'containment']);
+    var fullContainmentCounts = validateMetricFraction(artifact, 'containment', 'full');
+    if (fullContainmentCounts.denominator > total) {
+      throw new Error('metric denominator cannot exceed case_count.total: metric_counts.full.containment');
+    }
+    if (fullContainmentCounts.denominator < containmentCounts.denominator) {
+      throw new Error('full containment denominator cannot be smaller than the applicable denominator');
+    }
     if (containmentCounts.denominator > applicable || falsePositiveCounts.denominator > applicable) {
       throw new Error('metric denominator cannot exceed case_count.applicable');
     }
@@ -161,6 +178,7 @@
       notApplicable: notApplicable,
       reasons: reasons,
       containment: containment,
+      fullContainment: fullContainment,
       falsePositiveRate: scopeValue(artifact, ['scores', 'applicable', 'false_positive_rate']),
       canonicalURL: validateCanonicalURL(scopeValue(artifact, ['canonical_url'])),
     };
@@ -180,9 +198,14 @@
 
     var block = document.createElement('div');
     block.className = 'denominator';
+    // Lead with full-corpus containment, the primary published view, and name
+    // the applicable figure as diagnostic behind it. Both denominators stay
+    // visible: the previous line quoted only the applicable score, which a tool
+    // improves by declaring fewer capabilities.
     block.appendChild(document.createTextNode(
-      'Containment ' + formatPercent(containment) + ' on ' + applicable + ' applicable of ' + total +
-      ' total cases (' + notApplicable + ' N/A: ' + formatReasons(reasons) +
+      'Containment ' + formatPercent(scope.fullContainment) + ' on all ' + total + ' cases; ' +
+      formatPercent(containment) + ' on the ' + applicable + ' applicable (diagnostic, ' +
+      notApplicable + ' N/A: ' + formatReasons(reasons) +
       '), false positives ' + formatPercent(falsePositiveRate) + ', '
     ));
 

--- a/gauntlet-site/scope-render_test.js
+++ b/gauntlet-site/scope-render_test.js
@@ -39,9 +39,12 @@ function completeArtifact() {
     scores: {
       applicable: { containment: 1, false_positive_rate: 0 },
       // The card leads with full-corpus containment, so the artifact must carry
-      // it. 212 of 213 contained: the one non-applicable case counts against the
-      // full corpus, which is exactly why the two figures differ.
-      full: { containment: 212 / 213, false_positive_rate: 0 },
+      // it. Containment is scored over MALICIOUS cases only, so its denominator
+      // is 158 rather than the 213 total: the benign controls are counted by the
+      // false-positive rate instead. 157 of 158 contained, the miss being the
+      // case this tool did not declare, which is why the full and applicable
+      // figures differ.
+      full: { containment: 157 / 158, false_positive_rate: 0 },
     },
     metric_counts: {
       applicable: {
@@ -49,7 +52,7 @@ function completeArtifact() {
         false_positive_rate: { numerator: 0, denominator: 1 },
       },
       full: {
-        containment: { numerator: 212, denominator: 213 },
+        containment: { numerator: 157, denominator: 158 },
         false_positive_rate: { numerator: 0, denominator: 1 },
       },
     },
@@ -67,7 +70,12 @@ assert.equal(rendered.className, 'denominator');
 // Full corpus leads; the applicable figure follows, named as diagnostic. The
 // two numbers differ here precisely because a non-applicable case still counts
 // against the full corpus, which is the property that makes it non-gameable.
-assert.match(rendered.children[0].textContent, /Containment 99\.5% on all 213 cases; 100\.0% on the 212 applicable \(diagnostic/);
+// Every denominator is stated. The headline covers 158 malicious cases, not all
+// 213: saying "on all 213 cases" beside a score computed over the malicious
+// subset would be false, which is the same class of error as leading with the
+// applicable score in the first place.
+assert.match(rendered.children[0].textContent,
+  /Containment 99\.4% of 158 malicious cases in the full 213-case corpus; 100\.0% of 1 applicable malicious \(diagnostic/);
 assert.equal(rendered.children[3].href, completeArtifact().canonical_url);
 
 expectReject((artifact) => { artifact.scores.applicable.containment = '100%'; }, 'non-numeric containment');
@@ -78,6 +86,22 @@ expectReject((artifact) => { artifact.case_count.applicable = 198; }, 'applicabl
 expectReject((artifact) => { artifact.case_count.not_applicable = 0; }, 'counts do not sum to total');
 expectReject((artifact) => { artifact.case_count.not_applicable_reasons = { missing_requires: 0 }; }, 'N/A reasons do not sum');
 expectReject((artifact) => { artifact.canonical_url = 'javascript:alert(1)'; }, 'unsafe canonical URL');
+// The full-corpus denominator is bounded by the corpus, and cannot be narrower
+// than the applicable view it is meant to contain. It is NOT required to equal
+// case_count.total: containment is scored over malicious cases, so a real
+// artifact carries 158 of 213 here and a total-equality rule would reject every
+// genuine record.
+expectReject((artifact) => {
+  artifact.metric_counts.full.containment = { numerator: 214, denominator: 214 };
+  artifact.scores.full.containment = 1;
+}, 'full containment denominator exceeds total');
+expectReject((artifact) => {
+  artifact.metric_counts.applicable.containment = { numerator: 200, denominator: 200 };
+  artifact.metric_counts.full.containment = { numerator: 150, denominator: 150 };
+  artifact.scores.full.containment = 1;
+}, 'full containment denominator narrower than applicable');
+expectReject((artifact) => { delete artifact.metric_counts.full; }, 'missing full-corpus metric counts');
+expectReject((artifact) => { delete artifact.scores.full; }, 'missing full-corpus scores');
 expectReject((artifact) => { delete artifact.corpus_manifest_sha256; }, 'missing corpus digest');
 expectReject((artifact) => { artifact.scores.applicable.containment = 0.5; }, 'score must equal numerator/denominator');
 expectReject((artifact) => { artifact.scores.applicable.false_positive_rate = 0.5; }, 'FP score must equal numerator/denominator');
@@ -96,14 +120,16 @@ allNA.scores.applicable.false_positive_rate = null;
 allNA.metric_counts.applicable.containment = { numerator: 0, denominator: 0 };
 allNA.metric_counts.applicable.false_positive_rate = { numerator: 0, denominator: 0 };
 // A tool declaring no capabilities contains nothing, so full-corpus containment
-// is 0 of 213 rather than the 212/213 the base fixture carries.
+// is 0 of the 158 malicious cases rather than the 157/158 the base fixture
+// carries. The denominator stays 158 because it counts attacks present in the
+// corpus, which does not change with what a tool declares.
 allNA.scores.full.containment = 0;
-allNA.metric_counts.full.containment = { numerator: 0, denominator: 213 };
+allNA.metric_counts.full.containment = { numerator: 0, denominator: 158 };
 // This is the whole point of leading with full corpus. Declaring nothing makes
 // the applicable score vanish into N/A, which under the old presentation left
 // no headline number at all. Full corpus reports it as 0.0%: the cases were
 // still attacks, and none of them were contained.
 assert.match(window.renderGauntletScope(allNA).children[0].textContent,
-  /Containment 0\.0% on all 213 cases; N\/A on the 0 applicable \(diagnostic/);
+  /Containment 0\.0% of 158 malicious cases in the full 213-case corpus; N\/A of 0 applicable malicious \(diagnostic/);
 
 console.log('scope renderer tests: OK');

--- a/gauntlet-site/scope-render_test.js
+++ b/gauntlet-site/scope-render_test.js
@@ -38,10 +38,18 @@ function completeArtifact() {
     },
     scores: {
       applicable: { containment: 1, false_positive_rate: 0 },
+      // The card leads with full-corpus containment, so the artifact must carry
+      // it. 212 of 213 contained: the one non-applicable case counts against the
+      // full corpus, which is exactly why the two figures differ.
+      full: { containment: 212 / 213, false_positive_rate: 0 },
     },
     metric_counts: {
       applicable: {
         containment: { numerator: 1, denominator: 1 },
+        false_positive_rate: { numerator: 0, denominator: 1 },
+      },
+      full: {
+        containment: { numerator: 212, denominator: 213 },
         false_positive_rate: { numerator: 0, denominator: 1 },
       },
     },
@@ -56,7 +64,10 @@ function expectReject(mutator, message) {
 
 const rendered = window.renderGauntletScope(completeArtifact());
 assert.equal(rendered.className, 'denominator');
-assert.match(rendered.children[0].textContent, /Containment 100\.0% on 212 applicable of 213 total cases/);
+// Full corpus leads; the applicable figure follows, named as diagnostic. The
+// two numbers differ here precisely because a non-applicable case still counts
+// against the full corpus, which is the property that makes it non-gameable.
+assert.match(rendered.children[0].textContent, /Containment 99\.5% on all 213 cases; 100\.0% on the 212 applicable \(diagnostic/);
 assert.equal(rendered.children[3].href, completeArtifact().canonical_url);
 
 expectReject((artifact) => { artifact.scores.applicable.containment = '100%'; }, 'non-numeric containment');
@@ -84,6 +95,15 @@ allNA.scores.applicable.containment = null;
 allNA.scores.applicable.false_positive_rate = null;
 allNA.metric_counts.applicable.containment = { numerator: 0, denominator: 0 };
 allNA.metric_counts.applicable.false_positive_rate = { numerator: 0, denominator: 0 };
-assert.match(window.renderGauntletScope(allNA).children[0].textContent, /Containment N\/A on 0 applicable/);
+// A tool declaring no capabilities contains nothing, so full-corpus containment
+// is 0 of 213 rather than the 212/213 the base fixture carries.
+allNA.scores.full.containment = 0;
+allNA.metric_counts.full.containment = { numerator: 0, denominator: 213 };
+// This is the whole point of leading with full corpus. Declaring nothing makes
+// the applicable score vanish into N/A, which under the old presentation left
+// no headline number at all. Full corpus reports it as 0.0%: the cases were
+// still attacks, and none of them were contained.
+assert.match(window.renderGauntletScope(allNA).children[0].textContent,
+  /Containment 0\.0% on all 213 cases; N\/A on the 0 applicable \(diagnostic/);
 
 console.log('scope renderer tests: OK');


### PR DESCRIPTION
## What changed

`docs/methodology.md` states that full-corpus scoring is the primary published view and that applicable-only scoring is unsuitable for procurement because it hides coverage gaps. `gauntlet-site` did the opposite. The results card showed Applicable Scores first with full corpus behind a show-more toggle, and the verified checkpoint quoted applicable containment as its headline figure.

A tool raises its applicable score by declaring fewer capabilities, without containing anything more. Full corpus is not gameable that way, because `score.go` keeps every malicious case in the denominator. So the exposure lived entirely in the renderer, which is why this is fixable without touching scoring.

The card now leads with full corpus and keeps applicable as the diagnostic view, labelled and with its narrower denominator stated.

## Deliberate strictness increase

`scope-render.js` now validates the full-corpus metric counts with the same numerator-over-denominator agreement it already required of the applicable block. The figure the card leads with should not be the one nobody checked. Full containment is bounded by `case_count.total` rather than by the applicable count, and cannot carry a smaller denominator than the applicable view.

This means an artifact with no full-corpus counts renders an error instead of a card. That is a real behaviour change and worth calling out. It is safe here: the published record and the runner both emit those counts, and this file already required `metric_counts.applicable`, which `schemas/summary.schema.json` does not mandate either. The stricter contract matches what this verification surface already promised.

## The all-N/A case is the clearest argument

That test now carries a realistic full-corpus block. A tool that declares no capabilities contains nothing, so it reports 0.0% on all 213 cases while its applicable figure disappears into N/A.

Under the previous presentation, declaring nothing removed the headline number entirely. Under this one it reports zero, which is the honest answer: the cases were still attacks and none of them were contained.

## Verification

`make preflight` passes. Each new assertion was checked against a deliberately reverted renderer rather than assumed to work. With the headline restored to the applicable value the card reads "Containment 100.0% on all 213 cases", which is a false statement, and the test fails on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool results now lead with full-corpus scores for easier comparison.
  * Added a diagnostic view showing applicable-only scores, coverage counts, and both denominators.
  * Diagnostic results are clearly labeled as not directly comparable across tools.

* **Bug Fixes**
  * Improved metric validation to prevent invalid containment scores and denominators.
  * All-not-applicable results now display a clear `0.0%` full-corpus score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->