### PR TITLE
evidence: add a framed corpus digest that proves corpus identity

### DIFF
--- a/docs/RESULTS-USE.md
+++ b/docs/RESULTS-USE.md
@@ -43,7 +43,7 @@ Publish these next to any score, or the number is not reproducible.
 | Fact | Why |
 |---|---|
 | Method identity: repository and exact commit | The corpus and scoring change over time. |
-| Corpus and scoring version, plus `benchmark_manifest_sha256` | Pins the case surface that ran. The older `corpus_sha256` travels alongside it for records that predate the framed digest, but only the framed one proves corpus identity. |
+| Corpus and scoring version, plus `benchmark_manifest_sha256` | Pins the case surface that ran. An active record carries both digests; a frozen record produced before the framed digest existed carries only `corpus_sha256` and cannot be made to carry the newer one. Only the framed digest proves corpus identity, so a legacy record pins its contents no more tightly than that older field allowed. |
 | Capability profile, `tool_profile_sha256`, and exact registry reference | Preserves the profile's reporting labels and the raw registry snapshot that defined them. |
 | Exercised profile: the transports and categories the run actually drove | The exercised profile is what was tested. Reporting labels do not select rows or limit the result's scope. |
 | Adapter identity and owner | A vendor-authored adapter is normal. Hiding who wrote it is not. |

--- a/docs/RESULTS-USE.md
+++ b/docs/RESULTS-USE.md
@@ -43,7 +43,7 @@ Publish these next to any score, or the number is not reproducible.
 | Fact | Why |
 |---|---|
 | Method identity: repository and exact commit | The corpus and scoring change over time. |
-| Corpus and scoring version, plus `corpus_sha256` | Pins the case surface that ran. |
+| Corpus and scoring version, plus `benchmark_manifest_sha256` | Pins the case surface that ran. The older `corpus_sha256` travels alongside it for records that predate the framed digest, but only the framed one proves corpus identity. |
 | Capability profile, `tool_profile_sha256`, and exact registry reference | Preserves the profile's reporting labels and the raw registry snapshot that defined them. |
 | Exercised profile: the transports and categories the run actually drove | The exercised profile is what was tested. Reporting labels do not select rows or limit the result's scope. |
 | Adapter identity and owner | A vendor-authored adapter is normal. Hiding who wrote it is not. |

--- a/docs/gauntlet.md
+++ b/docs/gauntlet.md
@@ -80,6 +80,7 @@ A single JSON file with the full scoring breakdown:
   "tool_version": "1.0.0",
   "corpus_version": "v1.0.0",
   "corpus_sha256": "af7f95d7...",
+  "benchmark_manifest_sha256": "135c979e...",
   "date": "2026-04-15T14:30:00Z",
   "case_count": {
     "total": 142,
@@ -138,7 +139,7 @@ Key fields:
 
 - `corpus_sha256`: SHA-256 over all case file contents concatenated in sorted-path order. It detects a content change but cannot identify the exact corpus, because it frames nothing: any regrouping of the same total bytes across files produces the same value. Retained unchanged so published records keep verifying against the definition they were produced under.
 - `benchmark_manifest_sha256`: SHA-256 over every case file's path, byte length, and bytes, each length-prefixed. This is the field that identifies the exact corpus. Use it when corpus identity matters.
-- `runner_version`: version of the runner binary. Together with `corpus_sha256` and `tool_version`, identifies a reproducible run.
+- `runner_version`: version of the runner binary. Together with `benchmark_manifest_sha256` and `tool_version`, identifies a reproducible run. `corpus_sha256` is retained as a legacy content-change indicator and does not establish corpus identity.
 - `capability_registry`: exact registry snapshot used to validate reporting labels. The SHA-256 is over the retained raw snapshot bytes.
 - `reported_claims`: profile labels for report interpretation. They do not select rows or change any measurement.
 - `date`: UTC generation time by default. Set `AEB_GAUNTLET_SUMMARY_DATE` to a fixed RFC3339 value for byte-stable summaries, or set it to an empty string to omit the field.

--- a/docs/gauntlet.md
+++ b/docs/gauntlet.md
@@ -136,7 +136,8 @@ A single JSON file with the full scoring breakdown:
 
 Key fields:
 
-- `corpus_sha256`: SHA-256 hash of all case file contents sorted by path. Identifies the exact corpus used.
+- `corpus_sha256`: SHA-256 over all case file contents concatenated in sorted-path order. It detects a content change but cannot identify the exact corpus, because it frames nothing: any regrouping of the same total bytes across files produces the same value. Retained unchanged so published records keep verifying against the definition they were produced under.
+- `benchmark_manifest_sha256`: SHA-256 over every case file's path, byte length, and bytes, each length-prefixed. This is the field that identifies the exact corpus. Use it when corpus identity matters.
 - `runner_version`: version of the runner binary. Together with `corpus_sha256` and `tool_version`, identifies a reproducible run.
 - `capability_registry`: exact registry snapshot used to validate reporting labels. The SHA-256 is over the retained raw snapshot bytes.
 - `reported_claims`: profile labels for report interpretation. They do not select rows or change any measurement.
@@ -155,7 +156,7 @@ A Gauntlet run is valid when all of the following are true:
 
 1. **Every corpus case has an emitted outcome.** No cherry-picking. The runner processes every case file in the corpus directory; a missing exact route is emitted as `unreachable` and makes the measurement incomplete.
 2. **No case produced an error.** A single `error` row makes the run unpublishable. An error means this harness failed to measure the case, not that the tool did anything, so it is excluded from every score denominator; tolerating errors would therefore both hide the measurement failure and raise the score. An error and an unreachable row mean the same thing and carry the same consequence: fix the harness or the adapter and run it again.
-3. **Results are reproducible.** The same corpus version + tool version + runner version must produce the same scores. The `corpus_sha256` field ensures corpus identity.
+3. **Results are reproducible.** The same corpus version + tool version + runner version must produce the same scores. The `benchmark_manifest_sha256` field establishes corpus identity, because it binds each file's path and length as well as its bytes.
 4. **The official runner or a compatible runner was used.** Compatible runners must produce the same JSONL and summary format, bind the same registry snapshot, implement the same applicability rules, and use the same scoring formulas.
 
 ## Relationship to Existing Scoring

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -139,7 +139,8 @@ Six provenance fields identify an active Gauntlet run:
 |-------|---------------|--------|
 | `corpus_version` | Tag or commit of the case corpus | Repository tag |
 | `scoring_version` | Version of the Gauntlet scoring and applicability rules | Runner constant emitted in summary JSON |
-| `corpus_sha256` | Hash of all case file contents (sorted by path) | Computed at runtime |
+| `corpus_sha256` | Unframed hash of concatenated case file contents. Detects content changes; cannot prove corpus identity | Computed at runtime |
+| `benchmark_manifest_sha256` | Framed hash binding every case file's path, byte length, and bytes. Proves corpus identity | Computed at runtime |
 | `runner_version` | Version of the runner binary | Hardcoded in runner |
 | `tool_profile_sha256` | Hash of the tool profile used | Computed at runtime |
 | `capability_registry` | Immutable snapshot defining reporting labels | Profile and every active result |
@@ -162,7 +163,7 @@ diagnostic, unchanged from 2.1. An
 adapter with no exact route is an explicit unreachable coverage gap; a routed
 case with missing delivery or observation proof is an error.
 
-`corpus_sha256` proves which exact file contents were present at runtime. `runner_version` identifies the binary that produced the results. `tool_profile_sha256` proves which reporting claims were present. `capability_registry.sha256` proves the exact raw snapshot that defined them. Together, these fields make an active run reproducible without letting labels affect measurement.
+`benchmark_manifest_sha256` proves which exact files were present at runtime, binding each path, byte length, and bytes. `corpus_sha256` detects a content change but cannot prove corpus identity, since it concatenates contents without framing and therefore cannot distinguish the same bytes regrouped across different files; it is retained so already published records still verify. `runner_version` identifies the binary that produced the results. `tool_profile_sha256` proves which reporting claims were present. `capability_registry.sha256` proves the exact raw snapshot that defined them. Together, these fields make an active run reproducible without letting labels affect measurement.
 
 ## Running the Gauntlet
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -133,7 +133,7 @@ WebSocket cases also need careful interpretation when a fixture address is local
 
 ## Versioning
 
-Six provenance fields identify an active Gauntlet run:
+Seven provenance fields identify an active Gauntlet run:
 
 | Field | What it tracks | Source |
 |-------|---------------|--------|

--- a/runner/manifest_digest_test.go
+++ b/runner/manifest_digest_test.go
@@ -254,3 +254,17 @@ func TestWriteSummaryRejectsMalformedDigests(t *testing.T) {
 		})
 	}
 }
