### PR TITLE
contracts: type required summary fields

### DIFF
--- a/runner/summary.go
+++ b/runner/summary.go
@@ -416,7 +416,7 @@ func buildSummary(
 		BenchmarkManifestSHA256: manifestSHA,
 		ToolProfileSHA256:       profileSHA,
 		CapabilityRegistry:      p.CapabilityRegistry,
-		ReportedClaims:          append([]string(nil), p.Claims...),
+		ReportedClaims:          append([]string{}, p.Claims...),
 		Date:                    date,
 		CaseCount: CaseCount{
 			Total:                len(allCases),

--- a/runner/summary_schema_conformance_test.go
+++ b/runner/summary_schema_conformance_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func compileSummarySchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	schemaRaw, err := os.ReadFile(filepath.Join("..", "schemas", "summary-v5.schema.json"))
+	if err != nil {
+		t.Fatalf("read summary schema: %v", err)
+	}
+	document, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaRaw))
+	if err != nil {
+		t.Fatalf("decode summary schema: %v", err)
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.AssertFormat()
+	if err := compiler.AddResource("summary-v5.schema.json", document); err != nil {
+		t.Fatalf("add summary schema: %v", err)
+	}
+	schema, err := compiler.Compile("summary-v5.schema.json")
+	if err != nil {
+		t.Fatalf("compile summary schema: %v", err)
+	}
+	return schema
+}
+
+func summaryRequiredFields(t *testing.T) []string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "schemas", "summary-v5.schema.json"))
+	if err != nil {
+		t.Fatalf("read summary schema: %v", err)
+	}
+	var document struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatalf("decode summary required fields: %v", err)
+	}
+	if len(document.Required) == 0 {
+		t.Fatal("summary schema has no required fields")
+	}
+	return document.Required
+}
+
+func validSummaryDocument(t *testing.T) map[string]any {
+	t.Helper()
+	return validSummaryDocumentForProfile(t, testProfile())
+}
+
+func validSummaryDocumentForProfile(t *testing.T, profile Profile) map[string]any {
+	t.Helper()
+	dir, profilePath := provenanceTestDirs(t)
+	caseValue := Case{
+		ID:              "a",
+		Category:        "url",
+		Transport:       "fetch_proxy",
+		ExpectedVerdict: "allow",
+		CapabilityTags:  []string{"url_dlp"},
+	}
+	result := CaseResult{CaseID: "a", ExpectedVerdict: "allow", ActualVerdict: "allow", Score: "pass"}
+	summary, err := buildSummary(
+		profile,
+		[]Case{caseValue},
+		[]CaseResult{result},
+		map[string]struct{}{},
+		map[NAKind]int{},
+		summarySnapshot(t, dir),
+		map[string]Case{"a": caseValue},
+		profilePath,
+		RunProvenance{},
+	)
+	if err != nil {
+		t.Fatalf("build valid summary: %v", err)
+	}
+	raw, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal valid summary: %v", err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatalf("decode valid summary: %v", err)
+	}
+	return document
+}
+
+func validateSummaryDocument(t *testing.T, schema *jsonschema.Schema, document map[string]any) error {
+	t.Helper()
+	raw, err := json.Marshal(document)
+	if err != nil {
+		t.Fatalf("marshal summary document: %v", err)
+	}
+	value, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("decode summary document: %v", err)
+	}
+	return schema.Validate(value)
+}
+
+func TestSummaryV5SchemaAcceptsRunnerDocument(t *testing.T) {
+	if err := validateSummaryDocument(t, compileSummarySchema(t), validSummaryDocument(t)); err != nil {
+		t.Fatalf("active summary schema rejected runner document: %v", err)
+	}
+}
+
+func TestSummaryV5SchemaAcceptsEmptyReportedClaims(t *testing.T) {
+	profile := testProfile()
+	profile.Claims = []string{}
+	document := validSummaryDocumentForProfile(t, profile)
+	if claims, ok := document["reported_claims"].([]any); !ok || len(claims) != 0 {
+		t.Fatalf("reported_claims = %#v, want an empty JSON array", document["reported_claims"])
+	}
+	if err := validateSummaryDocument(t, compileSummarySchema(t), document); err != nil {
+		t.Fatalf("active summary schema rejected empty reported claims: %v", err)
+	}
+}
+
+func TestSummaryV5SchemaAcceptsDocumentedExample(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "docs", "gauntlet.md"))
+	if err != nil {
+		t.Fatalf("read gauntlet documentation: %v", err)
+	}
+	const heading = "### Gauntlet summary (JSON file)"
+	section := strings.SplitN(string(raw), heading, 2)
+	if len(section) != 2 {
+		t.Fatalf("documentation does not contain %q", heading)
+	}
+	code := strings.SplitN(section[1], "```json\n", 2)
+	if len(code) != 2 {
+		t.Fatal("gauntlet summary section has no JSON example")
+	}
+	jsonBlock := strings.SplitN(code[1], "\n```", 2)
+	if len(jsonBlock) != 2 {
+		t.Fatal("gauntlet summary JSON example has no closing fence")
+	}
+	var document map[string]any
+	if err := json.Unmarshal([]byte(jsonBlock[0]), &document); err != nil {
+		t.Fatalf("decode documented summary: %v", err)
+	}
+	if err := validateSummaryDocument(t, compileSummarySchema(t), document); err != nil {
+		t.Fatalf("active summary schema rejected documented example: %v", err)
+	}
+}
+
+func TestSummaryV5SchemaRejectsUnknownTopLevelFields(t *testing.T) {
+	document := validSummaryDocument(t)
+	document["detection"] = 1
+	if err := validateSummaryDocument(t, compileSummarySchema(t), document); err == nil {
+		t.Fatal("summary schema accepted retired or unknown top-level field")
+	}
+}
+
+func TestSummaryV5SchemaRejectsMissingAndNullRequiredFields(t *testing.T) {
+	schema := compileSummarySchema(t)
+	for _, field := range summaryRequiredFields(t) {
+		t.Run(field+"/missing", func(t *testing.T) {
+			document := validSummaryDocument(t)
+			delete(document, field)
+			if err := validateSummaryDocument(t, schema, document); err == nil {
+				t.Fatalf("summary schema accepted missing required field %q", field)
+			}
+		})
+		t.Run(field+"/null", func(t *testing.T) {
+			document := validSummaryDocument(t)
+			document[field] = nil
+			if err := validateSummaryDocument(t, schema, document); err == nil {
+				t.Fatalf("summary schema accepted null required field %q", field)
+			}
+		})
+	}
+}
+
+func TestSummaryV5SchemaRejectsWrongTypesForNewlyTypedFields(t *testing.T) {
+	schema := compileSummarySchema(t)
+	wrongValues := map[string]any{
+		"gauntlet_version": 1,
+		"scoring_version":  []any{},
+		"runner_version":   false,
+		"tool":             map[string]any{},
+		"tool_version":     1,
+		"corpus_version":   true,
+		"case_count":       []any{},
+		"exercised":        "fetch_proxy",
+	}
+	for field, wrong := range wrongValues {
+		t.Run(field, func(t *testing.T) {
+			document := validSummaryDocument(t)
+			document[field] = wrong
+			if err := validateSummaryDocument(t, schema, document); err == nil {
+				t.Fatalf("summary schema accepted wrong type for %q", field)
+			}
+		})
+	}
+}
+
+func TestSummaryV5SchemaRejectsMalformedDigests(t *testing.T) {
+	schema := compileSummarySchema(t)
+	for _, field := range []string{
+		"corpus_sha256", "benchmark_manifest_sha256", "tool_profile_sha256",
+	} {
+		t.Run(field, func(t *testing.T) {
+			document := validSummaryDocument(t)
+			document[field] = "not-a-sha256"
+			if err := validateSummaryDocument(t, schema, document); err == nil {
+				t.Fatalf("summary schema accepted malformed digest in %q", field)
+			}
+		})
+	}
+}

