### PR TITLE
scoring: retire field-presence rates from published scores

### DIFF
--- a/.github/workflows/promote-gauntlet-result.yaml
+++ b/.github/workflows/promote-gauntlet-result.yaml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       accept_policy_change:
-        description: "Prepare a review PR for an explicit score or pinned-version change"
+        description: "Prepare a review PR for an explicit score, summary-contract, or pinned-version change"
         required: true
         default: false
         type: boolean

--- a/README.md
+++ b/README.md
@@ -102,22 +102,22 @@ The raw directory intentionally has no made-up public URL. GitHub Actions or ano
 
 The repository's scheduled Pipelock lane is read-only and produces review candidates, not automatic public claims. Approved candidates are retained as digest-addressed, hash-linked evidence directories, and a reviewed pull request advances the `latest-verified` pointer. The included reference renderer verifies and displays score, scope, N/A reasons, false-positive rate, and the canonical run URL together. It renders this repository's first-party Pipelock history and ranks nothing. See [Continuous Gauntlet Results](docs/CONTINUOUS-RESULTS.md) for the repository review and publication contract.
 
-For other tools, the runner writes per-case JSONL results to stdout (one object per case, see [docs/RUNNER.md](docs/RUNNER.md)) and a Gauntlet summary JSON to the path passed via `--output` (containment, false-positive rate, detection, evidence, per-category, see [docs/gauntlet.md](docs/gauntlet.md)). `--emit-receipt-profile` additionally writes a byte-reproducible receipt-scoring profile (see [docs/RECEIPT-SCORING.md](docs/RECEIPT-SCORING.md)).
+For other tools, the runner writes per-case JSONL results to stdout (one object per case, see [docs/RUNNER.md](docs/RUNNER.md)) and a Gauntlet summary JSON to the path passed via `--output` (containment, false-positive rate, non-scoring output-field diagnostics, and per-category results, see [docs/gauntlet.md](docs/gauntlet.md)). `--emit-receipt-profile` additionally writes a byte-reproducible receipt-scoring profile (see [docs/RECEIPT-SCORING.md](docs/RECEIPT-SCORING.md)).
 
 > A minimal legacy shell example for fetch-only cases lives at [`examples/pipelock/harness.sh`](examples/pipelock/harness.sh). It covers a single transport (`/fetch?url=...` GET) and is kept for illustration only — it is not the Gauntlet and will misreport every body, header, WebSocket, MCP, and response-content case. Use the Go runner for any real benchmark.
 
 ## Gauntlet scoring
 
-The Gauntlet evaluates tools on four independent metrics beyond pass/fail:
+The Gauntlet evaluates tools on two independent outcome metrics beyond pass/fail:
 
 | Metric | What it measures |
 |--------|-----------------|
 | **Containment** | Percentage of attacks correctly blocked |
 | **False positive rate** | Percentage of benign traffic incorrectly blocked (lower is better) |
-| **Detection** | Whether the tool identified what it caught |
-| **Evidence** | Whether the tool emitted structured proof |
 
-The summary reports `measurement_status: measured` when every applicable case produced an observed outcome, or `measurement_status: incomplete` when any case errored, was unreachable, or carried synthetic calibration evidence. This status does not judge the metric values. There is no composite score or pass mark. Each metric is reported independently. The maintainer's own Pipelock run history is published at [pipelab.org/gauntlet](https://pipelab.org/gauntlet/) as disclosed first-party evidence. Every other tool publishes and owns its own results; see [Results Use and Attribution](docs/RESULTS-USE.md) for the facts that travel with a public result.
+The summary also carries non-scoring field-presence diagnostics. They do not validate detection accuracy or proof.
+
+The summary reports `measurement_status: measured` when every applicable case produced an observed outcome, or `measurement_status: incomplete` when any case errored, was unreachable, or carried synthetic calibration evidence. This status does not judge the score values. There is no composite score or pass mark. Each score is reported independently. The maintainer's own Pipelock run history is published at [pipelab.org/gauntlet](https://pipelab.org/gauntlet/) as disclosed first-party evidence. Every other tool publishes and owns its own results; see [Results Use and Attribution](docs/RESULTS-USE.md) for the facts that travel with a public result.
 
 Full methodology: [docs/gauntlet.md](docs/gauntlet.md)
 
@@ -220,7 +220,7 @@ Each publisher publishes and owns its own results. This repository publishes no 
 - [CONTROL-EVIDENCE-V1.md](docs/CONTROL-EVIDENCE-V1.md): active v4 registry-bound control-evidence contract
 - [CAPABILITY-VOCABULARY.md](docs/CAPABILITY-VOCABULARY.md): immutable reporting-label registry and profile evolution policy
 - [ARTIFACT-PROVENANCE.md](docs/ARTIFACT-PROVENANCE.md): opt-in external `schema-valid`, `authenticated-at(T)`, and `buyer-reproduced` provenance assessments
-- [gauntlet.md](docs/gauntlet.md): Gauntlet scoring methodology (containment, FP rate, detection, evidence)
+- [gauntlet.md](docs/gauntlet.md): Gauntlet scoring methodology (containment, false-positive rate, and non-scoring diagnostics)
 - [RUNNER.md](docs/RUNNER.md): runner output contract and verdict mapping
 - [GATEWAY-ADAPTER.md](docs/GATEWAY-ADAPTER.md): the narrow generic MCP gateway plugin contract and its current limits
 - [ADOPTION.md](docs/ADOPTION.md): guide for vendors adopting the benchmark

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -29,7 +29,7 @@ changes before a runner may exclude any case.
 
 ## Versioning
 
-The spec uses `schema_version`. v4 is the active coordinated schema for cases, tool profiles, results, summaries, and receipt profiles. Earlier schemas are frozen readers only; active scoring rejects them and never normalizes them into v4 semantics. Every active profile and result binds an immutable capability-registry snapshot by ID, format, revision, and raw-byte SHA-256. Adding or deprecating a reporting label creates a registry revision, not a schema bump. A structural, scoring, delivery-protocol, provenance, or security-validation change increments the schema version and publishes the affected artifacts together. The validator enforces the active schema version.
+The spec uses `schema_version`. V4 is the active coordinated schema for cases, tool profiles, result rows, and receipt profiles. V5 is the active summary and candidate-provenance schema: it removes two overclaimed fields from `scores` and retains them only as non-scoring diagnostics. Earlier schemas are frozen readers only; active scoring rejects mixed input schemas and never normalizes a historical record into an active definition. Every active profile and result binds an immutable capability-registry snapshot by ID, format, revision, and raw-byte SHA-256. Adding or deprecating a reporting label creates a registry revision, not a schema bump. A structural, scoring, delivery-protocol, provenance, or security-validation change increments the affected schema and publishes the affected artifacts together. The validator enforces the active schema version.
 
 ## Contribution acceptance
 

--- a/docs/RESULTS-USE.md
+++ b/docs/RESULTS-USE.md
@@ -49,7 +49,7 @@ Publish these next to any score, or the number is not reproducible.
 | Adapter identity and owner | A vendor-authored adapter is normal. Hiding who wrote it is not. |
 | Target product, version, and configuration | A score against an unnamed configuration cannot be repeated. |
 | Applicable, unreachable, historical not-applicable, and error counts, with N/A reasons | An N/A case that silently leaves the denominator inflates the score; an unreachable row exposes an adapter coverage gap without pretending it was a measurement. |
-| Containment, detection, evidence, and false-positive rate, reported separately | There is no composite score in this corpus. |
+| Containment and false-positive rate, reported separately | There is no composite score in this corpus. V5 field-presence diagnostics are non-scoring observations, not detection or proof claims. |
 | The non-claims that apply | See below. |
 
 The runner writes these into the summary JSON. The corpus-derived facts come from the run itself; repository and commit, adapter owner, and the target configuration are operator declarations, supplied with `--method-repository`, `--method-commit`, `--adapter-owner`, and `--target-config`. A fact you do not declare is omitted rather than guessed, and the buyer report names it as absent. Reproduction instructions belong

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -91,7 +91,7 @@ sufficiency, change a score, or gate publication.
 
 Delivery, fixture, and base-observation prerequisites only. `requires` must never encode attack difficulty, evasion resistance, or an enforcement claim (for example `encoding_evasion_scanning`, `ssrf_bypass_scanning`, or `budget_enforcement`); those belong in `capability_tags` or result evidence. The validator rejects those tokens for both single-file and multi-file cases.
 
-All live case, profile, result, summary, and receipt artifacts use schema v4 together. The scorer rejects a mixed-version input set. Each active profile and result names the exact capability-registry snapshot by ID, format, revision, and raw-byte SHA-256. Historical artifacts are readable only through their frozen readers and are never normalized into v4 scoring semantics. See [Capability Vocabulary and Profile Evolution](CAPABILITY-VOCABULARY.md).
+Live case, profile, result-row, and receipt artifacts use schema v4 together. The scorer rejects a mixed-version input set. The generated summary and its candidate provenance use schema v5 because their published metric contract changed, while the v4 inputs remain unchanged. Each active profile and result names the exact capability-registry snapshot by ID, format, revision, and raw-byte SHA-256. Historical artifacts are readable only through their frozen readers and are never normalized into active semantics. See [Capability Vocabulary and Profile Evolution](CAPABILITY-VOCABULARY.md).
 
 ## Payload Formats
 

--- a/docs/gauntlet.md
+++ b/docs/gauntlet.md
@@ -1,21 +1,19 @@
 # Gauntlet Scoring Methodology
 
-The Gauntlet is a structured scoring program built on top of the agent-egress-bench corpus. It adds four independent metrics to the existing per-case scoring and a machine-readable summary format.
+The Gauntlet is a structured scoring program built on top of the agent-egress-bench corpus. It adds two independent outcome metrics, non-scoring output-field diagnostics, and a machine-readable summary format.
 
 The Gauntlet is completely free, open source, and tool-neutral. It does not replace the existing scoring defined in [SCORING.md](SCORING.md) — it is a layer on top.
 
 ## How Scoring Works
 
-The Gauntlet evaluates tool performance on four independent metrics. There is no composite score. Each metric is reported separately so users can evaluate trade-offs themselves.
+The Gauntlet evaluates tool performance on two independent outcome metrics. There is no composite score. Each score is reported separately so users can evaluate trade-offs themselves.
 
 | Metric | What it measures | Formula | Denominator |
 |--------|-----------------|---------|-------------|
 | **Containment** | Attacks correctly blocked | `blocked_malicious / total_malicious` | Full or applicable malicious cases, depending on view |
 | **False positive rate** | Benign traffic incorrectly blocked | `blocked_benign / total_benign` | Full or applicable benign cases, depending on view |
-| **Detection** | Attack classification accuracy | `classified_correctly / correctly_blocked_malicious` | Correctly blocked malicious cases |
-| **Evidence** | Structured proof emission | `evidence_emitted / correctly_blocked_malicious` | Correctly blocked malicious cases |
 
-Lower is better for false positive rate (0.0 = perfect). Higher is better for the other three (1.0 = perfect).
+Lower is better for false positive rate (0.0 = perfect). Higher is better for containment (1.0 = perfect).
 
 ## Measurement Status
 
@@ -23,7 +21,7 @@ The summary reports `measurement_status: measured` when every applicable case pr
 
 Measurement status says whether the runner measured the declared scope. It does not judge containment or any other metric. Historical non-applicable malicious rows remain in the full-corpus denominator; error and unreachable rows are not measurements and stay outside score denominators.
 
-All four metrics are still computed for an incomplete run. The metric vector reports observed target behavior, while `measurement_status` reports whether any cases lacked an observed outcome.
+Both scores are still computed for an incomplete run. The score vector reports observed target behavior, while `measurement_status` reports whether any cases lacked an observed outcome.
 
 ## Result state
 
@@ -47,34 +45,17 @@ from profile labels.
 
 Not every metric applies to every category:
 
-- **Categories with only benign cases** (e.g., `false_positive`): containment, detection, and evidence are N/A. Only false positive rate is reported.
-- **Categories with only malicious cases**: false positive rate is N/A. Only containment, detection, and evidence are reported.
+- **Categories with only benign cases** (e.g., `false_positive`): containment is N/A. Only false positive rate is reported.
+- **Categories with only malicious cases**: false positive rate is N/A. Only containment is reported.
 - **Categories with zero applicable cases**: the entire category is omitted from per-category results.
 
 In the summary JSON, N/A metrics are represented as `null`.
 
-## Detection Scoring
+## Non-scoring output-field diagnostics
 
-Detection measures whether the tool said *something* about what it caught, rather than only that it caught something.
+V5 reports two diagnostics outside `scores`: `classification_present_rate` and `structured_evidence_present_rate`. Each uses correctly blocked malicious cases as its denominator. The first observes whether `kind`, `scanner`, `block_reason`, or an MCP `error_message` is present. The second also recognizes `decision` and `findings`.
 
-A detection is counted when the tool's own output for that case carries a non-empty classification field: `kind`, `scanner`, or `block_reason`, or a non-empty `error_message` for MCP results. That is the whole test.
-
-Two limits follow, and both matter when reading a detection score:
-
-- **The classification is not checked for correctness.** A tool that blocks an SSRF case and labels it a DLP finding scores the same as one that labels it correctly. The metric distinguishes a labelled block from an unlabelled one, and nothing finer.
-- **The case's `capability_tags` and `category` play no part.** They are reporting labels. They do not select cases, enter any denominator, or affect containment, detection, evidence, false-positive rate, or sufficiency.
-
-That second point is deliberate rather than an omission. Scoring must not consult anything a tool declares about itself, and tags travel with cases that a tool's own profile influences. Wiring tags into detection would let a self-description move a published score, which is the coupling the applicability model exists to prevent.
-
-Detection is only evaluated against correctly blocked malicious cases. False positives (incorrectly blocked benign cases) do not count toward the detection score.
-
-## Evidence Scoring
-
-Evidence measures whether the tool produced structured, machine-parseable proof of the detection.
-
-"Structured" means JSON, key-value pairs, protobuf, or another machine-readable format — not a freeform log line. Examples include a structured log entry, a Prometheus metric, a webhook event, or an API response with detection details.
-
-Evidence is only evaluated against correctly blocked malicious cases, using the same denominator as detection.
+These values are not detection or proof scores. A constant `block_reason: "policy"`, or an unrelated `kind`, earns the same presence observation as an accurate SSRF label. `capability_tags` and `category` do not enter either rate. A future detection score requires an edition-owned finding taxonomy with implication rules and a correctness oracle.
 
 ## Results Format
 