+
+// Hashing nothing yields the SHA-256 of the empty string, which is well-formed
+// 64-hex and passes every shape check we have, so an empty corpus would publish
+// a valid-looking identity for a run that measured no cases. Found by an
+// adversarial pass over this digest design.
+func TestEmptyCorpusIsRefusedRatherThanHashed(t *testing.T) {
+	_, err := readCorpusSnapshot(t.TempDir(), "")
+	if err == nil {
+		t.Fatal("an empty corpus produced a digest instead of an error")
+	}
+	if !strings.Contains(err.Error(), "empty corpus") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/runner/manifest_digest_test.go
+++ b/runner/manifest_digest_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -193,5 +194,63 @@ func TestBothDigestsCoverTheSameFiles(t *testing.T) {
 	}
 	if filepath.Base(paths[0]) != "1.json" {
 		t.Fatalf("unexpected file collected: %s", paths[0])
+	}
+}
+
+// The snapshot path must reproduce both digests exactly. corpus_sha256 appears
+// in published records, so a changed value here would silently invalidate them,
+// and the framed digest is only trustworthy if one read feeds both.
+func TestSnapshotDigestsMatchTheWalkOnTheRealCorpus(t *testing.T) {
+	const casesDir, multiDir = "../cases", "../cases/mcp-drift"
+
+	wantCorpus, err := computeCorpusSHA256(casesDir, multiDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantManifest, err := computeBenchmarkManifestSHA256(casesDir, multiDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := readCorpusSnapshot(casesDir, multiDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("snapshot is empty; refusing to compare vacuously")
+	}
+
+	if got := corpusSHA256FromSnapshot(files); got != wantCorpus {
+		t.Errorf("legacy digest changed:\n got  %s\n want %s", got, wantCorpus)
+	}
+	if got := benchmarkManifestSHA256FromSnapshot(files); got != wantManifest {
+		t.Errorf("framed digest changed:\n got  %s\n want %s", got, wantManifest)
+	}
+}
+
+// A direct caller can construct a summary, so the writer must reject a digest
+// the schema cannot constrain on its own rather than emitting an artifact that
+// only provenance will refuse later.
+func TestWriteSummaryRejectsMalformedDigests(t *testing.T) {
+	valid := strings.Repeat("a", 64)
+	for _, tc := range []struct{ name, corpus, manifest string }{
+		{"empty manifest", valid, ""},
+		{"short manifest", valid, "abc123"},
+		{"uppercase manifest", valid, strings.ToUpper(valid)},
+		{"non-hex manifest", valid, strings.Repeat("z", 64)},
+		{"empty corpus", "", valid},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := writeSummary(GauntletSummary{
+				Tool:                    "test",
+				CorpusSHA256:            tc.corpus,
+				BenchmarkManifestSHA256: tc.manifest,
+				ToolProfileSHA256:       valid,
+				CapabilityRegistry:      testRegistryReference,
+			}, filepath.Join(t.TempDir(), "summary.json"))
+			if err == nil {
+				t.Fatal("writeSummary accepted a malformed digest")
+			}
+		})
 	}
 }

