### PR TITLE
docs: gate the category mapping against the loaded corpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: preflight check-claim-language check-capability-registry-history test-label-boundary stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example validate-cases validate
+.PHONY: preflight check-claim-language check-readme-categories check-capability-registry-history test-label-boundary stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example validate-cases validate
 
 TMPDIR := $(HOME)/.cache/pipelock-tmp
 GOCACHE := $(HOME)/.cache/go-build
@@ -12,7 +12,7 @@ GAUNTLET_SCOPE_ARTIFACT ?= gauntlet-site/testdata/complete-provenance-artifact.j
 # below complete comfortably inside the edit-to-push budget and it catches real
 # shared-state defects that ordinary go test would miss. It requires the Go
 # toolchain needed by runner/go.mod (currently Go 1.25 or newer).
-preflight: test-capability-registry check-capability-registry-history test-label-boundary test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example check-stats check-gauntlet-site check-claim-language
+preflight: test-capability-registry check-capability-registry-history test-label-boundary test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example check-stats check-gauntlet-site check-claim-language check-readme-categories
 
 test-capability-registry:
 	@mkdir -p "$(TMPDIR)" "$(GOCACHE)"
@@ -32,6 +32,10 @@ test-label-boundary:
 check-claim-language:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_claim_language_test.py
 	@python3 scripts/check_claim_language.py
+
+check-readme-categories:
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_readme_categories_test.py
+	@python3 scripts/check_readme_categories.py --repo-root .
 
 test-validate:
 	@mkdir -p "$(TMPDIR)" "$(GOCACHE)"

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Start from the [runner template](examples/runner-template/) for a working skelet
 
 ## OWASP Agentic Top 10 mapping
 
-The 8 case categories map to the [OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/):
+Every case category maps to the [OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/). `make check-readme-categories` fails when this table and the corpus disagree, so the mapping stays complete as categories are added:
 
 | Case category | OWASP item | What the cases cover |
 |---------------|------------|---------------------|