@@ -90,7 +71,7 @@ A single JSON file with the full scoring breakdown:
 
 ```json
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "gauntlet_version": "1.0",
   "runner_version": "0.1.0",
   "tool": "example-tool",
@@ -119,15 +100,21 @@ A single JSON file with the full scoring breakdown:
   "scores": {
     "full": {
       "containment": 0.81,
-      "false_positive_rate": 0.02,
-      "detection": 0.91,
-      "evidence": 0.88
+      "false_positive_rate": 0.02
     },
     "applicable": {
       "containment": 0.96,
-      "false_positive_rate": 0.02,
-      "detection": 0.91,
-      "evidence": 0.88
+      "false_positive_rate": 0.02
+    }
+  },
+  "diagnostics": {
+    "full": {
+      "classification_present_rate": 0.91,
+      "structured_evidence_present_rate": 0.88
+    },
+    "applicable": {
+      "classification_present_rate": 0.91,
+      "structured_evidence_present_rate": 0.88
     }
   },
   "measurement_status": "measured",
@@ -136,8 +123,10 @@ A single JSON file with the full scoring breakdown:
       "applicable": 14,
       "containment": 1.0,
       "false_positive_rate": 0.0,
-      "detection": 0.93,
-      "evidence": 1.0
+      "diagnostics": {
+        "classification_present_rate": 0.93,
+        "structured_evidence_present_rate": 1.0
+      }
     }
   }
 }
@@ -153,6 +142,7 @@ Key fields:
 - `not_applicable_reasons`: breakdown of historical N/A rows, summing to `not_applicable`.
 - `unreachable`: exact-route coverage gaps. They are not scoreable errors or N/A, and make the measurement incomplete.
 - `measurement_status`: `measured` when every applicable case produced an observed outcome, otherwise `incomplete`. An error, an unreachable case, or a row carrying synthetic calibration evidence each make it `incomplete`. It does not encode a score threshold.
+- `diagnostics`: plainly named field-presence observations. They are not outcome scores and cannot establish detection correctness or proof.
 - `applicable`: every routed case, including cases that ended in `error`; `errors`
   is a subset of this count, not a third population.
 - `null` in per-category scores: metric is N/A for that category.
@@ -173,8 +163,7 @@ The existing pass/fail scoring in [SCORING.md](SCORING.md) remains the foundatio
 - **Pass/fail** answers: "did the tool get the right verdict?"
 - **Containment** answers: "what fraction of attacks were stopped?"
 - **False positive rate** answers: "how much legitimate traffic was incorrectly blocked?"
-- **Detection** answers: "did the tool know what it caught?"
-- **Evidence** answers: "did the tool prove what happened?"
+- **Field-presence diagnostics** answer only: "did the blocked result carry one of these fields?"
 
 Tools can still publish simple pass/fail results without the Gauntlet. The Gauntlet is a program, not a requirement.
 

--- a/docs/gauntlet.md
+++ b/docs/gauntlet.md
@@ -55,6 +55,8 @@ In the summary JSON, N/A metrics are represented as `null`.
 
 V5 reports two diagnostics outside `scores`: `classification_present_rate` and `structured_evidence_present_rate`. Each uses correctly blocked malicious cases as its denominator. The first observes whether `kind`, `scanner`, `block_reason`, or an MCP `error_message` is present. The second also recognizes `decision` and `findings`.
 
+V5 summaries validate against [`schemas/summary-v5.schema.json`](../schemas/summary-v5.schema.json). The unversioned [`schemas/summary.schema.json`](../schemas/summary.schema.json) remains the frozen v4 schema so historical artifacts keep their original validation contract.
+
 These values are not detection or proof scores. A constant `block_reason: "policy"`, or an unrelated `kind`, earns the same presence observation as an accurate SSRF label. `capability_tags` and `category` do not enter either rate. A future detection score requires an edition-owned finding taxonomy with implication rules and a correctness oracle.
 
 ## Results Format

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -79,14 +79,14 @@ Categories can contain malicious (`block`), benign (`allow`), or drift-guardrail
 
 ## Scoring
 
-The Gauntlet evaluates four independent dimensions. There is no composite score. Each metric is reported separately so users can evaluate trade-offs on their own terms.
+The Gauntlet evaluates two independent outcome dimensions. There is no composite score. Each score is reported separately so users can evaluate trade-offs on their own terms.
 
 | Metric | What it measures | Formula | Better |
 |--------|-----------------|---------|--------|
 | **Containment** | Attacks correctly blocked | blocked_malicious / malicious denominator for the selected view | Higher (1.0 = perfect) |
 | **False positive rate** | Benign traffic incorrectly blocked | blocked_benign / benign denominator for the selected view | Lower (0.0 = perfect) |
-| **Detection** | Correct classification of blocked attacks | classified_correctly / correctly_blocked_malicious | Higher (1.0 = perfect) |
-| **Evidence** | Structured proof emission | evidence_emitted / correctly_blocked_malicious | Higher (1.0 = perfect) |
+
+V5 also reports non-scoring `classification_present_rate` and `structured_evidence_present_rate` diagnostics. They only observe named output fields on correctly blocked malicious cases. They do not check that a label is accurate or that its contents prove a finding, so they are not detection or evidence scores.
 
 ### No composite score
 
@@ -104,7 +104,7 @@ The full corpus view is primary. Published results should use full corpus scorin
 
 ### Measurement status
 
-`measurement_status` reports whether the runner observed an outcome for every applicable case. `measured` means it did. `incomplete` means at least one case errored, was unreachable, or carried synthetic calibration evidence. A synthetic row is asserted by a calibration adapter rather than observed from a target, so it may still sit in a denominator while publication stays blocked. All four metrics are still computed, and the status does not assign a pass mark or interpret their values.
+`measurement_status` reports whether the runner observed an outcome for every applicable case. `measured` means it did. `incomplete` means at least one case errored, was unreachable, or carried synthetic calibration evidence. A synthetic row is asserted by a calibration adapter rather than observed from a target, so it may still sit in a denominator while publication stays blocked. Both outcome scores are still computed, and the status does not assign a pass mark or interpret their values.
 
 ## Capability Profiles
 

--- a/gauntlet-site/index.html
+++ b/gauntlet-site/index.html
@@ -62,7 +62,7 @@ pre { background: var(--bg); border: 1px solid var(--border); border-radius: 0.3
 }
 </style>
 </head>
-<body data-latest-url="./latest-verified.json" data-results-url="./gauntlet-results.json" data-corpus-version="v2.3.0" data-scoring-version="2.4">
+<body data-latest-url="./latest-verified.json" data-results-url="./gauntlet-results.json" data-corpus-version="v2.4.0" data-scoring-version="2.8">
 
 <h1>Pipelock Gauntlet</h1>
 <p class="subtitle">Agent egress security benchmark. Tests the security tool, not the agent.</p>
@@ -123,17 +123,24 @@ go build -o aeb-gauntlet .
     return txt('span', text, 'badge badge-' + cls);
   }
 
-  function makeScoresGrid(scores) {
+  function makeScoresGrid(scores, diagnostics, schemaVersion) {
     var grid = el('div', 'scores-grid');
     grid.appendChild(makeScoreBox('Containment', scores.containment));
     grid.appendChild(makeScoreBox('False Positive', scores.false_positive_rate));
-    grid.appendChild(makeScoreBox('Detection', scores.detection));
-    grid.appendChild(makeScoreBox('Evidence', scores.evidence));
+    if (schemaVersion === 5) {
+      diagnostics = diagnostics || {};
+      grid.appendChild(makeScoreBox('Label present (diagnostic)', diagnostics.classification_present_rate));
+      grid.appendChild(makeScoreBox('Structured field present (diagnostic)', diagnostics.structured_evidence_present_rate));
+    } else {
+      // Frozen v2 records retain their original published field names.
+      grid.appendChild(makeScoreBox('Detection', scores.detection));
+      grid.appendChild(makeScoreBox('Evidence', scores.evidence));
+    }
     return grid;
   }
 
   function measurementStatus(result) {
-    if (result.schema_version === 4) {
+    if (result.schema_version === 4 || result.schema_version === 5) {
       if (result.measurement_status === 'measured' || result.measurement_status === 'incomplete') {
         return result.measurement_status;
       }
@@ -145,7 +152,7 @@ go build -o aeb-gauntlet .
     return 'incomplete';
   }
 
-  function makeCategories(perCat) {
+  function makeCategories(perCat, schemaVersion) {
     if (!perCat || Object.keys(perCat).length === 0) return null;
     var wrap = el('div');
     var toggle = txt('div', 'Per-category breakdown \u25BE', 'toggle');
@@ -155,8 +162,8 @@ go build -o aeb-gauntlet .
     header.appendChild(txt('span', 'Category'));
     header.appendChild(txt('span', 'Contain.'));
     header.appendChild(txt('span', 'FP Rate'));
-    var dh = txt('span', 'Detect.'); dh.className = 'col-det'; header.appendChild(dh);
-    var eh = txt('span', 'Evidence'); eh.className = 'col-evi'; header.appendChild(eh);
+    var dh = txt('span', schemaVersion === 5 ? 'Label present*' : 'Detect.'); dh.className = 'col-det'; header.appendChild(dh);
+    var eh = txt('span', schemaVersion === 5 ? 'Structured field*' : 'Evidence'); eh.className = 'col-evi'; header.appendChild(eh);
     detail.appendChild(header);
 
     Object.keys(perCat).sort().forEach(function(cat) {
@@ -165,14 +172,20 @@ go build -o aeb-gauntlet .
       row.appendChild(txt('span', cat));
       row.appendChild(txt('span', fmtPct(c.containment)));
       row.appendChild(txt('span', fmtPct(c.false_positive_rate)));
-      var dr = txt('span', fmtPct(c.detection)); dr.className = 'col-det'; row.appendChild(dr);
-      var er = txt('span', fmtPct(c.evidence)); er.className = 'col-evi'; row.appendChild(er);
+      var diagnostics = c.diagnostics || {};
+      var classification = schemaVersion === 5 ? diagnostics.classification_present_rate : c.detection;
+      var structured = schemaVersion === 5 ? diagnostics.structured_evidence_present_rate : c.evidence;
+      var dr = txt('span', fmtPct(classification)); dr.className = 'col-det'; row.appendChild(dr);
+      var er = txt('span', fmtPct(structured)); er.className = 'col-evi'; row.appendChild(er);
       detail.appendChild(row);
     });
 
     toggle.addEventListener('click', function() { detail.classList.toggle('hidden'); });
     wrap.appendChild(toggle);
     wrap.appendChild(detail);
+    if (schemaVersion === 5) {
+      wrap.appendChild(txt('div', '* Non-scoring field-presence diagnostics. They do not validate a finding or prove detection.', 'denominator'));
+    }
     return wrap;
   }
 
@@ -203,15 +216,18 @@ go build -o aeb-gauntlet .
     }
 
     var scores = r.scores || {};
+    var diagnostics = r.diagnostics || {};
     var full = scores.full || scores;
     var applicable = scores.applicable;
+    var fullDiagnostics = diagnostics.full;
+    var applicableDiagnostics = diagnostics.applicable;
 
     if (applicable) {
       // Full corpus is the primary view. Applicable-only is a diagnostic of the
       // cases this adapter routed, rather than the whole corpus. Routed is not
       // the same as observed: the count includes rows that ended in error.
       card.appendChild(txt('div', 'Full Corpus Scores (' + (cc.total || 0) + ' cases)', 'section-label'));
-      card.appendChild(makeScoresGrid(full));
+      card.appendChild(makeScoresGrid(full, fullDiagnostics, r.schema_version));
 
       // A real button, not a click-handled div: the control is keyboard
       // operable and announced as a control, and aria-expanded is derived from
@@ -221,7 +237,7 @@ go build -o aeb-gauntlet .
       var aWrap = el('div', 'hidden');
       aToggle.setAttribute('aria-expanded', 'false');
       aWrap.appendChild(txt('div', 'Diagnostic only. Covers the ' + (cc.applicable || 0) + ' cases this adapter routed, which includes any that ended in error, not the complete corpus.', 'denominator'));
-      aWrap.appendChild(makeScoresGrid(applicable));
+      aWrap.appendChild(makeScoresGrid(applicable, applicableDiagnostics, r.schema_version));
       aToggle.addEventListener('click', function() {
         aWrap.classList.toggle('hidden');
         aToggle.setAttribute('aria-expanded', aWrap.classList.contains('hidden') ? 'false' : 'true');
@@ -230,10 +246,10 @@ go build -o aeb-gauntlet .
       card.appendChild(aWrap);
     } else {
       card.appendChild(txt('div', 'Scores', 'section-label'));
-      card.appendChild(makeScoresGrid(full));
+      card.appendChild(makeScoresGrid(full, fullDiagnostics, r.schema_version));
     }
 
-    var cats = makeCategories(r.per_category);
+    var cats = makeCategories(r.per_category, r.schema_version);
     if (cats) card.appendChild(cats);
 
     var prov = el('div', 'provenance');

--- a/gauntlet-site/latest-result.js
+++ b/gauntlet-site/latest-result.js
@@ -197,7 +197,7 @@
       }
       var profileBytes = await responseBytes(await fetchImpl(prefix + profileName), 'tool profile', 'tool profile');
       if (await sha256Hex(profileBytes, cryptoImpl) !== artifact.tool_profile_sha256) {
-        throw new Error('tool profile digest does not match v4 result');
+        throw new Error('tool profile digest does not match active result');
       }
       var profile;
       var snapshot;

--- a/gauntlet-site/latest-result.js
+++ b/gauntlet-site/latest-result.js
@@ -178,22 +178,22 @@
       }
     });
     // V2 records predate registry bytes and remain readable as frozen history.
-    // An active v4 result is not rendered until its pinned raw profile and raw
+    // An active v4/v5 result is not rendered until its pinned raw profile and raw
     // registry snapshot have both been fetched and bound to the candidate.
-    if (artifact.schema_version === 4) {
+    if (artifact.schema_version === 4 || artifact.schema_version === 5) {
       var reference = registryReference(artifact.capability_registry);
       if (!artifact.tool_profile_sha256 || !SHA256.test(artifact.tool_profile_sha256)) {
-        throw new Error('v4 result has no valid tool_profile_sha256');
+        throw new Error('active result has no valid tool_profile_sha256');
       }
       var prefix = './results/pipelock/' + pointer.candidate_sha256 + '/';
       var snapshotName = 'capability-registry.json';
       var profileName = 'tool-profile.json';
       if (!manifest.files || manifest.files[snapshotName] !== reference.sha256) {
-        throw new Error('record manifest does not bind the v4 capability registry snapshot');
+        throw new Error('record manifest does not bind the active capability registry snapshot');
       }
       var snapshotBytes = await responseBytes(await fetchImpl(prefix + snapshotName), 'capability registry snapshot', 'capability registry snapshot');
       if (await sha256Hex(snapshotBytes, cryptoImpl) !== reference.sha256) {
-        throw new Error('capability registry snapshot digest does not match v4 result');
+        throw new Error('capability registry snapshot digest does not match active result');
       }
       var profileBytes = await responseBytes(await fetchImpl(prefix + profileName), 'tool profile', 'tool profile');
       if (await sha256Hex(profileBytes, cryptoImpl) !== artifact.tool_profile_sha256) {
@@ -205,28 +205,28 @@
         profile = JSON.parse(decodeUTF8(profileBytes, 'tool profile'));
         snapshot = JSON.parse(decodeUTF8(snapshotBytes, 'capability registry snapshot'));
       } catch (error) {
-        throw new Error('v4 registry evidence is not valid JSON');
+        throw new Error('active registry evidence is not valid JSON');
       }
       if (JSON.stringify(registryReference(profile.capability_registry)) !== JSON.stringify(reference) ||
           snapshot.id !== reference.id || snapshot.format !== reference.format || snapshot.revision !== reference.revision) {
-        throw new Error('v4 registry evidence does not match result capability_registry');
+        throw new Error('active registry evidence does not match result capability_registry');
       }
       var entries = registryEntries(snapshot);
-      var profileClaims = activeLabels(profile.claims, 'v4 profile claims', entries);
-      var reportedClaims = activeLabels(artifact.reported_claims, 'v4 reported_claims', entries);
+      var profileClaims = activeLabels(profile.claims, 'active profile claims', entries);
+      var reportedClaims = activeLabels(artifact.reported_claims, 'active reported_claims', entries);
       var exercisedTags = activeLabels(
         artifact.exercised && artifact.exercised.capability_tags,
-        'v4 exercised capability_tags',
+        'active exercised capability_tags',
         entries
       );
       if (JSON.stringify(profileClaims) !== JSON.stringify(reportedClaims)) {
-        throw new Error('v4 profile claims do not match result reported_claims');
+        throw new Error('active profile claims do not match result reported_claims');
       }
       Object.defineProperty(artifact, '_capabilityRegistry', { value: snapshot, enumerable: false });
       Object.defineProperty(artifact, '_capabilityLabels', { value: entries, enumerable: false });
       Object.defineProperty(artifact, '_exercisedCapabilityTags', { value: exercisedTags, enumerable: false });
     } else if (artifact.schema_version !== 2) {
-      throw new Error('result record must be frozen schema v2 or active schema v4');
+      throw new Error('result record must be frozen schema v2 or active schema v4/v5');
     }
     return artifact;
   }

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -107,9 +107,9 @@
     if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
       throw new Error('artifact must be an object');
     }
-    if (artifact.schema_version === 4 && (!artifact._capabilityRegistry ||
+    if ((artifact.schema_version === 4 || artifact.schema_version === 5) && (!artifact._capabilityRegistry ||
         artifact._capabilityRegistry.id !== scopeValue(artifact, ['capability_registry', 'id']))) {
-      throw new Error('v4 artifact is uninterpretable without its verified capability registry snapshot');
+      throw new Error('active artifact is uninterpretable without its verified capability registry snapshot');
     }
 
     nonEmptyString(scopeValue(artifact, ['artifact_id']), 'artifact_id');
@@ -136,7 +136,7 @@
       throw new Error('case_count.applicable, unreachable, and not_applicable must equal case_count.total');
     }
     var measurementStatus;
-    if (artifact.schema_version === 4) {
+    if (artifact.schema_version === 4 || artifact.schema_version === 5) {
       measurementStatus = scopeValue(artifact, ['measurement_status']);
       if (measurementStatus !== 'measured' && measurementStatus !== 'incomplete') {
         throw new Error('measurement_status must be measured or incomplete');

--- a/gauntlet-site/scope-render_test.js
+++ b/gauntlet-site/scope-render_test.js
@@ -120,6 +120,12 @@ activeMeasured.scores.full.containment = 0.5;
 assert.match(window.renderGauntletScope(activeMeasured).children[0].textContent,
   /Containment 50\.0% of 158 malicious cases/);
 
+const activeV5 = JSON.parse(JSON.stringify(activeMeasured));
+activeV5.schema_version = 5;
+activeV5._capabilityRegistry = { id: 'aeb.core-capabilities' };
+assert.match(window.renderGauntletScope(activeV5).children[0].textContent,
+  /Containment 50\.0% of 158 malicious cases/);
+
 ['incomplete', 'complete', undefined].forEach((status) => {
   const artifact = JSON.parse(JSON.stringify(activeMeasured));
   artifact._capabilityRegistry = { id: 'aeb.core-capabilities' };

--- a/runner/corpus.go
+++ b/runner/corpus.go
@@ -15,6 +15,7 @@ type caseIndexDocument struct {
 
 type caseIndexEntry struct {
 	CaseID          string `json:"case_id"`
+	Category        string `json:"category"`
 	ExpectedVerdict string `json:"expected_verdict"`
 }
 
@@ -129,7 +130,7 @@ func writeCorpusStats(w io.Writer, cases []corpusStatCase) error {
 func writeCaseIndex(w io.Writer, cases []Case) error {
 	entries := make([]caseIndexEntry, 0, len(cases))
 	for _, c := range cases {
-		entries = append(entries, caseIndexEntry{CaseID: c.ID, ExpectedVerdict: c.ExpectedVerdict})
+		entries = append(entries, caseIndexEntry{CaseID: c.ID, Category: c.Category, ExpectedVerdict: c.ExpectedVerdict})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].CaseID < entries[j].CaseID })
 	return json.NewEncoder(w).Encode(caseIndexDocument{SchemaVersion: 1, Cases: entries})

--- a/runner/integration_test.go
+++ b/runner/integration_test.go
@@ -215,10 +215,14 @@ func TestIntegrationRealCases(t *testing.T) {
 	}
 
 	// Dry-run emits synthetic adapter markers, which are not explanatory fields.
-	if summary.Diagnostics.Applicable.ClassificationPresentRate != nil && *summary.Diagnostics.Applicable.ClassificationPresentRate != 0.0 {
+	if summary.Diagnostics.Applicable.ClassificationPresentRate == nil {
+		t.Error("dry-run classification_present_rate should not be nil")
+	} else if *summary.Diagnostics.Applicable.ClassificationPresentRate != 0.0 {
 		t.Errorf("dry-run classification_present_rate = %f, want 0.0", *summary.Diagnostics.Applicable.ClassificationPresentRate)
 	}
-	if summary.Diagnostics.Applicable.StructuredEvidencePresentRate != nil && *summary.Diagnostics.Applicable.StructuredEvidencePresentRate != 0.0 {
+	if summary.Diagnostics.Applicable.StructuredEvidencePresentRate == nil {
+		t.Error("dry-run structured_evidence_present_rate should not be nil")
+	} else if *summary.Diagnostics.Applicable.StructuredEvidencePresentRate != 0.0 {
 		t.Errorf("dry-run structured_evidence_present_rate = %f, want 0.0", *summary.Diagnostics.Applicable.StructuredEvidencePresentRate)
 	}
 

--- a/runner/integration_test.go
+++ b/runner/integration_test.go
@@ -214,12 +214,12 @@ func TestIntegrationRealCases(t *testing.T) {
 		t.Errorf("dry-run applicable false_positive_rate = %f, want 0.0", *summary.Scores.Applicable.FalsePositiveRate)
 	}
 
-	// Dry-run: detection and evidence are 0.0.
-	if summary.Scores.Applicable.Detection != nil && *summary.Scores.Applicable.Detection != 0.0 {
-		t.Errorf("dry-run applicable detection = %f, want 0.0", *summary.Scores.Applicable.Detection)
+	// Dry-run emits synthetic adapter markers, which are not explanatory fields.
+	if summary.Diagnostics.Applicable.ClassificationPresentRate != nil && *summary.Diagnostics.Applicable.ClassificationPresentRate != 0.0 {
+		t.Errorf("dry-run classification_present_rate = %f, want 0.0", *summary.Diagnostics.Applicable.ClassificationPresentRate)
 	}
-	if summary.Scores.Applicable.Evidence != nil && *summary.Scores.Applicable.Evidence != 0.0 {
-		t.Errorf("dry-run applicable evidence = %f, want 0.0", *summary.Scores.Applicable.Evidence)
+	if summary.Diagnostics.Applicable.StructuredEvidencePresentRate != nil && *summary.Diagnostics.Applicable.StructuredEvidencePresentRate != 0.0 {
+		t.Errorf("dry-run structured_evidence_present_rate = %f, want 0.0", *summary.Diagnostics.Applicable.StructuredEvidencePresentRate)
 	}
 
 	// Dry-run keeps scoreable calibration rows but cannot become publication

--- a/runner/main.go
+++ b/runner/main.go
@@ -413,7 +413,7 @@ func debugf(debug bool, format string, args ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stderr, debugPrefix+format+"\n", args...)
 }
 
-// printScores writes a score block with a label to the given writer.
+// printScores writes outcome metrics with a label to the given writer.
 func printScores(w *os.File, label string, scores Scores) {
 	_, _ = fmt.Fprintf(w, "\n  %s:\n", label)
 	if scores.Containment != nil {
@@ -425,15 +425,5 @@ func printScores(w *os.File, label string, scores Scores) {
 		_, _ = fmt.Fprintf(w, "    False Positive:   %.1f%%\n", *scores.FalsePositiveRate*100)
 	} else {
 		_, _ = fmt.Fprintf(w, "    False Positive:   N/A\n")
-	}
-	if scores.Detection != nil {
-		_, _ = fmt.Fprintf(w, "    Detection:        %.1f%%\n", *scores.Detection*100)
-	} else {
-		_, _ = fmt.Fprintf(w, "    Detection:        N/A\n")
-	}
-	if scores.Evidence != nil {
-		_, _ = fmt.Fprintf(w, "    Evidence:         %.1f%%\n", *scores.Evidence*100)
-	} else {
-		_, _ = fmt.Fprintf(w, "    Evidence:         N/A\n")
 	}
 }

--- a/runner/receipt_profile.go
+++ b/runner/receipt_profile.go
@@ -240,13 +240,13 @@ func buildReceiptProfile(
 
 // hasExplanation returns true when the adapter evidence carries a
 // machine- or human-readable signal tied to the action. The rubric
-// "explained" dimension is boolean; this helper mirrors how scoring.go
-// already classifies evidence for the gauntlet detection score.
+// "explained" dimension is boolean; this helper reuses the runner's field
+// presence checks without treating them as a Gauntlet detection score.
 func hasExplanation(ev map[string]interface{}) bool {
-	if hasClassification(ev) {
+	if hasClassificationField(ev) {
 		return true
 	}
-	if hasStructuredEvidence(ev) {
+	if hasStructuredEvidenceField(ev) {
 		return true
 	}
 	return false

--- a/runner/report.go
+++ b/runner/report.go
@@ -386,7 +386,11 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 
 	line("# Agent Egress Bench Run Report")
 	line("")
-	line("This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.")
+	if reportNumber(r.summary, "schema_version") == "5" {
+		line("This report renders facts retained by one Gauntlet run. It does not combine outcome scores or assign a grade, rank, or pass mark.")
+	} else {
+		line("This report renders facts retained by one Gauntlet run. It does not combine the four metrics or assign a grade, rank, or pass mark.")
+	}
 	line("")
 	line("## Artifact input status")
 	line("")
@@ -399,7 +403,7 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 	if problem := r.v4RegistryBindingError(); problem != "" {
 		line("## Result unavailable")
 		line("")
-		line("This v4 result is uninterpretable: %s.", markdownInline(problem))
+		line("This active result is uninterpretable: %s.", markdownInline(problem))
 		return
 	}
 	line("## Method identity")
@@ -471,21 +475,44 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 	line("")
 	line("## Metric vector")
 	line("")
-	line("Each metric stands on its own. Full-corpus scores retain historical N/A rows as misses; error and unreachable rows are excluded and make the measurement incomplete. Applicable-only scores cover only cases this adapter delivered and observed.")
-	line("")
-	line("### Full corpus")
-	line("")
-	bullet("Containment", reportPercent(r.summary, "scores", "full", "containment"))
-	bullet("Detection", reportPercent(r.summary, "scores", "full", "detection"))
-	bullet("Evidence", reportPercent(r.summary, "scores", "full", "evidence"))
-	bullet("False-positive rate", reportPercent(r.summary, "scores", "full", "false_positive_rate"))
-	line("")
-	line("### Applicable cases")
-	line("")
-	bullet("Containment", reportPercent(r.summary, "scores", "applicable", "containment"))
-	bullet("Detection", reportPercent(r.summary, "scores", "applicable", "detection"))
-	bullet("Evidence", reportPercent(r.summary, "scores", "applicable", "evidence"))
-	bullet("False-positive rate", reportPercent(r.summary, "scores", "applicable", "false_positive_rate"))
+	if reportNumber(r.summary, "schema_version") == "5" {
+		line("Each score stands on its own. Full-corpus scores retain historical N/A rows as misses; error and unreachable rows are excluded and make the measurement incomplete. Applicable-only scores cover only cases this adapter delivered and observed.")
+		line("")
+		line("### Full corpus")
+		line("")
+		bullet("Containment", reportPercent(r.summary, "scores", "full", "containment"))
+		bullet("False-positive rate", reportPercent(r.summary, "scores", "full", "false_positive_rate"))
+		line("")
+		line("### Applicable cases")
+		line("")
+		bullet("Containment", reportPercent(r.summary, "scores", "applicable", "containment"))
+		bullet("False-positive rate", reportPercent(r.summary, "scores", "applicable", "false_positive_rate"))
+		line("")
+		line("### Non-scoring field-presence diagnostics")
+		line("")
+		line("These observations report only whether a blocked malicious result carried a named field. They do not establish correct detection or proof.")
+		line("")
+		bullet("Full corpus label present", reportPercent(r.summary, "diagnostics", "full", "classification_present_rate"))
+		bullet("Full corpus structured field present", reportPercent(r.summary, "diagnostics", "full", "structured_evidence_present_rate"))
+		bullet("Applicable label present", reportPercent(r.summary, "diagnostics", "applicable", "classification_present_rate"))
+		bullet("Applicable structured field present", reportPercent(r.summary, "diagnostics", "applicable", "structured_evidence_present_rate"))
+	} else {
+		line("Each metric stands on its own. Full-corpus scores retain historical N/A rows as misses; error and unreachable rows are excluded and make the measurement incomplete. Applicable-only scores cover only cases this adapter delivered and observed.")
+		line("")
+		line("### Full corpus")
+		line("")
+		bullet("Containment", reportPercent(r.summary, "scores", "full", "containment"))
+		bullet("Detection", reportPercent(r.summary, "scores", "full", "detection"))
+		bullet("Evidence", reportPercent(r.summary, "scores", "full", "evidence"))
+		bullet("False-positive rate", reportPercent(r.summary, "scores", "full", "false_positive_rate"))
+		line("")
+		line("### Applicable cases")
+		line("")
+		bullet("Containment", reportPercent(r.summary, "scores", "applicable", "containment"))
+		bullet("Detection", reportPercent(r.summary, "scores", "applicable", "detection"))
+		bullet("Evidence", reportPercent(r.summary, "scores", "applicable", "evidence"))
+		bullet("False-positive rate", reportPercent(r.summary, "scores", "applicable", "false_positive_rate"))
+	}
 	line("")
 	line("## Execution and bundle status")
 	line("")
@@ -600,7 +627,7 @@ func (r *buyerReport) evidenceFiles() map[string]string {
 	for key, name := range reportEvidenceFiles {
 		files[key] = name
 	}
-	if reportNumber(r.summary, "schema_version") == "4" {
+	if schema := reportNumber(r.summary, "schema_version"); schema == "4" || schema == "5" {
 		files["tool_profile"] = "tool-profile.json"
 		files["capability_registry"] = "capability-registry.json"
 		files["receipt_profile"] = "receipt-profile.json"
@@ -647,8 +674,11 @@ func (r *buyerReport) bundleValidation() string {
 			failures = append(failures, "candidate_scope is malformed")
 		} else if r.summary.data != nil && r.metadata.data != nil {
 			keys := []string{"scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "case_count", "scores"}
-			if reportNumber(r.summary, "schema_version") == "4" {
+			if schema := reportNumber(r.summary, "schema_version"); schema == "4" || schema == "5" {
 				keys = append(keys, "capability_registry")
+			}
+			if reportNumber(r.summary, "schema_version") == "5" {
+				keys = append(keys, "diagnostics")
 			}
 			for _, key := range keys {
 				candidateValue, candidatePresent := candidateMap[key]
@@ -696,51 +726,51 @@ func (r *buyerReport) bundleValidation() string {
 }
 
 func (r *buyerReport) v4RegistryBindingError() string {
-	if reportNumber(r.summary, "schema_version") != "4" {
+	if schema := reportNumber(r.summary, "schema_version"); schema != "4" && schema != "5" {
 		return ""
 	}
 	value, present := nestedValue(r.summary.data, "capability_registry")
 	if !present {
-		return "v4 capability_registry is absent"
+		return "active capability_registry is absent"
 	}
 	encoded, err := json.Marshal(value)
 	if err != nil {
-		return "v4 capability_registry is malformed"
+		return "active capability_registry is malformed"
 	}
 	var reference capabilityregistry.Reference
 	if err := json.Unmarshal(encoded, &reference); err != nil {
-		return "v4 capability_registry is malformed"
+		return "active capability_registry is malformed"
 	}
 	snapshot, err := os.ReadFile(filepath.Join(r.dir, "capability-registry.json"))
 	if err != nil {
-		return "v4 capability registry snapshot is absent or unreadable"
+		return "active capability registry snapshot is absent or unreadable"
 	}
 	resolved, err := capabilityregistry.ResolveRaw(reference, snapshot)
 	if err != nil {
-		return "v4 capability registry snapshot does not match the result"
+		return "active capability registry snapshot does not match the result"
 	}
 	profilePath := filepath.Join(r.dir, "tool-profile.json")
 	profile, err := loadProfile(profilePath)
 	if err != nil {
-		return "v4 tool profile is invalid"
+		return "active tool profile is invalid"
 	}
 	if profile.CapabilityRegistry != reference {
-		return "v4 tool profile registry reference does not match the result"
+		return "active tool profile registry reference does not match the result"
 	}
 	profileBytes, err := os.ReadFile(profilePath)
 	if err != nil || capabilityregistry.SHA256(profileBytes) != reportString(r.summary, "tool_profile_sha256") {
-		return "v4 tool profile digest does not match the result"
+		return "active tool profile digest does not match the result"
 	}
 	reported, err := reportRegistryLabels(r.summary, "reported_claims")
 	if err != nil || resolved.ValidateActiveIDs("reported_claim", reported) != nil {
-		return "v4 reported_claims are not active IDs in the retained registry"
+		return "active reported_claims are not active IDs in the retained registry"
 	}
 	if !sameStrings(profile.Claims, reported) {
-		return "v4 tool profile claims do not match reported_claims"
+		return "active tool profile claims do not match reported_claims"
 	}
 	tags, err := reportRegistryLabels(r.summary, "exercised", "capability_tags")
 	if err != nil || resolved.ValidateActiveIDs("exercised capability_tag", tags) != nil {
-		return "v4 exercised capability_tags are not active IDs in the retained registry"
+		return "active exercised capability_tags are not active IDs in the retained registry"
 	}
 	return ""
 }

--- a/runner/score.go
+++ b/runner/score.go
@@ -123,6 +123,10 @@ func measuredResult(r CaseResult) bool {
 	return r.ActualVerdict != "unreachable" && r.Score != "error"
 }
 
+func correctlyBlockedMalicious(r CaseResult) bool {
+	return measuredResult(r) && r.ExpectedVerdict == "block" && r.ActualVerdict == "block" && r.Score == "pass"
+}
+
 // computeScores calculates the outcome metrics from measured case results.
 func computeScores(results []CaseResult) Scores {
 	var totalMalicious, blockedMalicious int
@@ -167,7 +171,7 @@ func computeScores(results []CaseResult) Scores {
 func computePresenceDiagnostics(results []CaseResult) PresenceDiagnostics {
 	var blockedMalicious, classificationPresent, structuredEvidencePresent int
 	for _, r := range results {
-		if !measuredResult(r) || r.ExpectedVerdict != "block" || r.ActualVerdict != "block" {
+		if !correctlyBlockedMalicious(r) {
 			continue
 		}
 		blockedMalicious++

--- a/runner/score.go
+++ b/runner/score.go
@@ -16,21 +16,27 @@ type CaseResult struct {
 	Notes              string                       `json:"notes"`
 }
 
-// Scores holds the four scoring dimensions.
+// Scores holds the outcome metrics that the corpus can measure without an
+// edition-owned finding oracle.
 type Scores struct {
 	Containment       *float64 `json:"containment"`
 	FalsePositiveRate *float64 `json:"false_positive_rate"`
-	Detection         *float64 `json:"detection"`
-	Evidence          *float64 `json:"evidence"`
 }
 
-// CategoryScores holds per-category scoring plus applicable count.
+// PresenceDiagnostics records whether a correctly blocked malicious result
+// contains one of the runner-recognized explanatory fields. These rates make
+// no claim that the field is accurate, sufficient, or proof of a finding.
+type PresenceDiagnostics struct {
+	ClassificationPresentRate     *float64 `json:"classification_present_rate"`
+	StructuredEvidencePresentRate *float64 `json:"structured_evidence_present_rate"`
+}
+
+// CategoryScores holds per-category outcome metrics and non-scoring diagnostics.
 type CategoryScores struct {
-	Applicable        int      `json:"applicable"`
-	Containment       *float64 `json:"containment"`
-	FalsePositiveRate *float64 `json:"false_positive_rate"`
-	Detection         *float64 `json:"detection"`
-	Evidence          *float64 `json:"evidence"`
+	Applicable        int                 `json:"applicable"`
+	Containment       *float64            `json:"containment"`
+	FalsePositiveRate *float64            `json:"false_positive_rate"`
+	Diagnostics       PresenceDiagnostics `json:"diagnostics"`
 }
 
 // scoreCase determines the score field for a case result.
@@ -80,9 +86,9 @@ func isBudgetTimingFailure(c Case, actual string, evidence map[string]interface{
 	return evidence["budget_block_timing"] != "at_over_budget"
 }
 
-// hasClassification checks if the evidence contains scanner/kind information
-// that demonstrates the tool identified what KIND of attack it blocked.
-func hasClassification(ev map[string]interface{}) bool {
+// hasClassificationField checks only whether an evidence field is present. It
+// does not determine whether the field identifies the attack correctly.
+func hasClassificationField(ev map[string]interface{}) bool {
 	// Scan API results include "kind" (dlp, prompt_injection, tool_call),
 	// while fetch proxy results include "scanner" or "block_reason". A null
 	// field is not a classification and must match the provenance wrapper.
@@ -98,10 +104,10 @@ func hasClassification(ev map[string]interface{}) bool {
 	return false
 }
 
-// hasStructuredEvidence checks if the evidence contains structured proof
-// fields beyond a bare pass/fail signal.
-func hasStructuredEvidence(ev map[string]interface{}) bool {
-	// Any of these fields constitute structured evidence.
+// hasStructuredEvidenceField checks only for an explanatory structured field.
+// It does not establish that the field proves the result is correct.
+func hasStructuredEvidenceField(ev map[string]interface{}) bool {
+	// Any of these fields constitute structured explanatory data.
 	for _, key := range []string{"kind", "scanner", "block_reason", "error_message", "decision", "findings"} {
 		if v, ok := ev[key]; ok && v != nil {
 			return true
@@ -117,11 +123,10 @@ func measuredResult(r CaseResult) bool {
 	return r.ActualVerdict != "unreachable" && r.Score != "error"
 }
 
-// computeScores calculates the four scoring dimensions from measured case results.
+// computeScores calculates the outcome metrics from measured case results.
 func computeScores(results []CaseResult) Scores {
 	var totalMalicious, blockedMalicious int
 	var totalBenign, blockedBenign int
-	var classifiedCorrectly, evidenceEmitted int
 
 	for _, r := range results {
 		if !measuredResult(r) {
@@ -132,12 +137,6 @@ func computeScores(results []CaseResult) Scores {
 			totalMalicious++
 			if r.ActualVerdict == "block" {
 				blockedMalicious++
-				if hasClassification(r.Evidence) {
-					classifiedCorrectly++
-				}
-				if hasStructuredEvidence(r.Evidence) {
-					evidenceEmitted++
-				}
 			}
 		case "allow":
 			totalBenign++
@@ -159,14 +158,35 @@ func computeScores(results []CaseResult) Scores {
 		s.FalsePositiveRate = &v
 	}
 
-	if blockedMalicious > 0 {
-		det := float64(classifiedCorrectly) / float64(blockedMalicious)
-		s.Detection = &det
-		evi := float64(evidenceEmitted) / float64(blockedMalicious)
-		s.Evidence = &evi
+	return s
+}
+
+// computePresenceDiagnostics calculates plainly named field-presence rates
+// from correctly blocked malicious cases. Keep these outside Scores until a
+// versioned finding taxonomy can check classification correctness.
+func computePresenceDiagnostics(results []CaseResult) PresenceDiagnostics {
+	var blockedMalicious, classificationPresent, structuredEvidencePresent int
+	for _, r := range results {
+		if !measuredResult(r) || r.ExpectedVerdict != "block" || r.ActualVerdict != "block" {
+			continue
+		}
+		blockedMalicious++
+		if hasClassificationField(r.Evidence) {
+			classificationPresent++
+		}
+		if hasStructuredEvidenceField(r.Evidence) {
+			structuredEvidencePresent++
+		}
 	}
 
-	return s
+	var diagnostics PresenceDiagnostics
+	if blockedMalicious > 0 {
+		classificationRate := float64(classificationPresent) / float64(blockedMalicious)
+		diagnostics.ClassificationPresentRate = &classificationRate
+		structuredRate := float64(structuredEvidencePresent) / float64(blockedMalicious)
+		diagnostics.StructuredEvidencePresentRate = &structuredRate
+	}
+	return diagnostics
 }
 
 // computeFullCorpusScores computes scores with every measured case in the
@@ -177,7 +197,6 @@ func computeScores(results []CaseResult) Scores {
 func computeFullCorpusScores(applicableResults []CaseResult, allCases []Case, unmeasuredIDs map[string]struct{}) Scores {
 	var totalMalicious, blockedMalicious int
 	var totalBenign, blockedBenign int
-	var classifiedCorrectly, evidenceEmitted int
 
 	for _, c := range allCases {
 		if _, unmeasured := unmeasuredIDs[c.ID]; unmeasured {
@@ -199,12 +218,6 @@ func computeFullCorpusScores(applicableResults []CaseResult, allCases []Case, un
 		case "block":
 			if r.ActualVerdict == "block" {
 				blockedMalicious++
-				if hasClassification(r.Evidence) {
-					classifiedCorrectly++
-				}
-				if hasStructuredEvidence(r.Evidence) {
-					evidenceEmitted++
-				}
 			}
 		case "allow":
 			if r.ActualVerdict == "block" {
@@ -221,12 +234,6 @@ func computeFullCorpusScores(applicableResults []CaseResult, allCases []Case, un
 	if totalBenign > 0 {
 		v := float64(blockedBenign) / float64(totalBenign)
 		s.FalsePositiveRate = &v
-	}
-	if blockedMalicious > 0 {
-		det := float64(classifiedCorrectly) / float64(blockedMalicious)
-		s.Detection = &det
-		evi := float64(evidenceEmitted) / float64(blockedMalicious)
-		s.Evidence = &evi
 	}
 	return s
 }
@@ -250,8 +257,7 @@ func computeCategoryScores(results []CaseResult, casesByID map[string]Case) map[
 			Applicable:        len(catResults),
 			Containment:       scores.Containment,
 			FalsePositiveRate: scores.FalsePositiveRate,
-			Detection:         scores.Detection,
-			Evidence:          scores.Evidence,
+			Diagnostics:       computePresenceDiagnostics(catResults),
 		}
 	}
 

--- a/runner/score_test.go
+++ b/runner/score_test.go
@@ -9,12 +9,9 @@ import (
 	"testing"
 )
 
-// docs/gauntlet.md states the detection contract exactly: a detection counts
-// when the tool's output carries a non-empty kind, scanner, or block_reason, or
-// a non-empty error_message for MCP results. Documenting a contract without
-// pinning it is how the doc drifted from the code in the first place, so these
-// cases hold the implementation to what the doc now promises.
-func TestHasClassificationMatchesDocumentedContract(t *testing.T) {
+// The diagnostics contract counts a non-empty kind, scanner, block_reason, or
+// MCP error_message field. It deliberately says nothing about correctness.
+func TestHasClassificationFieldMatchesDocumentedContract(t *testing.T) {
 	tests := []struct {
 		name     string
 		evidence map[string]interface{}
@@ -42,17 +39,64 @@ func TestHasClassificationMatchesDocumentedContract(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := hasClassification(tt.evidence); got != tt.want {
-				t.Fatalf("hasClassification(%v) = %t, want %t", tt.evidence, got, tt.want)
+			if got := hasClassificationField(tt.evidence); got != tt.want {
+				t.Fatalf("hasClassificationField(%v) = %t, want %t", tt.evidence, got, tt.want)
 			}
 		})
 	}
 }
 
-// Detection is evaluated only against correctly blocked malicious cases. A
-// benign case that was wrongly blocked is a false positive and must not earn
-// detection credit, and a malicious case that was not blocked cannot either.
-func TestDetectionCountsOnlyCorrectlyBlockedMaliciousCases(t *testing.T) {
+// This characterizes the published v4 defect. Before the v5 summary contract,
+// the three fields below each produced detection=1 despite only the first
+// describing the SSRF attack. V5 preserves this fact only as a diagnostic.
+func TestPublishedDetectionCreditsVagueAndWrongLabels(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		evidence map[string]interface{}
+	}{
+		{"correct SSRF label", map[string]interface{}{"kind": "ssrf", "scanner": "ssrf_metadata"}},
+		{"vague policy label", map[string]interface{}{"block_reason": "policy"}},
+		{"unrelated label", map[string]interface{}{"kind": "totally_unrelated_nonsense"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			diagnostics := computePresenceDiagnostics([]CaseResult{{
+				ExpectedVerdict: "block",
+				ActualVerdict:   "block",
+				Evidence:        tt.evidence,
+			}})
+			if diagnostics.ClassificationPresentRate == nil || *diagnostics.ClassificationPresentRate != 1.0 {
+				t.Fatalf("classification_present_rate = %v, want 1.0", ptrVal(diagnostics.ClassificationPresentRate))
+			}
+		})
+	}
+}
+
+// V5 must retain these observations only as plainly named diagnostics. They
+// describe field presence, never whether a tool classified an attack correctly
+// or emitted proof that the result is true.
+func TestPresenceDiagnosticsReportFieldPresenceWithoutScoringIt(t *testing.T) {
+	for _, evidence := range []map[string]interface{}{
+		{"kind": "ssrf", "scanner": "ssrf_metadata"},
+		{"block_reason": "policy"},
+		{"kind": "totally_unrelated_nonsense"},
+	} {
+		diagnostics := computePresenceDiagnostics([]CaseResult{{
+			ExpectedVerdict: "block",
+			ActualVerdict:   "block",
+			Evidence:        evidence,
+		}})
+		if diagnostics.ClassificationPresentRate == nil || *diagnostics.ClassificationPresentRate != 1.0 {
+			t.Fatalf("classification_present_rate = %v, want 1.0", ptrVal(diagnostics.ClassificationPresentRate))
+		}
+		if diagnostics.StructuredEvidencePresentRate == nil || *diagnostics.StructuredEvidencePresentRate != 1.0 {
+			t.Fatalf("structured_evidence_present_rate = %v, want 1.0", ptrVal(diagnostics.StructuredEvidencePresentRate))
+		}
+	}
+}
+
+// Presence diagnostics apply only to correctly blocked malicious cases. A
+// benign false positive and a malicious miss cannot earn presence credit.
+func TestPresenceDiagnosticsCountOnlyCorrectlyBlockedMaliciousCases(t *testing.T) {
 	classified := map[string]interface{}{"kind": "dlp"}
 	results := []CaseResult{
 		{ExpectedVerdict: "block", ActualVerdict: "block", Evidence: classified},
@@ -61,33 +105,29 @@ func TestDetectionCountsOnlyCorrectlyBlockedMaliciousCases(t *testing.T) {
 		{ExpectedVerdict: "allow", ActualVerdict: "allow", Evidence: classified},
 	}
 
-	scores := computeScores(results)
-	if scores.Detection == nil {
-		t.Fatal("detection is nil despite a correctly blocked malicious case")
+	diagnostics := computePresenceDiagnostics(results)
+	if diagnostics.ClassificationPresentRate == nil {
+		t.Fatal("classification_present_rate is nil despite a correctly blocked malicious case")
 	}
-	// One malicious case was blocked and it carried a classification, so
-	// detection is 1/1. The wrongly blocked benign case carries the same
-	// classification and must not widen the denominator to 2.
-	if *scores.Detection != 1 {
-		t.Fatalf("detection = %v, want 1: only the correctly blocked malicious case counts", *scores.Detection)
+	if *diagnostics.ClassificationPresentRate != 1 {
+		t.Fatalf("classification_present_rate = %v, want 1: only the correctly blocked malicious case counts", *diagnostics.ClassificationPresentRate)
 	}
 }
 
-// With nothing correctly blocked there is no denominator, so detection and
-// evidence are absent rather than zero. Reporting 0% would state a measurement
-// that was never taken.
-func TestDetectionIsAbsentWhenNothingWasCorrectlyBlocked(t *testing.T) {
+// With nothing correctly blocked there is no diagnostic denominator, so both
+// presence rates are absent rather than zero.
+func TestPresenceDiagnosticsAreAbsentWhenNothingWasCorrectlyBlocked(t *testing.T) {
 	results := []CaseResult{
 		{ExpectedVerdict: "block", ActualVerdict: "allow", Evidence: map[string]interface{}{"kind": "dlp"}},
 		{ExpectedVerdict: "allow", ActualVerdict: "allow", Evidence: nil},
 	}
 
-	scores := computeScores(results)
-	if scores.Detection != nil {
-		t.Fatalf("detection = %v, want nil when no malicious case was blocked", *scores.Detection)
+	diagnostics := computePresenceDiagnostics(results)
+	if diagnostics.ClassificationPresentRate != nil {
+		t.Fatalf("classification_present_rate = %v, want nil when no malicious case was blocked", *diagnostics.ClassificationPresentRate)
 	}
-	if scores.Evidence != nil {
-		t.Fatalf("evidence = %v, want nil when no malicious case was blocked", *scores.Evidence)
+	if diagnostics.StructuredEvidencePresentRate != nil {
+		t.Fatalf("structured_evidence_present_rate = %v, want nil when no malicious case was blocked", *diagnostics.StructuredEvidencePresentRate)
 	}
 }
 
@@ -210,20 +250,20 @@ func TestScoreCaseWithEvidence_ExpectedBlockForwardedAllowFails(t *testing.T) {
 }
 
 func TestComputeScores(t *testing.T) {
-	t.Run("null evidence fields earn no detection or evidence credit", func(t *testing.T) {
+	t.Run("null evidence fields earn no diagnostic credit", func(t *testing.T) {
 		for _, key := range []string{"kind", "scanner", "block_reason"} {
 			t.Run(key, func(t *testing.T) {
-				scores := computeScores([]CaseResult{{
+				diagnostics := computePresenceDiagnostics([]CaseResult{{
 					CaseID:          "malicious",
 					ExpectedVerdict: "block",
 					ActualVerdict:   "block",
 					Evidence:        map[string]interface{}{key: nil},
 				}})
-				if scores.Detection == nil || *scores.Detection != 0 {
-					t.Fatalf("detection = %v, want 0 for null %s", ptrVal(scores.Detection), key)
+				if diagnostics.ClassificationPresentRate == nil || *diagnostics.ClassificationPresentRate != 0 {
+					t.Fatalf("classification_present_rate = %v, want 0 for null %s", ptrVal(diagnostics.ClassificationPresentRate), key)
 				}
-				if scores.Evidence == nil || *scores.Evidence != 0 {
-					t.Fatalf("evidence = %v, want 0 for null %s", ptrVal(scores.Evidence), key)
+				if diagnostics.StructuredEvidencePresentRate == nil || *diagnostics.StructuredEvidencePresentRate != 0 {
+					t.Fatalf("structured_evidence_present_rate = %v, want 0 for null %s", ptrVal(diagnostics.StructuredEvidencePresentRate), key)
 				}
 			})
 		}
@@ -241,8 +281,9 @@ func TestComputeScores(t *testing.T) {
 		if scores.FalsePositiveRate != nil {
 			t.Errorf("false_positive_rate should be nil with no benign cases")
 		}
-		if scores.Detection == nil || *scores.Detection != 0.0 {
-			t.Errorf("detection = %v, want 0.0 (dry run)", scores.Detection)
+		diagnostics := computePresenceDiagnostics(results)
+		if diagnostics.ClassificationPresentRate == nil || *diagnostics.ClassificationPresentRate != 0.0 {
+			t.Errorf("classification_present_rate = %v, want 0.0 (dry run)", diagnostics.ClassificationPresentRate)
 		}
 	})
 
@@ -273,11 +314,9 @@ func TestComputeScores(t *testing.T) {
 		if scores.Containment != nil {
 			t.Errorf("containment should be nil with only benign cases")
 		}
-		if scores.Detection != nil {
-			t.Errorf("detection should be nil with only benign cases")
-		}
-		if scores.Evidence != nil {
-			t.Errorf("evidence should be nil with only benign cases")
+		diagnostics := computePresenceDiagnostics(results)
+		if diagnostics.ClassificationPresentRate != nil || diagnostics.StructuredEvidencePresentRate != nil {
+			t.Errorf("presence diagnostics should be nil with only benign cases")
 		}
 		if scores.FalsePositiveRate == nil || *scores.FalsePositiveRate != 0.0 {
 			t.Errorf("false_positive_rate = %v, want 0.0", ptrVal(scores.FalsePositiveRate))

--- a/runner/score_test.go
+++ b/runner/score_test.go
@@ -62,6 +62,7 @@ func TestPublishedDetectionCreditsVagueAndWrongLabels(t *testing.T) {
 			diagnostics := computePresenceDiagnostics([]CaseResult{{
 				ExpectedVerdict: "block",
 				ActualVerdict:   "block",
+				Score:           "pass",
 				Evidence:        tt.evidence,
 			}})
 			if diagnostics.ClassificationPresentRate == nil || *diagnostics.ClassificationPresentRate != 1.0 {
@@ -83,6 +84,7 @@ func TestPresenceDiagnosticsReportFieldPresenceWithoutScoringIt(t *testing.T) {
 		diagnostics := computePresenceDiagnostics([]CaseResult{{
 			ExpectedVerdict: "block",
 			ActualVerdict:   "block",
+			Score:           "pass",
 			Evidence:        evidence,
 		}})
 		if diagnostics.ClassificationPresentRate == nil || *diagnostics.ClassificationPresentRate != 1.0 {
@@ -99,7 +101,7 @@ func TestPresenceDiagnosticsReportFieldPresenceWithoutScoringIt(t *testing.T) {
 func TestPresenceDiagnosticsCountOnlyCorrectlyBlockedMaliciousCases(t *testing.T) {
 	classified := map[string]interface{}{"kind": "dlp"}
 	results := []CaseResult{
-		{ExpectedVerdict: "block", ActualVerdict: "block", Evidence: classified},
+		{ExpectedVerdict: "block", ActualVerdict: "block", Score: "pass", Evidence: classified},
 		{ExpectedVerdict: "block", ActualVerdict: "allow", Evidence: classified},
 		{ExpectedVerdict: "allow", ActualVerdict: "block", Evidence: classified},
 		{ExpectedVerdict: "allow", ActualVerdict: "allow", Evidence: classified},
@@ -111,6 +113,18 @@ func TestPresenceDiagnosticsCountOnlyCorrectlyBlockedMaliciousCases(t *testing.T
 	}
 	if *diagnostics.ClassificationPresentRate != 1 {
 		t.Fatalf("classification_present_rate = %v, want 1: only the correctly blocked malicious case counts", *diagnostics.ClassificationPresentRate)
+	}
+}
+
+func TestPresenceDiagnosticsExcludeFailedLateBlocks(t *testing.T) {
+	results := []CaseResult{
+		{ExpectedVerdict: "block", ActualVerdict: "block", Score: "pass", Evidence: map[string]interface{}{"kind": "dlp"}},
+		{ExpectedVerdict: "block", ActualVerdict: "block", Score: "fail", Evidence: map[string]interface{}{"kind": "late_budget_block"}},
+	}
+
+	diagnostics := computePresenceDiagnostics(results)
+	if diagnostics.ClassificationPresentRate == nil || *diagnostics.ClassificationPresentRate != 1 {
+		t.Fatalf("classification_present_rate = %v, want 1 from the passing block only", ptrVal(diagnostics.ClassificationPresentRate))
 	}
 }
 
@@ -257,6 +271,7 @@ func TestComputeScores(t *testing.T) {
 					CaseID:          "malicious",
 					ExpectedVerdict: "block",
 					ActualVerdict:   "block",
+					Score:           "pass",
 					Evidence:        map[string]interface{}{key: nil},
 				}})
 				if diagnostics.ClassificationPresentRate == nil || *diagnostics.ClassificationPresentRate != 0 {
@@ -271,8 +286,8 @@ func TestComputeScores(t *testing.T) {
 
 	t.Run("all malicious blocked", func(t *testing.T) {
 		results := []CaseResult{
-			{CaseID: "a", ExpectedVerdict: "block", ActualVerdict: "block"},
-			{CaseID: "b", ExpectedVerdict: "block", ActualVerdict: "block"},
+			{CaseID: "a", ExpectedVerdict: "block", ActualVerdict: "block", Score: "pass"},
+			{CaseID: "b", ExpectedVerdict: "block", ActualVerdict: "block", Score: "pass"},
 		}
 		scores := computeScores(results)
 		if scores.Containment == nil || *scores.Containment != 1.0 {

--- a/runner/summary.go
+++ b/runner/summary.go
@@ -16,6 +16,11 @@ import (
 
 const (
 	gauntletVersion = "1.0"
+	// 2.8 retires detection and evidence as scores. The runner only knew that a
+	// result carried a named field, not that the name correctly classified the
+	// case or that its contents proved the finding. V5 retains those facts as
+	// plainly named diagnostics and leaves outcome metrics in scores.
+	//
 	// 2.7 is the pass-mark boundary. A hidden 80 percent containment threshold
 	// decided whether a run could publish; it is gone, and publication now turns
 	// only on whether the run measured what it claims to have measured. Which
@@ -29,8 +34,8 @@ const (
 	// under 2.5 and earlier are therefore not comparable to those, and the
 	// repository's own staleness rule requires the bump rather than allowing
 	// two different rule sets to publish under one label.
-	scoringVersion = "2.7"
-	runnerVersion  = "0.4.2"
+	scoringVersion = "2.8"
+	runnerVersion  = "0.4.3"
 	corpusVersion  = "v2.4.0"
 	summaryDateEnv = "AEB_GAUNTLET_SUMMARY_DATE"
 
@@ -38,10 +43,23 @@ const (
 	measurementStatusIncomplete = "incomplete"
 )
 
+// activeSummarySchemaVersion is intentionally separate from the v4 case,
+// profile, result-row, and receipt-profile contract. This change only affects
+// the published summary and its provenance readers; changing immutable cases
+// or runner input declarations would add compatibility churn without changing
+// the corrected metric.
+const activeSummarySchemaVersion = 5
+
 // DualScores holds both full-corpus and applicable-only score views.
 type DualScores struct {
 	Full       Scores `json:"full"`
 	Applicable Scores `json:"applicable"`
+}
+
+// DualDiagnostics holds non-scoring observations for both score views.
+type DualDiagnostics struct {
+	Full       PresenceDiagnostics `json:"full"`
+	Applicable PresenceDiagnostics `json:"applicable"`
 }
 
 // GauntletSummary is the top-level output written to --output.
@@ -61,6 +79,7 @@ type GauntletSummary struct {
 	CaseCount          CaseCount                    `json:"case_count"`
 	Exercised          ExercisedCapabilities        `json:"exercised"`
 	Scores             DualScores                   `json:"scores"`
+	Diagnostics        DualDiagnostics              `json:"diagnostics"`
 	MeasurementStatus  string                       `json:"measurement_status"`
 	PerCategory        map[string]CategoryScores    `json:"per_category"`
 
@@ -212,6 +231,8 @@ func buildSummary(
 
 	applicableScores := computeScores(applicableResults)
 	fullScores := computeFullCorpusScores(applicableResults, allCases, unmeasuredIDs)
+	applicableDiagnostics := computePresenceDiagnostics(applicableResults)
+	fullDiagnostics := computePresenceDiagnostics(applicableResults)
 	perCategory := computeCategoryScores(applicableResults, casesByID)
 
 	naReasonsStr := make(map[string]int, len(naReasons))
@@ -229,7 +250,7 @@ func buildSummary(
 	}
 
 	return GauntletSummary{
-		SchemaVersion:      activeSchemaVersion,
+		SchemaVersion:      activeSummarySchemaVersion,
 		GauntletVersion:    gauntletVersion,
 		ScoringVersion:     scoringVersion,
 		RunnerVersion:      runnerVersion,
@@ -253,6 +274,10 @@ func buildSummary(
 		Scores: DualScores{
 			Full:       fullScores,
 			Applicable: applicableScores,
+		},
+		Diagnostics: DualDiagnostics{
+			Full:       fullDiagnostics,
+			Applicable: applicableDiagnostics,
 		},
 		// Calibration adapters assert proof flags rather than observing them, so
 		// they do not produce a complete measurement and cannot publish.
@@ -307,14 +332,14 @@ func countErrors(results []CaseResult) (int, error) {
 
 // writeSummary writes the GauntletSummary as indented JSON to a file.
 func writeSummary(s GauntletSummary, path string) error {
-	// Every newly emitted summary belongs to the active coordinated artifact
-	// set. Tests and library callers may construct a summary directly, so make
-	// the writer enforce the same boundary as buildSummary.
+	// Every newly emitted summary belongs to the active summary contract. Tests
+	// and library callers may construct a summary directly, so make the writer
+	// enforce the same boundary as buildSummary.
 	if s.SchemaVersion == 0 {
-		s.SchemaVersion = activeSchemaVersion
+		s.SchemaVersion = activeSummarySchemaVersion
 	}
-	if s.SchemaVersion != activeSchemaVersion {
-		return fmt.Errorf("summary schema_version must be %d, got %d", activeSchemaVersion, s.SchemaVersion)
+	if s.SchemaVersion != activeSummarySchemaVersion {
+		return fmt.Errorf("summary schema_version must be %d, got %d", activeSummarySchemaVersion, s.SchemaVersion)
 	}
 	if err := validateRegistryReference(s.CapabilityRegistry); err != nil {
 		return fmt.Errorf("invalid summary capability_registry: %w", err)

--- a/runner/summary_test.go
+++ b/runner/summary_test.go
@@ -328,8 +328,8 @@ func TestWriteSummary(t *testing.T) {
 
 	containment := 0.95
 	fpRate := 0.02
-	detection := 0.0
-	evidence := 0.0
+	classificationPresent := 0.0
+	structuredEvidencePresent := 0.0
 
 	s := GauntletSummary{
 		GauntletVersion:    gauntletVersion,
@@ -357,14 +357,20 @@ func TestWriteSummary(t *testing.T) {
 			Full: Scores{
 				Containment:       &containment,
 				FalsePositiveRate: &fpRate,
-				Detection:         &detection,
-				Evidence:          &evidence,
 			},
 			Applicable: Scores{
 				Containment:       &containment,
 				FalsePositiveRate: &fpRate,
-				Detection:         &detection,
-				Evidence:          &evidence,
+			},
+		},
+		Diagnostics: DualDiagnostics{
+			Full: PresenceDiagnostics{
+				ClassificationPresentRate:     &classificationPresent,
+				StructuredEvidencePresentRate: &structuredEvidencePresent,
+			},
+			Applicable: PresenceDiagnostics{
+				ClassificationPresentRate:     &classificationPresent,
+				StructuredEvidencePresentRate: &structuredEvidencePresent,
 			},
 		},
 		MeasurementStatus: measurementStatusMeasured,
@@ -388,8 +394,8 @@ func TestWriteSummary(t *testing.T) {
 	if parsed.Tool != "test-tool" {
 		t.Errorf("tool = %q, want test-tool", parsed.Tool)
 	}
-	if parsed.SchemaVersion != activeSchemaVersion {
-		t.Errorf("summary schema_version = %d, want %d", parsed.SchemaVersion, activeSchemaVersion)
+	if parsed.SchemaVersion != activeSummarySchemaVersion {
+		t.Errorf("summary schema_version = %d, want %d", parsed.SchemaVersion, activeSummarySchemaVersion)
 	}
 	if parsed.MeasurementStatus != measurementStatusMeasured {
 		t.Errorf("measurement status = %q, want measured", parsed.MeasurementStatus)

--- a/schemas/summary-v5.schema.json
+++ b/schemas/summary-v5.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/summary-v5.schema.json",
+  "title": "agent-egress-bench Gauntlet Summary",
+  "description": "Active v5 summary. Scores contain only measured outcome rates. Field-presence observations live in diagnostics and do not establish detection accuracy or proof.",
+  "type": "object",
+  "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "diagnostics", "measurement_status", "per_category"],
+  "properties": {
+    "schema_version": {"type": "integer", "const": 5},
+    "capability_registry": {"$ref": "#/$defs/capability_registry"},
+    "reported_claims": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "scores": {"$ref": "#/$defs/dual_outcome_scores"},
+    "diagnostics": {"$ref": "#/$defs/dual_presence_diagnostics"},
+    "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]},
+    "per_category": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/category_scores"}
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "capability_registry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "format", "revision", "sha256"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "format": {"type": "integer", "minimum": 1},
+        "revision": {"type": "integer", "minimum": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "rate_or_null": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "maximum": 1
+    },
+    "outcome_scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["containment", "false_positive_rate"],
+      "properties": {
+        "containment": {"$ref": "#/$defs/rate_or_null"},
+        "false_positive_rate": {"$ref": "#/$defs/rate_or_null"}
+      }
+    },
+    "presence_diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["classification_present_rate", "structured_evidence_present_rate"],
+      "properties": {
+        "classification_present_rate": {"$ref": "#/$defs/rate_or_null"},
+        "structured_evidence_present_rate": {"$ref": "#/$defs/rate_or_null"}
+      }
+    },
+    "dual_outcome_scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["full", "applicable"],
+      "properties": {
+        "full": {"$ref": "#/$defs/outcome_scores"},
+        "applicable": {"$ref": "#/$defs/outcome_scores"}
+      }
+    },
+    "dual_presence_diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["full", "applicable"],
+      "properties": {
+        "full": {"$ref": "#/$defs/presence_diagnostics"},
+        "applicable": {"$ref": "#/$defs/presence_diagnostics"}
+      }
+    },
+    "category_scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["applicable", "containment", "false_positive_rate", "diagnostics"],
+      "properties": {
+        "applicable": {"type": "integer", "minimum": 0},
+        "containment": {"$ref": "#/$defs/rate_or_null"},
+        "false_positive_rate": {"$ref": "#/$defs/rate_or_null"},
+        "diagnostics": {"$ref": "#/$defs/presence_diagnostics"}
+      }
+    }
+  }
+}

--- a/schemas/summary.schema.json
+++ b/schemas/summary.schema.json
@@ -9,6 +9,8 @@
     "schema_version": {"type": "integer", "const": 5},
     "capability_registry": {"$ref": "#/$defs/capability_registry"},
     "reported_claims": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "scores": {"$ref": "#/$defs/dual_outcome_scores"},
+    "diagnostics": {"$ref": "#/$defs/dual_presence_diagnostics"},
     "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]}
   },
   "additionalProperties": true,
@@ -22,6 +24,47 @@
         "format": {"type": "integer", "minimum": 1},
         "revision": {"type": "integer", "minimum": 1},
         "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "rate_or_null": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "maximum": 1
+    },
+    "outcome_scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["containment", "false_positive_rate"],
+      "properties": {
+        "containment": {"$ref": "#/$defs/rate_or_null"},
+        "false_positive_rate": {"$ref": "#/$defs/rate_or_null"}
+      }
+    },
+    "presence_diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["classification_present_rate", "structured_evidence_present_rate"],
+      "properties": {
+        "classification_present_rate": {"$ref": "#/$defs/rate_or_null"},
+        "structured_evidence_present_rate": {"$ref": "#/$defs/rate_or_null"}
+      }
+    },
+    "dual_outcome_scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["full", "applicable"],
+      "properties": {
+        "full": {"$ref": "#/$defs/outcome_scores"},
+        "applicable": {"$ref": "#/$defs/outcome_scores"}
+      }
+    },
+    "dual_presence_diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["full", "applicable"],
+      "properties": {
+        "full": {"$ref": "#/$defs/presence_diagnostics"},
+        "applicable": {"$ref": "#/$defs/presence_diagnostics"}
       }
     }
   }

--- a/schemas/summary.schema.json
+++ b/schemas/summary.schema.json
@@ -11,7 +11,11 @@
     "reported_claims": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
     "scores": {"$ref": "#/$defs/dual_outcome_scores"},
     "diagnostics": {"$ref": "#/$defs/dual_presence_diagnostics"},
-    "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]}
+    "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]},
+    "per_category": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/category_scores"}
+    }
   },
   "additionalProperties": true,
   "$defs": {
@@ -65,6 +69,17 @@
       "properties": {
         "full": {"$ref": "#/$defs/presence_diagnostics"},
         "applicable": {"$ref": "#/$defs/presence_diagnostics"}
+      }
+    },
+    "category_scores": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["applicable", "containment", "false_positive_rate", "diagnostics"],
+      "properties": {
+        "applicable": {"type": "integer", "minimum": 0},
+        "containment": {"$ref": "#/$defs/rate_or_null"},
+        "false_positive_rate": {"$ref": "#/$defs/rate_or_null"},
+        "diagnostics": {"$ref": "#/$defs/presence_diagnostics"}
       }
     }
   }

--- a/schemas/summary.schema.json
+++ b/schemas/summary.schema.json
@@ -2,11 +2,11 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/summary.schema.json",
   "title": "agent-egress-bench Gauntlet Summary",
-  "description": "Active v4 summary. Reporting labels are registry-bound metadata and cannot affect measured scope or score.",
+  "description": "Active v5 summary. Scores contain only measured outcome rates. Field-presence observations live in diagnostics and do not establish detection accuracy or proof.",
   "type": "object",
-  "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "measurement_status", "per_category"],
+  "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "diagnostics", "measurement_status", "per_category"],
   "properties": {
-    "schema_version": {"type": "integer", "const": 4},
+    "schema_version": {"type": "integer", "const": 5},
     "capability_registry": {"$ref": "#/$defs/capability_registry"},
     "reported_claims": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
     "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]}

--- a/schemas/summary.schema.json
+++ b/schemas/summary.schema.json
@@ -2,20 +2,14 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/summary.schema.json",
   "title": "agent-egress-bench Gauntlet Summary",
-  "description": "Active v5 summary. Scores contain only measured outcome rates. Field-presence observations live in diagnostics and do not establish detection accuracy or proof.",
+  "description": "Frozen v4 summary. Reporting labels are registry-bound metadata and cannot affect measured scope or score.",
   "type": "object",
-  "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "diagnostics", "measurement_status", "per_category"],
+  "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "measurement_status", "per_category"],
   "properties": {
-    "schema_version": {"type": "integer", "const": 5},
+    "schema_version": {"type": "integer", "const": 4},
     "capability_registry": {"$ref": "#/$defs/capability_registry"},
     "reported_claims": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
-    "scores": {"$ref": "#/$defs/dual_outcome_scores"},
-    "diagnostics": {"$ref": "#/$defs/dual_presence_diagnostics"},
-    "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]},
-    "per_category": {
-      "type": "object",
-      "additionalProperties": {"$ref": "#/$defs/category_scores"}
-    }
+    "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]}
   },
   "additionalProperties": true,
   "$defs": {
@@ -28,58 +22,6 @@
         "format": {"type": "integer", "minimum": 1},
         "revision": {"type": "integer", "minimum": 1},
         "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
-      }
-    },
-    "rate_or_null": {
-      "type": ["number", "null"],
-      "minimum": 0,
-      "maximum": 1
-    },
-    "outcome_scores": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["containment", "false_positive_rate"],
-      "properties": {
-        "containment": {"$ref": "#/$defs/rate_or_null"},
-        "false_positive_rate": {"$ref": "#/$defs/rate_or_null"}
-      }
-    },
-    "presence_diagnostics": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["classification_present_rate", "structured_evidence_present_rate"],
-      "properties": {
-        "classification_present_rate": {"$ref": "#/$defs/rate_or_null"},
-        "structured_evidence_present_rate": {"$ref": "#/$defs/rate_or_null"}
-      }
-    },
-    "dual_outcome_scores": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["full", "applicable"],
-      "properties": {
-        "full": {"$ref": "#/$defs/outcome_scores"},
-        "applicable": {"$ref": "#/$defs/outcome_scores"}
-      }
-    },
-    "dual_presence_diagnostics": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["full", "applicable"],
-      "properties": {
-        "full": {"$ref": "#/$defs/presence_diagnostics"},
-        "applicable": {"$ref": "#/$defs/presence_diagnostics"}
-      }
-    },
-    "category_scores": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["applicable", "containment", "false_positive_rate", "diagnostics"],
-      "properties": {
-        "applicable": {"type": "integer", "minimum": 0},
-        "containment": {"$ref": "#/$defs/rate_or_null"},
-        "false_positive_rate": {"$ref": "#/$defs/rate_or_null"},
-        "diagnostics": {"$ref": "#/$defs/presence_diagnostics"}
       }
     }
   }

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -4,6 +4,7 @@
 import argparse
 import hashlib
 import json
+import math
 import os
 import re
 import shlex
@@ -42,6 +43,11 @@ V4_RAW_EVIDENCE = {
 }
 ACTIVE_SUMMARY_SCHEMA_VERSIONS = frozenset({4, 5})
 SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
+V5_SCOPES = frozenset({"full", "applicable"})
+V5_OUTCOME_SCORE_FIELDS = frozenset({"containment", "false_positive_rate"})
+V5_DIAGNOSTIC_FIELDS = frozenset(
+    {"classification_present_rate", "structured_evidence_present_rate"}
+)
 
 
 def raw_evidence_for_summary(summary):
@@ -280,6 +286,51 @@ def expected_fraction(numerator, denominator):
     return numerator / denominator if denominator else None
 
 
+def require_exact_keys(value, label, expected):
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    actual = set(value)
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing:
+        raise ValueError(f"{label} is missing fields: {missing!r}")
+    if unexpected:
+        raise ValueError(f"{label} has unexpected fields: {unexpected!r}")
+    return value
+
+
+def require_rate_or_null(value, label):
+    if value is None:
+        return None
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or not 0 <= value <= 1
+    ):
+        raise ValueError(f"{label} must be a finite rate or null")
+    return value
+
+
+def validate_v5_summary_metric_contract(summary):
+    """Reject fields a v5 bundle must neither retain nor promote."""
+    scores = require_exact_keys(summary.get("scores"), "runner summary scores", V5_SCOPES)
+    diagnostics = require_exact_keys(
+        summary.get("diagnostics"), "runner summary diagnostics", V5_SCOPES
+    )
+    for scope in V5_SCOPES:
+        scope_scores = require_exact_keys(
+            scores[scope], f"runner summary scores.{scope}", V5_OUTCOME_SCORE_FIELDS
+        )
+        scope_diagnostics = require_exact_keys(
+            diagnostics[scope], f"runner summary diagnostics.{scope}", V5_DIAGNOSTIC_FIELDS
+        )
+        for metric, value in scope_scores.items():
+            require_rate_or_null(value, f"runner summary scores.{scope}.{metric}")
+        for diagnostic, value in scope_diagnostics.items():
+            require_rate_or_null(value, f"runner summary diagnostics.{scope}.{diagnostic}")
+
+
 def verify_score(summary, scope, metric, numerator, denominator):
     try:
         actual = summary["scores"][scope][metric]
@@ -344,6 +395,8 @@ def measurements(repo_root, run_dir):
         # scoring bump silently reopened the hole this closes: a summary
         # carrying the new version matched neither branch.
         raise ValueError("active runner summary missing schema_version")
+    if summary_schema_version == 5:
+        validate_v5_summary_metric_contract(summary)
     for key in (
         "gauntlet_version",
         "scoring_version",

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -229,7 +229,7 @@ def load_manifest(repo_root, run_dir):
     return manifest, ids
 
 
-def load_case_index(path, manifest_ids):
+def load_case_index(path, manifest_ids, require_categories=False):
     case_index_bytes = path.read_bytes()
     case_index = json.loads(case_index_bytes)
     if not isinstance(case_index, dict) or case_index.get("schema_version") != 1:
@@ -238,11 +238,13 @@ def load_case_index(path, manifest_ids):
     if not isinstance(rows, list):
         raise ValueError("loader case index cases must be an array")
     expected_by_id = {}
+    category_by_id = {}
     for row_number, row in enumerate(rows, 1):
         if not isinstance(row, dict):
             raise ValueError(f"loader case index row {row_number} is not an object")
         case_id = row.get("case_id")
         expected = row.get("expected_verdict")
+        category = row.get("category")
         if not isinstance(case_id, str) or not case_id:
             raise ValueError(f"loader case index row {row_number} has no case_id")
         if case_id in expected_by_id:
@@ -251,10 +253,14 @@ def load_case_index(path, manifest_ids):
             raise ValueError(
                 f"loader case index row {row_number} has invalid normalized expected_verdict {expected!r}"
             )
+        if require_categories and (not isinstance(category, str) or not category):
+            raise ValueError(f"loader case index row {row_number} has no category")
         expected_by_id[case_id] = expected
+        if isinstance(category, str) and category:
+            category_by_id[case_id] = category
     if set(expected_by_id) != manifest_ids:
         raise ValueError("loader case index IDs do not match cases/MANIFEST.txt")
-    return case_index_bytes, expected_by_id
+    return case_index_bytes, expected_by_id, category_by_id
 
 
 def count_stat(make_stats, name):
@@ -329,6 +335,25 @@ def validate_v5_summary_metric_contract(summary):
             require_rate_or_null(value, f"runner summary scores.{scope}.{metric}")
         for diagnostic, value in scope_diagnostics.items():
             require_rate_or_null(value, f"runner summary diagnostics.{scope}.{diagnostic}")
+    per_category = summary.get("per_category")
+    if not isinstance(per_category, dict):
+        raise ValueError("runner summary per_category must be an object")
+    category_fields = frozenset({"applicable", "containment", "false_positive_rate", "diagnostics"})
+    for category, category_summary in per_category.items():
+        if not isinstance(category, str) or not category:
+            raise ValueError("runner summary per_category has an invalid category")
+        values = require_exact_keys(
+            category_summary, f"runner summary per_category.{category}", category_fields
+        )
+        if isinstance(values["applicable"], bool) or not isinstance(values["applicable"], int) or values["applicable"] < 0:
+            raise ValueError(f"runner summary per_category.{category}.applicable must be a non-negative integer")
+        require_rate_or_null(values["containment"], f"runner summary per_category.{category}.containment")
+        require_rate_or_null(values["false_positive_rate"], f"runner summary per_category.{category}.false_positive_rate")
+        category_diagnostics = require_exact_keys(
+            values["diagnostics"], f"runner summary per_category.{category}.diagnostics", V5_DIAGNOSTIC_FIELDS
+        )
+        for diagnostic, value in category_diagnostics.items():
+            require_rate_or_null(value, f"runner summary per_category.{category}.diagnostics.{diagnostic}")
 
 
 def verify_score(summary, scope, metric, numerator, denominator):
@@ -418,8 +443,10 @@ def measurements(repo_root, run_dir):
     if summary_schema_version in ACTIVE_SUMMARY_SCHEMA_VERSIONS:
         registry = validate_v4_registry_binding(run_dir, summary, results)
     manifest, manifest_ids = load_manifest(repo_root, run_dir)
-    case_index_bytes, expected_by_id = load_case_index(
-        run_dir / RAW_EVIDENCE["case_index"], manifest_ids
+    case_index_bytes, expected_by_id, category_by_id = load_case_index(
+        run_dir / RAW_EVIDENCE["case_index"],
+        manifest_ids,
+        require_categories=summary_schema_version == 5,
     )
 
     try:
@@ -508,12 +535,13 @@ def measurements(repo_root, run_dir):
     blocked_malicious = [
         row for row in applicable_malicious if row.get("actual_verdict") == "block"
     ]
+    correctly_blocked_malicious = [row for row in blocked_malicious if row.get("score") == "pass"]
     blocked_benign = [
         row for row in applicable_benign if row.get("actual_verdict") == "block"
     ]
-    classified = sum(has_classification(row.get("evidence")) for row in blocked_malicious)
+    classified = sum(has_classification(row.get("evidence")) for row in correctly_blocked_malicious)
     evidence_emitted = sum(
-        has_structured_evidence(row.get("evidence")) for row in blocked_malicious
+        has_structured_evidence(row.get("evidence")) for row in correctly_blocked_malicious
     )
     full_malicious = sum(
         row.get("expected_verdict") == "block"
@@ -551,11 +579,11 @@ def measurements(repo_root, run_dir):
         scope: {
             "classification_present_rate": {
                 "numerator": classified,
-                "denominator": len(blocked_malicious),
+                "denominator": len(correctly_blocked_malicious),
             },
             "structured_evidence_present_rate": {
                 "numerator": evidence_emitted,
-                "denominator": len(blocked_malicious),
+                "denominator": len(correctly_blocked_malicious),
             },
         }
         for scope in ("applicable", "full")
@@ -635,6 +663,34 @@ def measurements(repo_root, run_dir):
                 verify_diagnostic(
                     summary, scope, diagnostic, counts["numerator"], counts["denominator"]
                 )
+        rows_by_category = {}
+        for row in applicable_results:
+            rows_by_category.setdefault(category_by_id[row["case_id"]], []).append(row)
+        if set(summary["per_category"]) != set(rows_by_category):
+            raise ValueError("runner summary per_category keys do not match bound result categories")
+        for category, category_rows in rows_by_category.items():
+            category_summary = summary["per_category"][category]
+            malicious = [row for row in category_rows if row["expected_verdict"] == "block"]
+            benign = [row for row in category_rows if row["expected_verdict"] == "allow"]
+            blocked = [row for row in malicious if row["actual_verdict"] == "block"]
+            correct_blocks = [row for row in blocked if row["score"] == "pass"]
+            expected_category = {
+                "applicable": len(category_rows),
+                "containment": expected_fraction(len(blocked), len(malicious)),
+                "false_positive_rate": expected_fraction(
+                    sum(row["actual_verdict"] == "block" for row in benign), len(benign)
+                ),
+                "diagnostics": {
+                    "classification_present_rate": expected_fraction(
+                        sum(has_classification(row["evidence"]) for row in correct_blocks), len(correct_blocks)
+                    ),
+                    "structured_evidence_present_rate": expected_fraction(
+                        sum(has_structured_evidence(row["evidence"]) for row in correct_blocks), len(correct_blocks)
+                    ),
+                },
+            }
+            if category_summary != expected_category:
+                raise ValueError(f"runner summary per_category.{category} does not match bound result rows")
     if summary_schema_version in ACTIVE_SUMMARY_SCHEMA_VERSIONS:
         # Scoped to the applicable rows so this mirrors exactly what the Go
         # runner can observe when it derives the same field. Synthetic rows

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -40,17 +40,18 @@ V4_RAW_EVIDENCE = {
     "capability_registry": "capability-registry.json",
     "receipt_profile": "receipt-profile.json",
 }
+ACTIVE_SUMMARY_SCHEMA_VERSIONS = frozenset({4, 5})
 SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
 
 
 def raw_evidence_for_summary(summary):
     """Return the immutable evidence members for this artifact generation.
 
-    V2 evidence is frozen and did not retain registry bytes. Active v4 is a
+    V2 evidence is frozen and did not retain registry bytes. Active v4/v5 is a
     different contract: its raw profile, snapshot, and receipt profile are
     first-class evidence rather than a reconstructed view of current files.
     """
-    if summary.get("schema_version") == 4:
+    if summary.get("schema_version") in ACTIVE_SUMMARY_SCHEMA_VERSIONS:
         return {**RAW_EVIDENCE, **V4_RAW_EVIDENCE}
     return RAW_EVIDENCE
 
@@ -125,9 +126,9 @@ def validate_v4_registry_binding(run_dir, summary, results):
         profile = json.loads(profile_bytes)
         snapshot = json.loads(snapshot_bytes)
     except json.JSONDecodeError as exc:
-        raise ValueError(f"v4 registry evidence is not valid JSON: {exc}") from exc
+        raise ValueError(f"active registry evidence is not valid JSON: {exc}") from exc
     if not isinstance(profile, dict) or not isinstance(snapshot, dict):
-        raise ValueError("v4 registry evidence must be JSON objects")
+        raise ValueError("active registry evidence must be JSON objects")
     reference = registry_reference(summary.get("capability_registry"), "summary capability_registry")
     if hashlib.sha256(snapshot_bytes).hexdigest() != reference["sha256"]:
         raise ValueError("capability registry raw snapshot digest does not match summary")
@@ -292,9 +293,22 @@ def verify_score(summary, scope, metric, numerator, denominator):
         )
 
 
+def verify_diagnostic(summary, scope, diagnostic, numerator, denominator):
+    try:
+        actual = summary["diagnostics"][scope][diagnostic]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(f"runner summary is missing diagnostics.{scope}.{diagnostic}") from exc
+    expected = expected_fraction(numerator, denominator)
+    if actual != expected:
+        raise ValueError(
+            f"runner summary diagnostics.{scope}.{diagnostic} does not match bound diagnostic counts: "
+            f"{actual!r} != {expected!r}"
+        )
+
+
 def measurements(repo_root, run_dir):
     summary = load_object(run_dir / RAW_EVIDENCE["raw_summary"])
-    # Active v4 summaries always serialize the explicit unreachable counter.
+    # Active summaries always serialize the explicit unreachable counter.
     # The retained v2.4 summary predates that field and carries no
     # schema_version, so it keeps its original byte shape. Any scoring version
     # that is not a retained frozen one is active output and cannot borrow that
@@ -305,7 +319,7 @@ def measurements(repo_root, run_dir):
     # bump silently reopened the hole it was written to close, because a summary
     # carrying the new version matched neither branch.
     summary_schema_version = summary.get("schema_version")
-    if summary_schema_version == 4:
+    if summary_schema_version in ACTIVE_SUMMARY_SCHEMA_VERSIONS:
         active_case_count = summary.get("case_count")
         if not isinstance(active_case_count, dict) or "unreachable" not in active_case_count:
             raise ValueError("active runner summary missing case_count.unreachable")
@@ -317,7 +331,7 @@ def measurements(repo_root, run_dir):
         ):
             raise ValueError("active runner summary case_count.unreachable must be a non-negative integer")
     elif summary_schema_version is not None:
-        raise ValueError("runner summary schema_version must be frozen v2 or active v4")
+        raise ValueError("runner summary schema_version must be frozen v2 or active v4/v5")
     elif summary.get("scoring_version") not in FROZEN_SCORING_VERSIONS:
         # Both guards are load-bearing and neither replaces the other. The
         # first rejects a summary carrying an unrecognised schema_version. This
@@ -344,11 +358,11 @@ def measurements(repo_root, run_dir):
     make_stats = (run_dir / RAW_EVIDENCE["stats"]).read_text(encoding="utf-8")
     stderr = (run_dir / RAW_EVIDENCE["runner_stderr"]).read_text(encoding="utf-8")
     results = read_results(run_dir / RAW_EVIDENCE["results"])
-    # An active v4 artifact is uninterpretable without the exact raw registry
+    # An active artifact is uninterpretable without the exact raw registry
     # snapshot it names. Frozen v2 evidence has no such bytes and remains on the
     # historical reader path above.
     registry = None
-    if summary_schema_version == 4:
+    if summary_schema_version in ACTIVE_SUMMARY_SCHEMA_VERSIONS:
         registry = validate_v4_registry_binding(run_dir, summary, results)
     manifest, manifest_ids = load_manifest(repo_root, run_dir)
     case_index_bytes, expected_by_id = load_case_index(
@@ -458,7 +472,7 @@ def measurements(repo_root, run_dir):
         for row in results
         if row.get("actual_verdict") != "unreachable"
     )
-    metric_counts = {
+    outcome_metric_counts = {
         "applicable": {
             "containment": {
                 "numerator": len(blocked_malicious),
@@ -467,11 +481,6 @@ def measurements(repo_root, run_dir):
             "false_positive_rate": {
                 "numerator": len(blocked_benign),
                 "denominator": len(applicable_benign),
-            },
-            "detection": {"numerator": classified, "denominator": len(blocked_malicious)},
-            "evidence": {
-                "numerator": evidence_emitted,
-                "denominator": len(blocked_malicious),
             },
         },
         "full": {
@@ -483,13 +492,33 @@ def measurements(repo_root, run_dir):
                 "numerator": len(blocked_benign),
                 "denominator": full_benign,
             },
-            "detection": {"numerator": classified, "denominator": len(blocked_malicious)},
-            "evidence": {
+        },
+    }
+    diagnostic_counts = {
+        scope: {
+            "classification_present_rate": {
+                "numerator": classified,
+                "denominator": len(blocked_malicious),
+            },
+            "structured_evidence_present_rate": {
                 "numerator": evidence_emitted,
                 "denominator": len(blocked_malicious),
             },
-        },
+        }
+        for scope in ("applicable", "full")
     }
+    if summary_schema_version != 5:
+        # Frozen and active-v4 records keep the former score names and definition.
+        metric_counts = {
+            scope: {
+                **outcome_metric_counts[scope],
+                "detection": diagnostic_counts[scope]["classification_present_rate"],
+                "evidence": diagnostic_counts[scope]["structured_evidence_present_rate"],
+            }
+            for scope in ("applicable", "full")
+        }
+    else:
+        metric_counts = outcome_metric_counts
 
     logical_case_count = len(manifest_ids)
     case_count = summary.get("case_count")
@@ -547,7 +576,13 @@ def measurements(repo_root, run_dir):
     for scope, metrics in metric_counts.items():
         for metric, counts in metrics.items():
             verify_score(summary, scope, metric, counts["numerator"], counts["denominator"])
-    if summary_schema_version == 4:
+    if summary_schema_version == 5:
+        for scope, diagnostics in diagnostic_counts.items():
+            for diagnostic, counts in diagnostics.items():
+                verify_diagnostic(
+                    summary, scope, diagnostic, counts["numerator"], counts["denominator"]
+                )
+    if summary_schema_version in ACTIVE_SUMMARY_SCHEMA_VERSIONS:
         # Scoped to the applicable rows so this mirrors exactly what the Go
         # runner can observe when it derives the same field. Synthetic rows
         # outside that scope are rejected outright above.
@@ -581,6 +616,7 @@ def measurements(repo_root, run_dir):
         "command": command,
         "make_stats": make_stats,
         "metric_counts": metric_counts,
+        "diagnostic_counts": diagnostic_counts if summary_schema_version == 5 else None,
         "manifest_sha256": hashlib.sha256(manifest).hexdigest(),
         "case_index_sha256": hashlib.sha256(case_index_bytes).hexdigest(),
         "logical_case_count": logical_case_count,
@@ -686,7 +722,11 @@ def build_complete_bundle(repo_root, run_dir):
         candidate_case_count["unreachable"] = summary["case_count"]["unreachable"]
 
     candidate_scope = {
-        "schema_version": 4 if summary.get("schema_version") == 4 else 2,
+        "schema_version": (
+            summary.get("schema_version")
+            if summary.get("schema_version") in ACTIVE_SUMMARY_SCHEMA_VERSIONS
+            else 2
+        ),
         "local_run_id": metadata["local_run_id"],
         "generated_at": metadata["generated_at"],
         "corpus_ref_kind": metadata["corpus_ref_kind"],
@@ -723,6 +763,10 @@ def build_complete_bundle(repo_root, run_dir):
     }
     if summary.get("schema_version") == 4:
         candidate_scope["measurement_status"] = summary["measurement_status"]
+    elif summary.get("schema_version") == 5:
+        candidate_scope["measurement_status"] = summary["measurement_status"]
+        candidate_scope["diagnostics"] = summary["diagnostics"]
+        candidate_scope["diagnostic_counts"] = measured["diagnostic_counts"]
     else:
         candidate_scope["sufficient"] = summary["sufficient"]
     if measured["capability_registry"] is not None:

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -214,7 +214,7 @@ class ProvenanceBuilderTest(unittest.TestCase):
         summary["exercised"] = {"capability_tags": ["test"]}
         summary["tool_profile_sha256"] = hashlib.sha256(profile_bytes).hexdigest()
         summary["measurement_status"] = measurement_status
-        summary.pop("sufficient")
+        summary.pop("sufficient", None)
         if summary_schema_version == 5:
             summary["scoring_version"] = "2.8"
             summary["runner_version"] = "0.4.3"
@@ -309,6 +309,107 @@ class ProvenanceBuilderTest(unittest.TestCase):
             scope["diagnostic_counts"]["applicable"]["classification_present_rate"],
             {"numerator": 1, "denominator": 1},
         )
+
+    def test_v5_rejects_retired_score_fields_before_they_enter_a_bundle(self):
+        for retired_field in ("detection", "evidence"):
+            with self.subTest(retired_field=retired_field):
+                self.write_fixture()
+                self.make_active_fixture(summary_schema_version=5)
+                summary_path = self.run_dir / "raw-summary.json"
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+                summary["scores"]["applicable"][retired_field] = 1.0
+                summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+                result = self.bundle()
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    f"runner summary scores.applicable has unexpected fields: ['{retired_field}']",
+                    result.stderr,
+                )
+
+    def test_v5_rejects_unknown_metric_scopes_and_non_rate_values(self):
+        mutations = (
+            (
+                "unknown score scope",
+                lambda summary: summary["scores"].__setitem__(
+                    "legacy", {"containment": 1.0, "false_positive_rate": 0.0}
+                ),
+                "runner summary scores has unexpected fields: ['legacy']",
+            ),
+            (
+                "unknown diagnostic scope",
+                lambda summary: summary["diagnostics"].__setitem__(
+                    "legacy",
+                    {
+                        "classification_present_rate": 1.0,
+                        "structured_evidence_present_rate": 1.0,
+                    },
+                ),
+                "runner summary diagnostics has unexpected fields: ['legacy']",
+            ),
+            (
+                "unknown diagnostic field",
+                lambda summary: summary["diagnostics"]["full"].__setitem__("detection", 1.0),
+                "runner summary diagnostics.full has unexpected fields: ['detection']",
+            ),
+            (
+                "boolean outcome rate",
+                lambda summary: summary["scores"]["applicable"].__setitem__(
+                    "containment", True
+                ),
+                "runner summary scores.applicable.containment must be a finite rate or null",
+            ),
+            (
+                "boolean diagnostic rate",
+                lambda summary: summary["diagnostics"]["full"].__setitem__(
+                    "classification_present_rate", True
+                ),
+                "runner summary diagnostics.full.classification_present_rate must be a finite rate or null",
+            ),
+        )
+        for name, mutate, message in mutations:
+            with self.subTest(name=name):
+                self.write_fixture()
+                self.make_active_fixture(summary_schema_version=5)
+                summary_path = self.run_dir / "raw-summary.json"
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+                mutate(summary)
+                summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+                result = self.bundle()
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(message, result.stderr)
+
+    def test_v5_accepts_null_rates_when_the_observed_denominator_is_zero(self):
+        self.make_active_fixture(summary_schema_version=5)
+        summary_path = self.run_dir / "raw-summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        for scope in ("full", "applicable"):
+            summary["scores"][scope]["false_positive_rate"] = None
+        summary["scores"]["full"]["containment"] = 1 / 3
+        summary["scores"]["applicable"]["containment"] = 1 / 2
+        summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+        rows = [
+            json.loads(line)
+            for line in (self.run_dir / "results.jsonl").read_text(encoding="utf-8").splitlines()
+        ]
+        rows[1]["expected_verdict"] = "block"
+        rows[1]["score"] = "fail"
+        (self.run_dir / "results.jsonl").write_text(
+            "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+        )
+        case_index_path = self.run_dir / "case-index.json"
+        case_index = json.loads(case_index_path.read_text(encoding="utf-8"))
+        case_index["cases"][1]["expected_verdict"] = "block"
+        case_index_path.write_text(json.dumps(case_index), encoding="utf-8")
+        (self.run_dir / "make-stats.txt").write_text("block: 3\nallow: 0\nwarn: 0\n", encoding="utf-8")
+
+        result = self.bundle()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_active_measurement_status_must_match_result_coverage(self):
         self.make_active_fixture("incomplete")

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -180,7 +180,7 @@ class ProvenanceBuilderTest(unittest.TestCase):
         )
         (self.run_dir / "corpus-manifest.txt").write_text("a\nb\nc\n", encoding="utf-8")
 
-    def make_active_fixture(self, measurement_status="measured"):
+    def make_active_fixture(self, measurement_status="measured", summary_schema_version=4):
         snapshot_bytes = json.dumps(
             {
                 "id": "aeb.test-capabilities",
@@ -207,7 +207,7 @@ class ProvenanceBuilderTest(unittest.TestCase):
 
         summary_path = self.run_dir / "raw-summary.json"
         summary = json.loads(summary_path.read_text(encoding="utf-8"))
-        summary["schema_version"] = 4
+        summary["schema_version"] = summary_schema_version
         summary["case_count"]["unreachable"] = 0
         summary["capability_registry"] = reference
         summary["reported_claims"] = ["test"]
@@ -215,6 +215,16 @@ class ProvenanceBuilderTest(unittest.TestCase):
         summary["tool_profile_sha256"] = hashlib.sha256(profile_bytes).hexdigest()
         summary["measurement_status"] = measurement_status
         summary.pop("sufficient")
+        if summary_schema_version == 5:
+            summary["scoring_version"] = "2.8"
+            summary["runner_version"] = "0.4.3"
+            summary["diagnostics"] = {
+                scope: {
+                    "classification_present_rate": values.pop("detection"),
+                    "structured_evidence_present_rate": values.pop("evidence"),
+                }
+                for scope, values in summary["scores"].items()
+            }
         summary_path.write_text(json.dumps(summary), encoding="utf-8")
 
         for row in self.results:
@@ -283,6 +293,22 @@ class ProvenanceBuilderTest(unittest.TestCase):
         self.assertEqual(scope["scores"]["full"]["containment"], 0.5)
         self.assertEqual(scope["measurement_status"], "measured")
         self.assertNotIn("sufficient", scope)
+
+    def test_v5_moves_field_presence_out_of_scores_and_binds_it_as_diagnostics(self):
+        self.make_active_fixture(summary_schema_version=5)
+
+        result = self.bundle()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        scope = json.loads(
+            (self.run_dir / "run-bundle.json").read_text(encoding="utf-8")
+        )["candidate_scope"]
+        self.assertEqual(scope["schema_version"], 5)
+        self.assertEqual(set(scope["scores"]["applicable"]), {"containment", "false_positive_rate"})
+        self.assertEqual(
+            scope["diagnostic_counts"]["applicable"]["classification_present_rate"],
+            {"numerator": 1, "denominator": 1},
+        )
 
     def test_active_measurement_status_must_match_result_coverage(self):
         self.make_active_fixture("incomplete")

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -128,9 +128,9 @@ class ProvenanceBuilderTest(unittest.TestCase):
                 {
                     "schema_version": 1,
                     "cases": [
-                        {"case_id": "a", "expected_verdict": "block"},
-                        {"case_id": "b", "expected_verdict": "allow"},
-                        {"case_id": "c", "expected_verdict": "block"},
+                        {"case_id": "a", "category": "test", "expected_verdict": "block"},
+                        {"case_id": "b", "category": "test", "expected_verdict": "allow"},
+                        {"case_id": "c", "category": "test", "expected_verdict": "block"},
                     ],
                 }
             ),
@@ -224,6 +224,17 @@ class ProvenanceBuilderTest(unittest.TestCase):
                     "structured_evidence_present_rate": values.pop("evidence"),
                 }
                 for scope, values in summary["scores"].items()
+            }
+            summary["per_category"] = {
+                "test": {
+                    "applicable": 2,
+                    "containment": 1.0,
+                    "false_positive_rate": 0.0,
+                    "diagnostics": {
+                        "classification_present_rate": 1.0,
+                        "structured_evidence_present_rate": 1.0,
+                    },
+                }
             }
         summary_path.write_text(json.dumps(summary), encoding="utf-8")
 
@@ -328,6 +339,37 @@ class ProvenanceBuilderTest(unittest.TestCase):
                     result.stderr,
                 )
 
+    def test_v5_rejects_retired_or_forged_per_category_fields(self):
+        mutations = (
+            (
+                lambda summary: summary["per_category"]["test"].__setitem__("detection", 1.0),
+                "per_category.test has unexpected fields",
+            ),
+            (
+                lambda summary: summary["per_category"]["test"].__setitem__("containment", 0.0),
+                "per_category.test does not match bound result rows",
+            ),
+            (
+                lambda summary: summary["per_category"]["test"]["diagnostics"].__setitem__(
+                    "classification_present_rate", 0.0
+                ),
+                "per_category.test does not match bound result rows",
+            ),
+        )
+        for mutate, message in mutations:
+            with self.subTest(message=message):
+                self.write_fixture()
+                self.make_active_fixture(summary_schema_version=5)
+                summary_path = self.run_dir / "raw-summary.json"
+                summary = json.loads(summary_path.read_text(encoding="utf-8"))
+                mutate(summary)
+                summary_path.write_text(json.dumps(summary), encoding="utf-8")
+
+                result = self.bundle()
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(message, result.stderr)
+
     def test_v5_rejects_unknown_metric_scopes_and_non_rate_values(self):
         mutations = (
             (
@@ -390,6 +432,8 @@ class ProvenanceBuilderTest(unittest.TestCase):
             summary["scores"][scope]["false_positive_rate"] = None
         summary["scores"]["full"]["containment"] = 1 / 3
         summary["scores"]["applicable"]["containment"] = 1 / 2
+        summary["per_category"]["test"]["containment"] = 1 / 2
+        summary["per_category"]["test"]["false_positive_rate"] = None
         summary_path.write_text(json.dumps(summary), encoding="utf-8")
 
         rows = [

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -30,6 +30,11 @@ REQUIRED_IDENTITIES = (
 )
 SCOPE_IDENTITIES = {"corpus_sha256", "corpus_version", "scoring_version", "runner_version"}
 SHA256_HEX = set("0123456789abcdef")
+V5_SCOPES = frozenset({"full", "applicable"})
+V5_OUTCOME_SCORE_FIELDS = frozenset({"containment", "false_positive_rate"})
+V5_DIAGNOSTIC_FIELDS = frozenset(
+    {"classification_present_rate", "structured_evidence_present_rate"}
+)
 
 
 def load_object(path):
@@ -61,6 +66,12 @@ def fraction(value, label):
     return number
 
 
+def rate_or_null(value, label):
+    if value is None:
+        return None
+    return fraction(value, label)
+
+
 def nested_value(document, path):
     current = document
     for key in path:
@@ -87,6 +98,38 @@ def metric_contract_for(schema_version):
     if schema_version == 5:
         return ACTIVE_V5_REQUIRED_FLOORS, ACTIVE_V5_REQUIRED_CEILINGS
     return LEGACY_REQUIRED_FLOORS, LEGACY_REQUIRED_CEILINGS
+
+
+def require_exact_keys(value, label, expected):
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    actual = set(value)
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing:
+        raise ValueError(f"{label} is missing fields: {missing!r}")
+    if unexpected:
+        raise ValueError(f"{label} has unexpected fields: {unexpected!r}")
+    return value
+
+
+def validate_v5_candidate_metric_contract(candidate):
+    """Require the same v5 score surface used when a bundle was built."""
+    scores = require_exact_keys(candidate.get("scores"), "candidate scores", V5_SCOPES)
+    diagnostics = require_exact_keys(
+        candidate.get("diagnostics"), "candidate diagnostics", V5_SCOPES
+    )
+    for scope in V5_SCOPES:
+        scope_scores = require_exact_keys(
+            scores[scope], f"candidate scores.{scope}", V5_OUTCOME_SCORE_FIELDS
+        )
+        scope_diagnostics = require_exact_keys(
+            diagnostics[scope], f"candidate diagnostics.{scope}", V5_DIAGNOSTIC_FIELDS
+        )
+        for metric, value in scope_scores.items():
+            rate_or_null(value, f"candidate scores.{scope}.{metric}")
+        for diagnostic, value in scope_diagnostics.items():
+            rate_or_null(value, f"candidate diagnostics.{scope}.{diagnostic}")
 
 
 def atomic_json_write(path, value):
@@ -138,6 +181,8 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
             raise ValueError("candidate schema_version must be 2, 4, or 5")
         if candidate_schema_version in {4, 5}:
             require_capability_registry(candidate)
+        if candidate_schema_version == 5:
+            validate_v5_candidate_metric_contract(candidate)
 
         decision["artifact_id"] = nested_value(candidate, ("artifact_id",))
         decision["canonical_url"] = nested_value(candidate, ("canonical_url",))

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -315,10 +315,17 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
                 )
             for metric, raw_ceiling in metrics.items():
                 ceiling = fraction(raw_ceiling, f"baseline score_ceilings.{scope}.{metric}")
-                actual = fraction(
-                    nested_value(candidate, ("scores", scope, metric)),
-                    f"candidate scores.{scope}.{metric}",
-                )
+                raw_actual = nested_value(candidate, ("scores", scope, metric))
+                if raw_actual is None:
+                    denominator = nested_value(
+                        candidate, ("metric_counts", scope, metric, "denominator")
+                    )
+                    if isinstance(denominator, bool) or not isinstance(denominator, int) or denominator != 0:
+                        decision["failures"].append(
+                            f"scores.{scope}.{metric}=null requires a zero metric denominator"
+                        )
+                    continue
+                actual = fraction(raw_actual, f"candidate scores.{scope}.{metric}")
                 if actual > ceiling + 1e-12:
                     decision["failures"].append(
                         f"scores.{scope}.{metric}={actual}, above baseline ceiling {ceiling}"

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -10,11 +10,16 @@ import tempfile
 from pathlib import Path
 
 
-REQUIRED_FLOORS = {
+LEGACY_REQUIRED_FLOORS = {
     "full": {"containment"},
     "applicable": {"containment", "detection", "evidence"},
 }
-REQUIRED_CEILINGS = {"applicable": {"false_positive_rate"}}
+ACTIVE_V5_REQUIRED_FLOORS = {
+    "full": {"containment"},
+    "applicable": {"containment"},
+}
+LEGACY_REQUIRED_CEILINGS = {"applicable": {"false_positive_rate"}}
+ACTIVE_V5_REQUIRED_CEILINGS = {"applicable": {"false_positive_rate"}}
 REQUIRED_COUNT_KEYS = ("total", "applicable", "not_applicable", "not_applicable_reasons")
 REQUIRED_IDENTITIES = (
     "corpus_git_sha",
@@ -78,6 +83,12 @@ def require_capability_registry(candidate):
     return reference
 
 
+def metric_contract_for(schema_version):
+    if schema_version == 5:
+        return ACTIVE_V5_REQUIRED_FLOORS, ACTIVE_V5_REQUIRED_CEILINGS
+    return LEGACY_REQUIRED_FLOORS, LEGACY_REQUIRED_CEILINGS
+
+
 def atomic_json_write(path, value):
     path.parent.mkdir(parents=True, exist_ok=True)
     descriptor, temporary_name = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
@@ -122,9 +133,10 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
         candidate = load_object(candidate_path)
         baseline = load_object(baseline_path)
 
-        if candidate.get("schema_version") not in {2, 4}:
-            raise ValueError("candidate schema_version must be 2 or 4")
-        if candidate.get("schema_version") == 4:
+        candidate_schema_version = candidate.get("schema_version")
+        if candidate_schema_version not in {2, 4, 5}:
+            raise ValueError("candidate schema_version must be 2, 4, or 5")
+        if candidate_schema_version in {4, 5}:
             require_capability_registry(candidate)
 
         decision["artifact_id"] = nested_value(candidate, ("artifact_id",))
@@ -150,7 +162,7 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
                     f"candidate {candidate_key} does not match {evidence_label} evidence"
                 )
 
-        if candidate.get("schema_version") == 4:
+        if candidate_schema_version in {4, 5}:
             if candidate.get("measurement_status") != "measured":
                 decision["failures"].append(
                     "measurement_status="
@@ -191,10 +203,16 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
                 f"pipelock_version={actual_version!r}, baseline is {expected_version!r}"
             )
 
+        required_floors, required_ceilings = metric_contract_for(candidate_schema_version)
+        if candidate_schema_version == 5 and baseline.get("summary_schema_version") != 5:
+            raise ValueError(
+                "v5 candidate requires a reviewed baseline with summary_schema_version=5"
+            )
+
         floors = baseline.get("score_floors")
         if not isinstance(floors, dict):
             raise ValueError("baseline score_floors must be an object")
-        for scope, required_metrics in REQUIRED_FLOORS.items():
+        for scope, required_metrics in required_floors.items():
             metrics = floors.get(scope)
             if not isinstance(metrics, dict):
                 raise ValueError(f"baseline score_floors.{scope} must be an object")
@@ -206,6 +224,13 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
         for scope, metrics in floors.items():
             if not isinstance(metrics, dict):
                 raise ValueError(f"baseline score_floors.{scope} must be an object")
+            allowed = required_floors.get(scope, set())
+            unexpected = set(metrics) - allowed
+            if unexpected:
+                raise ValueError(
+                    f"baseline score_floors.{scope} has unsupported metrics for candidate schema "
+                    f"v{candidate_schema_version}: {sorted(unexpected)!r}"
+                )
             for metric, raw_floor in metrics.items():
                 floor = fraction(raw_floor, f"baseline score_floors.{scope}.{metric}")
                 actual = fraction(
@@ -224,7 +249,7 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
         ceilings = baseline.get("score_ceilings")
         if not isinstance(ceilings, dict):
             raise ValueError("baseline score_ceilings must be an object")
-        for scope, required_metrics in REQUIRED_CEILINGS.items():
+        for scope, required_metrics in required_ceilings.items():
             metrics = ceilings.get(scope)
             if not isinstance(metrics, dict):
                 raise ValueError(f"baseline score_ceilings.{scope} must be an object")
@@ -236,6 +261,13 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
         for scope, metrics in ceilings.items():
             if not isinstance(metrics, dict):
                 raise ValueError(f"baseline score_ceilings.{scope} must be an object")
+            allowed = required_ceilings.get(scope, set())
+            unexpected = set(metrics) - allowed
+            if unexpected:
+                raise ValueError(
+                    f"baseline score_ceilings.{scope} has unsupported metrics for candidate schema "
+                    f"v{candidate_schema_version}: {sorted(unexpected)!r}"
+                )
             for metric, raw_ceiling in metrics.items():
                 ceiling = fraction(raw_ceiling, f"baseline score_ceilings.{scope}.{metric}")
                 actual = fraction(

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -74,6 +74,27 @@ def active_candidate():
     return value
 
 
+def v5_candidate():
+    value = active_candidate()
+    value["schema_version"] = 5
+    value["scoring_version"] = "2.8"
+    value["runner_version"] = "0.4.3"
+    for scope in ("full", "applicable"):
+        value["scores"][scope].pop("detection", None)
+        value["scores"][scope].pop("evidence", None)
+    value["diagnostics"] = {
+        "full": {
+            "classification_present_rate": 1.0,
+            "structured_evidence_present_rate": 1.0,
+        },
+        "applicable": {
+            "classification_present_rate": 1.0,
+            "structured_evidence_present_rate": 1.0,
+        },
+    }
+    return value
+
+
 def baseline():
     return {
         "schema_version": 1,
@@ -95,6 +116,16 @@ def baseline():
         },
         "score_ceilings": {"applicable": {"false_positive_rate": 0.0}},
     }
+
+
+def v5_baseline():
+    value = baseline()
+    value["summary_schema_version"] = 5
+    value["scoring_version"] = "2.8"
+    value["runner_version"] = "0.4.3"
+    del value["score_floors"]["applicable"]["detection"]
+    del value["score_floors"]["applicable"]["evidence"]
+    return value
 
 
 class CandidateEvaluationTest(unittest.TestCase):
@@ -201,6 +232,17 @@ class CandidateEvaluationTest(unittest.TestCase):
             self.run_enforce(decision_path, candidate_path, baseline_path, evidence_path).returncode,
             0,
         )
+
+    def test_v5_candidate_cannot_silently_use_a_legacy_detection_baseline(self):
+        decision, *_ = self.run_evaluate(v5_candidate(), baseline())
+
+        self.assertTrue(decision["blocked"])
+        self.assertIn("summary_schema_version=5", decision["failures"][-1])
+
+    def test_v5_candidate_uses_only_reviewed_outcome_metric_contract(self):
+        decision, *_ = self.run_evaluate(v5_candidate(), v5_baseline())
+
+        self.assertFalse(decision["blocked"], decision["failures"])
 
     def test_measured_candidate_below_historical_floor_reaches_publication_gate(self):
         value = active_candidate()

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -93,6 +93,16 @@ def v5_candidate():
             "structured_evidence_present_rate": 1.0,
         },
     }
+    value["metric_counts"] = {
+        "full": {
+            "containment": {"numerator": 157, "denominator": 158},
+            "false_positive_rate": {"numerator": 0, "denominator": 55},
+        },
+        "applicable": {
+            "containment": {"numerator": 157, "denominator": 157},
+            "false_positive_rate": {"numerator": 0, "denominator": 55},
+        },
+    }
     return value
 
 
@@ -244,6 +254,25 @@ class CandidateEvaluationTest(unittest.TestCase):
         decision, *_ = self.run_evaluate(v5_candidate(), v5_baseline())
 
         self.assertFalse(decision["blocked"], decision["failures"])
+
+    def test_v5_null_ceiling_rate_requires_zero_denominator(self):
+        value = v5_candidate()
+        value["scores"]["applicable"]["false_positive_rate"] = None
+        value["metric_counts"]["applicable"]["false_positive_rate"] = {
+            "numerator": 0,
+            "denominator": 0,
+        }
+
+        decision, *_ = self.run_evaluate(value, v5_baseline())
+
+        self.assertFalse(decision["blocked"], decision["failures"])
+
+        value["metric_counts"]["applicable"]["false_positive_rate"]["denominator"] = 1
+        decision, *_ = self.run_evaluate(value, v5_baseline())
+        self.assertTrue(decision["blocked"])
+        self.assertTrue(
+            any("requires a zero metric denominator" in failure for failure in decision["failures"])
+        )
 
     def test_v5_candidate_rejects_retired_or_malformed_metric_fields(self):
         mutations = (

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -82,6 +82,7 @@ def v5_candidate():
     for scope in ("full", "applicable"):
         value["scores"][scope].pop("detection", None)
         value["scores"][scope].pop("evidence", None)
+    value["scores"]["full"]["false_positive_rate"] = 0.0
     value["diagnostics"] = {
         "full": {
             "classification_present_rate": 1.0,
@@ -243,6 +244,43 @@ class CandidateEvaluationTest(unittest.TestCase):
         decision, *_ = self.run_evaluate(v5_candidate(), v5_baseline())
 
         self.assertFalse(decision["blocked"], decision["failures"])
+
+    def test_v5_candidate_rejects_retired_or_malformed_metric_fields(self):
+        mutations = (
+            (
+                "retired score",
+                lambda value: value["scores"]["applicable"].__setitem__("detection", 1.0),
+                "candidate scores.applicable has unexpected fields: ['detection']",
+            ),
+            (
+                "unknown score scope",
+                lambda value: value["scores"].__setitem__(
+                    "legacy", {"containment": 1.0, "false_positive_rate": 0.0}
+                ),
+                "candidate scores has unexpected fields: ['legacy']",
+            ),
+            (
+                "retired diagnostic",
+                lambda value: value["diagnostics"]["full"].__setitem__("evidence", 1.0),
+                "candidate diagnostics.full has unexpected fields: ['evidence']",
+            ),
+            (
+                "boolean rate",
+                lambda value: value["scores"]["applicable"].__setitem__(
+                    "containment", True
+                ),
+                "candidate scores.applicable.containment must be a finite number",
+            ),
+        )
+        for name, mutate, message in mutations:
+            with self.subTest(name=name):
+                value = v5_candidate()
+                mutate(value)
+
+                decision, *_ = self.run_evaluate(value, v5_baseline())
+
+                self.assertTrue(decision["blocked"])
+                self.assertIn(message, decision["failures"])
 
     def test_measured_candidate_below_historical_floor_reaches_publication_gate(self):
         value = active_candidate()

--- a/scripts/gauntlet_site_index_test.py
+++ b/scripts/gauntlet_site_index_test.py
@@ -43,8 +43,8 @@ class GauntletSiteIndexTest(unittest.TestCase):
         self.assertNotIn("matching this tool\\u2019s declared capabilities", self.html)
 
     def test_current_scope_identity_matches_repository_versions(self):
-        self.assertIn('data-corpus-version="v2.3.0"', self.html)
-        self.assertIn('data-scoring-version="2.4"', self.html)
+        self.assertIn('data-corpus-version="v2.4.0"', self.html)
+        self.assertIn('data-scoring-version="2.8"', self.html)
 
 
 if __name__ == "__main__":

--- a/scripts/promote_gauntlet_candidate.py
+++ b/scripts/promote_gauntlet_candidate.py
@@ -69,7 +69,7 @@ def parse_timestamp(value, label):
 
 def evidence_files_for(candidate):
     files = dict(EVIDENCE_FILES)
-    if candidate.get("schema_version") == 4:
+    if candidate.get("schema_version") in {4, 5}:
         files.update(provenance.V4_RAW_EVIDENCE)
     return files
 
@@ -119,9 +119,9 @@ def validate_candidate_origin(candidate, artifact_prefix, url_prefix, expected_r
 
 
 def validate_reference_candidate(candidate):
-    if candidate.get("schema_version") not in {2, 4}:
-        raise ValueError("candidate schema_version must be 2 or 4")
-    if candidate.get("schema_version") == 4:
+    if candidate.get("schema_version") not in {2, 4, 5}:
+        raise ValueError("candidate schema_version must be 2, 4, or 5")
+    if candidate.get("schema_version") in {4, 5}:
         evaluator.require_capability_registry(candidate)
     if candidate.get("tool") != "pipelock":
         raise ValueError("reference promotion candidate tool must be pipelock")
@@ -134,6 +134,8 @@ def reviewable_policy_failure(failure):
     if not isinstance(failure, str):
         return False
     if REVIEWABLE_SCORE_FAILURE.fullmatch(failure):
+        return True
+    if failure == "v5 candidate requires a reviewed baseline with summary_schema_version=5":
         return True
     return failure.startswith("pipelock_version=") and ", baseline is " in failure
 
@@ -151,7 +153,7 @@ def proposed_baseline(candidate, candidate_sha256):
     if not isinstance(applicable_scores, dict) or not isinstance(full_scores, dict):
         raise ValueError("candidate full and applicable scores must be objects")
 
-    return {
+    baseline = {
         "_comment": (
             "Reviewed baseline for the continuous Gauntlet lane. Exact candidate scores become "
             "the next run's floors and ceiling only through a promotion PR. Public records remain "
@@ -176,16 +178,22 @@ def proposed_baseline(candidate, candidate_sha256):
         },
         "score_floors": {
             "full": {"containment": full_scores.get("containment")},
-            "applicable": {
-                "containment": applicable_scores.get("containment"),
-                "detection": applicable_scores.get("detection"),
-                "evidence": applicable_scores.get("evidence"),
-            },
+            "applicable": {"containment": applicable_scores.get("containment")},
         },
         "score_ceilings": {
             "applicable": {"false_positive_rate": applicable_scores.get("false_positive_rate")}
         },
     }
+    if candidate.get("schema_version") == 5:
+        baseline["summary_schema_version"] = 5
+    else:
+        baseline["score_floors"]["applicable"].update(
+            {
+                "detection": applicable_scores.get("detection"),
+                "evidence": applicable_scores.get("evidence"),
+            }
+        )
+    return baseline
 
 
 def atomic_copy(source, destination):

--- a/scripts/promote_gauntlet_candidate_test.py
+++ b/scripts/promote_gauntlet_candidate_test.py
@@ -218,6 +218,23 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
             )
         )
 
+    def test_legacy_candidate_baseline_round_trips_through_evaluation(self):
+        fixture = self.fixture()
+        generated = promotion.proposed_baseline(
+            fixture.candidate_value, evaluator.file_sha256(fixture.candidate_path)
+        )
+        generated_path = fixture.root / "generated-legacy-baseline.json"
+        write_json(generated_path, generated)
+
+        decision = evaluator.evaluate(fixture.candidate_path, generated_path, fixture.evidence)
+
+        self.assertNotIn("summary_schema_version", generated)
+        self.assertEqual(
+            set(generated["score_floors"]["applicable"]),
+            {"containment", "detection", "evidence"},
+        )
+        self.assertFalse(decision["blocked"], decision["failures"])
+
     def test_clean_candidate_creates_append_only_record_pointer_and_baseline(self):
         fixture = self.fixture()
         original_candidate = fixture.candidate_path.read_bytes()

--- a/scripts/promote_gauntlet_candidate_test.py
+++ b/scripts/promote_gauntlet_candidate_test.py
@@ -211,6 +211,13 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
         self.addCleanup(temporary.cleanup)
         return PromotionFixture(Path(temporary.name), candidate_value, baseline_value)
 
+    def test_v5_baseline_contract_change_requires_explicit_review(self):
+        self.assertTrue(
+            promotion.reviewable_policy_failure(
+                "v5 candidate requires a reviewed baseline with summary_schema_version=5"
+            )
+        )
+
     def test_clean_candidate_creates_append_only_record_pointer_and_baseline(self):
         fixture = self.fixture()
         original_candidate = fixture.candidate_path.read_bytes()

--- a/scripts/render_gauntlet_run_summary.py
+++ b/scripts/render_gauntlet_run_summary.py
@@ -157,9 +157,9 @@ def build_summary(candidate_path, decision_path, baseline_path, enforcement_path
 
     details = {}
     if candidate is not None:
-        if candidate.get("schema_version") not in {2, 4}:
-            failures.append("candidate schema_version must be 2 or 4")
-        elif candidate.get("schema_version") == 4:
+        if candidate.get("schema_version") not in {2, 4, 5}:
+            failures.append("candidate schema_version must be 2, 4, or 5")
+        elif candidate.get("schema_version") in {4, 5}:
             try:
                 import evaluate_gauntlet_candidate as evaluator
                 evaluator.require_capability_registry(candidate)
@@ -170,7 +170,7 @@ def build_summary(candidate_path, decision_path, baseline_path, enforcement_path
         for key in ("total", "applicable", "not_applicable", "errors"):
             details[key] = count(candidate, key, failures)
         details["unreachable"] = optional_count(candidate, "unreachable", failures)
-        if candidate.get("schema_version") == 4:
+        if candidate.get("schema_version") in {4, 5}:
             if candidate.get("measurement_status") != "measured":
                 failures.append("candidate measurement_status must be 'measured'")
         elif candidate.get("sufficient") is not True:

--- a/scripts/validate_gauntlet_records_test.py
+++ b/scripts/validate_gauntlet_records_test.py
@@ -134,9 +134,9 @@ class ValidRecordFixture:
             {
                 "schema_version": 1,
                 "cases": [
-                    {"case_id": "attack-a", "expected_verdict": "block"},
-                    {"case_id": "attack-b", "expected_verdict": "block"},
-                    {"case_id": "benign-a", "expected_verdict": "allow"},
+                    {"case_id": "attack-a", "category": "test", "expected_verdict": "block"},
+                    {"case_id": "attack-b", "category": "test", "expected_verdict": "block"},
+                    {"case_id": "benign-a", "category": "test", "expected_verdict": "allow"},
                 ],
             },
         )

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -7,6 +7,7 @@ import math
 import re
 import sys
 import urllib.parse
+from copy import deepcopy
 from pathlib import Path
 
 
@@ -45,6 +46,11 @@ V2_REQUIRED_SCOPE_PATHS = (
     ("canonical_url",),
 )
 METRICS = ("containment", "false_positive_rate", "detection", "evidence")
+OUTCOME_METRICS = ("containment", "false_positive_rate")
+PRESENCE_DIAGNOSTICS = (
+    "classification_present_rate",
+    "structured_evidence_present_rate",
+)
 SCOPES = ("applicable", "full")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -138,6 +144,42 @@ def validate_metric_fraction(document, scope, metric):
     return numerator, denominator
 
 
+def validate_diagnostic_fraction(document, scope, diagnostic):
+    """Bind a non-scoring diagnostic to its explicit numerator/denominator."""
+    rate_path = ("diagnostics", scope, diagnostic)
+    count_path = ("diagnostic_counts", scope, diagnostic)
+    numerator = non_negative_integer(document, count_path + ("numerator",))
+    denominator = non_negative_integer(document, count_path + ("denominator",))
+    if numerator > denominator:
+        raise ValueError("diagnostic numerator cannot exceed denominator: " + ".".join(count_path))
+
+    rate = finite_fraction(document, rate_path, allow_null=True)
+    if denominator == 0:
+        if rate is not None:
+            raise ValueError("diagnostic must be null when denominator is zero: " + ".".join(rate_path))
+        return numerator, denominator
+    if rate is None:
+        raise ValueError("diagnostic must be a number when denominator is non-zero: " + ".".join(rate_path))
+    if rate != numerator / denominator:
+        raise ValueError("diagnostic must equal numerator/denominator: " + ".".join(rate_path))
+    return numerator, denominator
+
+
+def require_exact_keys(document, path, expected):
+    value = path_value(document, path)
+    if not isinstance(value, dict):
+        raise ValueError("scope field must be an object: " + ".".join(path))
+    actual = set(value)
+    expected = set(expected)
+    if actual != expected:
+        raise ValueError(
+            "scope field has unexpected keys: "
+            + ".".join(path)
+            + f" (got {sorted(actual)!r}, want {sorted(expected)!r})"
+        )
+    return value
+
+
 def validate_canonical_url(document):
     """Require an absolute HTTPS canonical artifact URL."""
     canonical_url = path_value(document, ("canonical_url",))
@@ -161,6 +203,9 @@ def validate_scope(document):
         return
     if version == 4:
         validate_scope_v4(document)
+        return
+    if version == 5:
+        validate_scope_v5(document)
         return
     raise ValueError(f"unsupported schema_version: {version!r}")
 
@@ -338,6 +383,65 @@ def validate_scope_v4(document):
             raise ValueError(f"capability_registry.{key} must be a positive integer")
     if not isinstance(reference["sha256"], str) or not SHA256_HEX.fullmatch(reference["sha256"]):
         raise ValueError("capability_registry.sha256 must be 64 lower-case hex characters")
+
+
+def validate_scope_v5(document):
+    """Validate the active outcome-score plus presence-diagnostics contract."""
+    if document.get("schema_version") != 5:
+        raise ValueError("schema_version must be 5 for a v5 artifact")
+
+    # Reuse the v2 arithmetic and partition checks with an internal projection.
+    # V5 deliberately moved the old field-presence values out of scores, so the
+    # projection is validation machinery only and never changes the artifact.
+    projected = deepcopy(document)
+    projected["schema_version"] = 2
+    projected["scores"] = {}
+    projected["metric_counts"] = {}
+    for scope in SCOPES:
+        scores = require_exact_keys(document, ("scores", scope), OUTCOME_METRICS)
+        diagnostics = require_exact_keys(
+            document, ("diagnostics", scope), PRESENCE_DIAGNOSTICS
+        )
+        metric_counts = require_exact_keys(
+            document, ("metric_counts", scope), OUTCOME_METRICS
+        )
+        diagnostic_counts = require_exact_keys(
+            document, ("diagnostic_counts", scope), PRESENCE_DIAGNOSTICS
+        )
+        projected["scores"][scope] = {
+            **scores,
+            "detection": diagnostics["classification_present_rate"],
+            "evidence": diagnostics["structured_evidence_present_rate"],
+        }
+        projected["metric_counts"][scope] = {
+            **metric_counts,
+            "detection": diagnostic_counts["classification_present_rate"],
+            "evidence": diagnostic_counts["structured_evidence_present_rate"],
+        }
+
+    validate_scope_v2(projected)
+    validate_scope_v4({**projected, "capability_registry": document.get("capability_registry")})
+
+    counts = {
+        scope: {
+            diagnostic: validate_diagnostic_fraction(document, scope, diagnostic)
+            for diagnostic in PRESENCE_DIAGNOSTICS
+        }
+        for scope in SCOPES
+    }
+    for diagnostic in PRESENCE_DIAGNOSTICS:
+        if counts["full"][diagnostic][0] != counts["applicable"][diagnostic][0]:
+            raise ValueError(
+                f"diagnostic_counts.full.{diagnostic}.numerator must equal applicable numerator"
+            )
+        for scope in SCOPES:
+            containment_numerator = non_negative_integer(
+                document, ("metric_counts", scope, "containment", "numerator")
+            )
+            if counts[scope][diagnostic][1] != containment_numerator:
+                raise ValueError(
+                    f"diagnostic_counts.{scope}.{diagnostic}.denominator must equal blocked malicious count"
+                )
 
 
 def main(argv):

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -397,6 +397,10 @@ def validate_scope_v5(document):
     projected["schema_version"] = 2
     projected["scores"] = {}
     projected["metric_counts"] = {}
+    require_exact_keys(document, ("scores",), SCOPES)
+    require_exact_keys(document, ("diagnostics",), SCOPES)
+    require_exact_keys(document, ("metric_counts",), SCOPES)
+    require_exact_keys(document, ("diagnostic_counts",), SCOPES)
     for scope in SCOPES:
         scores = require_exact_keys(document, ("scores", scope), OUTCOME_METRICS)
         diagnostics = require_exact_keys(

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -75,6 +75,34 @@ def complete_artifact():
     }
 
 
+def complete_v5_artifact():
+    artifact = complete_artifact()
+    artifact["schema_version"] = 5
+    artifact["runner_version"] = "0.4.3"
+    artifact["scoring_version"] = "2.8"
+    artifact["measurement_status"] = "measured"
+    artifact["capability_registry"] = {
+        "id": "aeb.core-capabilities",
+        "format": 1,
+        "revision": 1,
+        "sha256": "d" * 64,
+    }
+    artifact["diagnostics"] = {}
+    artifact["diagnostic_counts"] = {}
+    for scope in ("full", "applicable"):
+        scores = artifact["scores"][scope]
+        counts = artifact["metric_counts"][scope]
+        artifact["diagnostics"][scope] = {
+            "classification_present_rate": scores.pop("detection"),
+            "structured_evidence_present_rate": scores.pop("evidence"),
+        }
+        artifact["diagnostic_counts"][scope] = {
+            "classification_present_rate": counts.pop("detection"),
+            "structured_evidence_present_rate": counts.pop("evidence"),
+        }
+    return artifact
+
+
 def all_na_artifact():
     artifact = complete_artifact()
     artifact["case_count"] = {
@@ -120,6 +148,21 @@ class ValidateGauntletScopeTest(unittest.TestCase):
     def test_complete_artifact_passes(self):
         result = self.run_validator(complete_artifact())
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_complete_v5_artifact_passes_with_presence_diagnostics(self):
+        result = self.run_validator(complete_v5_artifact())
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_v5_rejects_legacy_presence_metric_names_in_scores(self):
+        artifact = complete_v5_artifact()
+        artifact["scores"]["applicable"]["detection"] = 1.0
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("scores.applicable", result.stderr)
+        self.assertIn("unexpected keys", result.stderr)
 
     def test_unreachable_coverage_is_visible_but_outside_full_denominator(self):
         artifact = complete_artifact()

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -164,6 +164,18 @@ class ValidateGauntletScopeTest(unittest.TestCase):
         self.assertIn("scores.applicable", result.stderr)
         self.assertIn("unexpected keys", result.stderr)
 
+    def test_v5_rejects_unexpected_outer_metric_scopes(self):
+        for field in ("scores", "diagnostics", "metric_counts", "diagnostic_counts"):
+            with self.subTest(field=field):
+                artifact = complete_v5_artifact()
+                artifact[field]["legacy"] = {}
+
+                result = self.run_validator(artifact)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(field, result.stderr)
+                self.assertIn("unexpected keys", result.stderr)
+
     def test_unreachable_coverage_is_visible_but_outside_full_denominator(self):
         artifact = complete_artifact()
         total = artifact["case_count"]["total"]


### PR DESCRIPTION
`detection` counted whether a classification field was present and non-null, not whether it was correct, and `evidence` counted field presence the same way. On a blocked malicious case, a correct finding of `kind: ssrf, scanner: ssrf_metadata`, a generic `block_reason: "policy"`, and an actively wrong `kind: "totally_unrelated_nonsense"` each produced `detection = 1.0`. A tool stamping one constant reason string on every block published a perfect score, and the accumulator was named `classifiedCorrectly` while the predicate behind it tested presence.

Measuring classification correctly needs a per-case finding oracle the corpus does not have, so this removes the claim rather than weakening it further. `scores` now carries only the outcome metrics the corpus can measure without an oracle: containment and false-positive rate. The two presence rates move to a `diagnostics` block as `classification_present_rate` and `structured_evidence_present_rate`, which describe what they count and make no claim that the field is accurate, sufficient, or proof of a finding.

The active summary and candidate-provenance contract becomes schema v5. Cases, profiles, result rows, and receipt profiles stay v4, so immutable inputs are untouched. A v5 artifact must carry exactly the outcome keys under `scores`; a legacy `detection` or `evidence` key there is rejected rather than ignored.

`measurement_status` does not read either metric, so this cannot make an incomplete run report itself as measured. The candidate evaluator previously required both fields at 1.0 from the baseline, and a v5 candidate now fails against that legacy baseline rather than silently dropping the floors. Moving forward requires the existing reviewed-policy-change path, which establishes a baseline marked `summary_schema_version: 5`.

Frozen records and the CI baseline are not rewritten. Older records keep `detection` and `evidence` under their original schema behavior, and retained-record validation still passes against them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for summary schema version 5.
  - Added non-scoring diagnostics for classification and structured-evidence field presence.
  - Updated the Gauntlet site to display schema 5 results and diagnostics.

- **Changes**
  - Gauntlet outcome scoring now reports only containment and false-positive rate.
  - Updated validation and candidate evaluation for schema 5 artifacts.
  - Preserved compatibility with existing schema 4 results.

- **Documentation**
  - Updated scoring, results, governance, and artifact-versioning guidance to reflect the new metrics and schema behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->