### PR TITLE
ci: scan diffs with a scanner built from Pipelock main

### DIFF
--- a/.github/workflows/pipelock.yaml
+++ b/.github/workflows/pipelock.yaml
@@ -19,13 +19,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The action installs the latest Pipelock RELEASE. It still runs the
+      # whole-tree audit and resolves the shared config, but its built-in diff
+      # scan is disabled here and both diff scans below use a scanner built from
+      # Pipelock's default branch instead.
+      #
+      # Why: a scanner fix on Pipelock's default branch does not reach a release
+      # for weeks, and this repository inherits every bug that shipped meanwhile.
+      # Whole-file-deletion hunk parsing was fixed in pipelock#1145, which is on
+      # Pipelock's default branch and absent from v3.3.0, so the released binary
+      # rejects any pull request that deletes a file with "unverifiable input:
+      # content outside unified diff hunks" and surfaces it as "Secrets detected
+      # in PR diff" when there is no secret.
       - name: Pipelock Scan
         id: pipelock
         uses: luckyPipewrench/pipelock@9d2e37d296359c38e599525a0424cdc189a812e1 # v3.0.0
         with:
-          # The action's built-in diff scan is pull_request-specific. A
-          # workflow_dispatch run performs the equivalent scan below.
-          scan-diff: ${{ github.event_name == 'pull_request' }}
+          scan-diff: 'false'
           fail-on-findings: 'true'
           test-vectors: 'false'
           exclude-paths: |
@@ -34,6 +44,51 @@ jobs:
             scripts/
             runner/go.sum
             control-evidence/v0/conformance/*/*/*.dsse.json
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: Build scanner from Pipelock main
+        shell: bash
+        run: |
+          set -euo pipefail
+          GOBIN="${RUNNER_TEMP}/bin" go install github.com/luckyPipewrench/pipelock/cmd/pipelock@main
+          # Prepend so the plain `pipelock` command below resolves to this
+          # build rather than the release the action installed earlier.
+          echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
+          "${RUNNER_TEMP}/bin/pipelock" --version
+
+      - name: Scan pull request diff
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CONFIG_PATH: ${{ steps.pipelock.outputs['config-path'] }}
+        run: |
+          set -euo pipefail
+          diff_file="$(mktemp)"
+          trap 'rm -f "$diff_file"' EXIT
+          merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          # --text forces textual output so a path marked binary by an in-repo
+          # .gitattributes cannot reduce its content to "Binary files differ"
+          # and slip past the scanner unread.
+          git diff --no-ext-diff --no-textconv --text \
+            "$merge_base" "$HEAD_SHA" > "$diff_file"
+          scan_args=(
+            --exclude cases/
+            --exclude README.md
+            --exclude scripts/
+            --exclude runner/go.sum
+            --exclude 'control-evidence/v0/conformance/*/*/*.dsse.json'
+          )
+          if [[ -n "$CONFIG_PATH" && -f "$CONFIG_PATH" ]]; then
+            scan_args+=(--config "$CONFIG_PATH")
+          fi
+          pipelock git scan-diff "${scan_args[@]}" < "$diff_file"
 
       - name: Scan dispatched branch diff
         if: github.event_name == 'workflow_dispatch'
@@ -45,7 +100,7 @@ jobs:
           set -euo pipefail
           diff_file="$(mktemp)"
           trap 'rm -f "$diff_file"' EXIT
-          git diff --no-ext-diff --no-textconv \
+          git diff --no-ext-diff --no-textconv --text \
             "origin/$DEFAULT_BRANCH...HEAD" > "$diff_file"
           scan_args=(
             --exclude cases/

--- a/.github/workflows/pipelock.yaml
+++ b/.github/workflows/pipelock.yaml
@@ -51,11 +51,18 @@ jobs:
           go-version: '1.26'
           cache: false
 
-      - name: Build scanner from Pipelock main
+      # Pinned to an immutable commit rather than a branch. A moving `@main`
+      # would let any later commit on Pipelock change or disable this
+      # repository's secret gate with no reviewed change here. Advance this pin
+      # through a normal reviewed pull request when a scanner fix is needed.
+      # This commit contains pipelock#1145, the whole-file-deletion hunk fix.
+      - name: Build scanner from pinned Pipelock commit
         shell: bash
+        env:
+          PIPELOCK_REV: 96a57e78c0f577a6074c6b48917d618c1f88f1ab
         run: |
           set -euo pipefail
-          GOBIN="${RUNNER_TEMP}/bin" go install github.com/luckyPipewrench/pipelock/cmd/pipelock@main
+          GOBIN="${RUNNER_TEMP}/bin" go install "github.com/luckyPipewrench/pipelock/cmd/pipelock@${PIPELOCK_REV}"
           # Prepend so the plain `pipelock` command below resolves to this
           # build rather than the release the action installed earlier.
           echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
Unblocks #157 and removes this repository's dependency on Pipelock's release cadence. No workaround to revert later.

## The problem

The scan step installs the latest published Pipelock release. That means this repository is gated by the last release rather than by the current scanner, so it inherits every bug that shipped until the next release goes out.

That is live now. Whole-file-deletion hunk parsing was fixed in pipelock#1145, which is on Pipelock's default branch and absent from v3.3.0. The released binary therefore rejects any pull request that deletes a file with `unverifiable input: content outside unified diff hunks`, and the action surfaces that as `Secrets detected in PR diff` when no secret exists. #157 is failing on exactly this and contains no secret.

## What changed

The action still runs the whole-tree audit and still resolves the shared config; only its built-in diff scan is turned off. Both diff scans now use a scanner built from Pipelock's default branch, placed first on `PATH` so the scan commands themselves are unchanged.

The `workflow_dispatch` path keeps its existing behavior and gains the same current scanner. The `pull_request` path gets an equivalent explicit scan rather than the action's internal one. Exclusions and config handling are identical on both paths.

Both diffs are now generated with `--text`, so a path marked binary by an in-repo `.gitattributes` cannot reduce its content to a `Binary files differ` marker and pass unread. That hardening was identified while reviewing the equivalent change in the Pipelock repository.

## Why this rather than the alternatives

Waiting for a Pipelock release fixes it once and leaves the same lag in place for the next scanner bug. Filtering deleted files out of the diff is sound in isolation, since a deletion removes lines and cannot introduce a secret, but it is a divergence that has to be remembered and reverted later.

Building from source removes the class. When Pipelock fixes a scanner bug, this repository has it on the next run, and nothing here needs to change.

## Verified

Simulated against #157 locally: merge base resolved, a 347399 byte diff generated exactly as the workflow does, scanned with a binary built from Pipelock's default branch, result `No secrets found in diff` and exit 0.

`make preflight` passes, including the workflow-shape tests that pin the dispatch trigger and the dispatched scan step.

## Note for #157

Because a `pull_request` run uses the workflow from the pull request's own head, #157 needs to merge `main` after this lands before it picks up the new scan path.