--- a/schemas/summary-v5.schema.json
+++ b/schemas/summary-v5.schema.json
@@ -7,21 +7,41 @@
   "required": ["schema_version", "gauntlet_version", "scoring_version", "runner_version", "tool", "tool_version", "corpus_version", "corpus_sha256", "benchmark_manifest_sha256", "tool_profile_sha256", "capability_registry", "reported_claims", "case_count", "exercised", "scores", "diagnostics", "measurement_status", "per_category"],
   "properties": {
     "schema_version": {"type": "integer", "const": 5},
+    "gauntlet_version": {"$ref": "#/$defs/nonempty_string"},
+    "scoring_version": {"$ref": "#/$defs/nonempty_string"},
+    "runner_version": {"$ref": "#/$defs/nonempty_string"},
+    "tool": {"$ref": "#/$defs/nonempty_string"},
+    "tool_version": {"$ref": "#/$defs/nonempty_string"},
+    "corpus_version": {"$ref": "#/$defs/nonempty_string"},
     "corpus_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "benchmark_manifest_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "tool_profile_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "capability_registry": {"$ref": "#/$defs/capability_registry"},
     "reported_claims": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "date": {"type": "string", "format": "date-time"},
+    "case_count": {"$ref": "#/$defs/case_count"},
+    "exercised": {"$ref": "#/$defs/exercised"},
     "scores": {"$ref": "#/$defs/dual_outcome_scores"},
     "diagnostics": {"$ref": "#/$defs/dual_presence_diagnostics"},
     "measurement_status": {"type": "string", "enum": ["measured", "incomplete"]},
     "per_category": {
       "type": "object",
+      "propertyNames": {"type": "string", "minLength": 1},
       "additionalProperties": {"$ref": "#/$defs/category_scores"}
-    }
+    },
+    "method_repository": {"$ref": "#/$defs/nonempty_string"},
+    "method_commit": {"$ref": "#/$defs/nonempty_string"},
+    "adapter_id": {"$ref": "#/$defs/nonempty_string"},
+    "adapter_owner": {"$ref": "#/$defs/nonempty_string"},
+    "target_config_ref": {"$ref": "#/$defs/nonempty_string"},
+    "target_config_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$defs": {
+    "nonempty_string": {
+      "type": "string",
+      "minLength": 1
+    },
     "capability_registry": {
       "type": "object",
       "additionalProperties": false,
@@ -32,6 +52,38 @@
         "revision": {"type": "integer", "minimum": 1},
         "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
       }
+    },
+    "case_count": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "applicable", "unreachable", "not_applicable", "not_applicable_reasons", "errors"],
+      "properties": {
+        "total": {"type": "integer", "minimum": 1},
+        "applicable": {"type": "integer", "minimum": 0},
+        "unreachable": {"type": "integer", "minimum": 0},
+        "not_applicable": {"type": "integer", "minimum": 0},
+        "not_applicable_reasons": {
+          "type": "object",
+          "propertyNames": {"type": "string", "minLength": 1},
+          "additionalProperties": {"type": "integer", "minimum": 1}
+        },
+        "errors": {"type": "integer", "minimum": 0}
+      }
+    },
+    "exercised": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transports", "categories", "capability_tags"],
+      "properties": {
+        "transports": {"$ref": "#/$defs/string_set"},
+        "categories": {"$ref": "#/$defs/string_set"},
+        "capability_tags": {"$ref": "#/$defs/string_set"}
+      }
+    },
+    "string_set": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/nonempty_string"}
     },
     "rate_or_null": {
       "type": ["number", "null"],

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -225,6 +225,71 @@ def declared_schema_version(document, label):
     return declared.get("const")
 
 
+def resolve_local_schema_ref(document, reference):
+    """Resolve one local JSON Pointer, returning None when it is unusable."""
+    if not isinstance(reference, str) or not reference.startswith("#/"):
+        return None
+    current = document
+    for raw_token in reference[2:].split("/"):
+        token = raw_token.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or token not in current:
+            return None
+        current = current[token]
+    return current
+
+
+def schema_accepts_null(schema, document, resolving=()):
+    """Return whether a JSON Schema permits null, conservatively on ambiguity."""
+    if schema is True:
+        return True
+    if schema is False:
+        return False
+    if not isinstance(schema, dict):
+        return True
+
+    accepts = True
+    if "$ref" in schema:
+        reference = schema["$ref"]
+        if reference in resolving:
+            return True
+        target = resolve_local_schema_ref(document, reference)
+        accepts = accepts and (
+            True
+            if target is None
+            else schema_accepts_null(target, document, resolving + (reference,))
+        )
+
+    if "type" in schema:
+        declared_type = schema["type"]
+        accepts = accepts and (
+            declared_type == "null"
+            or (isinstance(declared_type, list) and "null" in declared_type)
+        )
+    if "enum" in schema:
+        accepts = accepts and isinstance(schema["enum"], list) and None in schema["enum"]
+    if "const" in schema:
+        accepts = accepts and schema["const"] is None
+    if "allOf" in schema and isinstance(schema["allOf"], list):
+        accepts = accepts and all(
+            schema_accepts_null(branch, document, resolving) for branch in schema["allOf"]
+        )
+    if "anyOf" in schema and isinstance(schema["anyOf"], list):
+        accepts = accepts and any(
+            schema_accepts_null(branch, document, resolving) for branch in schema["anyOf"]
+        )
+    if "oneOf" in schema and isinstance(schema["oneOf"], list):
+        accepts = accepts and sum(
+            schema_accepts_null(branch, document, resolving) for branch in schema["oneOf"]
+        ) == 1
+    if "not" in schema:
+        accepts = accepts and not schema_accepts_null(schema["not"], document, resolving)
+    if "if" in schema:
+        branch = "then" if schema_accepts_null(schema["if"], document, resolving) else "else"
+        if branch in schema:
+            accepts = accepts and schema_accepts_null(schema[branch], document, resolving)
+    return accepts
+
+
 def require_top_level_required_properties(document, label):
     """Require every top-level required name to have an explicit schema.
 
@@ -246,29 +311,11 @@ def require_top_level_required_properties(document, label):
     missing = sorted(set(required) - set(properties))
     if missing:
         fail(f"{label}: required fields lack property definitions: {missing}")
-    validation_keywords = {
-        "$ref", "$dynamicRef", "type", "enum", "const",
-        "multipleOf", "maximum", "exclusiveMaximum", "minimum", "exclusiveMinimum",
-        "maxLength", "minLength", "pattern",
-        "maxItems", "minItems", "uniqueItems", "maxContains", "minContains",
-        "maxProperties", "minProperties", "required", "dependentRequired",
-        "allOf", "anyOf", "oneOf", "not", "if", "then", "else",
-        "properties", "patternProperties", "additionalProperties", "propertyNames",
-        "dependentSchemas", "unevaluatedProperties",
-        "prefixItems", "items", "contains", "unevaluatedItems",
-    }
-    unconstrained = sorted(
-        field
-        for field in required
-        if properties[field] is True
-        or properties[field] == {}
-        or (
-            isinstance(properties[field], dict)
-            and not validation_keywords.intersection(properties[field])
-        )
+    null_permissive = sorted(
+        field for field in required if schema_accepts_null(properties[field], document)
     )
-    if unconstrained:
-        fail(f"{label}: required fields have unconstrained property definitions: {unconstrained}")
+    if null_permissive:
+        fail(f"{label}: required field definitions accept null: {null_permissive}")
 
 
 def versioned_schema_inventory(root):

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -246,8 +246,26 @@ def require_top_level_required_properties(document, label):
     missing = sorted(set(required) - set(properties))
     if missing:
         fail(f"{label}: required fields lack property definitions: {missing}")
+    validation_keywords = {
+        "$ref", "$dynamicRef", "type", "enum", "const",
+        "multipleOf", "maximum", "exclusiveMaximum", "minimum", "exclusiveMinimum",
+        "maxLength", "minLength", "pattern",
+        "maxItems", "minItems", "uniqueItems", "maxContains", "minContains",
+        "maxProperties", "minProperties", "required", "dependentRequired",
+        "allOf", "anyOf", "oneOf", "not", "if", "then", "else",
+        "properties", "patternProperties", "additionalProperties", "propertyNames",
+        "dependentSchemas", "unevaluatedProperties",
+        "prefixItems", "items", "contains", "unevaluatedItems",
+    }
     unconstrained = sorted(
-        field for field in required if properties[field] is True or properties[field] == {}
+        field
+        for field in required
+        if properties[field] is True
+        or properties[field] == {}
+        or (
+            isinstance(properties[field], dict)
+            and not validation_keywords.intersection(properties[field])
+        )
     )
     if unconstrained:
         fail(f"{label}: required fields have unconstrained property definitions: {unconstrained}")

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -225,6 +225,34 @@ def declared_schema_version(document, label):
     return declared.get("const")
 
 
+def require_top_level_required_properties(document, label):
+    """Require every top-level required name to have an explicit schema.
+
+    JSON Schema permits a name in ``required`` without a matching entry in
+    ``properties``. With an open object that means the field must exist but may
+    contain any JSON value, including null. Active interchange contracts must
+    define the shape they require instead of relying on that permissive default.
+    """
+    required = document.get("required", [])
+    if not isinstance(required, list):
+        fail(f"{label}: required must be an array")
+    if any(not isinstance(field, str) or not field for field in required):
+        fail(f"{label}: required entries must be non-empty strings")
+    if len(required) != len(set(required)):
+        fail(f"{label}: required contains duplicate field names")
+    properties = document.get("properties", {})
+    if not isinstance(properties, dict):
+        fail(f"{label}: properties must be an object")
+    missing = sorted(set(required) - set(properties))
+    if missing:
+        fail(f"{label}: required fields lack property definitions: {missing}")
+    unconstrained = sorted(
+        field for field in required if properties[field] is True or properties[field] == {}
+    )
+    if unconstrained:
+        fail(f"{label}: required fields have unconstrained property definitions: {unconstrained}")
+
+
 def versioned_schema_inventory(root):
     inventory = set()
     schema_dir = root / "schemas"
@@ -410,6 +438,7 @@ def check(root, manifest_path):
             if declared != version:
                 fail(f"{relative}: declares schema_version {declared!r}, manifest says {version}")
             if status == "active":
+                require_top_level_required_properties(document, relative)
                 active_schema_paths.append(relative)
 
         if schemas and schema_versions != set(accepted):

--- a/scripts/check_contracts_test.py
+++ b/scripts/check_contracts_test.py
@@ -115,7 +115,13 @@ class MalformedJsonTypeTest(unittest.TestCase):
         )
 
     def test_rejects_unconstrained_required_property_definition(self):
-        for unconstrained in ({}, True):
+        for unconstrained in (
+            {},
+            True,
+            {"title": "typed"},
+            {"description": "typed"},
+            {"$defs": {"value": {"type": "string"}}},
+        ):
             with self.subTest(unconstrained=unconstrained):
                 with self.assertRaisesRegex(
                     ValueError, "required fields have unconstrained property definitions: \\['typed'\\]"

--- a/scripts/check_contracts_test.py
+++ b/scripts/check_contracts_test.py
@@ -121,15 +121,40 @@ class MalformedJsonTypeTest(unittest.TestCase):
             {"title": "typed"},
             {"description": "typed"},
             {"$defs": {"value": {"type": "string"}}},
+            {"minLength": 1},
+            {"pattern": "^[a-z]+$"},
+            {"anyOf": [{}]},
+            {"$ref": "#/$defs/missing"},
         ):
             with self.subTest(unconstrained=unconstrained):
                 with self.assertRaisesRegex(
-                    ValueError, "required fields have unconstrained property definitions: \\['typed'\\]"
+                    ValueError, "required field definitions accept null: \\['typed'\\]"
                 ):
                     check_contracts.require_top_level_required_properties(
                         {"required": ["typed"], "properties": {"typed": unconstrained}},
                         "fixture",
                     )
+
+    def test_accepts_required_property_definitions_that_reject_null(self):
+        fixtures = (
+            {"type": "string"},
+            {"enum": ["one", "two"]},
+            {"const": 1},
+            {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+            {"allOf": [{"minLength": 1}, {"type": "string"}]},
+            {"not": {"type": "null"}},
+            {"$ref": "#/$defs/value"},
+        )
+        for constrained in fixtures:
+            with self.subTest(constrained=constrained):
+                check_contracts.require_top_level_required_properties(
+                    {
+                        "$defs": {"value": {"type": "string"}},
+                        "required": ["typed"],
+                        "properties": {"typed": constrained},
+                    },
+                    "fixture",
+                )
 
     def test_check_applies_required_property_gate_to_every_active_schema(self):
         manifest = ROOT / "contracts" / "artifacts.json"

--- a/scripts/check_contracts_test.py
+++ b/scripts/check_contracts_test.py
@@ -93,6 +93,54 @@ class MalformedJsonTypeTest(unittest.TestCase):
             ),
         )
 
+    def test_rejects_required_field_without_property_definition(self):
+        with self.assertRaisesRegex(
+            ValueError, "required fields lack property definitions: \\['untyped'\\]"
+        ):
+            check_contracts.require_top_level_required_properties(
+                {
+                    "required": ["typed", "untyped"],
+                    "properties": {"typed": {"type": "string"}},
+                },
+                "fixture",
+            )
+
+    def test_accepts_required_fields_with_property_definitions(self):
+        check_contracts.require_top_level_required_properties(
+            {
+                "required": ["typed"],
+                "properties": {"typed": {"type": "string"}},
+            },
+            "fixture",
+        )
+
+    def test_rejects_unconstrained_required_property_definition(self):
+        for unconstrained in ({}, True):
+            with self.subTest(unconstrained=unconstrained):
+                with self.assertRaisesRegex(
+                    ValueError, "required fields have unconstrained property definitions: \\['typed'\\]"
+                ):
+                    check_contracts.require_top_level_required_properties(
+                        {"required": ["typed"], "properties": {"typed": unconstrained}},
+                        "fixture",
+                    )
+
+    def test_check_applies_required_property_gate_to_every_active_schema(self):
+        manifest = ROOT / "contracts" / "artifacts.json"
+        expected = {
+            entry["path"]
+            for family in json.loads(manifest.read_text(encoding="utf-8"))["artifact_families"]
+            for entry in family["schemas"]
+            if entry["status"] == "active"
+        }
+        with mock.patch.object(
+            check_contracts,
+            "require_top_level_required_properties",
+            wraps=check_contracts.require_top_level_required_properties,
+        ) as gate:
+            check_contracts.check(ROOT, manifest)
+        self.assertEqual(expected, {call.args[1] for call in gate.call_args_list})
+
     def test_rejects_non_object_source_version_entry(self):
         manifest = json.loads((ROOT / "contracts" / "artifacts.json").read_text(encoding="utf-8"))
         manifest["artifact_families"][0]["source_versions"] = ["runner/case.go"]


### PR DESCRIPTION
The active v5 summary schema now defines every required field and rejects unknown top-level fields. It also declares the optional fields emitted by the runner.

The contract gate rejects required fields with missing or unconstrained definitions. Schema conformance tests cover runner output, the documented example, empty claims, missing and null values, wrong types, malformed digests, and unknown fields.

Empty claim lists now serialize as JSON arrays instead of null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty reported claims now appear as `[]` instead of `null` in JSON summaries.
  * Summary documents now enforce valid metadata, field types, digest formats, and supported properties.

* **Validation**
  * Added comprehensive checks for valid and invalid summary documents.
  * Schema contracts now reject undefined or unconstrained required fields and unknown properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->