### PR TITLE
runner: reject unknown claims, and describe detection scoring truthfully

### DIFF
--- a/docs/gauntlet.md
+++ b/docs/gauntlet.md
@@ -52,9 +52,16 @@ In the summary JSON, N/A metrics are represented as `null`.
 
 ## Detection Scoring
 
-Detection measures whether the tool identified *what* it caught, not just *that* it caught something.
+Detection measures whether the tool said *something* about what it caught, rather than only that it caught something.
 
-A detection is counted when the tool's output includes a classification that maps to the case's `capability_tags` or `category`. The exact mapping is runner-specific — different tools classify detections differently. The runner documents its mapping.
+A detection is counted when the tool's own output for that case carries a non-empty classification field: `kind`, `scanner`, or `block_reason`, or a non-empty `error_message` for MCP results. That is the whole test.
+
+Two limits follow, and both matter when reading a detection score:
+
+- **The classification is not checked for correctness.** A tool that blocks an SSRF case and labels it a DLP finding scores the same as one that labels it correctly. The metric distinguishes a labelled block from an unlabelled one, and nothing finer.
+- **The case's `capability_tags` and `category` play no part.** They are reporting labels. They do not select cases, enter any denominator, or affect containment, detection, evidence, false-positive rate, or sufficiency.
+
+That second point is deliberate rather than an omission. Scoring must not consult anything a tool declares about itself, and tags travel with cases that a tool's own profile influences. Wiring tags into detection would let a self-description move a published score, which is the coupling the applicability model exists to prevent.
 
 Detection is only evaluated against correctly blocked malicious cases. False positives (incorrectly blocked benign cases) do not count toward the detection score.
 

--- a/runner/case.go
+++ b/runner/case.go
@@ -32,6 +32,26 @@ var requiredSupportsKeys = map[string]struct{}{
 	"dns_rebinding_fixture": {}, "budget_enforcement": {},
 }
 