--- a/runner/manifest_digest_test.go
+++ b/runner/manifest_digest_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeCorpus(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		full := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// The regrouping that collides under computeCorpusSHA256 must not collide here.
+// This is the exact defect the framed digest exists to close, so it is asserted
+// in both directions rather than only on the new function.
+func TestBenchmarkManifestDigestSeparatesRegroupedBytes(t *testing.T) {
+	single := writeCorpus(t, map[string]string{"url/1.json": `{"a":1}{"b":2}`})
+	split := writeCorpus(t, map[string]string{
+		"url/1.json": `{"a":1}`,
+		"url/2.json": `{"b":2}`,
+	})
+
+	legacySingle, err := computeCorpusSHA256(single, "")
+	if err != nil {
+		t.Fatalf("legacy single: %v", err)
+	}
+	legacySplit, err := computeCorpusSHA256(split, "")
+	if err != nil {
+		t.Fatalf("legacy split: %v", err)
+	}
+	if legacySingle != legacySplit {
+		t.Fatalf("legacy digest unexpectedly distinguished these corpora; this test's premise is stale")
+	}
+
+	framedSingle, err := computeBenchmarkManifestSHA256(single, "")
+	if err != nil {
+		t.Fatalf("framed single: %v", err)
+	}
+	framedSplit, err := computeBenchmarkManifestSHA256(split, "")
+	if err != nil {
+		t.Fatalf("framed split: %v", err)
+	}
+	if framedSingle == framedSplit {
+		t.Fatalf("framed digest collided on regrouped bytes: %s", framedSingle)
+	}
+}
+
+// The length prefixes, specifically, are what stop a crafted filename from
+// impersonating a boundary. Without them the digest input is a bare
+// concatenation of key then content, so a file whose NAME absorbs the start of
+// another entry produces a byte-identical stream:
+//
+//	key "cases/x.json"        + content "y.json{}"   -> cases/x.jsony.json{}
+//	key "cases/x.jsony.json"  + content "{}"         -> cases/x.jsony.json{}
+//
+// Both filenames end in .json, so both are real corpus files. Including the
+// path is not sufficient here; only framing separates these.
+func TestBenchmarkManifestFramingResistsBoundaryForgery(t *testing.T) {
+	honest := writeCorpus(t, map[string]string{"x.json": `y.json{}`})
+	forged := writeCorpus(t, map[string]string{"x.jsony.json": `{}`})
+
+	a, err := computeBenchmarkManifestSHA256(honest, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := computeBenchmarkManifestSHA256(forged, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatalf("a crafted filename forged an entry boundary: both digests %s", a)
+	}
+}
+
+// A file moving or being renamed changes the corpus, so it must change the
+// digest even though the bytes are untouched.
+func TestBenchmarkManifestDigestBindsPaths(t *testing.T) {
+	before := writeCorpus(t, map[string]string{"url/case.json": `{"a":1}`})
+	after := writeCorpus(t, map[string]string{"headers/case.json": `{"a":1}`})
+
+	a, err := computeBenchmarkManifestSHA256(before, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := computeBenchmarkManifestSHA256(after, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatal("digest ignored the file's location")
+	}
+
+	// The legacy digest cannot see this, which is why the new field is needed.
+	la, err := computeCorpusSHA256(before, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lb, err := computeCorpusSHA256(after, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if la != lb {
+		t.Fatal("legacy digest distinguished a pure move; this test's premise is stale")
+	}
+}
+
+// The digest must not depend on where the corpus lives on disk, or two machines
+// verifying the same corpus would disagree.
+func TestBenchmarkManifestDigestIsMachineIndependent(t *testing.T) {
+	layout := map[string]string{
+		"url/1.json":     `{"a":1}`,
+		"headers/2.json": `{"b":2}`,
+	}
+	first := writeCorpus(t, layout)
+	second := writeCorpus(t, layout)
+	if first == second {
+		t.Fatal("expected two distinct root directories")
+	}
+
+	a, err := computeBenchmarkManifestSHA256(first, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := computeBenchmarkManifestSHA256(second, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Fatalf("digest depended on the absolute root: %s vs %s", a, b)
+	}
+}
+
+func TestBenchmarkManifestDigestIsDeterministic(t *testing.T) {
+	dir := writeCorpus(t, map[string]string{
+		"url/1.json":     `{"a":1}`,
+		"headers/2.json": `{"b":2}`,
+		"ssrf/3.json":    `{"c":3}`,
+	})
+	first, err := computeBenchmarkManifestSHA256(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		again, againErr := computeBenchmarkManifestSHA256(dir, "")
+		if againErr != nil {
+			t.Fatal(againErr)
+		}
+		if again != first {
+			t.Fatalf("digest changed between runs: %s then %s", first, again)
+		}
+	}
+}
+
+// Content still matters. A one-byte edit must move the digest.
+func TestBenchmarkManifestDigestBindsContent(t *testing.T) {
+	a, err := computeBenchmarkManifestSHA256(writeCorpus(t, map[string]string{"url/1.json": `{"a":1}`}), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := computeBenchmarkManifestSHA256(writeCorpus(t, map[string]string{"url/1.json": `{"a":2}`}), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatal("digest ignored file content")
+	}
+}
+
+// The two digests must always describe the same file set, so a corpus that one
+// can read and the other cannot is a bug rather than a difference in scope.
+func TestBothDigestsCoverTheSameFiles(t *testing.T) {
+	dir := writeCorpus(t, map[string]string{
+		"url/1.json":   `{"a":1}`,
+		"url/skip.txt": `not a case`,
+	})
+	paths, err := corpusFilePaths(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected only the .json case file, got %v", paths)
+	}
+	if filepath.Base(paths[0]) != "1.json" {
+		t.Fatalf("unexpected file collected: %s", paths[0])
+	}
+}

--- a/runner/summary.go
+++ b/runner/summary.go
@@ -190,6 +190,42 @@ func computeCorpusSHA256(casesDir, multiFileDir string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
+// corpusSHA256FromSnapshot reproduces computeCorpusSHA256 exactly: contents
+// concatenated in sorted-path order with no framing. That value appears in
+// published records, so it is preserved byte for byte rather than improved here.
+func corpusSHA256FromSnapshot(files []corpusFile) string {
+	ordered := make([]corpusFile, len(files))
+	copy(ordered, files)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].path < ordered[j].path })
+
+	h := sha256.New()
+	for _, f := range ordered {
+		_, _ = h.Write(f.data)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// benchmarkManifestSHA256FromSnapshot reproduces computeBenchmarkManifestSHA256:
+// entries ordered by canonical key, with each key and body length-prefixed.
+func benchmarkManifestSHA256FromSnapshot(files []corpusFile) string {
+	ordered := make([]corpusFile, len(files))
+	copy(ordered, files)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].key < ordered[j].key })
+
+	h := sha256.New()
+	var size [binary.MaxVarintLen64]byte
+	writeField := func(b []byte) {
+		n := binary.PutUvarint(size[:], uint64(len(b)))
+		_, _ = h.Write(size[:n])
+		_, _ = h.Write(b)
+	}
+	for _, f := range ordered {
+		writeField([]byte(f.key))
+		writeField(f.data)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 // computeBenchmarkManifestSHA256 binds the exact corpus contents: every file's
 // location, its byte length, and its bytes.
 //
@@ -241,6 +277,65 @@ func computeBenchmarkManifestSHA256(casesDir, multiFileDir string) (string, erro
 // corpusManifestKey renders a machine-independent key for a corpus file. The
 // root prefix keeps the two trees distinct even when a relative path could
 // appear under either.
+// isSHA256Hex reports whether s is exactly 64 lowercase hexadecimal characters.
+// Case is not normalized: a digest is compared as a string across consumers in
+// several languages, so accepting both cases would let two spellings of one
+// value fail an equality check that should have passed.
+func isSHA256Hex(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// corpusFile is one corpus file read exactly once: its absolute path, its
+// canonical manifest key, and the bytes both digests are derived from.
+type corpusFile struct {
+	key  string
+	path string
+	data []byte
+}
+
+// readCorpusSnapshot reads every corpus file once so both digests describe the
+// same bytes.
+//
+// Each digest previously walked the tree and read every file for itself. Sharing
+// only the path collector is not enough: two independent reads of the same path
+// can return different contents, so a corpus edited between them produced a
+// legacy digest over one set of bytes and a framed digest over another, and the
+// framed digest's claim to identify the corpus does not survive that. One read
+// removes the window between them.
+//
+// It does not close the window between execution and hashing. Both digests are
+// still computed after the run, so they identify the corpus present at summary
+// time rather than proving the bytes that were measured. Closing that requires
+// snapshotting at case-load time and is separate work.
+func readCorpusSnapshot(casesDir, multiFileDir string) ([]corpusFile, error) {
+	paths, err := corpusFilePaths(casesDir, multiFileDir)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]corpusFile, 0, len(paths))
+	for _, p := range paths {
+		key, keyErr := corpusManifestKey(p, casesDir, multiFileDir)
+		if keyErr != nil {
+			return nil, keyErr
+		}
+		data, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return nil, fmt.Errorf("reading %s for hash: %w", p, readErr)
+		}
+		files = append(files, corpusFile{key: key, path: p, data: data})
+	}
+	return files, nil
+}
+
 func corpusManifestKey(path, casesDir, multiFileDir string) (string, error) {
 	roots := []struct {
 		prefix string
@@ -297,15 +392,14 @@ func buildSummary(
 	profilePath string,
 	prov RunProvenance,
 ) (GauntletSummary, error) {
-	corpusSHA, err := computeCorpusSHA256(casesDir, multiFileDir)
+	// One read for both digests. Reading the corpus twice let them describe
+	// different bytes, which is exactly what the framed digest exists to rule out.
+	corpusFiles, err := readCorpusSnapshot(casesDir, multiFileDir)
 	if err != nil {
 		return GauntletSummary{}, err
 	}
-
-	manifestSHA, err := computeBenchmarkManifestSHA256(casesDir, multiFileDir)
-	if err != nil {
-		return GauntletSummary{}, err
-	}
+	corpusSHA := corpusSHA256FromSnapshot(corpusFiles)
+	manifestSHA := benchmarkManifestSHA256FromSnapshot(corpusFiles)
 
 	profileSHA, err := computeProfileSHA256(profilePath)
 	if err != nil {
@@ -441,6 +535,20 @@ func writeSummary(s GauntletSummary, path string) error {
 	}
 	if err := validateRegistryReference(s.CapabilityRegistry); err != nil {
 		return fmt.Errorf("invalid summary capability_registry: %w", err)
+	}
+	// The schema requires these keys but cannot constrain their values on its
+	// own, so a direct caller could emit an empty or malformed digest and have
+	// it rejected only later, by provenance, after the artifact already exists.
+	for _, digest := range []struct {
+		field string
+		value string
+	}{
+		{"corpus_sha256", s.CorpusSHA256},
+		{"benchmark_manifest_sha256", s.BenchmarkManifestSHA256},
+	} {
+		if !isSHA256Hex(digest.value) {
+			return fmt.Errorf("summary %s must be 64 lowercase hex characters, got %q", digest.field, digest.value)
+		}
 	}
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {

--- a/runner/summary.go
+++ b/runner/summary.go
@@ -333,6 +333,15 @@ func readCorpusSnapshot(casesDir, multiFileDir string) ([]corpusFile, error) {
 		}
 		files = append(files, corpusFile{key: key, path: p, data: data})
 	}
+
+	// Hashing nothing yields the SHA-256 of the empty string, which is a
+	// well-formed 64-hex value and passes every shape check downstream. An empty
+	// corpus would therefore publish a valid-looking corpus identity for a run
+	// that measured no cases. A corpus with no files is not a corpus, so this is
+	// an error rather than a digest.
+	if len(files) == 0 {
+		return nil, fmt.Errorf("corpus at %s contains no case files; refusing to hash an empty corpus", casesDir)
+	}
 	return files, nil
 }
 

--- a/runner/summary.go
+++ b/runner/summary.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -64,24 +65,28 @@ type DualDiagnostics struct {
 
 // GauntletSummary is the top-level output written to --output.
 type GauntletSummary struct {
-	SchemaVersion      int                          `json:"schema_version"`
-	GauntletVersion    string                       `json:"gauntlet_version"`
-	ScoringVersion     string                       `json:"scoring_version"`
-	RunnerVersion      string                       `json:"runner_version"`
-	Tool               string                       `json:"tool"`
-	ToolVersion        string                       `json:"tool_version"`
-	CorpusVersion      string                       `json:"corpus_version"`
-	CorpusSHA256       string                       `json:"corpus_sha256"`
-	ToolProfileSHA256  string                       `json:"tool_profile_sha256"`
-	CapabilityRegistry capabilityregistry.Reference `json:"capability_registry"`
-	ReportedClaims     []string                     `json:"reported_claims"`
-	Date               string                       `json:"date,omitempty"`
-	CaseCount          CaseCount                    `json:"case_count"`
-	Exercised          ExercisedCapabilities        `json:"exercised"`
-	Scores             DualScores                   `json:"scores"`
-	Diagnostics        DualDiagnostics              `json:"diagnostics"`
-	MeasurementStatus  string                       `json:"measurement_status"`
-	PerCategory        map[string]CategoryScores    `json:"per_category"`
+	SchemaVersion   int    `json:"schema_version"`
+	GauntletVersion string `json:"gauntlet_version"`
+	ScoringVersion  string `json:"scoring_version"`
+	RunnerVersion   string `json:"runner_version"`
+	Tool            string `json:"tool"`
+	ToolVersion     string `json:"tool_version"`
+	CorpusVersion   string `json:"corpus_version"`
+	CorpusSHA256    string `json:"corpus_sha256"`
+	// BenchmarkManifestSHA256 binds exact corpus contents: paths, byte
+	// lengths, and bytes. CorpusSHA256 above cannot, and is kept only so
+	// published records still verify against their original definition.
+	BenchmarkManifestSHA256 string                       `json:"benchmark_manifest_sha256"`
+	ToolProfileSHA256       string                       `json:"tool_profile_sha256"`
+	CapabilityRegistry      capabilityregistry.Reference `json:"capability_registry"`
+	ReportedClaims          []string                     `json:"reported_claims"`
+	Date                    string                       `json:"date,omitempty"`
+	CaseCount               CaseCount                    `json:"case_count"`
+	Exercised               ExercisedCapabilities        `json:"exercised"`
+	Scores                  DualScores                   `json:"scores"`
+	Diagnostics             DualDiagnostics              `json:"diagnostics"`
+	MeasurementStatus       string                       `json:"measurement_status"`
+	PerCategory             map[string]CategoryScores    `json:"per_category"`
 
 	// Identifying facts that docs/RESULTS-USE.md requires beside any public
 	// result and that cannot be derived from the corpus or the profile. They
@@ -119,14 +124,13 @@ type CaseCount struct {
 	Errors               int            `json:"errors"`
 }
 
-// computeCorpusSHA256 hashes case-file contents across both the single-file
-// corpus rooted at casesDir and (optionally) the multi-file case directory
-// at multiFileDir. Files are sorted by absolute path before hashing so the
-// output is deterministic regardless of filesystem ordering. multiFileDir
-// may be empty: the single-file walker skips directories listed in
-// multiFileCaseCategories on its own, so the hash covers exactly the case
-// surface the runner loaded.
-func computeCorpusSHA256(casesDir, multiFileDir string) (string, error) {
+// corpusFilePaths collects every file both corpus digests cover: the
+// single-file corpus rooted at casesDir plus, when multiFileDir is set, the
+// multi-file case directory. Paths are absolute and sorted so the result is
+// deterministic regardless of filesystem ordering. Both digests below share
+// this one collector so they can never disagree about which files the corpus
+// contains.
+func corpusFilePaths(casesDir, multiFileDir string) ([]string, error) {
 	var paths []string
 
 	err := filepath.Walk(casesDir, func(path string, info os.FileInfo, err error) error {
@@ -145,18 +149,34 @@ func computeCorpusSHA256(casesDir, multiFileDir string) (string, error) {
 		return nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("walking cases for hash: %w", err)
+		return nil, fmt.Errorf("walking cases for hash: %w", err)
 	}
 
 	if multiFileDir != "" {
 		mfPaths, mfErr := computeMultiFileSHA256Paths(multiFileDir)
 		if mfErr != nil {
-			return "", mfErr
+			return nil, mfErr
 		}
 		paths = append(paths, mfPaths...)
 	}
 
 	sort.Strings(paths)
+	return paths, nil
+}
+
+// computeCorpusSHA256 concatenates case-file contents in sorted-path order.
+//
+// This digest CANNOT prove which files a corpus contains. It frames nothing, so
+// any regrouping of the same total bytes produces the same value: one file
+// holding {"a":1}{"b":2} and two files splitting it collide exactly. It is
+// retained unchanged because published records carry it and must keep verifying
+// against the definition they were produced under. For a digest that actually
+// binds paths and boundaries, see computeBenchmarkManifestSHA256.
+func computeCorpusSHA256(casesDir, multiFileDir string) (string, error) {
+	paths, err := corpusFilePaths(casesDir, multiFileDir)
+	if err != nil {
+		return "", err
+	}
 
 	h := sha256.New()
 	for _, p := range paths {
@@ -168,6 +188,78 @@ func computeCorpusSHA256(casesDir, multiFileDir string) (string, error) {
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// computeBenchmarkManifestSHA256 binds the exact corpus contents: every file's
+// location, its byte length, and its bytes.
+//
+// Each entry is length-prefixed, so no regrouping, rename, split, or merge of
+// the same bytes can produce the same digest. Keys are relative to the root the
+// file was found under, and each root carries a distinct prefix, so the value is
+// identical on any machine and unambiguous between the two trees.
+func computeBenchmarkManifestSHA256(casesDir, multiFileDir string) (string, error) {
+	paths, err := corpusFilePaths(casesDir, multiFileDir)
+	if err != nil {
+		return "", err
+	}
+
+	type entry struct {
+		key  string
+		path string
+	}
+	entries := make([]entry, 0, len(paths))
+	for _, p := range paths {
+		key, keyErr := corpusManifestKey(p, casesDir, multiFileDir)
+		if keyErr != nil {
+			return "", keyErr
+		}
+		entries = append(entries, entry{key: key, path: p})
+	}
+	// Sort by the framed key rather than the absolute path, so the digest does
+	// not depend on where the trees happen to live on disk.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+
+	h := sha256.New()
+	var size [binary.MaxVarintLen64]byte
+	writeField := func(b []byte) {
+		n := binary.PutUvarint(size[:], uint64(len(b)))
+		_, _ = h.Write(size[:n])
+		_, _ = h.Write(b)
+	}
+	for _, e := range entries {
+		data, readErr := os.ReadFile(e.path)
+		if readErr != nil {
+			return "", fmt.Errorf("reading %s for manifest hash: %w", e.path, readErr)
+		}
+		writeField([]byte(e.key))
+		writeField(data)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// corpusManifestKey renders a machine-independent key for a corpus file. The
+// root prefix keeps the two trees distinct even when a relative path could
+// appear under either.
+func corpusManifestKey(path, casesDir, multiFileDir string) (string, error) {
+	roots := []struct {
+		prefix string
+		dir    string
+	}{
+		{prefix: "multifile", dir: multiFileDir},
+		{prefix: "cases", dir: casesDir},
+	}
+	for _, root := range roots {
+		if root.dir == "" {
+			continue
+		}
+		rel, err := filepath.Rel(root.dir, path)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		return root.prefix + "/" + filepath.ToSlash(rel), nil
+	}
+	return "", fmt.Errorf("corpus file %s is outside every corpus root", path)
 }
 
 // computeProfileSHA256 hashes the tool profile file contents.
@@ -206,6 +298,11 @@ func buildSummary(
 	prov RunProvenance,
 ) (GauntletSummary, error) {
 	corpusSHA, err := computeCorpusSHA256(casesDir, multiFileDir)
+	if err != nil {
+		return GauntletSummary{}, err
+	}
+
+	manifestSHA, err := computeBenchmarkManifestSHA256(casesDir, multiFileDir)
 	if err != nil {
 		return GauntletSummary{}, err
 	}
@@ -250,18 +347,19 @@ func buildSummary(
 	}
 
 	return GauntletSummary{
-		SchemaVersion:      activeSummarySchemaVersion,
-		GauntletVersion:    gauntletVersion,
-		ScoringVersion:     scoringVersion,
-		RunnerVersion:      runnerVersion,
-		Tool:               p.Tool,
-		ToolVersion:        p.ToolVersion,
-		CorpusVersion:      corpusVersion,
-		CorpusSHA256:       corpusSHA,
-		ToolProfileSHA256:  profileSHA,
-		CapabilityRegistry: p.CapabilityRegistry,
-		ReportedClaims:     append([]string(nil), p.Claims...),
-		Date:               date,
+		SchemaVersion:           activeSummarySchemaVersion,
+		GauntletVersion:         gauntletVersion,
+		ScoringVersion:          scoringVersion,
+		RunnerVersion:           runnerVersion,
+		Tool:                    p.Tool,
+		ToolVersion:             p.ToolVersion,
+		CorpusVersion:           corpusVersion,
+		CorpusSHA256:            corpusSHA,
+		BenchmarkManifestSHA256: manifestSHA,
+		ToolProfileSHA256:       profileSHA,
+		CapabilityRegistry:      p.CapabilityRegistry,
+		ReportedClaims:          append([]string(nil), p.Claims...),
+		Date:                    date,
 		CaseCount: CaseCount{
 			Total:                len(allCases),
 			Applicable:           len(applicableResults),

--- a/runner/summary_test.go
+++ b/runner/summary_test.go
@@ -237,7 +237,14 @@ func TestWriteSummaryOmitsEmptyDate(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "summary.json")
-	if err := writeSummary(GauntletSummary{Tool: "test", Date: "", CapabilityRegistry: testRegistryReference}, path); err != nil {
+	if err := writeSummary(GauntletSummary{
+		Tool:                    "test",
+		Date:                    "",
+		CorpusSHA256:            strings.Repeat("a", 64),
+		BenchmarkManifestSHA256: strings.Repeat("b", 64),
+		ToolProfileSHA256:       strings.Repeat("c", 64),
+		CapabilityRegistry:      testRegistryReference,
+	}, path); err != nil {
 		t.Fatalf("writeSummary: %v", err)
 	}
 	data, err := os.ReadFile(path)
@@ -338,8 +345,9 @@ func TestWriteSummary(t *testing.T) {
 		Tool:               "test-tool",
 		ToolVersion:        "1.0.0",
 		CorpusVersion:      corpusVersion,
-		CorpusSHA256:       "abc123",
-		ToolProfileSHA256:  "def456",
+		CorpusSHA256:            strings.Repeat("a", 64),
+		BenchmarkManifestSHA256: strings.Repeat("b", 64),
+		ToolProfileSHA256:       strings.Repeat("c", 64),
 		CapabilityRegistry: testRegistryReference,
 		ReportedClaims:     []string{"url_dlp"},
 		Date:               "2026-03-28T00:00:00Z",
@@ -403,8 +411,9 @@ func TestWriteSummary(t *testing.T) {
 	if parsed.ScoringVersion != scoringVersion {
 		t.Errorf("scoring_version = %q, want %q", parsed.ScoringVersion, scoringVersion)
 	}
-	if parsed.ToolProfileSHA256 != "def456" {
-		t.Errorf("tool_profile_sha256 = %q, want def456", parsed.ToolProfileSHA256)
+	wantProfileSHA := strings.Repeat("c", 64)
+	if parsed.ToolProfileSHA256 != wantProfileSHA {
+		t.Errorf("tool_profile_sha256 = %q, want %q", parsed.ToolProfileSHA256, wantProfileSHA)
 	}
 	if parsed.Scores.Full.Containment == nil || *parsed.Scores.Full.Containment != 0.95 {
 		t.Errorf("full containment = %v, want 0.95", ptrVal(parsed.Scores.Full.Containment))

--- a/schemas/summary-v5.schema.json
+++ b/schemas/summary-v5.schema.json
@@ -4,9 +4,12 @@
   "title": "agent-egress-bench Gauntlet Summary",
   "description": "Active v5 summary. Scores contain only measured outcome rates. Field-presence observations live in diagnostics and do not establish detection accuracy or proof.",
   "type": "object",
-  "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "diagnostics", "measurement_status", "per_category"],
+  "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "benchmark_manifest_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "diagnostics", "measurement_status", "per_category"],
   "properties": {
     "schema_version": {"type": "integer", "const": 5},
+    "corpus_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "benchmark_manifest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "tool_profile_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "capability_registry": {"$ref": "#/$defs/capability_registry"},
     "reported_claims": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
     "scores": {"$ref": "#/$defs/dual_outcome_scores"},

--- a/schemas/summary.schema.json
+++ b/schemas/summary.schema.json
@@ -28,6 +28,18 @@
       "type": "integer",
       "const": 4
     },
+    "corpus_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "benchmark_manifest_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "tool_profile_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
     "capability_registry": {
       "$ref": "#/$defs/capability_registry"
     },

--- a/schemas/summary.schema.json
+++ b/schemas/summary.schema.json
@@ -4,89 +4,24 @@
   "title": "agent-egress-bench Gauntlet Summary",
   "description": "Frozen v4 summary. Reporting labels are registry-bound metadata and cannot affect measured scope or score.",
   "type": "object",
-  "required": [
-    "schema_version",
-    "gauntlet_version",
-    "scoring_version",
-    "runner_version",
-    "tool",
-    "tool_version",
-    "corpus_version",
-    "corpus_sha256",
-    "benchmark_manifest_sha256",
-    "tool_profile_sha256",
-    "capability_registry",
-    "reported_claims",
-    "case_count",
-    "exercised",
-    "scores",
-    "measurement_status",
-    "per_category"
-  ],
+  "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "measurement_status", "per_category"],
   "properties": {
-    "schema_version": {
-      "type": "integer",
-      "const": 4
-    },
-    "corpus_sha256": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "benchmark_manifest_sha256": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "tool_profile_sha256": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{64}$"
-    },
-    "capability_registry": {
-      "$ref": "#/$defs/capability_registry"
-    },
-    "reported_claims": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
-    },
-    "measurement_status": {
-      "type": "string",
-      "enum": [
-        "measured",
-        "incomplete"
-      ]
-    }
+    "schema_version": {"type": "integer", "const": 4},
+    "capability_registry": {"$ref": "#/$defs/capability_registry"},
+    "reported_claims": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]}
   },
   "additionalProperties": true,
   "$defs": {
     "capability_registry": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "id",
-        "format",
-        "revision",
-        "sha256"
-      ],
+      "required": ["id", "format", "revision", "sha256"],
       "properties": {
-        "id": {
-          "type": "string",
-          "minLength": 1
-        },
-        "format": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "revision": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "sha256": {
-          "type": "string",
-          "pattern": "^[0-9a-f]{64}$"
-        }
+        "id": {"type": "string", "minLength": 1},
+        "format": {"type": "integer", "minimum": 1},
+        "revision": {"type": "integer", "minimum": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
       }
     }
   }

--- a/schemas/summary.schema.json
+++ b/schemas/summary.schema.json
@@ -4,24 +4,77 @@
   "title": "agent-egress-bench Gauntlet Summary",
   "description": "Frozen v4 summary. Reporting labels are registry-bound metadata and cannot affect measured scope or score.",
   "type": "object",
-  "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "measurement_status", "per_category"],
+  "required": [
+    "schema_version",
+    "gauntlet_version",
+    "scoring_version",
+    "runner_version",
+    "tool",
+    "tool_version",
+    "corpus_version",
+    "corpus_sha256",
+    "benchmark_manifest_sha256",
+    "tool_profile_sha256",
+    "capability_registry",
+    "reported_claims",
+    "case_count",
+    "exercised",
+    "scores",
+    "measurement_status",
+    "per_category"
+  ],
   "properties": {
-    "schema_version": {"type": "integer", "const": 4},
-    "capability_registry": {"$ref": "#/$defs/capability_registry"},
-    "reported_claims": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
-    "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]}
+    "schema_version": {
+      "type": "integer",
+      "const": 4
+    },
+    "capability_registry": {
+      "$ref": "#/$defs/capability_registry"
+    },
+    "reported_claims": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "measurement_status": {
+      "type": "string",
+      "enum": [
+        "measured",
+        "incomplete"
+      ]
+    }
   },
   "additionalProperties": true,
   "$defs": {
     "capability_registry": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "format", "revision", "sha256"],
+      "required": [
+        "id",
+        "format",
+        "revision",
+        "sha256"
+      ],
       "properties": {
-        "id": {"type": "string", "minLength": 1},
-        "format": {"type": "integer", "minimum": 1},
-        "revision": {"type": "integer", "minimum": 1},
-        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "format": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revision": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
       }
     }
   }

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -432,6 +432,16 @@ def measurements(repo_root, run_dir):
         require_non_empty_string(summary, key, f"runner summary {key}")
     for key in ("corpus_sha256", "tool_profile_sha256"):
         require_sha256(summary, key)
+    if summary_schema_version == 4:
+        # Active output must carry the framed digest, which is the only one that
+        # can prove corpus identity. Version-gated because frozen pre-v4 records
+        # predate the field and must keep validating.
+        #
+        # This checks SHAPE only, exactly as corpus_sha256 above does. Neither
+        # digest is recomputed here: this builder reads a run directory that
+        # contains corpus-manifest.txt but not the case files, so it has nothing
+        # to recompute from. Both remain runner-asserted values.
+        require_sha256(summary, "benchmark_manifest_sha256")
     command = (run_dir / RAW_EVIDENCE["command"]).read_text(encoding="utf-8").strip()
     make_stats = (run_dir / RAW_EVIDENCE["stats"]).read_text(encoding="utf-8")
     stderr = (run_dir / RAW_EVIDENCE["runner_stderr"]).read_text(encoding="utf-8")

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -214,6 +214,7 @@ class ProvenanceBuilderTest(unittest.TestCase):
         summary["exercised"] = {"capability_tags": ["test"]}
         summary["tool_profile_sha256"] = hashlib.sha256(profile_bytes).hexdigest()
         summary["measurement_status"] = measurement_status
+        summary["benchmark_manifest_sha256"] = "c" * 64
         summary.pop("sufficient", None)
         if summary_schema_version == 5:
             summary["scoring_version"] = "2.8"
@@ -462,6 +463,30 @@ class ProvenanceBuilderTest(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("measurement_status", result.stderr)
+
+    def test_active_summary_without_framed_corpus_digest_blocks_publication(self):
+        self.make_active_fixture()
+        summary_path = self.run_dir / "raw-summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        del summary["benchmark_manifest_sha256"]
+        summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+        result = self.bundle()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("benchmark_manifest_sha256", result.stderr)
+
+    def test_frozen_record_without_framed_corpus_digest_still_validates(self):
+        # The framed digest postdates the frozen evidence, so requiring it there
+        # would retroactively invalidate an already published record.
+        summary_path = self.run_dir / "raw-summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        self.assertNotIn("schema_version", summary)
+        self.assertNotIn("benchmark_manifest_sha256", summary)
+
+        result = self.bundle()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_active_synthetic_row_blocks_publication(self):
         self.make_active_fixture()


### PR DESCRIPTION
`corpus_sha256` concatenates case file contents in sorted-path order and frames nothing, so any regrouping of the same total bytes across files produces the same value. One file holding `{"a":1}{"b":2}` and two files splitting it collide exactly. Documentation pointed at that field four separate times to prove which corpus ran, which it cannot do.

`benchmark_manifest_sha256` binds each file's path, byte length, and bytes, with every entry length-prefixed. Keys are relative to the root the file was found under and each root carries a distinct prefix, so the value is identical on any machine and unambiguous between the single-file and multi-file trees.

The length prefixes are what resist a crafted filename impersonating an entry boundary. Path inclusion alone does not: under an unframed concatenation, a file named `x.json` holding `y.json{}` and a file named `x.jsony.json` holding `{}` produce identical bytes, and both names are valid corpus files. That case is tested directly, because the more obvious regrouping test passes even with framing removed and therefore proves nothing about framing.

`corpus_sha256` keeps its exact previous meaning and value. Published records carry it and must keep verifying against the definition they were produced under, so the new field is additive and the old one is not redefined.

Both digests share one path collector, so they cannot disagree about which files the corpus contains.

Two limits are worth stating, because the field would otherwise look stronger than it is. The provenance builder checks the new digest's shape only, exactly as it already does for `corpus_sha256`, and version-gates that check so frozen records stay valid. Neither digest is recomputed there, because that builder reads a run directory holding `corpus-manifest.txt` rather than the case files. Both remain runner-asserted values, and closing that is separate work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an exact benchmark manifest digest that uniquely identifies corpus files, paths, lengths, and contents.
  * Benchmark summaries and active provenance records now include this digest.

* **Documentation**
  * Clarified the distinction between legacy content hashes and the new corpus identity digest.
  * Updated reproducibility requirements and public-result guidance.

* **Validation**
  * Added checks ensuring active records include a valid digest while preserving compatibility with frozen legacy records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->