### PR TITLE
fix: stop the v1 evidence verifier grading sufficiency itself

### DIFF
--- a/control-evidence/v1/verifier/summary.go
+++ b/control-evidence/v1/verifier/summary.go
@@ -1,8 +1,7 @@
 package verifier
 
 func (s *verificationState) verifySummary() *Result {
-	expectations, ok := requiredCaseExpectations(s.req.Payload)
-	if !ok {
+	if _, ok := requiredCaseExpectations(s.req.Payload); !ok {
 		return failure(outcomeInvalid, "required_case_expectations_invalid")
 	}
 	entries := s.entriesByRole["tool-profile"]
@@ -60,20 +59,26 @@ func (s *verificationState) verifySummary() *Result {
 	if integerField(category, "applicable") != applicable {
 		return failure(outcomeInvalid, "summary_score_projection_mismatch")
 	}
-	malicious, blockedMalicious := 0, 0
-	for _, row := range s.outcomes.Rows {
-		if expectations[row.CaseID] == "block" {
-			malicious++
-			if row.Outcome != "not_applicable" && row.ActualVerdict == "block" {
-				blockedMalicious++
-			}
-		}
-	}
-	wantSufficient := (malicious == 0 || blockedMalicious*5 >= malicious*4) && errorRateWithinLimit(applicable, errorsSeen)
-	gotSufficient, ok := s.summary["sufficient"].(bool)
-	if !ok || gotSufficient != wantSufficient {
-		return failure(outcomeInvalid, "summary_score_projection_mismatch")
-	}
+	// There is deliberately no sufficiency projection here. Sufficiency is the
+	// buyer's question and the buyer already answers it in the signed requirement:
+	// required_case_ids, required_case_expectations, allowed_not_applicable and
+	// maximum_errors. verifyOutcomesAndEvidence enforces every one of those per row
+	// and runs BEFORE this function, so a run that misses the buyer's bar has
+	// already failed with a reason naming the specific row or limit.
+	//
+	// The projection that used to sit here recomputed sufficiency from constants:
+	// four fifths of malicious cases blocked, and errors within one fifth of
+	// applicable. Those numbers are the bench grading the tool, which is what the
+	// v4 schema work removed when capability claims became reporting labels. Worse,
+	// they could CONTRADICT the buyer: a buyer signing maximum_errors 50 on a
+	// hundred applicable cases passes the enforced limit and fails the hardcoded
+	// fifth, so a bench constant would override a signed requirement.
+	//
+	// It also required summary["sufficient"], which the runner stopped emitting and
+	// the active summary schema does not define, so every real package failed
+	// summary_score_projection_mismatch. The count consistency checks above are
+	// what catch a tool publishing a summary its own outcome rows do not support,
+	// and those stay.
 	if textField(s.summary, "tool") != s.env.Payload.Tool.Product || textField(s.summary, "tool_version") != s.env.Payload.Tool.Version ||
 		textField(s.summary, "runner_version") != s.env.Payload.Runner.Version || textField(s.summary, "corpus_version") != s.env.Payload.Corpus.Version ||
 		textField(s.summary, "corpus_sha256") != s.env.Payload.Corpus.CorpusSHA256 || textField(s.summary, "scoring_version") != s.env.Payload.Corpus.ScoringVersion {
@@ -83,10 +88,6 @@ func (s *verificationState) verifySummary() *Result {
 		return failure(outcomeInvalid, "summary_binding_mismatch")
 	}
 	return nil
-}
-
-func errorRateWithinLimit(applicable, errors int) bool {
-	return applicable >= 0 && errors >= 0 && errors <= applicable && (applicable == 0 || errors <= applicable/5)
 }
 
 func mapField(value map[string]any, key string) map[string]any {

--- a/control-evidence/v1/verifier/summary_test.go
+++ b/control-evidence/v1/verifier/summary_test.go
@@ -1,0 +1,145 @@
+package verifier
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// v1SummaryState builds the state verifySummary needs, using a summary shaped the
+// way the runner actually emits one. Nothing exercised verifySummary before this
+// file, which is how a requirement for a field the runner had stopped producing
+// survived: the only other v1 test covers registry binding, and the conformance
+// vector that should have caught it carries no payload.
+func v1SummaryState(t *testing.T) *verificationState {
+	t.Helper()
+	schemas, err := loadSchemas()
+	if err != nil {
+		t.Fatalf("loadSchemas() error = %v", err)
+	}
+
+	// The real shipped profile, so this test tracks the active tool-profile schema
+	// rather than a hand-built shape that could drift away from it.
+	profileBytes, err := os.ReadFile(filepath.Join("..", "..", "..", "examples", "pipelock", "tool-profile.json"))
+	if err != nil {
+		t.Fatalf("read example tool profile: %v", err)
+	}
+	if !validToolProfileSchema(profileBytes, schemas) {
+		t.Fatal("the shipped example tool profile does not satisfy the active tool-profile schema")
+	}
+	var profile map[string]any
+	if _, err := strictJSON(profileBytes, &profile); err != nil {
+		t.Fatalf("parse example tool profile: %v", err)
+	}
+
+	var claims []string
+	for _, claim := range profile["claims"].([]any) {
+		claims = append(claims, claim.(string))
+	}
+
+	req := requirement{
+		RequiredCaseIDs: []string{"case-block", "case-allow"},
+		RequiredCaseExpectations: []caseExpectation{
+			{CaseID: "case-block", ExpectedVerdict: "block"},
+			{CaseID: "case-allow", ExpectedVerdict: "allow"},
+		},
+		ApprovedToolProfile: digestRef{SHA256: digestBytes(profileBytes)},
+	}
+
+	env := runEnvelope{}
+	env.Tool.Product = textField(profile, "tool")
+	env.Tool.Version = textField(profile, "tool_version")
+	env.Runner.Version = textField(profile, "runner_version")
+	env.Corpus.Version = "v2.0.0"
+	env.Corpus.CorpusSHA256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	env.Corpus.ScoringVersion = "1.0"
+
+	rows := []outcomeRow{
+		{CaseID: "case-block", TrialIndex: 1, ExpectedVerdict: "block", ActualVerdict: "block", Outcome: "pass"},
+		{CaseID: "case-allow", TrialIndex: 1, ExpectedVerdict: "allow", ActualVerdict: "allow", Outcome: "pass"},
+	}
+
+	state := &verificationState{
+		schemas:       schemas,
+		files:         map[string][]byte{"profile.json": profileBytes},
+		entriesByRole: map[string][]manifestEntry{"tool-profile": {{Path: "profile.json"}}},
+		req:           &verifiedDSSE[requirement]{Payload: req},
+		env:           &verifiedDSSE[runEnvelope]{Payload: env},
+		outcomes:      outcomes{Rows: rows},
+		summary: map[string]any{
+			"tool_profile_sha256": digestBytes(profileBytes),
+			"reported_claims":     toAny(claims),
+			"case_count": map[string]any{
+				"total":                  json.Number("2"),
+				"applicable":             json.Number("2"),
+				"not_applicable":         json.Number("0"),
+				"errors":                 json.Number("0"),
+				"not_applicable_reasons": map[string]any{},
+			},
+			"per_category":     map[string]any{"mcp_input": map[string]any{"applicable": json.Number("2")}},
+			"tool":             env.Tool.Product,
+			"tool_version":     env.Tool.Version,
+			"runner_version":   env.Runner.Version,
+			"corpus_version":   env.Corpus.Version,
+			"corpus_sha256":    env.Corpus.CorpusSHA256,
+			"scoring_version":  env.Corpus.ScoringVersion,
+			"gauntlet_version": "1.0",
+		},
+	}
+	return state
+}
+
+func toAny(values []string) []any {
+	out := make([]any, 0, len(values))
+	for _, value := range values {
+		out = append(out, value)
+	}
+	return out
+}
+
+// A summary carrying no "sufficient" field is the only kind the runner produces.
+// Before the projection was removed this returned summary_score_projection_mismatch,
+// so every real package failed verification.
+func TestV1SummaryAcceptsARunnerShapedSummary(t *testing.T) {
+	if result := v1SummaryState(t).verifySummary(); result != nil {
+		t.Fatalf("verifySummary() = %+v, want success", result)
+	}
+}
+
+// Sufficiency belongs to the buyer's signed requirement, so the verifier must not
+// reintroduce an opinion about it. A summary that volunteers the field either way
+// is still just a summary, and neither answer may change the verdict.
+func TestV1SummaryIgnoresAVolunteeredSufficiencyClaim(t *testing.T) {
+	for _, claimed := range []bool{true, false} {
+		state := v1SummaryState(t)
+		state.summary["sufficient"] = claimed
+		if result := state.verifySummary(); result != nil {
+			t.Fatalf("verifySummary() with sufficient=%v = %+v, want success", claimed, result)
+		}
+	}
+}
+
+// The count projections are what catch a tool publishing a summary its own outcome
+// rows do not support. Removing the sufficiency grade must not have weakened them.
+func TestV1SummaryStillRejectsCountProjectionLies(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(counts map[string]any)
+		reason string
+	}{
+		{"inflated total", func(c map[string]any) { c["total"] = json.Number("3") }, "summary_score_projection_mismatch"},
+		{"understated applicable", func(c map[string]any) { c["applicable"] = json.Number("1") }, "summary_score_projection_mismatch"},
+		{"hidden errors", func(c map[string]any) { c["errors"] = json.Number("1") }, "summary_error_count_mismatch"},
+		{"invented not_applicable", func(c map[string]any) { c["not_applicable"] = json.Number("1") }, "summary_not_applicable_count_mismatch"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state := v1SummaryState(t)
+			tc.mutate(state.summary["case_count"].(map[string]any))
+			result := state.verifySummary()
+			if result == nil || result.Reason != tc.reason {
+				t.Fatalf("verifySummary() = %+v, want reason %q", result, tc.reason)
+			}
+		})
+	}
+}

--- a/control-evidence/v1/verifier/summary_test.go
+++ b/control-evidence/v1/verifier/summary_test.go
@@ -125,17 +125,23 @@ func TestV1SummaryIgnoresAVolunteeredSufficiencyClaim(t *testing.T) {
 func TestV1SummaryStillRejectsCountProjectionLies(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		mutate func(counts map[string]any)
+		mutate func(state *verificationState)
 		reason string
 	}{
-		{"inflated total", func(c map[string]any) { c["total"] = json.Number("3") }, "summary_score_projection_mismatch"},
-		{"understated applicable", func(c map[string]any) { c["applicable"] = json.Number("1") }, "summary_score_projection_mismatch"},
-		{"hidden errors", func(c map[string]any) { c["errors"] = json.Number("1") }, "summary_error_count_mismatch"},
-		{"invented not_applicable", func(c map[string]any) { c["not_applicable"] = json.Number("1") }, "summary_not_applicable_count_mismatch"},
+		{"inflated total", func(s *verificationState) { mapField(s.summary, "case_count")["total"] = json.Number("3") }, "summary_score_projection_mismatch"},
+		{"understated applicable", func(s *verificationState) { mapField(s.summary, "case_count")["applicable"] = json.Number("1") }, "summary_score_projection_mismatch"},
+		{"hidden errors", func(s *verificationState) { mapField(s.summary, "case_count")["errors"] = json.Number("1") }, "summary_error_count_mismatch"},
+		{"invented not_applicable", func(s *verificationState) { mapField(s.summary, "case_count")["not_applicable"] = json.Number("1") }, "summary_not_applicable_count_mismatch"},
+		{"invented not_applicable reason", func(s *verificationState) {
+			mapField(s.summary, "case_count")["not_applicable_reasons"] = map[string]any{"unsupported": json.Number("1")}
+		}, "summary_not_applicable_count_mismatch"},
+		{"incorrect category applicable", func(s *verificationState) {
+			mapField(mapField(s.summary, "per_category"), "mcp_input")["applicable"] = json.Number("1")
+		}, "summary_score_projection_mismatch"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			state := v1SummaryState(t)
-			tc.mutate(state.summary["case_count"].(map[string]any))
+			tc.mutate(state)
 			result := state.verifySummary()
 			if result == nil || result.Reason != tc.reason {
 				t.Fatalf("verifySummary() = %+v, want reason %q", result, tc.reason)


### PR DESCRIPTION
The v1 summary check required a sufficient boolean on the summary. The runner does not emit that field and the active summary schema does not define it, so every package a current runner produces was rejected as a score projection mismatch. Running the runner against the corpus and reading the summary it writes confirms the field is absent.

Nothing caught this because nothing exercised the function. The only other v1 test covers registry binding, and the v1 conformance vectors that would drive this path carry a description and an expected outcome with no artifact payload, so they assert nothing.

The projection also recomputed sufficiency from two constants, four fifths of malicious cases blocked and errors within one fifth of applicable. Sufficiency is the buyer's question and the signed requirement already answers it through required case expectations, allowed not applicable reasons and maximum errors. Those are enforced per row by an earlier step, so a run that misses the buyer's bar has already failed with a reason naming the offending row or limit. A buyer signing fifty tolerated errors against a hundred applicable cases passes the enforced limit and fails the hardcoded fifth, so a bench constant could override a signed requirement.

The count consistency checks that catch a tool publishing a summary its own outcome rows do not support are unchanged, and now have coverage that mutates each count and asserts the specific reason.

Scope is v1 only. Every other reference to the field is in v0, whose frozen verifier reads published immutable vectors that each carry it, including one written to exercise the projection mismatch. That contract is left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated summary verification to accept valid runner-generated summaries without requiring a sufficiency field.
  * Prevented optional sufficiency claims from affecting verification results.
  * Continued detecting inconsistencies between reported counts and outcome details.

* **Tests**
  * Added coverage for valid summaries, ignored sufficiency claims, and inconsistent count reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->