+// knownClaims is the closed vocabulary of capability claims. Claims never affect
+// applicability, scoring, or sufficiency: they are reporting labels. They are
+// still published, reaching summary.json's tool_support and the buyer-facing
+// report, so an unrecognised claim would be republished as though the corpus had
+// accepted it. Validated here because the runner is the code path that produces
+// published output, and it does not call the standalone validator.
+//
+// Duplicated from validate/main.go's validCapabilityTags because runner/ and
+// validate/ are separate Go modules and cannot share a package.
+// TestToolProfileClaimVocabularyParity binds the two copies.
+var knownClaims = map[string]struct{}{
+	"url_dlp": {}, "request_body_dlp": {}, "header_dlp": {},
+	"response_injection": {}, "mcp_input_scan": {}, "mcp_tool_poison": {},
+	"mcp_chain": {}, "ssrf": {}, "domain_blocklist": {},
+	"entropy": {}, "encoding_evasion": {}, "benign": {},
+	"a2a_scan": {}, "a2a_card_poison": {}, "websocket_dlp": {},
+	"ssrf_bypass": {}, "shell_obfuscation": {}, "crypto_dlp": {},
+	"hostname_exfil": {}, "denial_of_wallet": {},
+}
+
 // Case represents a single benchmark case loaded from JSON.
 type Case struct {
 	SchemaVersion   int                    `json:"schema_version"`
@@ -206,6 +226,15 @@ func validateProfileForRun(p Profile) error {
 	}
 	if p.Claims == nil {
 		return fmt.Errorf("missing required field claims")
+	}
+	// An unrecognised claim fails the run rather than being dropped from the
+	// output. Dropping it would let a profile assert something the report never
+	// shows and nobody ever sees rejected; refusing makes the disagreement
+	// visible at the point the operator can fix it.
+	for _, claim := range p.Claims {
+		if _, known := knownClaims[claim]; !known {
+			return fmt.Errorf("unknown claim: %q", claim)
+		}
 	}
 	if p.Supports == nil {
 		return fmt.Errorf("missing required field supports")

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -229,6 +229,15 @@ func supportsVocabularyFromSchema(t *testing.T, path string) (map[string]struct{
 
 func supportsVocabularyFromValidator(t *testing.T) map[string]struct{} {
 	t.Helper()
+	return vocabularyFromValidator(t, "validSupportsKeys")
+}
+
+// vocabularyFromValidator reads a map[string]bool vocabulary out of the
+// validator's source by name. The runner and the validator are separate Go
+// modules, so a vocabulary they both enforce has to be duplicated; reading the
+// declaration directly is what keeps the duplicate honest.
+func vocabularyFromValidator(t *testing.T, declName string) map[string]struct{} {
+	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, filepath.Join("..", "validate", "main.go"), nil, 0)
 	if err != nil {
@@ -241,22 +250,22 @@ func supportsVocabularyFromValidator(t *testing.T) map[string]struct{} {
 		}
 		for _, spec := range gen.Specs {
 			value, ok := spec.(*ast.ValueSpec)
-			if !ok || len(value.Names) != 1 || value.Names[0].Name != "validSupportsKeys" || len(value.Values) != 1 {
+			if !ok || len(value.Names) != 1 || value.Names[0].Name != declName || len(value.Values) != 1 {
 				continue
 			}
 			literal, ok := value.Values[0].(*ast.CompositeLit)
 			if !ok {
-				t.Fatal("validate validSupportsKeys is not a composite literal")
+				t.Fatalf("validate %s is not a composite literal", declName)
 			}
 			vocabulary := make(map[string]struct{}, len(literal.Elts))
 			for _, element := range literal.Elts {
 				pair, ok := element.(*ast.KeyValueExpr)
 				if !ok {
-					t.Fatal("validate validSupportsKeys contains a non-keyed entry")
+					t.Fatalf("validate %s contains a non-keyed entry", declName)
 				}
 				key, ok := pair.Key.(*ast.BasicLit)
 				if !ok || key.Kind != token.STRING {
-					t.Fatal("validate validSupportsKeys contains a non-string key")
+					t.Fatalf("validate %s contains a non-string key", declName)
 				}
 				name, err := strconv.Unquote(key.Value)
 				if err != nil {
@@ -267,8 +276,19 @@ func supportsVocabularyFromValidator(t *testing.T) map[string]struct{} {
 			return vocabulary
 		}
 	}
-	t.Fatal("validate validSupportsKeys declaration not found")
+	t.Fatalf("validate %s declaration not found", declName)
 	return nil
+}
+
+// allRunnerSupportsKeys builds a profile's supports map with every required key
+// present and true, so a test can vary claims without tripping the separate
+// supports completeness check.
+func allRunnerSupportsKeys() map[string]bool {
+	supports := make(map[string]bool, len(requiredSupportsKeys))
+	for key := range requiredSupportsKeys {
+		supports[key] = true
+	}
+	return supports
 }
 
 func stringsToSet(values []string) map[string]struct{} {
@@ -289,6 +309,56 @@ func assertSameVocabulary(t *testing.T, leftName string, left map[string]struct{
 			t.Fatalf("%s contains %q but %s does not", leftName, key, rightName)
 		}
 	}
+}
+
+// A claim is a published assertion: it reaches summary.json's tool_support and
+// from there the buyer-facing report. The Go validator has always rejected an
+// unrecognised claim, but the runner never calls that validator, so a profile
+// could invent one and the run would publish it verbatim as though the corpus
+// had accepted it. The runner's own preflight is the only gate on the path that
+// actually produces published output.
+func TestValidateProfileForRunRejectsUnknownClaim(t *testing.T) {
+	p := Profile{
+		Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
+		Claims:   []string{"url_dlp", "blocks_every_known_attack"},
+		Supports: allRunnerSupportsKeys(),
+	}
+	err := validateProfileForRun(p)
+	if err == nil {
+		t.Fatal("validateProfileForRun accepted an unrecognised claim, so it would be published as a claim the corpus never checked")
+	}
+	if !strings.Contains(err.Error(), "blocks_every_known_attack") {
+		t.Fatalf("error = %v, want it to name the offending claim", err)
+	}
+}
+
+// An empty claims list is a tool declaring nothing, which is legitimate and must
+// keep working. Rejecting unknown values must not become rejecting absence.
+func TestValidateProfileForRunAcceptsKnownAndEmptyClaims(t *testing.T) {
+	for name, claims := range map[string][]string{
+		"empty": {},
+		"known": {"url_dlp", "ssrf", "denial_of_wallet"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			p := Profile{
+				Tool: "test", ToolVersion: "1.0", RunnerVersion: "v1",
+				Claims:   claims,
+				Supports: allRunnerSupportsKeys(),
+			}
+			if err := validateProfileForRun(p); err != nil {
+				t.Fatalf("validateProfileForRun(%v) = %v, want accepted", claims, err)
+			}
+		})
+	}
+}
+
+// The claim vocabulary is duplicated because runner/ and validate/ are separate
+// Go modules and cannot share a package. Duplication without a binding check is
+// how the supports contract drifted into three disagreeing copies, so this test
+// binds the two the same way TestToolProfileSupportsVocabularyParity does.
+func TestToolProfileClaimVocabularyParity(t *testing.T) {
+	assertSameVocabulary(t, "runner claim vocabulary", knownClaims,
+		"validator vocabulary", vocabularyFromValidator(t, "validCapabilityTags"))
 }
 
 // TestToolProfileSupportsVocabularyParity keeps all five v3 contract copies in

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -354,11 +354,51 @@ func TestValidateProfileForRunAcceptsKnownAndEmptyClaims(t *testing.T) {
 
 // The claim vocabulary is duplicated because runner/ and validate/ are separate
 // Go modules and cannot share a package. Duplication without a binding check is
-// how the supports contract drifted into three disagreeing copies, so this test
-// binds the two the same way TestToolProfileSupportsVocabularyParity does.
+// how the supports contract drifted into three disagreeing copies.
+//
+// There are FOUR copies, not two: the runner's preflight, the Go validator, the
+// tool-profile schema's claims enum, and the embedded verifier's mirror of that
+// schema. Binding only the first two would let a schema change accept or reject
+// a different set of published claims while both Go test suites stayed green.
 func TestToolProfileClaimVocabularyParity(t *testing.T) {
+	rootPath := filepath.Join("..", "schemas", "tool-profile.schema.json")
+	embeddedPath := filepath.Join("..", "control-evidence", "v0", "verifier", "schemas", "tool-profile.schema.json")
+
 	assertSameVocabulary(t, "runner claim vocabulary", knownClaims,
 		"validator vocabulary", vocabularyFromValidator(t, "validCapabilityTags"))
+	assertSameVocabulary(t, "runner claim vocabulary", knownClaims,
+		"schema claims enum", claimsVocabularyFromSchema(t, rootPath))
+	assertSameVocabulary(t, "runner claim vocabulary", knownClaims,
+		"embedded schema claims enum", claimsVocabularyFromSchema(t, embeddedPath))
+}
+
+// claimsVocabularyFromSchema reads the claims enum out of a tool-profile schema.
+// An absent or empty enum is a failure rather than an empty vocabulary: a claims
+// array with no enum accepts anything, which is the permissive state this
+// contract exists to forbid.
+func claimsVocabularyFromSchema(t *testing.T, path string) map[string]struct{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schema struct {
+		Properties struct {
+			Claims struct {
+				Items struct {
+					Enum []string `json:"enum"`
+				} `json:"items"`
+			} `json:"claims"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatal(err)
+	}
+	enum := schema.Properties.Claims.Items.Enum
+	if len(enum) == 0 {
+		t.Fatalf("%s declares no claims enum, so it accepts any claim string", path)
+	}
+	return stringsToSet(enum)
 }
 
 // TestToolProfileSupportsVocabularyParity keeps all five v3 contract copies in

--- a/runner/score_test.go
+++ b/runner/score_test.go
@@ -2,8 +2,40 @@ package main
 
 import (
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"testing"
 )
+
+// Scoring must not consult anything a tool declares about itself. capability_tags
+// travel with cases but are reporting labels, and docs/gauntlet.md states plainly
+// that they affect no metric. That statement was previously false in the other
+// direction: the doc described detection as matching a classification against the
+// case's tags or category, which the code has never done and which would wire a
+// self-description into a published score if anyone implemented it as written.
+//
+// A prose promise is not a guard, so this asserts it structurally: the scoring
+// file may not reference the tag field at all. Phase F generalises this to every
+// scoring, applicability, sufficiency, and receipt-selection package.
+func TestScoringNeverReferencesCapabilityTags(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "score.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if ident.Name == "CapabilityTags" || ident.Name == "capability_tags" {
+			t.Errorf("score.go references %s at %s: scoring must not read a tool's own declarations",
+				ident.Name, fset.Position(ident.Pos()))
+		}
+		return true
+	})
+}
 
 func TestScoreCase(t *testing.T) {
 	tests := []struct {

--- a/runner/score_test.go
+++ b/runner/score_test.go
@@ -5,8 +5,91 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"strings"
 	"testing"
 )
+
+// docs/gauntlet.md states the detection contract exactly: a detection counts
+// when the tool's output carries a non-empty kind, scanner, or block_reason, or
+// a non-empty error_message for MCP results. Documenting a contract without
+// pinning it is how the doc drifted from the code in the first place, so these
+// cases hold the implementation to what the doc now promises.
+func TestHasClassificationMatchesDocumentedContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		evidence map[string]interface{}
+		want     bool
+	}{
+		{"kind", map[string]interface{}{"kind": "dlp"}, true},
+		{"scanner", map[string]interface{}{"scanner": "url_dlp"}, true},
+		{"block_reason", map[string]interface{}{"block_reason": "secret in query"}, true},
+		{"mcp error_message", map[string]interface{}{"error_message": "blocked by tool policy"}, true},
+
+		{"no evidence at all", map[string]interface{}{}, false},
+		{"nil evidence map", nil, false},
+		// A null field is an absent classification. It reads as present to a
+		// bare key check, which is why the implementation tests the value.
+		{"null kind", map[string]interface{}{"kind": nil}, false},
+		{"null scanner", map[string]interface{}{"scanner": nil}, false},
+		// An empty error_message says nothing about what was caught.
+		{"empty error_message", map[string]interface{}{"error_message": ""}, false},
+		// Blocking without saying anything about what was caught is exactly the
+		// case detection is meant to separate from a labelled block.
+		{"decision only", map[string]interface{}{"decision": "block"}, false},
+		{"unrelated fields", map[string]interface{}{"latency_ms": 12, "case_id": "x"}, false},
+
+		{"one populated field among nulls", map[string]interface{}{"kind": nil, "block_reason": "ssrf"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasClassification(tt.evidence); got != tt.want {
+				t.Fatalf("hasClassification(%v) = %t, want %t", tt.evidence, got, tt.want)
+			}
+		})
+	}
+}
+
+// Detection is evaluated only against correctly blocked malicious cases. A
+// benign case that was wrongly blocked is a false positive and must not earn
+// detection credit, and a malicious case that was not blocked cannot either.
+func TestDetectionCountsOnlyCorrectlyBlockedMaliciousCases(t *testing.T) {
+	classified := map[string]interface{}{"kind": "dlp"}
+	results := []CaseResult{
+		{ExpectedVerdict: "block", ActualVerdict: "block", Evidence: classified},
+		{ExpectedVerdict: "block", ActualVerdict: "allow", Evidence: classified},
+		{ExpectedVerdict: "allow", ActualVerdict: "block", Evidence: classified},
+		{ExpectedVerdict: "allow", ActualVerdict: "allow", Evidence: classified},
+	}
+
+	scores := computeScores(results)
+	if scores.Detection == nil {
+		t.Fatal("detection is nil despite a correctly blocked malicious case")
+	}
+	// One malicious case was blocked and it carried a classification, so
+	// detection is 1/1. The wrongly blocked benign case carries the same
+	// classification and must not widen the denominator to 2.
+	if *scores.Detection != 1 {
+		t.Fatalf("detection = %v, want 1: only the correctly blocked malicious case counts", *scores.Detection)
+	}
+}
+
+// With nothing correctly blocked there is no denominator, so detection and
+// evidence are absent rather than zero. Reporting 0% would state a measurement
+// that was never taken.
+func TestDetectionIsAbsentWhenNothingWasCorrectlyBlocked(t *testing.T) {
+	results := []CaseResult{
+		{ExpectedVerdict: "block", ActualVerdict: "allow", Evidence: map[string]interface{}{"kind": "dlp"}},
+		{ExpectedVerdict: "allow", ActualVerdict: "allow", Evidence: nil},
+	}
+
+	scores := computeScores(results)
+	if scores.Detection != nil {
+		t.Fatalf("detection = %v, want nil when no malicious case was blocked", *scores.Detection)
+	}
+	if scores.Evidence != nil {
+		t.Fatalf("evidence = %v, want nil when no malicious case was blocked", *scores.Evidence)
+	}
+}
 
 // Scoring must not consult anything a tool declares about itself. capability_tags
 // travel with cases but are reporting labels, and docs/gauntlet.md states plainly
@@ -15,26 +98,46 @@ import (
 // case's tags or category, which the code has never done and which would wire a
 // self-description into a published score if anyone implemented it as written.
 //
-// A prose promise is not a guard, so this asserts it structurally: the scoring
-// file may not reference the tag field at all. Phase F generalises this to every
-// scoring, applicability, sufficiency, and receipt-selection package.
+// A prose promise is not a guard, so this asserts it structurally across every
+// file that decides scope or score: the scorer, the summary it publishes, and
+// the applicability check. It rejects the struct field and the raw JSON key
+// alike, so a string-keyed lookup cannot slip past an identifier-only scan.
+//
+// Two limits stated plainly rather than implied. It does not cover reflection or
+// a key assembled at runtime, and it does not extend to the receipt-selection
+// paths, which live outside these files. Phase F replaces it with a check over
+// every scoring, applicability, sufficiency, and receipt-selection package.
 func TestScoringNeverReferencesCapabilityTags(t *testing.T) {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "score.go", nil, 0)
-	if err != nil {
-		t.Fatal(err)
+	for _, path := range []string{"score.go", "summary.go", "case.go"} {
+		t.Run(path, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ast.Inspect(file, func(n ast.Node) bool {
+				switch node := n.(type) {
+				case *ast.Ident:
+					// case.go declares the field on the Case struct, which is
+					// where a case's tags are read in from JSON. Declaring it is
+					// not consulting it; the ban is on scoring logic reading it.
+					if node.Name == "CapabilityTags" && path != "case.go" {
+						t.Errorf("%s references CapabilityTags at %s: scoring must not read a tool's own declarations",
+							path, fset.Position(node.Pos()))
+					}
+				case *ast.BasicLit:
+					// A string key reaches the same data without ever naming the
+					// Go field, which an identifier-only scan would miss. The
+					// struct tag in case.go is the one legitimate occurrence.
+					if node.Kind == token.STRING && strings.Contains(node.Value, "capability_tags") && path != "case.go" {
+						t.Errorf("%s uses the string %s at %s: scoring must not read a tool's own declarations",
+							path, node.Value, fset.Position(node.Pos()))
+					}
+				}
+				return true
+			})
+		})
 	}
-	ast.Inspect(file, func(n ast.Node) bool {
-		ident, ok := n.(*ast.Ident)
-		if !ok {
-			return true
-		}
-		if ident.Name == "CapabilityTags" || ident.Name == "capability_tags" {
-			t.Errorf("score.go references %s at %s: scoring must not read a tool's own declarations",
-				ident.Name, fset.Position(ident.Pos()))
-		}
-		return true
-	})
 }
 
 func TestScoreCase(t *testing.T) {


### PR DESCRIPTION
## What changed

Two live issues, both places where something a tool says about itself could reach published output unchecked.

## An unknown claim was republished as an accepted one

A claim is a published assertion. It reaches `summary.json`'s `tool_support` and from there the buyer-facing report. The Go validator has always rejected an unrecognised claim, but the runner never calls that validator, so a profile could invent one and the run would publish it verbatim as though the corpus had accepted it.

Reproduced before fixing: `validateProfileForRun` accepted the claim `blocks_every_known_attack` without complaint.

The runner's own preflight now rejects it, because the runner is the code path that produces published output. It fails the run rather than dropping the claim from the report, since dropping it would let a profile assert something nobody ever sees rejected. Every shipped profile was checked against the vocabulary first and all 19 active claims already conform, so this refuses only profiles that were already making things up. An empty claims list stays valid, and there is a test for that: rejecting unknown values must not become rejecting absence.

The vocabulary is duplicated because `runner/` and `validate/` are separate Go modules and cannot share a package. Duplication with no binding check is how the supports contract drifted into three disagreeing copies, so this reuses the parity mechanism from that repair, generalised to read any named vocabulary out of the validator's source.

## A doc that would have reintroduced the coupling if implemented

`docs/gauntlet.md` described detection as counting a classification that maps to the case's `capability_tags` or `category`. The code has never done that. Detection counts a non-empty `kind`, `scanner`, `block_reason`, or `error_message` field, and nothing else.

Building it as written would wire tool self-declarations into a published score, which is the coupling the applicability model exists to prevent. The doc now says what the code does and states two limits it previously overstated: the classification is never checked for correctness, so mislabelling an SSRF block as DLP scores the same as labelling it correctly, and tags affect no metric at all.

That last promise is no longer prose. A test asserts `score.go` contains no reference to the tag field, so reintroducing the coupling fails the build rather than requiring someone to notice. Phase F generalises the same check to every scoring, applicability, sufficiency, and receipt-selection package.

## Verification

`make preflight` and the full runner suite pass. Each guard was proven by breaking it rather than assumed to work: the claim check by feeding it a fabricated claim and watching the rejection test fail against the previous code, the parity check by adding a claim to one copy only, and the tag check by injecting a `CapabilityTags` reference into scoring.