@@ -194,6 +194,7 @@ The 8 case categories map to the [OWASP Top 10 for Agentic Applications (2026)](
 | `mcp_input` | ASI02 Tool Misuse | DLP and injection in tool arguments |
 | `mcp_tool` | ASI04 Supply Chain | Poisoned tool descriptions, rug-pull changes |
 | `mcp_chain` | ASI02 Tool Misuse + ASI08 Cascading Failures | Multi-step exfiltration sequences |
+| `mcp_drift` | ASI04 Supply Chain | Tool inventory changes after approval |
 | `a2a_message` | ASI07 Inter-Agent Communication | Secrets and injection in A2A messages |
 | `a2a_agent_card` | ASI04 Supply Chain + ASI07 Inter-Agent | Poisoned Agent Card skill descriptions |
 | `websocket_dlp` | ASI02 Tool Misuse | Secrets in WebSocket frames, fragment evasion |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -49,7 +49,9 @@ Each case is a single JSON file in the `cases/` directory tree. Files are named 
 
 ### category
 
-`url`, `request_body`, `headers`, `hostname_exfiltration`, `response_fetch`, `response_mitm`, `mcp_input`, `mcp_tool`, `mcp_chain`, `a2a_message`, `a2a_agent_card`, `websocket_dlp`, `ssrf_bypass`, `encoding_evasion`, `shell_obfuscation`, `crypto_financial`, `false_positive`
+`url`, `request_body`, `headers`, `hostname_exfiltration`, `response_fetch`, `response_mitm`, `mcp_input`, `mcp_tool`, `mcp_chain`, `mcp_drift`, `a2a_message`, `a2a_agent_card`, `websocket_dlp`, `ssrf_bypass`, `encoding_evasion`, `shell_obfuscation`, `crypto_financial`, `false_positive`
+
+`mcp_drift` is carried only by multi-file cases under `cases/mcp-drift/`, so the single-file validator does not accept it; the multi-file loader requires it.
 
 ### input_type
 

--- a/scripts/check_readme_categories.py
+++ b/scripts/check_readme_categories.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Fail when the README category mapping no longer covers the live corpus.
+
+The README maps every case category to an OWASP Agentic Top 10 item. That table
+is hand-maintained prose, so it drifts the moment a category is added: on
+2026-08-09 it was missing `mcp_drift` and its lead-in sentence still claimed
+eight categories while the corpus held eighteen.
+
+Counting categories in prose is what rotted, so this gate does not check a
+number. It compares the SET of categories the runner actually loads against the
+set the table documents, in both directions. A category with cases and no row is
+undocumented; a row with no cases documents something that does not exist.
+
+The runner is the authority. Its exit status is checked before its output is
+parsed, because an empty stats report otherwise yields an empty category set,
+which trivially matches nothing missing and would pass while proving nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# `| `category` | ASI02 ... |` -- the first cell of an OWASP mapping row.
+TABLE_ROW = re.compile(r"^\|\s*`([a-z0-9_]+)`\s*\|")
+STATS_ENTRY = re.compile(r"^\s+([a-z0-9_]+):\s*\d+\s*$")
+
+
+def live_categories(repo_root: Path) -> set[str]:
+    """Categories the runner loads, from its own stats output."""
+    proc = subprocess.run(
+        ["go", "run", ".", "--stats", "--cases", "../cases"],
+        cwd=repo_root / "runner",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(
+            "check-readme-categories: FAIL - the runner could not load the corpus\n"
+            f"{proc.stderr.strip()}"
+        )
+
+    categories: set[str] = set()
+    in_block = False
+    for line in proc.stdout.splitlines():
+        if line.startswith("by_category:"):
+            in_block = True
+            continue
+        if in_block:
+            match = STATS_ENTRY.match(line)
+            if not match:
+                break
+            categories.add(match.group(1))
+
+    if not categories:
+        raise SystemExit(
+            "check-readme-categories: FAIL - the runner reported no categories; "
+            "refusing to compare against an empty set"
+        )
+    return categories
+
+
+def documented_categories(readme: Path) -> set[str]:
+    return {
+        match.group(1)
+        for line in readme.read_text(encoding="utf-8").splitlines()
+        if (match := TABLE_ROW.match(line))
+    }
+
+
+def spec_categories(spec: Path) -> set[str]:
+    """The category enum SPEC.md declares, read from under its own heading.
+
+    Scoped to the `### category` section so the surrounding enums for
+    `input_type`, `transport`, `capability_tags`, and `requires` cannot leak in
+    and mask a missing category.
+    """
+    lines = spec.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() != "### category":
+            continue
+        for candidate in lines[index + 1 :]:
+            if candidate.startswith("#"):
+                break
+            if candidate.strip().startswith("`"):
+                return set(re.findall(r"`([a-z0-9_]+)`", candidate))
+        break
+    raise SystemExit(
+        "check-readme-categories: FAIL - could not find the category enum under "
+        "'### category' in docs/SPEC.md"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", type=Path)
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    readme = repo_root / "README.md"
+    if not readme.is_file():
+        raise SystemExit(f"check-readme-categories: FAIL - missing {readme}")
+
+    spec = repo_root / "docs" / "SPEC.md"
+    if not spec.is_file():
+        raise SystemExit(f"check-readme-categories: FAIL - missing {spec}")
+
+    live = live_categories(repo_root)
+    documented = documented_categories(readme)
+    declared = spec_categories(spec)
+
+    failed = False
+    for label, names, fix in (
+        ("README rows", documented, "update the OWASP mapping table in README.md"),
+        ("the docs/SPEC.md category enum", declared, "update the enum under '### category'"),
+    ):
+        missing = sorted(live - names)
+        phantom = sorted(names - live)
+        if missing:
+            print(
+                f"check-readme-categories: FAIL - categories have cases but are absent from {label}: "
+                + ", ".join(missing)
+            )
+        if phantom:
+            print(
+                f"check-readme-categories: FAIL - {label} name categories with no cases: "
+                + ", ".join(phantom)
+            )
+        if missing or phantom:
+            print(f"  fix: {fix}")
+            failed = True
+
+    if failed:
+        return 1
+
+    print(f"check-readme-categories: OK ({len(live)} categories documented in README and SPEC)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_readme_categories.py
+++ b/scripts/check_readme_categories.py
@@ -24,20 +24,47 @@ import subprocess
 import sys
 from pathlib import Path
 
-# `| `category` | ASI02 ... |` -- the first cell of an OWASP mapping row.
-TABLE_ROW = re.compile(r"^\|\s*`([a-z0-9_]+)`\s*\|")
+# `| `category` | ASI02 Tool Misuse | ... |` -- category cell plus its mapping cell.
+TABLE_ROW = re.compile(r"^\|\s*`([a-z0-9_]+)`\s*\|([^|]*)\|")
 STATS_ENTRY = re.compile(r"^\s+([a-z0-9_]+):\s*\d+\s*$")
+# The mapping must name at least one OWASP item, or say N/A for a benign
+# category. An empty cell is a row that documents nothing.
+OWASP_ITEM = re.compile(r"\bASI(?:0[1-9]|10)\b|\bN/A\b")
+# The header that identifies the mapping table, so an unrelated table whose
+# first cell happens to be a lowercase code span cannot satisfy this gate.
+TABLE_HEADER = re.compile(r"^\|\s*Case category\s*\|")
+
+STATS_TIMEOUT_SECONDS = 300
 
 
 def live_categories(repo_root: Path) -> set[str]:
-    """Categories the runner loads, from its own stats output."""
-    proc = subprocess.run(
-        ["go", "run", ".", "--stats", "--cases", "../cases"],
-        cwd=repo_root / "runner",
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    """Categories the runner loads, from its own stats output.
+
+    The runner is the authority precisely because it loads both the single-file
+    corpus and the multi-file cases under `cases/mcp-drift/`, so a category that
+    only a special loader accepts still appears here. A test asserts that, since
+    a runner that stopped reporting multi-file categories would make this gate
+    quietly stop covering them.
+    """
+    try:
+        proc = subprocess.run(
+            ["go", "run", ".", "--stats", "--cases", "../cases"],
+            cwd=repo_root / "runner",
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=STATS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        raise SystemExit(
+            "check-readme-categories: FAIL - the runner did not finish within "
+            f"{STATS_TIMEOUT_SECONDS}s; refusing to treat a hung run as a result"
+        ) from None
+    except OSError as err:
+        raise SystemExit(
+            f"check-readme-categories: FAIL - could not execute the runner: {err}"
+        ) from None
+
     if proc.returncode != 0:
         raise SystemExit(
             "check-readme-categories: FAIL - the runner could not load the corpus\n"
@@ -45,17 +72,30 @@ def live_categories(repo_root: Path) -> set[str]:
         )
 
     categories: set[str] = set()
+    found_section = False
     in_block = False
     for line in proc.stdout.splitlines():
         if line.startswith("by_category:"):
+            found_section = True
             in_block = True
             continue
         if in_block:
+            if not line.strip():
+                # A blank separator inside the block is formatting, not the end
+                # of it. Treating it as the end silently truncated the set.
+                continue
             match = STATS_ENTRY.match(line)
             if not match:
                 break
             categories.add(match.group(1))
 
+    # A missing section and an empty one are different failures, and neither may
+    # be compared against: an empty set makes every "missing" check trivially true.
+    if not found_section:
+        raise SystemExit(
+            "check-readme-categories: FAIL - the runner output had no 'by_category:' "
+            "section; the stats format may have changed"
+        )
     if not categories:
         raise SystemExit(
             "check-readme-categories: FAIL - the runner reported no categories; "
@@ -65,11 +105,45 @@ def live_categories(repo_root: Path) -> set[str]:
 
 
 def documented_categories(readme: Path) -> set[str]:
-    return {
-        match.group(1)
-        for line in readme.read_text(encoding="utf-8").splitlines()
-        if (match := TABLE_ROW.match(line))
-    }
+    """Categories mapped by the README's OWASP table, with the mapping checked.
+
+    Scoped to the table under the `Case category` header. Set equality alone was
+    too weak: an unrelated table whose first cell is a lowercase code span would
+    satisfy it, and a row with an empty mapping cell counted as mapped while
+    documenting nothing.
+    """
+    categories: set[str] = set()
+    unmapped: list[str] = []
+    in_table = False
+
+    for line in readme.read_text(encoding="utf-8").splitlines():
+        if TABLE_HEADER.match(line):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not line.startswith("|"):
+            in_table = False
+            continue
+        match = TABLE_ROW.match(line)
+        if not match:
+            continue
+        name, mapping = match.group(1), match.group(2)
+        categories.add(name)
+        if not OWASP_ITEM.search(mapping):
+            unmapped.append(name)
+
+    if not in_table and not categories:
+        raise SystemExit(
+            "check-readme-categories: FAIL - could not find the mapping table under a "
+            "'| Case category |' header in README.md"
+        )
+    if unmapped:
+        raise SystemExit(
+            "check-readme-categories: FAIL - README rows carry no OWASP item: "
+            + ", ".join(sorted(unmapped))
+        )
+    return categories
 
 
 def spec_categories(spec: Path) -> set[str]:

--- a/scripts/check_readme_categories_test.py
+++ b/scripts/check_readme_categories_test.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Tests for check_readme_categories.
+
+The empty-set test is the important one. An empty category set makes every
+"missing" comparison trivially true, so a runner that produced nothing would
+otherwise pass this gate while proving nothing, which is the exact defect the
+sibling stats gate already had to fix.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "check_readme_categories.py"
+
+spec = importlib.util.spec_from_file_location("check_readme_categories", SCRIPT)
+assert spec and spec.loader
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+class DocumentedCategoriesTest(unittest.TestCase):
+    def _readme(self, body: str) -> Path:
+        path = Path(self.tmp.name) / "README.md"
+        path.write_text(textwrap.dedent(body), encoding="utf-8")
+        return path
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_reads_category_cells(self) -> None:
+        readme = self._readme(
+            """
+            | Case category | OWASP item | What the cases cover |
+            |---------------|------------|---------------------|
+            | `url` | ASI02 Tool Misuse | Secrets in query strings |
+            | `mcp_drift` | ASI04 Supply Chain | Inventory changes |
+            """
+        )
+        self.assertEqual(mod.documented_categories(readme), {"url", "mcp_drift"})
+
+    def test_ignores_prose_and_non_category_tables(self) -> None:
+        readme = self._readme(
+            """
+            Some prose mentioning `url` inline should not count.
+
+            | Field | Meaning |
+            |-------|---------|
+            | not a category cell | because the row does not lead with a code span |
+            """
+        )
+        self.assertEqual(mod.documented_categories(readme), set())
+
+
+class SpecCategoriesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _spec(self, body: str) -> Path:
+        path = Path(self.tmp.name) / "SPEC.md"
+        path.write_text(textwrap.dedent(body), encoding="utf-8")
+        return path
+
+    def test_reads_only_the_category_section(self) -> None:
+        """A neighbouring enum must not satisfy a missing category."""
+        spec = self._spec(
+            """
+            ### category
+
+            `url`, `mcp_drift`
+
+            ### input_type
+
+            `url`, `websocket_frame`, `mcp_tool_call`
+            """
+        )
+        self.assertEqual(mod.spec_categories(spec), {"url", "mcp_drift"})
+
+    def test_missing_section_is_refused(self) -> None:
+        spec = self._spec(
+            """
+            ### input_type
+
+            `url`, `websocket_frame`
+            """
+        )
+        with self.assertRaises(SystemExit):
+            mod.spec_categories(spec)
+
+
+class ComparisonTest(unittest.TestCase):
+    """The gate's decision, exercised without invoking the Go runner."""
+
+    def _run(self, live: set[str], documented: set[str]) -> int:
+        undocumented = sorted(live - documented)
+        phantom = sorted(documented - live)
+        return 1 if (undocumented or phantom) else 0
+
+    def test_complete_mapping_passes(self) -> None:
+        self.assertEqual(self._run({"url", "mcp_drift"}, {"url", "mcp_drift"}), 0)
+
+    def test_category_without_a_row_fails(self) -> None:
+        self.assertEqual(self._run({"url", "mcp_drift"}, {"url"}), 1)
+
+    def test_row_without_cases_fails(self) -> None:
+        self.assertEqual(self._run({"url"}, {"url", "retired_category"}), 1)
+
+
+class EmptyRunnerOutputTest(unittest.TestCase):
+    def test_refuses_an_empty_category_set(self) -> None:
+        """A runner reporting nothing must not satisfy the gate by vacuity."""
+
+        def fake_run(*_args, **_kwargs):
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        original = mod.subprocess.run
+        mod.subprocess.run = fake_run
+        try:
+            with self.assertRaises(SystemExit) as caught:
+                mod.live_categories(Path("."))
+        finally:
+            mod.subprocess.run = original
+        self.assertIn("no categories", str(caught.exception))
+
+    def test_refuses_a_failing_runner(self) -> None:
+        def fake_run(*_args, **_kwargs):
+            return subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="corpus load failed"
+            )
+
+        original = mod.subprocess.run
+        mod.subprocess.run = fake_run
+        try:
+            with self.assertRaises(SystemExit) as caught:
+                mod.live_categories(Path("."))
+        finally:
+            mod.subprocess.run = original
+        self.assertIn("could not load the corpus", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check_readme_categories_test.py
+++ b/scripts/check_readme_categories_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Tests for check_readme_categories.
 
-The empty-set test is the important one. An empty category set makes every
+The empty-set tests are the important ones. An empty category set makes every
 "missing" comparison trivially true, so a runner that produced nothing would
 otherwise pass this gate while proving nothing, which is the exact defect the
 sibling stats gate already had to fix.
@@ -11,69 +11,74 @@ from __future__ import annotations
 
 import importlib.util
 import subprocess
+import tempfile
 import textwrap
 import unittest
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent / "check_readme_categories.py"
+REPO_ROOT = SCRIPT.parent.parent
 
 spec = importlib.util.spec_from_file_location("check_readme_categories", SCRIPT)
 assert spec and spec.loader
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 
+TABLE_HEAD = "| Case category | OWASP item | What the cases cover |\n|---|---|---|\n"
 
-class DocumentedCategoriesTest(unittest.TestCase):
-    def _readme(self, body: str) -> Path:
-        path = Path(self.tmp.name) / "README.md"
-        path.write_text(textwrap.dedent(body), encoding="utf-8")
-        return path
 
+class TempFileTest(unittest.TestCase):
     def setUp(self) -> None:
-        import tempfile
-
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
 
-    def test_reads_category_cells(self) -> None:
-        readme = self._readme(
-            """
-            | Case category | OWASP item | What the cases cover |
-            |---------------|------------|---------------------|
-            | `url` | ASI02 Tool Misuse | Secrets in query strings |
-            | `mcp_drift` | ASI04 Supply Chain | Inventory changes |
-            """
+    def _write(self, name: str, body: str) -> Path:
+        path = Path(self.tmp.name) / name
+        path.write_text(textwrap.dedent(body), encoding="utf-8")
+        return path
+
+
+class DocumentedCategoriesTest(TempFileTest):
+    def test_reads_mapped_category_cells(self) -> None:
+        readme = self._write(
+            "README.md",
+            TABLE_HEAD
+            + "| `url` | ASI02 Tool Misuse | Secrets in query strings |\n"
+            + "| `mcp_drift` | ASI04 Supply Chain | Inventory changes |\n",
         )
         self.assertEqual(mod.documented_categories(readme), {"url", "mcp_drift"})
 
-    def test_ignores_prose_and_non_category_tables(self) -> None:
-        readme = self._readme(
-            """
-            Some prose mentioning `url` inline should not count.
-
-            | Field | Meaning |
-            |-------|---------|
-            | not a category cell | because the row does not lead with a code span |
-            """
+    def test_accepts_not_applicable_for_benign_categories(self) -> None:
+        readme = self._write(
+            "README.md",
+            TABLE_HEAD + "| `false_positive` | N/A | Benign traffic |\n",
         )
-        self.assertEqual(mod.documented_categories(readme), set())
+        self.assertEqual(mod.documented_categories(readme), {"false_positive"})
+
+    def test_row_without_an_owasp_item_is_refused(self) -> None:
+        readme = self._write(
+            "README.md", TABLE_HEAD + "| `url` |  | Secrets in query strings |\n"
+        )
+        with self.assertRaises(SystemExit) as caught:
+            mod.documented_categories(readme)
+        self.assertIn("no OWASP item", str(caught.exception))
+
+    def test_unrelated_table_does_not_satisfy_the_gate(self) -> None:
+        """A code-span first cell in some other table must not count as a mapping."""
+        readme = self._write(
+            "README.md",
+            "| Field | Meaning |\n|---|---|\n| `url` | a config key, not a category |\n",
+        )
+        with self.assertRaises(SystemExit) as caught:
+            mod.documented_categories(readme)
+        self.assertIn("could not find the mapping table", str(caught.exception))
 
 
-class SpecCategoriesTest(unittest.TestCase):
-    def setUp(self) -> None:
-        import tempfile
-
-        self.tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(self.tmp.cleanup)
-
-    def _spec(self, body: str) -> Path:
-        path = Path(self.tmp.name) / "SPEC.md"
-        path.write_text(textwrap.dedent(body), encoding="utf-8")
-        return path
-
+class SpecCategoriesTest(TempFileTest):
     def test_reads_only_the_category_section(self) -> None:
         """A neighbouring enum must not satisfy a missing category."""
-        spec = self._spec(
+        spec_md = self._write(
+            "SPEC.md",
             """
             ### category
 
@@ -82,29 +87,28 @@ class SpecCategoriesTest(unittest.TestCase):
             ### input_type
 
             `url`, `websocket_frame`, `mcp_tool_call`
-            """
+            """,
         )
-        self.assertEqual(mod.spec_categories(spec), {"url", "mcp_drift"})
+        self.assertEqual(mod.spec_categories(spec_md), {"url", "mcp_drift"})
 
     def test_missing_section_is_refused(self) -> None:
-        spec = self._spec(
+        spec_md = self._write(
+            "SPEC.md",
             """
             ### input_type
 
             `url`, `websocket_frame`
-            """
+            """,
         )
         with self.assertRaises(SystemExit):
-            mod.spec_categories(spec)
+            mod.spec_categories(spec_md)
 
 
 class ComparisonTest(unittest.TestCase):
     """The gate's decision, exercised without invoking the Go runner."""
 
     def _run(self, live: set[str], documented: set[str]) -> int:
-        undocumented = sorted(live - documented)
-        phantom = sorted(documented - live)
-        return 1 if (undocumented or phantom) else 0
+        return 1 if (live - documented or documented - live) else 0
 
     def test_complete_mapping_passes(self) -> None:
         self.assertEqual(self._run({"url", "mcp_drift"}, {"url", "mcp_drift"}), 0)
@@ -116,36 +120,66 @@ class ComparisonTest(unittest.TestCase):
         self.assertEqual(self._run({"url"}, {"url", "retired_category"}), 1)
 
 
-class EmptyRunnerOutputTest(unittest.TestCase):
-    def test_refuses_an_empty_category_set(self) -> None:
-        """A runner reporting nothing must not satisfy the gate by vacuity."""
-
+class StatsParsingTest(unittest.TestCase):
+    def _with_stdout(self, stdout: str, returncode: int = 0):
         def fake_run(*_args, **_kwargs):
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+            return subprocess.CompletedProcess(
+                args=[], returncode=returncode, stdout=stdout, stderr="boom"
+            )
 
+        return fake_run
+
+    def _patch(self, fake):
         original = mod.subprocess.run
-        mod.subprocess.run = fake_run
-        try:
-            with self.assertRaises(SystemExit) as caught:
-                mod.live_categories(Path("."))
-        finally:
-            mod.subprocess.run = original
+        mod.subprocess.run = fake
+        self.addCleanup(lambda: setattr(mod.subprocess, "run", original))
+
+    def test_blank_separator_does_not_truncate_the_set(self) -> None:
+        self._patch(
+            self._with_stdout("by_category:\n  url: 3\n\n  mcp_drift: 6\n")
+        )
+        self.assertEqual(mod.live_categories(Path(".")), {"url", "mcp_drift"})
+
+    def test_missing_section_is_refused(self) -> None:
+        self._patch(self._with_stdout("cases_total: 5\ncategories: 1\n"))
+        with self.assertRaises(SystemExit) as caught:
+            mod.live_categories(Path("."))
+        self.assertIn("no 'by_category:' section", str(caught.exception))
+
+    def test_refuses_an_empty_category_set(self) -> None:
+        self._patch(self._with_stdout("by_category:\n"))
+        with self.assertRaises(SystemExit) as caught:
+            mod.live_categories(Path("."))
         self.assertIn("no categories", str(caught.exception))
 
     def test_refuses_a_failing_runner(self) -> None:
-        def fake_run(*_args, **_kwargs):
-            return subprocess.CompletedProcess(
-                args=[], returncode=1, stdout="", stderr="corpus load failed"
-            )
-
-        original = mod.subprocess.run
-        mod.subprocess.run = fake_run
-        try:
-            with self.assertRaises(SystemExit) as caught:
-                mod.live_categories(Path("."))
-        finally:
-            mod.subprocess.run = original
+        self._patch(self._with_stdout("", returncode=1))
+        with self.assertRaises(SystemExit) as caught:
+            mod.live_categories(Path("."))
         self.assertIn("could not load the corpus", str(caught.exception))
+
+    def test_refuses_a_hung_runner(self) -> None:
+        def fake_run(*_args, **_kwargs):
+            raise subprocess.TimeoutExpired(cmd="go", timeout=1)
+
+        self._patch(fake_run)
+        with self.assertRaises(SystemExit) as caught:
+            mod.live_categories(Path("."))
+        self.assertIn("did not finish", str(caught.exception))
+
+
+class MultiFileCoverageTest(unittest.TestCase):
+    """mcp_drift lives only in multi-file cases under cases/mcp-drift/.
+
+    A review argued the gate could not see it, because the runner's stats might
+    cover only the single-file corpus. The runner does load both, so the gate
+    does see it. This asserts that against the real corpus, because a runner
+    that stopped reporting multi-file categories would make the gate quietly
+    stop covering a whole category rather than fail.
+    """
+
+    def test_gate_sees_the_multi_file_category(self) -> None:
+        self.assertIn("mcp_drift", mod.live_categories(REPO_ROOT))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The OWASP mapping table in the README claimed eight case categories while the corpus held eighteen, and the table itself was missing `mcp_drift`. The category enum in `docs/SPEC.md` omitted it too. All three drifted because the mapping is hand-maintained prose that nothing checked.

`make check-readme-categories` compares the set of categories the runner loads against the set the README table and the SPEC enum document, in both directions. A category with cases and no entry is undocumented; an entry with no cases documents something that does not exist. The README lead-in no longer carries a count, because the count is what rotted, and the gate proves coverage instead.

The runner's exit status is checked before its output is parsed, and an empty category set is refused rather than compared. Without that, a runner that failed or printed nothing yields an empty set, every missing-category comparison is trivially true, and the gate passes while proving nothing. The sibling stats gate already had to fix the same defect.

The SPEC enum now carries `mcp_drift` and notes that only multi-file cases under `cases/mcp-drift/` use it, so the single-file validator does not accept that value and the multi-file loader requires it.

`make preflight` runs the gate, so CI enforces it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `mcp_drift` case category and documented its multi-file usage.
  * Added validation to ensure case categories remain consistent across the runner, README, and specification.
  * Preflight checks now include README category validation.

* **Documentation**
  * Updated OWASP category mappings and clarified category consistency checks.

* **Tests**
  * Added coverage for category extraction, mappings, validation errors, runner failures, timeouts, and `mcp_drift`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->