### PR TITLE
ci: recover the AI review when GitHub refuses a large diff

### DIFF
--- a/scripts/pr-review.py
+++ b/scripts/pr-review.py
@@ -31,6 +31,9 @@ import requests
 # --- Constants ---
 
 MAX_DIFF_CHARS = 100_000  # ~25k tokens, keeps costs reasonable
+# Page cap for the per-file diff fallback. 100 files per page, so this bounds a
+# pathological pull request without truncating any realistic one.
+MAX_DIFF_FILE_PAGES = 30
 DEFAULT_MODEL_FAST = "gpt-5.6-luna"
 DEFAULT_MODEL_DEEP = "gpt-5.6-terra"
 DEFAULT_TEMPERATURE = 0.2
@@ -73,15 +76,67 @@ If there are no material issues, say exactly: No material issues found in this d
 
 
 def get_pr_diff(repo: str, pr_number: str, token: str) -> str:
-    """Fetch the PR diff from GitHub."""
+    """Fetch the PR diff from GitHub.
+
+    GitHub refuses the diff media type with 406 Not Acceptable once a pull
+    request is large enough, which is exactly when a review is most valuable and
+    least likely to happen by hand. A corpus repository reaches that size
+    routinely: one mechanical edit across every case file, carrying a handful of
+    files that hold every real decision.
+
+    A 406 is therefore not a failure to report, it is a signal to fetch the same
+    content a different way. The per-file endpoint paginates and returns each
+    file's patch, so the diff is reassembled from those. Any other HTTP error
+    still raises, because those mean something genuinely went wrong.
+    """
     url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github.v3.diff",
     }
     resp = requests.get(url, headers=headers, timeout=30)
+    if resp.status_code == 406:
+        return get_pr_diff_from_files(repo, pr_number, token)
     resp.raise_for_status()
     return resp.text
+
+
+def get_pr_diff_from_files(repo: str, pr_number: str, token: str) -> str:
+    """Reassemble a unified diff from the paginated per-file endpoint.
+
+    Used when the diff media type is refused for size. Files GitHub omits a
+    patch for, binaries and files past its own per-file limits, are recorded as
+    an explicit note rather than dropped silently, so a reviewer can tell the
+    difference between a file that did not change and one that could not be
+    shown.
+    """
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    parts: list[str] = []
+    page = 1
+    while page <= MAX_DIFF_FILE_PAGES:
+        resp = requests.get(
+            f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files",
+            headers=headers,
+            params={"per_page": 100, "page": page},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        files = resp.json()
+        if not files:
+            break
+        for entry in files:
+            path = entry.get("filename", "")
+            patch = entry.get("patch")
+            if patch:
+                parts.append(f"diff --git a/{path} b/{path}\n{patch}")
+            else:
+                status = entry.get("status", "changed")
+                parts.append(f"diff --git a/{path} b/{path}\n# {status}, patch not provided by GitHub")
+        page += 1
+    return "\n".join(parts)
 
 
 def truncate_diff(diff: str, max_chars: int = MAX_DIFF_CHARS) -> str:

--- a/scripts/pr_review_test.py
+++ b/scripts/pr_review_test.py
@@ -25,6 +25,9 @@ class FakeResponse:
     def json(self) -> dict:
         return self._data
 
+    def raise_for_status(self) -> None:
+        return None
+
 
 class InvalidJSONResponse(FakeResponse):
     def json(self) -> dict:
@@ -181,6 +184,53 @@ class ResponseParsingTest(unittest.TestCase):
         ), mock.patch.object(pr_review.requests, "post", return_value=response):
             with self.assertRaisesRegex(pr_review.LLMReviewError, "invalid JSON"):
                 pr_review.call_llm("diff", "default")
+
+
+class LargeDiffFallbackTest(unittest.TestCase):
+    """A 406 on the diff media type must not lose the review.
+
+    GitHub refuses that media type once a pull request is large enough, which is
+    when a review matters most. PR #147 hit exactly this: 340 files, three
+    consecutive AI Review Error comments, and no review of a schema contract
+    rewrite. The fallback reassembles the same diff from the per-file endpoint.
+    """
+
+    def test_406_falls_back_to_per_file_endpoint(self):
+        calls = []
+
+        def fake_get(url, headers=None, params=None, timeout=None):
+            calls.append(url)
+            if url.endswith("/pulls/147"):
+                return FakeResponse({}, status_code=406)
+            page = (params or {}).get("page", 1)
+            if page == 1:
+                return FakeResponse([
+                    {"filename": "runner/score.go", "patch": "@@ -1 +1 @@\n-a\n+b"},
+                    {"filename": "assets/logo.png", "status": "modified"},
+                ])
+            return FakeResponse([])
+
+        with mock.patch.object(pr_review.requests, "get", side_effect=fake_get):
+            diff = pr_review.get_pr_diff("owner/repo", "147", "token")
+
+        self.assertIn("diff --git a/runner/score.go b/runner/score.go", diff)
+        self.assertIn("+b", diff)
+        # A file GitHub gives no patch for is recorded, never silently dropped:
+        # a reviewer must be able to tell "unchanged" from "not shown".
+        self.assertIn("assets/logo.png", diff)
+        self.assertIn("patch not provided by GitHub", diff)
+        self.assertTrue(any(u.endswith("/files") for u in calls), calls)
+
+    def test_non_406_errors_still_raise(self):
+        class Raiser(FakeResponse):
+            def raise_for_status(self):
+                raise RuntimeError("500 server error")
+
+        with mock.patch.object(
+            pr_review.requests, "get", return_value=Raiser({}, status_code=500)
+        ):
+            with self.assertRaises(RuntimeError):
+                pr_review.get_pr_diff("owner/repo", "147", "token")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The AI review cannot run on a large pull request. GitHub returns 406 Not Acceptable for the diff media type once a pull request is big enough, so the review fails exactly where it is most valuable and least likely to happen by hand. PR #147 produced three consecutive AI Review Error comments and got no review at all of a schema contract rewrite.

A 406 now falls back to the paginated per-file endpoint and reassembles the diff from each file's patch. Files GitHub provides no patch for, binaries and files past its own per-file limits, are recorded with an explicit note rather than dropped, so a reviewer can tell a file that did not change from one that could not be shown. Every other HTTP status still raises, because those mean something genuinely went wrong rather than something to route around.

This has to land on main to take effect. The workflow checks out the review script from the default branch on purpose, since the job holds pull-requests write permission and a pull request that could modify its own reviewer would be a privilege escalation. That property is worth keeping, so the fix ships separately rather than riding along on the branch that needs it.

The failure mode is worth naming because it hid itself well. Small pull requests were unaffected, so the workflow looked healthy, and the errors sat next to a green CodeRabbit check where they read as a flaky bot rather than a systematic gap in review coverage.

Verified by neutralizing the fallback and watching the new test fail, then restoring it.
