### PR TITLE
Bind public case and result contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ agent-egress-bench is a public, tool-neutral corpus for testing AI agent egress 
 | `runner/` | Gauntlet runner, adapters, loaders, scoring, and reports |
 | `schemas/` | Public JSON Schema documents |
 | `contracts/artifacts.json` | Machine-readable artifact compatibility inventory |
+| `contracts/case-shapes-v4.json`, `contracts/result-states-v4.json` | Gated public cross-field contracts |
 | `examples/` | Tool integration templates and reference runners |
 | `control-evidence/` | Control Evidence protocols, fixtures, and verifiers |
 | `gauntlet-site/` | Retained first-party result records and site data |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: preflight check-case-immutability check-schema-copies check-docs check-contracts check-claim-language check-readme-categories check-capability-registry-history test-label-boundary test-runner-parity stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example validate-cases validate
+.PHONY: preflight check-case-immutability check-schema-copies check-docs check-contracts check-public-contracts check-claim-language check-readme-categories check-capability-registry-history test-label-boundary test-runner-parity stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example validate-cases validate
 
 TMPDIR := $(HOME)/.cache/pipelock-tmp
 GOCACHE := $(HOME)/.cache/go-build
@@ -13,7 +13,7 @@ AEB_IMMUTABILITY_BASE ?= origin/main
 # below complete comfortably inside the edit-to-push budget and it catches real
 # shared-state defects that ordinary go test would miss. It requires the Go
 # toolchain needed by runner/go.mod (currently Go 1.25 or newer).
-preflight: check-contracts check-case-immutability check-schema-copies check-docs test-capability-registry check-capability-registry-history test-label-boundary test-runner-parity test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example check-stats check-gauntlet-site check-claim-language check-readme-categories
+preflight: check-contracts check-public-contracts check-case-immutability check-schema-copies check-docs test-capability-registry check-capability-registry-history test-label-boundary test-runner-parity test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example check-stats check-gauntlet-site check-claim-language check-readme-categories
 # Keep the machine-readable compatibility inventory tied to the schemas,
 # source constants, and frozen public records it describes. The checker
 # rejects missing and empty inputs before it compares any values, so a failed
@@ -21,6 +21,14 @@ preflight: check-contracts check-case-immutability check-schema-copies check-doc
 check-contracts:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_contracts_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_contracts.py
+
+# Keep the human tables, machine-readable cross-field contracts, JSON Schemas,
+# scorer, and validator on one active definition.
+check-public-contracts:
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_public_contracts_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_public_contracts.py
+	@cd validate && go test -count=1 -run '^TestPublic' .
+	@cd runner && go test -count=1 -run '^TestPublic' .
 
 # Case bytes are immutable once their ID reaches the merge base. New IDs and
 # their MANIFEST.txt / STATS.md updates remain allowed. A documented maintainer

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,10 @@ check-contracts:
 # Keep the human tables, machine-readable cross-field contracts, JSON Schemas,
 # scorer, and validator on one active definition.
 check-public-contracts:
+	@mkdir -p "$(TMPDIR)" "$(GOCACHE)"
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_public_contracts_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_public_contracts.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.build_gauntlet_provenance_test.ProvenanceBuilderTest.test_active_result_score_enforces_budget_timing
 	@cd validate && go test -count=1 -run '^TestPublic' .
 	@cd runner && go test -count=1 -run '^TestPublic' .
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd validate && go build -o aeb-validate .
 **Validate a runner's results or tool profile:**
 
 ```bash
-./aeb-validate results path/to/results.jsonl
+./aeb-validate results path/to/results.jsonl ../cases
 ./aeb-validate profile path/to/tool-profile.json
 ```
 

--- a/contracts/case-shapes-v4.json
+++ b/contracts/case-shapes-v4.json
@@ -1,0 +1,27 @@
+{
+  "contract": "aeb.case-shapes",
+  "format": 1,
+  "case_schema_version": 4,
+  "single_file": {
+    "a2a_agent_card": {"input_types": ["a2a_agent_card"], "transports": ["a2a"]},
+    "a2a_message": {"input_types": ["a2a_message"], "transports": ["a2a"]},
+    "crypto_financial": {"input_types": ["header", "mcp_tool_call", "request_body", "url"], "transports": ["fetch_proxy", "http_proxy", "mcp_stdio"]},
+    "encoding_evasion": {"input_types": ["mcp_tool_call", "request_body", "url"], "transports": ["fetch_proxy", "mcp_stdio"]},
+    "false_positive": {"input_types": ["a2a_message", "header", "mcp_tool_call", "mcp_tool_definition", "mcp_tool_result", "request_body", "response_content", "url", "websocket_frame"], "transports": ["a2a", "fetch_proxy", "http_proxy", "mcp_http", "mcp_stdio", "websocket"]},
+    "headers": {"input_types": ["header"], "transports": ["fetch_proxy", "http_proxy", "websocket"]},
+    "hostname_exfiltration": {"input_types": ["url"], "transports": ["fetch_proxy", "http_proxy"]},
+    "mcp_chain": {"input_types": ["mcp_tool_sequence"], "transports": ["mcp_http", "mcp_stdio"]},
+    "mcp_input": {"input_types": ["mcp_tool_call"], "transports": ["mcp_http", "mcp_stdio"]},
+    "mcp_tool": {"input_types": ["mcp_tool_definition", "mcp_tool_result"], "transports": ["mcp_http", "mcp_stdio"]},
+    "request_body": {"input_types": ["request_body"], "transports": ["fetch_proxy", "http_proxy", "websocket"]},
+    "response_fetch": {"input_types": ["response_content"], "transports": ["fetch_proxy", "http_proxy", "websocket"]},
+    "response_mitm": {"input_types": ["response_content"], "transports": ["http_proxy"]},
+    "shell_obfuscation": {"input_types": ["mcp_tool_call"], "transports": ["mcp_http", "mcp_stdio"]},
+    "ssrf_bypass": {"input_types": ["url"], "transports": ["fetch_proxy", "http_proxy"]},
+    "url": {"input_types": ["url"], "transports": ["fetch_proxy", "http_proxy", "websocket"]},
+    "websocket_dlp": {"input_types": ["websocket_frame"], "transports": ["websocket"]}
+  },
+  "multi_file": {
+    "mcp_drift": {"input_types": ["mcp_tool_sequence_temporal"], "transports": ["mcp_http", "mcp_stdio"]}
+  }
+}

--- a/contracts/result-states-v4.json
+++ b/contracts/result-states-v4.json
@@ -1,0 +1,42 @@
+{
+  "contract": "aeb.result-states",
+  "format": 1,
+  "result_schema_version": 4,
+  "expected_verdicts": ["allow", "block"],
+  "actual_verdicts": ["allow", "block", "error", "unreachable"],
+  "scores": ["error", "fail", "pass"],
+  "matrix": [
+    {"expected_verdict": "allow", "actual_verdict": "allow", "score": "pass"},
+    {"expected_verdict": "allow", "actual_verdict": "block", "score": "fail"},
+    {"expected_verdict": "allow", "actual_verdict": "error", "score": "error"},
+    {"expected_verdict": "allow", "actual_verdict": "unreachable", "score": "error"},
+    {"expected_verdict": "block", "actual_verdict": "allow", "score": "fail"},
+    {"expected_verdict": "block", "actual_verdict": "block", "score": "pass"},
+    {"expected_verdict": "block", "actual_verdict": "error", "score": "error"},
+    {"expected_verdict": "block", "actual_verdict": "unreachable", "score": "error"}
+  ],
+  "case_specific_overrides": [
+    {
+      "name": "budget_block_timing",
+      "when": {
+        "expected_verdict": "block",
+        "actual_verdict": "block",
+        "evidence_fields": ["over_budget_call_id", "budget_block_timing"]
+      },
+      "scores_by_budget_block_timing": {
+        "at_over_budget": "pass",
+        "before_over_budget": "fail",
+        "after_over_budget": "fail"
+      }
+    }
+  ],
+  "adapter_only_states": {
+    "skip": {
+      "meaning": "A declared route could not prove delivery or observe a verdict.",
+      "active_result": {"actual_verdict": "error", "score": "error"}
+    }
+  },
+  "historical_only_states": {
+    "not_applicable": "Retained frozen evidence only. Active v4 runners do not emit it."
+  }
+}

--- a/contracts/result-states-v4.json
+++ b/contracts/result-states-v4.json
@@ -21,7 +21,8 @@
       "when": {
         "expected_verdict": "block",
         "actual_verdict": "block",
-        "evidence_fields": ["over_budget_call_id", "budget_block_timing"]
+        "case_payload_fields": ["budget_limit_calls"],
+        "required_evidence_fields": ["budget_block_timing"]
       },
       "scores_by_budget_block_timing": {
         "at_over_budget": "pass",

--- a/docs/ADOPTION.md
+++ b/docs/ADOPTION.md
@@ -20,7 +20,14 @@ The [Pipelock reference runner](../examples/pipelock/) is a complete example. Th
 
 ### What to claim
 
-[`RUNNER.md`](RUNNER.md) owns the active tool-profile and delivery contracts. [`CAPABILITY-VOCABULARY.md`](CAPABILITY-VOCABULARY.md) owns reporting-label semantics, and [`gauntlet.md`](gauntlet.md) owns result states and scoreability.
+[`RUNNER.md`](RUNNER.md) owns the active tool-profile and delivery contracts.
+[`SPEC.md`](SPEC.md) owns case shapes, with the exact combinations published in
+[`contracts/case-shapes-v4.json`](../contracts/case-shapes-v4.json).
+[`gauntlet.md`](gauntlet.md) owns result states and scoreability, with every
+active combination published in
+[`contracts/result-states-v4.json`](../contracts/result-states-v4.json).
+[`CAPABILITY-VOCABULARY.md`](CAPABILITY-VOCABULARY.md) owns reporting-label
+semantics.
 
 ## Publish results
 

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -287,15 +287,16 @@ The validator can check your runner's JSONL output and tool profile:
 
 ```bash
 cd validate && go build -o aeb-validate .
-./aeb-validate results path/to/results.jsonl
+./aeb-validate results path/to/results.jsonl ../cases
 ./aeb-validate profile path/to/tool-profile.json
 ```
 
-This checks field presence, enum validity, and every active
-`expected_verdict`/`actual_verdict`/`score` combination. A matching verdict
-passes except when a case-specific rule says the tool enforced the right
-verdict at the wrong boundary. The current exception is budget timing, where a
-block before or after the first forbidden call fails.
+This checks field presence, enum validity, and the active cross-field result
+rules defined by [Gauntlet Scoring](gauntlet.md#per-case-results) and the
+machine-readable [`result-states-v4.json`](../contracts/result-states-v4.json).
+The cases directory binds each row to canonical case metadata, including whether
+budget timing evidence is required. Omitting it performs structural checks only
+and cannot authenticate a result row's case-specific claims.
 
 ### Scope-artifact verification
 
@@ -351,9 +352,10 @@ the loader does not sort tool definitions or server responses. Missing files,
 malformed JSON/YAML, unsafe paths, duplicate server IDs, empty tool names, and
 metadata disagreements fail the load rather than dropping the case.
 
-Multi-file `warn` remains visible as the receipt-aware expectation in corpus
-metadata but maps to `allow` in the binary result row because the active result
-schema has only block/allow expectations. For the generic adapter, a pass proves
+Schema-v4 `warn` remains available for compatibility and maps to `allow` in the
+binary result row because the active result schema has only block/allow
+expectations. Current single-file cases use block/allow; multi-file drift cases
+retain `warn` as the receipt-aware expectation in corpus metadata. For the generic adapter, a pass proves
 only that the tool did not block the benign change. It does not prove that the
 tool detected the change or emitted a warning. The runner validates the
 normative `expected.json`, but an adapter must expose receipt comparison before

--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -4,6 +4,8 @@ A runner connects a specific tool to the benchmark corpus. This document defines
 
 **JSON Schemas:** [`schemas/result-v4.schema.json`](../schemas/result-v4.schema.json) (result lines), [`schemas/tool-profile-v4.schema.json`](../schemas/tool-profile-v4.schema.json) (tool profiles)
 
+**Cross-field result contract:** [`contracts/result-states-v4.json`](../contracts/result-states-v4.json). [`gauntlet.md`](gauntlet.md) explains the same matrix and owns its scoring meaning.
+
 **Starter template:** [`examples/runner-template/`](../examples/runner-template/)
 
 ## Can my tool be integrated?
@@ -289,7 +291,11 @@ cd validate && go build -o aeb-validate .
 ./aeb-validate profile path/to/tool-profile.json
 ```
 
-This checks field presence, enum validity, and score consistency. Most cases pass when `actual_verdict == expected_verdict`; sequence-boundary cases such as budget enforcement may still fail when evidence shows the tool blocked at the wrong step.
+This checks field presence, enum validity, and every active
+`expected_verdict`/`actual_verdict`/`score` combination. A matching verdict
+passes except when a case-specific rule says the tool enforced the right
+verdict at the wrong boundary. The current exception is budget timing, where a
+block before or after the first forbidden call fails.
 
 ### Scope-artifact verification
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,7 +1,7 @@
 # agent-egress-bench Specification
 
-**Version:** 1
-**Status:** Stable
+**Active case contract:** schema version 4
+**Status:** Active; merged case semantics are immutable
 
 **JSON Schemas:** [`case-v4`](../schemas/case-v4.schema.json) and
 [`multi-file-case-v4`](../schemas/multi-file-case-v4.schema.json)
@@ -62,6 +62,34 @@ Each case is a single JSON file in the `cases/` directory tree. Files are named 
 
 `fetch_proxy`, `http_proxy`, `mcp_stdio`, `mcp_http`, `websocket`, `a2a`
 
+### Valid category, input, and transport combinations
+
+[`contracts/case-shapes-v4.json`](../contracts/case-shapes-v4.json) is the
+complete machine-readable matrix. `make check-public-contracts` compares it
+with the case schemas and Go validator, so an undocumented combination
+cannot enter through one reader.
+
+| Category | Allowed input types | Allowed transports |
+| --- | --- | --- |
+| `url` | `url` | `fetch_proxy`, `http_proxy`, `websocket` |
+| `request_body` | `request_body` | `fetch_proxy`, `http_proxy`, `websocket` |
+| `headers` | `header` | `fetch_proxy`, `http_proxy`, `websocket` |
+| `response_fetch` | `response_content` | `fetch_proxy`, `http_proxy`, `websocket` |
+| `response_mitm` | `response_content` | `http_proxy` |
+| `mcp_input` | `mcp_tool_call` | `mcp_stdio`, `mcp_http` |
+| `mcp_tool` | `mcp_tool_result`, `mcp_tool_definition` | `mcp_stdio`, `mcp_http` |
+| `mcp_chain` | `mcp_tool_sequence` | `mcp_stdio`, `mcp_http` |
+| `a2a_message` | `a2a_message` | `a2a` |
+| `a2a_agent_card` | `a2a_agent_card` | `a2a` |
+| `websocket_dlp` | `websocket_frame` | `websocket` |
+| `ssrf_bypass` | `url` | `fetch_proxy`, `http_proxy` |
+| `encoding_evasion` | `url`, `request_body`, `mcp_tool_call` | `fetch_proxy`, `mcp_stdio` |
+| `shell_obfuscation` | `mcp_tool_call` | `mcp_stdio`, `mcp_http` |
+| `crypto_financial` | `url`, `request_body`, `header`, `mcp_tool_call` | `fetch_proxy`, `http_proxy`, `mcp_stdio` |
+| `false_positive` | `url`, `request_body`, `header`, `response_content`, `mcp_tool_call`, `mcp_tool_result`, `mcp_tool_definition`, `websocket_frame`, `a2a_message` | `fetch_proxy`, `http_proxy`, `mcp_stdio`, `mcp_http`, `websocket`, `a2a` |
+| `hostname_exfiltration` | `url` | `fetch_proxy`, `http_proxy` |
+| `mcp_drift` (multi-file only) | `mcp_tool_sequence_temporal` | `mcp_stdio`, `mcp_http` |
+
 ### expected_verdict
 
 `block`, `allow`
@@ -91,7 +119,7 @@ capability-registry snapshot bound by the active profile and result. Tags are
 reporting labels only. They never select cases, alter a denominator, affect
 sufficiency, change a score, or gate publication.
 
-## requires (v3)
+## requires
 
 `tls_interception`, `url_dlp_scanning`, `request_body_dlp_scanning`, `header_dlp_scanning`, `response_prompt_injection_scanning`, `mcp_input_dlp_scanning`, `mcp_input_prompt_injection_scanning`, `mcp_tool_policy`, `mcp_tool_result_prompt_injection_scanning`, `mcp_tool_poison_scanning`, `mcp_tool_baseline`, `mcp_chain_memory`, `mcp_cross_server_chain_memory`, `mcp_data_class_labels`, `a2a_dlp_scanning`, `a2a_prompt_injection_scanning`, `a2a_card_prompt_injection_scanning`, `a2a_card_drift_scanning`, `a2a_ssrf_scanning`, `websocket_dlp_scanning`, `websocket_prompt_injection_scanning`, `ssrf_scanning`, `domain_blocklist`, `entropy_scanning`, `shell_analysis`, `crypto_dlp_scanning`, `hostname_exfil_scanning`, `dns_rebinding_fixture`
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -92,12 +92,14 @@ cannot enter through one reader.
 
 ### expected_verdict
 
-`block`, `allow`
+Active result rows use `block` or `allow`.
 
-Single-file JSON v1 cases are binary. No `warn` appears in single-file JSON case expectations.
+Schema v4 still accepts `warn` for compatibility, but no current single-file case uses it and
+new single-file cases must use `block` or `allow`.
 The multi-file MCP drift fixtures use a separate `case.yaml` contract documented in
 [`cases/mcp-drift/README.md`](../cases/mcp-drift/README.md), where `warn` is allowed for
 benign drift that should be surfaced for operator review without being blocked.
+The runner normalizes that case expectation to `allow` in the binary active result row.
 Its JSON Schema applies to the decoded YAML data model. The Go validator and
 runner also enforce directory-name identity, distinct component filenames, and
 the referenced tools/list and expected-receipt document contracts.

--- a/docs/gauntlet.md
+++ b/docs/gauntlet.md
@@ -56,15 +56,31 @@ Current counts belong in [`cases/STATS.md`](../cases/STATS.md), not in this docu
 
 ## Per-case results
 
-An active result row separates the observed verdict from the score. `actual_verdict` is `block`, `allow`, `unreachable`, or `error`. `score` is `pass`, `fail`, or `error`. Frozen historical rows can also carry `not_applicable` under their original reader.
+An active v4 result row records an expected verdict, the verdict the runner
+observed, and the resulting score. The exhaustive public contract is
+[`contracts/result-states-v4.json`](../contracts/result-states-v4.json).
+`make check-public-contracts` compares every row with the result schema, Go
+scorer, and Go validator.
 
-| Result outcome | Meaning |
-| --- | --- |
-| `pass` | An observed `block` or `allow` satisfied the case contract |
-| `fail` | An observed `block` or `allow` violated the case contract |
-| `not_applicable` | Frozen historical N/A evidence, retained without reinterpretation |
-| `unreachable` | The adapter has no exact route, so no measurement occurred |
-| `error` | The runner, tool, delivery proof, or verdict observation failed |
+| Expected verdict | Actual verdict | Score | Meaning |
+| --- | --- | --- | --- |
+| `allow` | `allow` | `pass` | Benign traffic reached the target |
+| `allow` | `block` | `fail` | The tool blocked benign traffic |
+| `allow` | `unreachable` | `error` | The adapter had no exact route |
+| `allow` | `error` | `error` | Delivery or observation failed |
+| `block` | `block` | `pass` | The tool stopped the attack at the required boundary |
+| `block` | `allow` | `fail` | The attack reached the target |
+| `block` | `unreachable` | `error` | The adapter had no exact route |
+| `block` | `error` | `error` | Delivery or observation failed |
+
+Budget cases add one evidence-bound override. A block on the first forbidden
+call, recorded as `budget_block_timing: at_over_budget`, passes. A block before
+or after that call fails even though `actual_verdict` is `block`.
+
+`skip` is an adapter-only state. An active runner converts it to
+`actual_verdict: error` and `score: error`; it never writes `skip` into a v4
+result row. `not_applicable` belongs only to frozen historical evidence. Active
+v4 runners do not emit it or reinterpret it.
 
 ## How Scoring Works
 

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -125,7 +125,8 @@ test data, not a trusted identity boundary. Pipelock's session-wide tool-call
 limit measures a different boundary, so the benchmark config leaves it
 unlimited. This keeps an unrelated early session block from earning credit for
 per-subject enforcement. Pipelock either enforces the case boundary or records
-a measured failure; the adapter must not convert that outcome to N/A.
+a measured result under the owner [scoring rules](../../docs/gauntlet.md#per-case-results)
+and machine-readable [result-state contract](../../contracts/result-states-v4.json).
 
 The portable entry point above is the normal Pipelock operator surface. The long form below is retained for runner development and to make the managed-command contract inspectable:
 

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -116,17 +116,16 @@ runs.
 
 ### Budget capability scope
 
-The checked-in profile deliberately sets `budget_enforcement` to `false`.
-The current benchmark capability requires per-subject accounting with authenticated identities,
-but the canonical MCP stdio invocation above is one authenticated session.
-Caller-supplied tool arguments such as `subject_id` are payload data, not a
-trusted identity boundary. Pipelock can enforce a session-wide tool-call limit
-on this transport, but this adapter cannot honestly claim the benchmark's
-per-subject capability until it supplies a trusted multi-subject mapping. The
-benchmark config keeps that different session-wide limiter unlimited so it
-cannot decide unrelated cases. The current budget cases therefore score as
-`not_applicable` for this profile instead of as containment failures or
-accidental passes.
+Profiles do not select budget cases. The runner executes them whenever the
+adapter can deliver the MCP sequence and observe each result.
+
+The current cases require per-subject accounting, while the canonical MCP
+stdio invocation is one authenticated session. Their `subject_id` values are
+test data, not a trusted identity boundary. Pipelock's session-wide tool-call
+limit measures a different boundary, so the benchmark config leaves it
+unlimited. This keeps an unrelated early session block from earning credit for
+per-subject enforcement. Pipelock either enforces the case boundary or records
+a measured failure; the adapter must not convert that outcome to N/A.
 
 The portable entry point above is the normal Pipelock operator surface. The long form below is retained for runner development and to make the managed-command contract inspectable:
 

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -544,7 +544,8 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		}
 		if opcode == wsOpcodeClose {
 			closeCode, policyClose := webSocketCloseCode(payload)
-			if !policyClose {
+			compressedFrameRejection := closeCode == wsCloseProtocolError && caseUsesRSV1(c)
+			if !policyClose && !compressedFrameRejection {
 				return Result{
 					Verdict: "skip",
 					Evidence: map[string]interface{}{
@@ -555,11 +556,15 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 				}
 			}
 			upstreamAfter, upstreamProofAvailable := p.webSocketUpstreamMessageCount()
+			closeKind := "policy_close"
+			if compressedFrameRejection {
+				closeKind = "compressed_frame_rejection"
+			}
 			if !upstreamProofAvailable {
 				return Result{
 					Verdict: "skip",
 					Evidence: map[string]interface{}{
-						"reason":     "ws_policy_close_upstream_proof_unavailable",
+						"reason":     "ws_" + closeKind + "_upstream_proof_unavailable",
 						"close_code": closeCode,
 						"detail":     truncate(webSocketCloseReason(payload), 160),
 					},
@@ -569,7 +574,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 				return Result{
 					Verdict: "skip",
 					Evidence: map[string]interface{}{
-						"reason":                   "ws_policy_close_after_upstream_delivery",
+						"reason":                   "ws_" + closeKind + "_after_upstream_delivery",
 						"close_code":               closeCode,
 						"upstream_messages_before": upstreamBefore,
 						"upstream_messages_after":  upstreamAfter,
@@ -1326,8 +1331,26 @@ const (
 	wsOpcodeText           = 1
 	wsOpcodeBinary         = 2
 	wsOpcodeClose          = 8
+	wsCloseProtocolError   = 1002
 	wsClosePolicyViolation = 1008
 )
+
+func caseUsesRSV1(c Case) bool {
+	frames, ok := c.Payload["frames"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, raw := range frames {
+		frame, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if rsv1, _ := frame["rsv1"].(bool); rsv1 {
+			return true
+		}
+	}
+	return false
+}
 
 func (p *ProxyAdapter) writeWebSocketUpgrade(conn net.Conn, targetURL string) error {
 	keyBytes := make([]byte, 16)

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -305,6 +305,16 @@ func proxyPolicyRejection(policyText string) bool {
 	return proxyPolicyRejectionRe.MatchString(policyText)
 }
 
+func transportErrorProvesProxyRejection(errText string, requestedURLs ...string) bool {
+	policyText := errText
+	for _, requestedURL := range requestedURLs {
+		if requestedURL != "" {
+			policyText = strings.ReplaceAll(policyText, requestedURL, "")
+		}
+	}
+	return proxyPolicyRejection(policyText)
+}
+
 func observedProxyVerdict(result Result) Result {
 	if result.Err == nil && (result.Verdict == "allow" || result.Verdict == "block") {
 		result.DeliveryProven = true
@@ -544,8 +554,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		}
 		if opcode == wsOpcodeClose {
 			closeCode, policyClose := webSocketCloseCode(payload)
-			compressedFrameRejection := closeCode == wsCloseProtocolError && caseUsesRSV1(c)
-			if !policyClose && !compressedFrameRejection {
+			if !policyClose {
 				return Result{
 					Verdict: "skip",
 					Evidence: map[string]interface{}{
@@ -556,15 +565,11 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 				}
 			}
 			upstreamAfter, upstreamProofAvailable := p.webSocketUpstreamMessageCount()
-			closeKind := "policy_close"
-			if compressedFrameRejection {
-				closeKind = "compressed_frame_rejection"
-			}
 			if !upstreamProofAvailable {
 				return Result{
 					Verdict: "skip",
 					Evidence: map[string]interface{}{
-						"reason":     "ws_" + closeKind + "_upstream_proof_unavailable",
+						"reason":     "ws_policy_close_upstream_proof_unavailable",
 						"close_code": closeCode,
 						"detail":     truncate(webSocketCloseReason(payload), 160),
 					},
@@ -574,7 +579,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 				return Result{
 					Verdict: "skip",
 					Evidence: map[string]interface{}{
-						"reason":                   "ws_" + closeKind + "_after_upstream_delivery",
+						"reason":                   "ws_policy_close_after_upstream_delivery",
 						"close_code":               closeCode,
 						"upstream_messages_before": upstreamBefore,
 						"upstream_messages_after":  upstreamAfter,
@@ -1004,12 +1009,8 @@ func (p *ProxyAdapter) runHTTPProxy(c Case, timeout time.Duration) Result {
 		// fixture route rewrites the target, those differ, and stripping the
 		// wrong one leaves the case's own hostname in the text where it can
 		// still decide the verdict.
-		policyText := strings.ReplaceAll(errStr, req.URL.String(), "")
-		if targetURL != "" {
-			policyText = strings.ReplaceAll(policyText, targetURL, "")
-		}
 		// Proxy actively rejected the CONNECT (policy decision).
-		if proxyPolicyRejection(policyText) {
+		if transportErrorProvesProxyRejection(errStr, req.URL.String(), targetURL) {
 			ev := map[string]interface{}{"reason": "proxy_rejected"}
 			extractBlockEvidence(errStr, ev)
 			return observedProxyVerdict(Result{Verdict: "block", Evidence: ev})
@@ -1200,7 +1201,7 @@ func (p *ProxyAdapter) doHTTPProxyRequest(caseID, method, targetURL string, body
 	resp, err := client.Do(req)
 	if err != nil {
 		errStr := err.Error()
-		if strings.Contains(errStr, "Forbidden") || strings.Contains(errStr, "blocked") || strings.Contains(errStr, "403") || strings.Contains(errStr, "Method Not Allowed") || strings.Contains(errStr, "405") {
+		if transportErrorProvesProxyRejection(errStr, req.URL.String(), targetURL) {
 			ev := map[string]interface{}{"reason": "proxy_rejected"}
 			extractBlockEvidence(errStr, ev)
 			return observedProxyVerdict(Result{Verdict: "block", Evidence: ev})
@@ -1331,26 +1332,8 @@ const (
 	wsOpcodeText           = 1
 	wsOpcodeBinary         = 2
 	wsOpcodeClose          = 8
-	wsCloseProtocolError   = 1002
 	wsClosePolicyViolation = 1008
 )
-
-func caseUsesRSV1(c Case) bool {
-	frames, ok := c.Payload["frames"].([]interface{})
-	if !ok {
-		return false
-	}
-	for _, raw := range frames {
-		frame, ok := raw.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if rsv1, _ := frame["rsv1"].(bool); rsv1 {
-			return true
-		}
-	}
-	return false
-}
 
 func (p *ProxyAdapter) writeWebSocketUpgrade(conn net.Conn, targetURL string) error {
 	keyBytes := make([]byte, 16)

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -1964,19 +1964,32 @@ func TestRunWebSocketFrameViaProxy_CloseFrameBlocks(t *testing.T) {
 	}
 }
 
-func TestRunWebSocketFrameViaProxy_ProtocolCloseOnlyBlocksRSV1Case(t *testing.T) {
+func TestRunWebSocketFrameViaProxy_ProtocolCloseIsUnproven(t *testing.T) {
 	for _, tc := range []struct {
-		name              string
-		rsv1              bool
-		upstreamDelivered bool
-		wantVerdict       string
+		name   string
+		frames []interface{}
 	}{
-		{name: "compressed frame rejected before delivery", rsv1: true, wantVerdict: "block"},
-		{name: "ordinary frame protocol error", wantVerdict: "skip"},
-		{name: "compressed frame already delivered", rsv1: true, upstreamDelivered: true, wantVerdict: "skip"},
+		{
+			name: "single compressed frame",
+			frames: []interface{}{
+				map[string]interface{}{"opcode": "text", "payload": "probe", "rsv1": true},
+			},
+		},
+		{
+			name: "ordinary frame",
+			frames: []interface{}{
+				map[string]interface{}{"opcode": "text", "payload": "probe"},
+			},
+		},
+		{
+			name: "mixed fragmented message",
+			frames: []interface{}{
+				map[string]interface{}{"opcode": "text", "payload": "ordinary"},
+				map[string]interface{}{"opcode": "continuation", "payload": "probe", "rsv1": true},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			var upstreamMessages atomic.Int64
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				hj := w.(http.Hijacker)
 				conn, rw, err := hj.Hijack()
@@ -1990,9 +2003,6 @@ func TestRunWebSocketFrameViaProxy_ProtocolCloseOnlyBlocksRSV1Case(t *testing.T)
 				if _, _, err := readWebSocketFrame(rw.Reader); err != nil {
 					t.Fatalf("read websocket frame: %v", err)
 				}
-				if tc.upstreamDelivered {
-					upstreamMessages.Add(1)
-				}
 				payload := append([]byte{0x03, 0xea}, []byte("compressed frames not supported")...)
 				if err := writeServerWebSocketFrame(conn, wsOpcodeClose, payload); err != nil {
 					t.Fatalf("write close frame: %v", err)
@@ -2004,24 +2014,21 @@ func TestRunWebSocketFrameViaProxy_ProtocolCloseOnlyBlocksRSV1Case(t *testing.T)
 			if err != nil {
 				t.Fatal(err)
 			}
-			a.SetWSUpstreamMessageCounter(upstreamMessages.Load)
 			result := a.Run(Case{
 				ID: "ws-protocol-close", Transport: "websocket", InputType: "websocket_frame",
 				Payload: map[string]interface{}{
-					"url": "wss://example.com/ws",
-					"frames": []interface{}{
-						map[string]interface{}{"opcode": "text", "payload": "probe", "rsv1": tc.rsv1},
-					},
+					"url":    "wss://example.com/ws",
+					"frames": tc.frames,
 				},
 			}, time.Second)
-			if result.Err != nil || result.Verdict != tc.wantVerdict {
-				t.Fatalf("result = %+v, want verdict %q", result, tc.wantVerdict)
+			if result.Err != nil || result.Verdict != "skip" {
+				t.Fatalf("result = %+v, want unproven skip", result)
 			}
-			if tc.wantVerdict == "block" && (!result.DeliveryProven || !result.VerdictObserved) {
-				t.Fatalf("compressed-frame rejection did not become proof: %+v", result)
-			}
-			if tc.wantVerdict == "skip" && (result.DeliveryProven || result.VerdictObserved) {
+			if result.DeliveryProven || result.VerdictObserved {
 				t.Fatalf("unproven protocol close became proof: %+v", result)
+			}
+			if result.Evidence["reason"] != "ws_close_not_policy_violation" {
+				t.Fatalf("reason = %q, want ws_close_not_policy_violation", result.Evidence["reason"])
 			}
 		})
 	}
@@ -4083,5 +4090,51 @@ func TestProxyPolicyRejectionIgnoresNumbersInsideAddresses(t *testing.T) {
 				t.Fatalf("proxyPolicyRejection(%q) = %v, want %v", tc.text, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDoHTTPProxyRequestDoesNotTrustCaseURLAsPolicyEvidence(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	var accepted atomic.Int64
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return
+		}
+		accepted.Add(1)
+		if tcp, ok := conn.(*net.TCPConn); ok {
+			_ = tcp.SetLinger(0)
+		}
+		_ = conn.Close()
+	}()
+
+	proxyURL, err := url.Parse("http://" + ln.Addr().String())
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	adapter := &ProxyAdapter{proxyURL: proxyURL}
+	result := adapter.doHTTPProxyRequest(
+		"case-controlled-policy-words",
+		http.MethodGet,
+		"http://blocked.vendor.example/path/403/Forbidden",
+		nil,
+		nil,
+		3*time.Second,
+		"",
+	)
+
+	if result.Verdict == "block" {
+		t.Fatalf("case-controlled URL scored as an observed block after an ambiguous transport error: %+v", result)
+	}
+	if result.DeliveryProven || result.VerdictObserved {
+		t.Fatalf("ambiguous transport error proved a verdict: delivery=%v observed=%v", result.DeliveryProven, result.VerdictObserved)
+	}
+	if got := accepted.Load(); got != 1 {
+		t.Fatalf("reset fixture accepted %d connections, want 1", got)
 	}
 }

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -1964,6 +1964,69 @@ func TestRunWebSocketFrameViaProxy_CloseFrameBlocks(t *testing.T) {
 	}
 }
 
+func TestRunWebSocketFrameViaProxy_ProtocolCloseOnlyBlocksRSV1Case(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		rsv1              bool
+		upstreamDelivered bool
+		wantVerdict       string
+	}{
+		{name: "compressed frame rejected before delivery", rsv1: true, wantVerdict: "block"},
+		{name: "ordinary frame protocol error", wantVerdict: "skip"},
+		{name: "compressed frame already delivered", rsv1: true, upstreamDelivered: true, wantVerdict: "skip"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var upstreamMessages atomic.Int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				hj := w.(http.Hijacker)
+				conn, rw, err := hj.Hijack()
+				if err != nil {
+					t.Fatalf("hijack: %v", err)
+				}
+				defer conn.Close() //nolint:errcheck // test cleanup
+				if _, err := fmt.Fprint(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"); err != nil {
+					t.Fatalf("write upgrade response: %v", err)
+				}
+				if _, _, err := readWebSocketFrame(rw.Reader); err != nil {
+					t.Fatalf("read websocket frame: %v", err)
+				}
+				if tc.upstreamDelivered {
+					upstreamMessages.Add(1)
+				}
+				payload := append([]byte{0x03, 0xea}, []byte("compressed frames not supported")...)
+				if err := writeServerWebSocketFrame(conn, wsOpcodeClose, payload); err != nil {
+					t.Fatalf("write close frame: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			a, err := NewProxyAdapter(srv.Listener.Addr().String(), "", "", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			a.SetWSUpstreamMessageCounter(upstreamMessages.Load)
+			result := a.Run(Case{
+				ID: "ws-protocol-close", Transport: "websocket", InputType: "websocket_frame",
+				Payload: map[string]interface{}{
+					"url": "wss://example.com/ws",
+					"frames": []interface{}{
+						map[string]interface{}{"opcode": "text", "payload": "probe", "rsv1": tc.rsv1},
+					},
+				},
+			}, time.Second)
+			if result.Err != nil || result.Verdict != tc.wantVerdict {
+				t.Fatalf("result = %+v, want verdict %q", result, tc.wantVerdict)
+			}
+			if tc.wantVerdict == "block" && (!result.DeliveryProven || !result.VerdictObserved) {
+				t.Fatalf("compressed-frame rejection did not become proof: %+v", result)
+			}
+			if tc.wantVerdict == "skip" && (result.DeliveryProven || result.VerdictObserved) {
+				t.Fatalf("unproven protocol close became proof: %+v", result)
+			}
+		})
+	}
+}
+
 func TestProxyAdapterRunWebSocketNormalCloseIsUnproven(t *testing.T) {
 	// Close 1000 means normal completion, not a policy decision. Treating it as
 	// a block lets a generic upstream shutdown manufacture containment.

--- a/runner/case.go
+++ b/runner/case.go
@@ -102,6 +102,11 @@ func loadCases(dir string) ([]Case, error) {
 		if c.SchemaVersion != activeSchemaVersion {
 			return fmt.Errorf("%s: schema_version must be %d for scoring, got %d", path, activeSchemaVersion, c.SchemaVersion)
 		}
+		// Schema v4 historically accepted warn. Active result rows are binary,
+		// so a warning expectation is measured as the benign allow boundary.
+		if c.ExpectedVerdict == "warn" {
+			c.ExpectedVerdict = "allow"
+		}
 		cases = append(cases, c)
 		return nil
 	})

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -48,6 +48,22 @@ func TestLoadCases(t *testing.T) {
 	}
 }
 
+func TestLoadCasesNormalizesSchemaV4WarnToAllow(t *testing.T) {
+	dir := t.TempDir()
+	caseJSON := `{"schema_version":4,"id":"warn-case","expected_verdict":"warn"}`
+	if err := os.WriteFile(filepath.Join(dir, "warn-case.json"), []byte(caseJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases, err := loadCases(dir)
+	if err != nil {
+		t.Fatalf("loadCases: %v", err)
+	}
+	if len(cases) != 1 || cases[0].ExpectedVerdict != "allow" {
+		t.Fatalf("warn case = %+v, want one allow-normalized case", cases)
+	}
+}
+
 func TestLoadCasesDoesNotFilterSupersession(t *testing.T) {
 	dir := t.TempDir()
 	files := map[string]string{

--- a/runner/public_contract_test.go
+++ b/runner/public_contract_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type publicResultMatrixRow struct {
+	ExpectedVerdict string `json:"expected_verdict"`
+	ActualVerdict   string `json:"actual_verdict"`
+	Score           string `json:"score"`
+}
+
+type publicResultStateOverride struct {
+	Name                      string            `json:"name"`
+	ScoresByBudgetBlockTiming map[string]string `json:"scores_by_budget_block_timing"`
+}
+
+type publicResultStatesContract struct {
+	Contract              string                      `json:"contract"`
+	Format                int                         `json:"format"`
+	ResultSchemaVersion   int                         `json:"result_schema_version"`
+	Matrix                []publicResultMatrixRow     `json:"matrix"`
+	CaseSpecificOverrides []publicResultStateOverride `json:"case_specific_overrides"`
+}
+
+func loadPublicResultStates(t *testing.T) publicResultStatesContract {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "contracts", "result-states-v4.json"))
+	if err != nil {
+		t.Fatalf("read public result-state contract: %v", err)
+	}
+	var contract publicResultStatesContract
+	if err := json.Unmarshal(raw, &contract); err != nil {
+		t.Fatalf("decode public result-state contract: %v", err)
+	}
+	return contract
+}
+
+func TestPublicResultStateMatrixMatchesScorer(t *testing.T) {
+	contract := loadPublicResultStates(t)
+	if contract.Contract != "aeb.result-states" || contract.Format != 1 || contract.ResultSchemaVersion != activeSchemaVersion {
+		t.Fatalf("result-states identity/version = %q/%d/%d", contract.Contract, contract.Format, contract.ResultSchemaVersion)
+	}
+	for _, row := range contract.Matrix {
+		if got := scoreCase(row.ExpectedVerdict, row.ActualVerdict); got != row.Score {
+			t.Errorf("scoreCase(%q, %q) = %q, public contract wants %q", row.ExpectedVerdict, row.ActualVerdict, got, row.Score)
+		}
+	}
+}
+
+func TestPublicBudgetTimingOverrideMatchesScorer(t *testing.T) {
+	contract := loadPublicResultStates(t)
+	if len(contract.CaseSpecificOverrides) != 1 || contract.CaseSpecificOverrides[0].Name != "budget_block_timing" {
+		t.Fatalf("case-specific overrides = %+v", contract.CaseSpecificOverrides)
+	}
+	budgetCase := Case{ExpectedVerdict: "block", Payload: map[string]interface{}{"budget_limit_calls": float64(3)}}
+	for timing, want := range contract.CaseSpecificOverrides[0].ScoresByBudgetBlockTiming {
+		evidence := map[string]interface{}{"over_budget_call_id": float64(4), "budget_block_timing": timing}
+		if got := scoreCaseWithEvidence(budgetCase, "block", evidence); got != want {
+			t.Errorf("budget timing %q score = %q, public contract wants %q", timing, got, want)
+		}
+	}
+}

--- a/runner/public_contract_test.go
+++ b/runner/public_contract_test.go
@@ -14,7 +14,13 @@ type publicResultMatrixRow struct {
 }
 
 type publicResultStateOverride struct {
-	Name                      string            `json:"name"`
+	Name string `json:"name"`
+	When struct {
+		ExpectedVerdict        string   `json:"expected_verdict"`
+		ActualVerdict          string   `json:"actual_verdict"`
+		CasePayloadFields      []string `json:"case_payload_fields"`
+		RequiredEvidenceFields []string `json:"required_evidence_fields"`
+	} `json:"when"`
 	ScoresByBudgetBlockTiming map[string]string `json:"scores_by_budget_block_timing"`
 }
 
@@ -56,9 +62,15 @@ func TestPublicBudgetTimingOverrideMatchesScorer(t *testing.T) {
 	if len(contract.CaseSpecificOverrides) != 1 || contract.CaseSpecificOverrides[0].Name != "budget_block_timing" {
 		t.Fatalf("case-specific overrides = %+v", contract.CaseSpecificOverrides)
 	}
-	budgetCase := Case{ExpectedVerdict: "block", Payload: map[string]interface{}{"budget_limit_calls": float64(3)}}
-	for timing, want := range contract.CaseSpecificOverrides[0].ScoresByBudgetBlockTiming {
-		evidence := map[string]interface{}{"over_budget_call_id": float64(4), "budget_block_timing": timing}
+	override := contract.CaseSpecificOverrides[0]
+	if override.When.ExpectedVerdict != "block" || override.When.ActualVerdict != "block" ||
+		len(override.When.CasePayloadFields) != 1 || override.When.CasePayloadFields[0] != "budget_limit_calls" ||
+		len(override.When.RequiredEvidenceFields) != 1 || override.When.RequiredEvidenceFields[0] != "budget_block_timing" {
+		t.Fatalf("budget timing override condition = %+v", override.When)
+	}
+	budgetCase := Case{ExpectedVerdict: "block", Payload: map[string]interface{}{override.When.CasePayloadFields[0]: float64(3)}}
+	for timing, want := range override.ScoresByBudgetBlockTiming {
+		evidence := map[string]interface{}{override.When.RequiredEvidenceFields[0]: timing}
 		if got := scoreCaseWithEvidence(budgetCase, "block", evidence); got != want {
 			t.Errorf("budget timing %q score = %q, public contract wants %q", timing, got, want)
 		}

--- a/schemas/case-v4.schema.json
+++ b/schemas/case-v4.schema.json
@@ -103,9 +103,10 @@
       "type": "string",
       "enum": [
         "block",
-        "allow"
+        "allow",
+        "warn"
       ],
-      "description": "Expected tool verdict for an active single-file case. Temporal multi-file cases have their own schema and may also use warn."
+      "description": "Expected tool verdict. Current single-file corpus cases use block or allow; warn remains accepted for schema-v4 compatibility."
     },
     "severity": {
       "type": "string",

--- a/schemas/case-v4.schema.json
+++ b/schemas/case-v4.schema.json
@@ -103,10 +103,9 @@
       "type": "string",
       "enum": [
         "block",
-        "allow",
-        "warn"
+        "allow"
       ],
-      "description": "Expected tool verdict. v1 is binary (no warn)."
+      "description": "Expected tool verdict for an active single-file case. Temporal multi-file cases have their own schema and may also use warn."
     },
     "severity": {
       "type": "string",

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -51,6 +51,45 @@ V5_DIAGNOSTIC_FIELDS = frozenset(
 )
 
 
+def load_budget_timing_case_ids(repo_root):
+    case_ids = set()
+    for path in (repo_root / "cases").rglob("*.json"):
+        if "mcp-drift" in path.relative_to(repo_root / "cases").parts:
+            continue
+        try:
+            case = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"cannot read canonical case metadata from {path}: {exc}") from exc
+        if not isinstance(case, dict) or case.get("expected_verdict") != "block":
+            continue
+        payload = case.get("payload")
+        if isinstance(payload, dict) and "budget_limit_calls" in payload:
+            case_id = case.get("id")
+            if not isinstance(case_id, str) or not case_id:
+                raise ValueError(f"canonical budget case has no valid id: {path}")
+            if case_id in case_ids:
+                raise ValueError(f"duplicate canonical budget case id: {case_id}")
+            case_ids.add(case_id)
+    return case_ids
+
+
+def active_result_score(expected, actual, evidence, budget_timing_required):
+    if actual == "not_applicable":
+        return "not_applicable"
+    if actual in {"unreachable", "error"}:
+        return "error"
+    if budget_timing_required and expected == "block" and actual == "block":
+        timing = evidence.get("budget_block_timing")
+        if timing == "at_over_budget":
+            return "pass"
+        if timing in {"before_over_budget", "after_over_budget"}:
+            return "fail"
+        raise ValueError("budget block result requires a valid budget_block_timing")
+    if "budget_block_timing" in evidence:
+        raise ValueError("non-budget result carries budget_block_timing")
+    return "pass" if actual == expected else "fail"
+
+
 def raw_evidence_for_summary(summary):
     """Return the immutable evidence members for this artifact generation.
 
@@ -454,6 +493,7 @@ def measurements(repo_root, run_dir):
         manifest_ids,
         require_categories=summary_schema_version == 5,
     )
+    budget_timing_case_ids = load_budget_timing_case_ids(repo_root)
 
     try:
         command_argv = shlex.split(command)
@@ -503,19 +543,15 @@ def measurements(repo_root, run_dir):
             "tool_version"
         ):
             raise ValueError(f"runner JSONL row {row_number} tool identity does not match summary")
-        case_specific_failure = (
-            score == "fail"
-            and "over_budget_call_id" in evidence
-            and evidence.get("budget_block_timing") == "before_over_budget"
-        )
-        if actual == "not_applicable":
-            expected_score = "not_applicable"
-        elif actual in {"unreachable", "error"}:
-            expected_score = "error"
-        elif actual == expected:
-            expected_score = "fail" if case_specific_failure else "pass"
-        else:
-            expected_score = "fail"
+        try:
+            expected_score = active_result_score(
+                expected,
+                actual,
+                evidence,
+                row["case_id"] in budget_timing_case_ids,
+            )
+        except ValueError as exc:
+            raise ValueError(f"runner JSONL row {row_number}: {exc}") from exc
         if score != expected_score:
             raise ValueError(
                 f"runner JSONL row {row_number} score {score!r} does not match its verdicts"

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -11,6 +11,8 @@ import time
 import unittest
 from pathlib import Path
 
+from scripts import build_gauntlet_provenance
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BUILDER = REPO_ROOT / "scripts" / "build_gauntlet_provenance.py"
@@ -34,6 +36,26 @@ PIN_TAG = PIN["PIPELOCK_TAG"]
 
 
 class ProvenanceBuilderTest(unittest.TestCase):
+    def test_active_result_score_enforces_budget_timing(self):
+        contract = json.loads((REPO_ROOT / "contracts" / "result-states-v4.json").read_text())
+        scores = contract["case_specific_overrides"][0]["scores_by_budget_block_timing"]
+        for timing, expected_score in scores.items():
+            with self.subTest(timing=timing):
+                self.assertEqual(
+                    build_gauntlet_provenance.active_result_score(
+                        "block", "block", {"budget_block_timing": timing}, True
+                    ),
+                    expected_score,
+                )
+        for evidence in ({}, {"budget_block_timing": "unknown"}):
+            with self.subTest(evidence=evidence):
+                with self.assertRaisesRegex(ValueError, "valid budget_block_timing"):
+                    build_gauntlet_provenance.active_result_score("block", "block", evidence, True)
+        with self.assertRaisesRegex(ValueError, "non-budget"):
+            build_gauntlet_provenance.active_result_score(
+                "block", "block", {"budget_block_timing": "before_over_budget"}, False
+            )
+
     def setUp(self):
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)

--- a/scripts/check_public_contracts.py
+++ b/scripts/check_public_contracts.py
@@ -81,8 +81,8 @@ def check_case_shapes(root):
         fail("case schema input_type enum differs from case-shapes values")
     if set(schema_property(schema, "transport").get("enum", [])) != transports:
         fail("case schema transport enum differs from case-shapes values")
-    if set(schema_property(schema, "expected_verdict").get("enum", [])) != {"allow", "block"}:
-        fail("single-file case schema must accept only allow and block")
+    if set(schema_property(schema, "expected_verdict").get("enum", [])) != {"allow", "block", "warn"}:
+        fail("single-file case schema must preserve the schema-v4 allow/block/warn vocabulary")
     drift = multi["mcp_drift"]
     if schema_property(multi_schema, "category").get("const") != "mcp_drift":
         fail("multi-file schema category differs from case-shapes")
@@ -162,7 +162,8 @@ def check_result_states(root):
         "when": {
             "expected_verdict": "block",
             "actual_verdict": "block",
-            "evidence_fields": ["over_budget_call_id", "budget_block_timing"],
+            "case_payload_fields": ["budget_limit_calls"],
+            "required_evidence_fields": ["budget_block_timing"],
         },
         "scores_by_budget_block_timing": {
             "at_over_budget": "pass",

--- a/scripts/check_public_contracts.py
+++ b/scripts/check_public_contracts.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Keep public cross-field contracts aligned with schemas and owner docs."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+BACKTICK_VALUE = re.compile(r"`([^`]+)`")
+
+
+def fail(message):
+    raise ValueError(message)
+
+
+def load_json(path):
+    raw = path.read_bytes()
+    if not raw.strip():
+        fail(f"empty JSON input: {path}")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+
+
+def schema_property(schema, name):
+    value = schema.get("properties", {}).get(name)
+    if not isinstance(value, dict):
+        fail(f"schema property {name!r} is missing")
+    return value
+
+
+def markdown_table(document, marker):
+    if marker not in document:
+        fail(f"missing documentation heading {marker!r}")
+    section = document.split(marker, 1)[1]
+    rows = []
+    started = False
+    for line in section.splitlines():
+        if not line.startswith("|"):
+            if started:
+                break
+            continue
+        started = True
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if all(set(cell) <= {"-", ":"} for cell in cells):
+            continue
+        rows.append(cells)
+    if len(rows) < 2:
+        fail(f"documentation table under {marker!r} is empty")
+    return rows[0], rows[1:]
+
+
+def backtick_values(cell):
+    values = BACKTICK_VALUE.findall(cell)
+    if not values:
+        fail(f"table cell has no backtick value: {cell!r}")
+    return values
+
+
+def check_case_shapes(root):
+    contract = load_json(root / "contracts/case-shapes-v4.json")
+    schema = load_json(root / "schemas/case-v4.schema.json")
+    multi_schema = load_json(root / "schemas/multi-file-case-v4.schema.json")
+    if (contract.get("contract"), contract.get("format"), contract.get("case_schema_version")) != (
+        "aeb.case-shapes",
+        1,
+        4,
+    ):
+        fail("case-shapes identity or version is invalid")
+    single = contract.get("single_file")
+    multi = contract.get("multi_file")
+    if not isinstance(single, dict) or not single or not isinstance(multi, dict) or set(multi) != {"mcp_drift"}:
+        fail("case-shapes must contain non-empty single_file and exactly one mcp_drift multi_file shape")
+    if set(schema_property(schema, "category").get("enum", [])) != set(single):
+        fail("case schema category enum differs from case-shapes single_file categories")
+    input_types = {value for shape in single.values() for value in shape.get("input_types", [])}
+    transports = {value for shape in single.values() for value in shape.get("transports", [])}
+    if set(schema_property(schema, "input_type").get("enum", [])) != input_types:
+        fail("case schema input_type enum differs from case-shapes values")
+    if set(schema_property(schema, "transport").get("enum", [])) != transports:
+        fail("case schema transport enum differs from case-shapes values")
+    if set(schema_property(schema, "expected_verdict").get("enum", [])) != {"allow", "block"}:
+        fail("single-file case schema must accept only allow and block")
+    drift = multi["mcp_drift"]
+    if schema_property(multi_schema, "category").get("const") != "mcp_drift":
+        fail("multi-file schema category differs from case-shapes")
+    if schema_property(multi_schema, "input_type").get("const") not in drift.get("input_types", []):
+        fail("multi-file schema input_type differs from case-shapes")
+    if set(schema_property(multi_schema, "transport").get("enum", [])) != set(drift.get("transports", [])):
+        fail("multi-file schema transports differ from case-shapes")
+
+    header, rows = markdown_table(
+        (root / "docs/SPEC.md").read_text(),
+        "### Valid category, input, and transport combinations",
+    )
+    if header != ["Category", "Allowed input types", "Allowed transports"]:
+        fail(f"SPEC case-shape table header changed: {header}")
+    documented = {}
+    for row in rows:
+        if len(row) != 3:
+            fail(f"SPEC case-shape row has {len(row)} cells: {row}")
+        category = backtick_values(row[0])[0]
+        documented[category] = {
+            "input_types": sorted(backtick_values(row[1])),
+            "transports": sorted(backtick_values(row[2])),
+        }
+    expected = {name: {key: sorted(values) for key, values in shape.items()} for name, shape in single.items()}
+    expected.update({name: {key: sorted(values) for key, values in shape.items()} for name, shape in multi.items()})
+    if documented != expected:
+        fail("SPEC case-shape table differs from contracts/case-shapes-v4.json")
+
+
+def check_result_states(root):
+    contract = load_json(root / "contracts/result-states-v4.json")
+    schema = load_json(root / "schemas/result-v4.schema.json")
+    if (contract.get("contract"), contract.get("format"), contract.get("result_schema_version")) != (
+        "aeb.result-states",
+        1,
+        4,
+    ):
+        fail("result-states identity or version is invalid")
+    for field, schema_field in (
+        ("expected_verdicts", "expected_verdict"),
+        ("actual_verdicts", "actual_verdict"),
+        ("scores", "score"),
+    ):
+        if set(contract.get(field, [])) != set(schema_property(schema, schema_field).get("enum", [])):
+            fail(f"result schema {schema_field} enum differs from result-states {field}")
+    matrix = contract.get("matrix")
+    if not isinstance(matrix, list):
+        fail("result-states matrix must be an array")
+    rows = {
+        (row.get("expected_verdict"), row.get("actual_verdict"), row.get("score"))
+        for row in matrix
+        if isinstance(row, dict)
+    }
+    expected_pairs = {
+        (expected, actual)
+        for expected in contract["expected_verdicts"]
+        for actual in contract["actual_verdicts"]
+    }
+    if len(rows) != len(matrix) or {(expected, actual) for expected, actual, _ in rows} != expected_pairs:
+        fail("result-states matrix must cover each expected/actual pair exactly once")
+    allowed = {
+        ("allow", "allow", "pass"),
+        ("allow", "block", "fail"),
+        ("allow", "error", "error"),
+        ("allow", "unreachable", "error"),
+        ("block", "allow", "fail"),
+        ("block", "block", "pass"),
+        ("block", "error", "error"),
+        ("block", "unreachable", "error"),
+    }
+    if rows != allowed:
+        fail("result-states matrix has an invalid score binding")
+
+    overrides = contract.get("case_specific_overrides")
+    expected_override = {
+        "name": "budget_block_timing",
+        "when": {
+            "expected_verdict": "block",
+            "actual_verdict": "block",
+            "evidence_fields": ["over_budget_call_id", "budget_block_timing"],
+        },
+        "scores_by_budget_block_timing": {
+            "at_over_budget": "pass",
+            "before_over_budget": "fail",
+            "after_over_budget": "fail",
+        },
+    }
+    if (
+        not isinstance(overrides, list)
+        or len(overrides) != 1
+        or overrides[0] != expected_override
+    ):
+        fail("result-states budget timing override is invalid")
+    adapter_states = contract.get("adapter_only_states")
+    if not isinstance(adapter_states, dict) or set(adapter_states) != {"skip"}:
+        fail("result-states adapter-only states must contain exactly skip")
+    if adapter_states["skip"].get("active_result") != {"actual_verdict": "error", "score": "error"}:
+        fail("result-states skip must map to active error/error")
+    historical_states = contract.get("historical_only_states")
+    if (
+        not isinstance(historical_states, dict)
+        or set(historical_states) != {"not_applicable"}
+        or not isinstance(historical_states["not_applicable"], str)
+        or not historical_states["not_applicable"].strip()
+    ):
+        fail("result-states historical-only states must contain a not_applicable explanation")
+
+    header, doc_rows = markdown_table((root / "docs/gauntlet.md").read_text(), "## Per-case results")
+    if header != ["Expected verdict", "Actual verdict", "Score", "Meaning"]:
+        fail(f"gauntlet result-state table header changed: {header}")
+    documented = set()
+    for row in doc_rows:
+        if len(row) != 4:
+            fail(f"gauntlet result-state row has {len(row)} cells: {row}")
+        documented.add((backtick_values(row[0])[0], backtick_values(row[1])[0], backtick_values(row[2])[0]))
+    if documented != rows:
+        fail("gauntlet result-state table differs from contracts/result-states-v4.json")
+
+
+def check(root):
+    check_case_shapes(root)
+    check_result_states(root)
+    governance = (root / "docs/GOVERNANCE.md").read_text()
+    required = (
+        "relationship metadata, not a loader instruction",
+        "runner executes both cases",
+        "No mutable skip list",
+    )
+    for text in required:
+        if text not in governance:
+            fail(f"GOVERNANCE supersession contract is missing {text!r}")
+
+
+def main():
+    root = Path(__file__).resolve().parents[1]
+    try:
+        check(root)
+    except (OSError, UnicodeError, ValueError) as exc:
+        print(f"check-public-contracts: FAIL - {exc}", file=sys.stderr)
+        return 1
+    print("check-public-contracts: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_public_contracts_test.py
+++ b/scripts/check_public_contracts_test.py
@@ -1,0 +1,84 @@
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_public_contracts
+
+
+class PublicContractGateTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        source = Path(__file__).resolve().parents[1]
+        paths = (
+            "contracts/case-shapes-v4.json",
+            "contracts/result-states-v4.json",
+            "schemas/case-v4.schema.json",
+            "schemas/multi-file-case-v4.schema.json",
+            "schemas/result-v4.schema.json",
+            "docs/SPEC.md",
+            "docs/gauntlet.md",
+            "docs/GOVERNANCE.md",
+        )
+        for relative in paths:
+            destination = self.root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source / relative, destination)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_current_public_contracts_pass(self):
+        check_public_contracts.check(self.root)
+
+    def test_wrong_result_score_fails(self):
+        path = self.root / "contracts/result-states-v4.json"
+        contract = json.loads(path.read_text())
+        contract["matrix"][0]["score"] = "fail"
+        path.write_text(json.dumps(contract))
+        with self.assertRaisesRegex(ValueError, "invalid score binding"):
+            check_public_contracts.check(self.root)
+
+    def test_documented_case_shape_drift_fails(self):
+        path = self.root / "docs/SPEC.md"
+        path.write_text(path.read_text().replace("`fetch_proxy`, `http_proxy`, `websocket` |", "`fetch_proxy`, `http_proxy` |", 1))
+        with self.assertRaisesRegex(ValueError, "SPEC case-shape table differs"):
+            check_public_contracts.check(self.root)
+
+    def test_budget_override_drift_fails(self):
+        path = self.root / "contracts/result-states-v4.json"
+        contract = json.loads(path.read_text())
+        contract["case_specific_overrides"][0]["scores_by_budget_block_timing"]["before_over_budget"] = "pass"
+        path.write_text(json.dumps(contract))
+        with self.assertRaisesRegex(ValueError, "budget timing override is invalid"):
+            check_public_contracts.check(self.root)
+
+    def test_budget_override_evidence_field_drift_fails(self):
+        path = self.root / "contracts/result-states-v4.json"
+        contract = json.loads(path.read_text())
+        contract["case_specific_overrides"][0]["when"]["evidence_fields"][0] = "wrong_field"
+        path.write_text(json.dumps(contract))
+        with self.assertRaisesRegex(ValueError, "budget timing override is invalid"):
+            check_public_contracts.check(self.root)
+
+    def test_adapter_only_state_drift_fails(self):
+        path = self.root / "contracts/result-states-v4.json"
+        contract = json.loads(path.read_text())
+        contract["adapter_only_states"]["skip"]["active_result"]["score"] = "pass"
+        path.write_text(json.dumps(contract))
+        with self.assertRaisesRegex(ValueError, "skip must map to active error/error"):
+            check_public_contracts.check(self.root)
+
+    def test_historical_only_state_drift_fails(self):
+        path = self.root / "contracts/result-states-v4.json"
+        contract = json.loads(path.read_text())
+        contract["historical_only_states"] = {}
+        path.write_text(json.dumps(contract))
+        with self.assertRaisesRegex(ValueError, "historical-only states"):
+            check_public_contracts.check(self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check_public_contracts_test.py
+++ b/scripts/check_public_contracts_test.py
@@ -58,7 +58,7 @@ class PublicContractGateTest(unittest.TestCase):
     def test_budget_override_evidence_field_drift_fails(self):
         path = self.root / "contracts/result-states-v4.json"
         contract = json.loads(path.read_text())
-        contract["case_specific_overrides"][0]["when"]["evidence_fields"][0] = "wrong_field"
+        contract["case_specific_overrides"][0]["when"]["required_evidence_fields"][0] = "wrong_field"
         path.write_text(json.dumps(contract))
         with self.assertRaisesRegex(ValueError, "budget timing override is invalid"):
             check_public_contracts.check(self.root)

--- a/validate/main.go
+++ b/validate/main.go
@@ -55,7 +55,7 @@ var (
 
 	validMeasuredVerdicts = map[string]bool{"block": true, "allow": true}
 
-	validMultiFileExpectedVerdicts = map[string]bool{"block": true, "allow": true, "warn": true}
+	validCaseExpectedVerdicts = map[string]bool{"block": true, "allow": true, "warn": true}
 
 	validSeverities = map[string]bool{
 		"critical": true, "high": true, "medium": true, "low": true,
@@ -179,7 +179,7 @@ const usageText = `usage: validate <command> <target>
 
 commands:
   cases   <dir>    validate case JSON files in a directory
-  results <file>   validate a runner results JSONL file
+  results <file> [cases-dir]   validate runner JSONL; cases-dir enables case-bound checks
   profile <file>   validate a tool profile JSON file
 
 for backwards compatibility, 'validate <dir>' works as 'validate cases <dir>'.
@@ -200,11 +200,15 @@ func main() {
 		}
 		os.Exit(runCases(os.Args[2]))
 	case "results":
-		if len(os.Args) < 3 {
-			fmt.Fprintf(os.Stderr, "usage: validate results <results-file>\n")
+		if len(os.Args) < 3 || len(os.Args) > 4 {
+			fmt.Fprintf(os.Stderr, "usage: validate results <results-file> [cases-directory]\n")
 			os.Exit(1)
 		}
-		os.Exit(runResults(os.Args[2]))
+		casesDir := ""
+		if len(os.Args) > 3 {
+			casesDir = os.Args[3]
+		}
+		os.Exit(runResults(os.Args[2], casesDir))
 	case "profile":
 		if len(os.Args) < 3 {
 			fmt.Fprintf(os.Stderr, "usage: validate profile <profile-file>\n")
@@ -286,8 +290,8 @@ func runCases(casesDir string) int {
 	return 0
 }
 
-func runResults(path string) int {
-	errors := validateResultsFile(path)
+func runResults(path, casesDir string) int {
+	errors := validateResultsFileAgainstCases(path, casesDir)
 	if len(errors) > 0 {
 		fmt.Fprintf(os.Stderr, "validation failed with %d error(s):\n\n", len(errors))
 		for _, e := range errors {
@@ -496,7 +500,7 @@ func validateFile(path string, ids map[string]string) []string {
 	if !validTransports[c.Transport] {
 		addErr(fmt.Sprintf("invalid transport: %q", c.Transport))
 	}
-	if !validMeasuredVerdicts[c.ExpectedVerdict] {
+	if !validCaseExpectedVerdicts[c.ExpectedVerdict] {
 		addErr(fmt.Sprintf("invalid expected_verdict: %q", c.ExpectedVerdict))
 	}
 	if !validSeverities[c.Severity] {
@@ -939,7 +943,16 @@ type ResultLine struct {
 	Notes              *string                      `json:"notes"`
 }
 
+type resultCaseMetadata struct {
+	ExpectedVerdict      string
+	BudgetTimingRequired bool
+}
+
 func validateResultLine(lineNum int, r ResultLine) []string {
+	return validateResultLineAgainstCase(lineNum, r, nil)
+}
+
+func validateResultLineAgainstCase(lineNum int, r ResultLine, caseMetadata *resultCaseMetadata) []string {
 	var errors []string
 	addErr := func(msg string) {
 		errors = append(errors, fmt.Sprintf("line %d: %s", lineNum, msg))
@@ -975,13 +988,20 @@ func validateResultLine(lineNum int, r ResultLine) []string {
 	if err := validateRegistryReference(r.CapabilityRegistry); err != nil {
 		addErr(fmt.Sprintf("invalid capability_registry: %v", err))
 	}
+	if caseMetadata != nil && r.ExpectedVerdict != caseMetadata.ExpectedVerdict {
+		addErr(fmt.Sprintf("expected_verdict %q does not match case metadata %q", r.ExpectedVerdict, caseMetadata.ExpectedVerdict))
+	}
 
 	// Score consistency checks. The exhaustive public matrix lives in
 	// contracts/result-states-v4.json and contract tests compare every row to
 	// this validator.
 	if validActualVerdicts[r.ActualVerdict] && validMeasuredVerdicts[r.ExpectedVerdict] && validScores[r.Score] {
-		caseSpecificScore, hasCaseSpecificScore := expectedCaseSpecificScore(r)
+		caseSpecificScore, hasCaseSpecificScore, caseSpecificProblem := expectedCaseSpecificScore(r, caseMetadata)
+		if caseSpecificProblem != "" {
+			addErr(caseSpecificProblem)
+		}
 		switch {
+		case caseSpecificProblem != "":
 		case hasCaseSpecificScore && r.Score != caseSpecificScore:
 			addErr(fmt.Sprintf("inconsistent score: budget_block_timing requires score %q, got %q",
 				caseSpecificScore, r.Score))
@@ -1001,30 +1021,134 @@ func validateResultLine(lineNum int, r ResultLine) []string {
 	return errors
 }
 
-func expectedCaseSpecificScore(r ResultLine) (string, bool) {
-	if r.ExpectedVerdict != "block" || r.ActualVerdict != "block" || r.Evidence == nil {
-		return "", false
+func expectedCaseSpecificScore(r ResultLine, caseMetadata *resultCaseMetadata) (string, bool, string) {
+	if r.Evidence == nil {
+		return "", false, ""
 	}
-	// Gate on a budget-specific evidence field so an ordinary matching verdict
-	// cannot opt into the budget timing override.
-	if _, ok := r.Evidence["over_budget_call_id"]; !ok {
-		return "", false
+	if caseMetadata != nil && (!caseMetadata.BudgetTimingRequired || r.ExpectedVerdict != "block" || r.ActualVerdict != "block") {
+		if _, hasTiming := r.Evidence["budget_block_timing"]; hasTiming {
+			return "", false, "budget_block_timing is not valid for this case"
+		}
+		if !caseMetadata.BudgetTimingRequired {
+			if _, hasCallID := r.Evidence["over_budget_call_id"]; hasCallID {
+				return "", false, "over_budget_call_id is not valid for this case"
+			}
+		}
+	}
+	if r.ExpectedVerdict != "block" || r.ActualVerdict != "block" {
+		return "", false, ""
+	}
+	if caseMetadata != nil && !caseMetadata.BudgetTimingRequired {
+		return "", false, ""
+	}
+	if caseMetadata == nil {
+		// Structural-only validation has no corpus metadata. It can check a
+		// declared override but cannot require one for a particular case.
+		if _, ok := r.Evidence["over_budget_call_id"]; !ok {
+			return "", false, ""
+		}
 	}
 	timing, ok := r.Evidence["budget_block_timing"].(string)
 	if !ok {
-		return "", false
+		if caseMetadata != nil && caseMetadata.BudgetTimingRequired {
+			return "", false, "budget block result requires budget_block_timing evidence"
+		}
+		return "", false, ""
 	}
 	switch timing {
 	case "at_over_budget":
-		return "pass", true
+		return "pass", true, ""
 	case "before_over_budget", "after_over_budget":
-		return "fail", true
+		return "fail", true, ""
 	default:
-		return "", false
+		if caseMetadata != nil {
+			return "", false, fmt.Sprintf("invalid budget_block_timing: %q", timing)
+		}
+		return "", false, ""
 	}
 }
 
 func validateResultsFile(path string) []string {
+	return validateResultsFileWithMetadata(path, nil)
+}
+
+func validateResultsFileAgainstCases(path, casesDir string) []string {
+	if casesDir == "" {
+		return validateResultsFile(path)
+	}
+	metadata, err := loadResultCaseMetadata(casesDir)
+	if err != nil {
+		return []string{fmt.Sprintf("case metadata: %v", err)}
+	}
+	return validateResultsFileWithMetadata(path, metadata)
+}
+
+func loadResultCaseMetadata(casesDir string) (map[string]resultCaseMetadata, error) {
+	metadata := make(map[string]resultCaseMetadata)
+	add := func(id, expected string, budget bool) error {
+		if id == "" {
+			return fmt.Errorf("case has no id")
+		}
+		if expected == "warn" {
+			expected = "allow"
+		}
+		if _, exists := metadata[id]; exists {
+			return fmt.Errorf("duplicate case id %q", id)
+		}
+		metadata[id] = resultCaseMetadata{ExpectedVerdict: expected, BudgetTimingRequired: budget}
+		return nil
+	}
+	err := filepath.Walk(casesDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() && isMultiFileCaseDir(info.Name()) {
+			entries, err := os.ReadDir(path)
+			if err != nil {
+				return err
+			}
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				data, err := os.ReadFile(filepath.Join(path, entry.Name(), "case.yaml"))
+				if err != nil {
+					return err
+				}
+				c, err := parseMultiFileCaseYAML(data)
+				if err != nil {
+					return err
+				}
+				if err := add(c.ID, c.ExpectedVerdict, false); err != nil {
+					return err
+				}
+			}
+			return filepath.SkipDir
+		}
+		if info.IsDir() || !strings.HasSuffix(info.Name(), ".json") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var c Case
+		if err := json.Unmarshal(data, &c); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		_, budget := c.Payload["budget_limit_calls"]
+		return add(c.ID, c.ExpectedVerdict, budget && c.ExpectedVerdict == "block")
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(metadata) == 0 {
+		return nil, fmt.Errorf("no cases found in %s", casesDir)
+	}
+	return metadata, nil
+}
+
+func validateResultsFileWithMetadata(path string, caseMetadata map[string]resultCaseMetadata) []string {
 	f, err := os.Open(path)
 	if err != nil {
 		return []string{fmt.Sprintf("%s: read error: %v", path, err)}
@@ -1054,7 +1178,16 @@ func validateResultsFile(path string) []string {
 			continue
 		}
 
-		lineErrors := validateResultLine(lineNum, r)
+		var metadata *resultCaseMetadata
+		if caseMetadata != nil {
+			value, ok := caseMetadata[r.CaseID]
+			if !ok {
+				allErrors = append(allErrors, fmt.Sprintf("line %d: case_id %q is not in the supplied cases directory", lineNum, r.CaseID))
+			} else {
+				metadata = &value
+			}
+		}
+		lineErrors := validateResultLineAgainstCase(lineNum, r, metadata)
 		allErrors = append(allErrors, lineErrors...)
 		if registryReference == nil {
 			copy := r.CapabilityRegistry

--- a/validate/main.go
+++ b/validate/main.go
@@ -53,9 +53,9 @@ var (
 		"a2a": true,
 	}
 
-	validVerdicts = map[string]bool{"block": true, "allow": true, "warn": true}
-
 	validMeasuredVerdicts = map[string]bool{"block": true, "allow": true}
+
+	validMultiFileExpectedVerdicts = map[string]bool{"block": true, "allow": true, "warn": true}
 
 	validSeverities = map[string]bool{
 		"critical": true, "high": true, "medium": true, "low": true,
@@ -496,7 +496,7 @@ func validateFile(path string, ids map[string]string) []string {
 	if !validTransports[c.Transport] {
 		addErr(fmt.Sprintf("invalid transport: %q", c.Transport))
 	}
-	if !validVerdicts[c.ExpectedVerdict] {
+	if !validMeasuredVerdicts[c.ExpectedVerdict] {
 		addErr(fmt.Sprintf("invalid expected_verdict: %q", c.ExpectedVerdict))
 	}
 	if !validSeverities[c.Severity] {
@@ -976,12 +976,21 @@ func validateResultLine(lineNum int, r ResultLine) []string {
 		addErr(fmt.Sprintf("invalid capability_registry: %v", err))
 	}
 
-	// Score consistency checks.
-	if validActualVerdicts[r.ActualVerdict] && validVerdicts[r.ExpectedVerdict] && validScores[r.Score] {
+	// Score consistency checks. The exhaustive public matrix lives in
+	// contracts/result-states-v4.json and contract tests compare every row to
+	// this validator.
+	if validActualVerdicts[r.ActualVerdict] && validMeasuredVerdicts[r.ExpectedVerdict] && validScores[r.Score] {
+		caseSpecificScore, hasCaseSpecificScore := expectedCaseSpecificScore(r)
 		switch {
-		case r.ActualVerdict == r.ExpectedVerdict && r.Score != "pass" && !hasCaseSpecificFailureEvidence(r):
+		case hasCaseSpecificScore && r.Score != caseSpecificScore:
+			addErr(fmt.Sprintf("inconsistent score: budget_block_timing requires score %q, got %q",
+				caseSpecificScore, r.Score))
+		case !hasCaseSpecificScore && r.ActualVerdict == r.ExpectedVerdict && r.Score != "pass":
 			addErr(fmt.Sprintf("inconsistent score: actual_verdict matches expected_verdict (%q) but score is %q (should be pass)",
 				r.ActualVerdict, r.Score))
+		case validMeasuredVerdicts[r.ActualVerdict] && r.ActualVerdict != r.ExpectedVerdict && r.Score != "fail":
+			addErr(fmt.Sprintf("inconsistent score: actual_verdict %q does not match expected_verdict %q but score is %q (should be fail)",
+				r.ActualVerdict, r.ExpectedVerdict, r.Score))
 		case r.ActualVerdict == "unreachable" && r.Score != "error":
 			addErr(fmt.Sprintf("inconsistent score: actual_verdict is unreachable but score is %q (should be error)", r.Score))
 		case r.ActualVerdict == "error" && r.Score != "error":
@@ -992,18 +1001,27 @@ func validateResultLine(lineNum int, r ResultLine) []string {
 	return errors
 }
 
-func hasCaseSpecificFailureEvidence(r ResultLine) bool {
-	if r.Score != "fail" || r.Evidence == nil {
-		return false
+func expectedCaseSpecificScore(r ResultLine) (string, bool) {
+	if r.ExpectedVerdict != "block" || r.ActualVerdict != "block" || r.Evidence == nil {
+		return "", false
 	}
-	// Gate on a budget-specific evidence field so only a genuine
-	// budget-enforcement result (which always carries over_budget_call_id
-	// alongside before-over-budget timing) can bypass the
-	// matching-verdict-must-pass rule; a non-budget result line cannot.
+	// Gate on a budget-specific evidence field so an ordinary matching verdict
+	// cannot opt into the budget timing override.
 	if _, ok := r.Evidence["over_budget_call_id"]; !ok {
-		return false
+		return "", false
 	}
-	return r.Evidence["budget_block_timing"] == "before_over_budget"
+	timing, ok := r.Evidence["budget_block_timing"].(string)
+	if !ok {
+		return "", false
+	}
+	switch timing {
+	case "at_over_budget":
+		return "pass", true
+	case "before_over_budget", "after_over_budget":
+		return "fail", true
+	default:
+		return "", false
+	}
 }
 
 func validateResultsFile(path string) []string {

--- a/validate/main_test.go
+++ b/validate/main_test.go
@@ -693,6 +693,16 @@ func TestInvalidEnumValues(t *testing.T) {
 			assertContainsError(t, errors, tt.wantError)
 		})
 	}
+	t.Run("schema v4 warn remains accepted", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCase(t, dir, "url", "url-enum-001.json", baseJSON("expected_verdict", "warn"))
+		errors := validateFile(filepath.Join(dir, "url", "url-enum-001.json"), make(map[string]string))
+		for _, issue := range errors {
+			if strings.Contains(issue, "expected_verdict") {
+				t.Fatalf("schema-v4 warn rejected: %v", errors)
+			}
+		}
+	})
 }
 
 func TestUnknownCapabilityTagDefersToPinnedRegistry(t *testing.T) {

--- a/validate/multifile.go
+++ b/validate/multifile.go
@@ -82,7 +82,7 @@ func validateMultiFileCase(path string, ids map[string]string) []string {
 	if c.Transport != "mcp_stdio" && c.Transport != "mcp_http" {
 		add(fmt.Sprintf("transport must be mcp_stdio or mcp_http, got %q", c.Transport))
 	}
-	if !validVerdicts[c.ExpectedVerdict] {
+	if !validMultiFileExpectedVerdicts[c.ExpectedVerdict] {
 		add(fmt.Sprintf("invalid expected_verdict: %q", c.ExpectedVerdict))
 	}
 	if !validSeverities[c.Severity] {

--- a/validate/multifile.go
+++ b/validate/multifile.go
@@ -82,7 +82,7 @@ func validateMultiFileCase(path string, ids map[string]string) []string {
 	if c.Transport != "mcp_stdio" && c.Transport != "mcp_http" {
 		add(fmt.Sprintf("transport must be mcp_stdio or mcp_http, got %q", c.Transport))
 	}
-	if !validMultiFileExpectedVerdicts[c.ExpectedVerdict] {
+	if !validCaseExpectedVerdicts[c.ExpectedVerdict] {
 		add(fmt.Sprintf("invalid expected_verdict: %q", c.ExpectedVerdict))
 	}
 	if !validSeverities[c.Severity] {

--- a/validate/public_contract_test.go
+++ b/validate/public_contract_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+type caseShape struct {
+	InputTypes []string `json:"input_types"`
+	Transports []string `json:"transports"`
+}
+
+type caseShapesContract struct {
+	Contract          string               `json:"contract"`
+	Format            int                  `json:"format"`
+	CaseSchemaVersion int                  `json:"case_schema_version"`
+	SingleFile        map[string]caseShape `json:"single_file"`
+	MultiFile         map[string]caseShape `json:"multi_file"`
+}
+
+type resultMatrixRow struct {
+	ExpectedVerdict string `json:"expected_verdict"`
+	ActualVerdict   string `json:"actual_verdict"`
+	Score           string `json:"score"`
+}
+
+type resultStateOverride struct {
+	Name string `json:"name"`
+	When struct {
+		ExpectedVerdict string   `json:"expected_verdict"`
+		ActualVerdict   string   `json:"actual_verdict"`
+		EvidenceFields  []string `json:"evidence_fields"`
+	} `json:"when"`
+	ScoresByBudgetBlockTiming map[string]string `json:"scores_by_budget_block_timing"`
+}
+
+type resultStatesContract struct {
+	Contract              string                `json:"contract"`
+	Format                int                   `json:"format"`
+	ResultSchemaVersion   int                   `json:"result_schema_version"`
+	ExpectedVerdicts      []string              `json:"expected_verdicts"`
+	ActualVerdicts        []string              `json:"actual_verdicts"`
+	Scores                []string              `json:"scores"`
+	Matrix                []resultMatrixRow     `json:"matrix"`
+	CaseSpecificOverrides []resultStateOverride `json:"case_specific_overrides"`
+	AdapterOnlyStates     map[string]struct {
+		ActiveResult resultMatrixRow `json:"active_result"`
+	} `json:"adapter_only_states"`
+	HistoricalOnlyStates map[string]string `json:"historical_only_states"`
+}
+
+func readPublicContract[T any](t *testing.T, name string) T {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "contracts", name))
+	if err != nil {
+		t.Fatalf("read public contract %s: %v", name, err)
+	}
+	var value T
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("decode public contract %s: %v", name, err)
+	}
+	return value
+}
+
+func sortedCopy(values []string) []string {
+	copyOfValues := append([]string(nil), values...)
+	sort.Strings(copyOfValues)
+	return copyOfValues
+}
+
+func mapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return sortedCopy(keys)
+}
+
+func TestPublicCaseShapesMatchValidator(t *testing.T) {
+	contract := readPublicContract[caseShapesContract](t, "case-shapes-v4.json")
+	if contract.Contract != "aeb.case-shapes" || contract.Format != 1 || contract.CaseSchemaVersion != activeCaseSchemaVersion {
+		t.Fatalf("case-shapes identity/version = %q/%d/%d", contract.Contract, contract.Format, contract.CaseSchemaVersion)
+	}
+	if len(contract.SingleFile) != len(validCategoryInputType) || len(contract.SingleFile) != len(validCategoryTransport) {
+		t.Fatalf("single-file category count = %d, validator input/transport counts = %d/%d", len(contract.SingleFile), len(validCategoryInputType), len(validCategoryTransport))
+	}
+	for category, shape := range contract.SingleFile {
+		if got := sortedCopy(validCategoryInputType[category]); !reflect.DeepEqual(got, sortedCopy(shape.InputTypes)) {
+			t.Errorf("%s input_types = %v, public contract wants %v", category, got, sortedCopy(shape.InputTypes))
+		}
+		if got := sortedCopy(validCategoryTransport[category]); !reflect.DeepEqual(got, sortedCopy(shape.Transports)) {
+			t.Errorf("%s transports = %v, public contract wants %v", category, got, sortedCopy(shape.Transports))
+		}
+	}
+	multi, ok := contract.MultiFile["mcp_drift"]
+	if !ok || len(contract.MultiFile) != 1 {
+		t.Fatalf("multi-file shapes = %v, want exactly mcp_drift", contract.MultiFile)
+	}
+	if !reflect.DeepEqual(multi.InputTypes, []string{"mcp_tool_sequence_temporal"}) ||
+		!reflect.DeepEqual(sortedCopy(multi.Transports), []string{"mcp_http", "mcp_stdio"}) {
+		t.Fatalf("mcp_drift shape = %+v", multi)
+	}
+	if got, want := sortedCopy(mapKeys(validCategories)), sortedCopy(mapKeys(validCategoryInputType)); !reflect.DeepEqual(got, want) {
+		t.Fatalf("category enum = %v, shape categories = %v", got, want)
+	}
+}
+
+func TestPublicResultStateMatrixMatchesValidator(t *testing.T) {
+	contract := readPublicContract[resultStatesContract](t, "result-states-v4.json")
+	if contract.Contract != "aeb.result-states" || contract.Format != 1 || contract.ResultSchemaVersion != activeCaseSchemaVersion {
+		t.Fatalf("result-states identity/version = %q/%d/%d", contract.Contract, contract.Format, contract.ResultSchemaVersion)
+	}
+	if len(contract.Matrix) != len(contract.ExpectedVerdicts)*len(contract.ActualVerdicts) {
+		t.Fatalf("matrix has %d rows, want %d", len(contract.Matrix), len(contract.ExpectedVerdicts)*len(contract.ActualVerdicts))
+	}
+	for _, row := range contract.Matrix {
+		t.Run(row.ExpectedVerdict+"/"+row.ActualVerdict, func(t *testing.T) {
+			result := ResultLine{
+				SchemaVersion: 4, CaseID: "contract-case", Tool: "contract-tool", ToolVersion: "1",
+				CapabilityRegistry: testRegistryReference,
+				ExpectedVerdict:    row.ExpectedVerdict, ActualVerdict: row.ActualVerdict, Score: row.Score,
+				Evidence: map[string]interface{}{}, Notes: strPtr(""),
+			}
+			if errs := validateResultLine(1, result); len(errs) != 0 {
+				t.Fatalf("public matrix row rejected: %v", errs)
+			}
+			for _, wrongScore := range contract.Scores {
+				if wrongScore == row.Score {
+					continue
+				}
+				result.Score = wrongScore
+				if errs := validateResultLine(1, result); len(errs) == 0 {
+					t.Errorf("validator accepted wrong score %q", wrongScore)
+				}
+			}
+		})
+	}
+	if len(contract.CaseSpecificOverrides) != 1 || contract.CaseSpecificOverrides[0].Name != "budget_block_timing" {
+		t.Fatalf("case-specific overrides = %+v", contract.CaseSpecificOverrides)
+	}
+	override := contract.CaseSpecificOverrides[0]
+	if override.When.ExpectedVerdict != "block" || override.When.ActualVerdict != "block" ||
+		!reflect.DeepEqual(sortedCopy(override.When.EvidenceFields), []string{"budget_block_timing", "over_budget_call_id"}) {
+		t.Fatalf("budget timing override condition = %+v", override.When)
+	}
+	for timing, score := range override.ScoresByBudgetBlockTiming {
+		result := ResultLine{
+			SchemaVersion: 4, CaseID: "budget-case", Tool: "contract-tool", ToolVersion: "1",
+			CapabilityRegistry: testRegistryReference,
+			ExpectedVerdict:    "block", ActualVerdict: "block", Score: score,
+			Evidence: map[string]interface{}{"over_budget_call_id": float64(4), "budget_block_timing": timing}, Notes: strPtr(""),
+		}
+		if errs := validateResultLine(1, result); len(errs) != 0 {
+			t.Errorf("budget timing %q with score %q rejected: %v", timing, score, errs)
+		}
+		for _, wrongScore := range contract.Scores {
+			if wrongScore == score {
+				continue
+			}
+			result.Score = wrongScore
+			if errs := validateResultLine(1, result); len(errs) == 0 {
+				t.Errorf("budget timing %q accepted wrong score %q", timing, wrongScore)
+			}
+		}
+	}
+	skip, ok := contract.AdapterOnlyStates["skip"]
+	if !ok || len(contract.AdapterOnlyStates) != 1 || skip.ActiveResult.ActualVerdict != "error" || skip.ActiveResult.Score != "error" {
+		t.Fatalf("adapter-only states = %+v, want skip -> error/error", contract.AdapterOnlyStates)
+	}
+	if got, ok := contract.HistoricalOnlyStates["not_applicable"]; !ok || len(contract.HistoricalOnlyStates) != 1 || got == "" {
+		t.Fatalf("historical-only states = %+v, want a non-empty not_applicable entry", contract.HistoricalOnlyStates)
+	}
+}

--- a/validate/public_contract_test.go
+++ b/validate/public_contract_test.go
@@ -31,9 +31,10 @@ type resultMatrixRow struct {
 type resultStateOverride struct {
 	Name string `json:"name"`
 	When struct {
-		ExpectedVerdict string   `json:"expected_verdict"`
-		ActualVerdict   string   `json:"actual_verdict"`
-		EvidenceFields  []string `json:"evidence_fields"`
+		ExpectedVerdict        string   `json:"expected_verdict"`
+		ActualVerdict          string   `json:"actual_verdict"`
+		CasePayloadFields      []string `json:"case_payload_fields"`
+		RequiredEvidenceFields []string `json:"required_evidence_fields"`
 	} `json:"when"`
 	ScoresByBudgetBlockTiming map[string]string `json:"scores_by_budget_block_timing"`
 }
@@ -144,9 +145,11 @@ func TestPublicResultStateMatrixMatchesValidator(t *testing.T) {
 	}
 	override := contract.CaseSpecificOverrides[0]
 	if override.When.ExpectedVerdict != "block" || override.When.ActualVerdict != "block" ||
-		!reflect.DeepEqual(sortedCopy(override.When.EvidenceFields), []string{"budget_block_timing", "over_budget_call_id"}) {
+		!reflect.DeepEqual(override.When.CasePayloadFields, []string{"budget_limit_calls"}) ||
+		!reflect.DeepEqual(override.When.RequiredEvidenceFields, []string{"budget_block_timing"}) {
 		t.Fatalf("budget timing override condition = %+v", override.When)
 	}
+	budgetCase := &resultCaseMetadata{ExpectedVerdict: "block", BudgetTimingRequired: true}
 	for timing, score := range override.ScoresByBudgetBlockTiming {
 		result := ResultLine{
 			SchemaVersion: 4, CaseID: "budget-case", Tool: "contract-tool", ToolVersion: "1",
@@ -154,7 +157,7 @@ func TestPublicResultStateMatrixMatchesValidator(t *testing.T) {
 			ExpectedVerdict:    "block", ActualVerdict: "block", Score: score,
 			Evidence: map[string]interface{}{"over_budget_call_id": float64(4), "budget_block_timing": timing}, Notes: strPtr(""),
 		}
-		if errs := validateResultLine(1, result); len(errs) != 0 {
+		if errs := validateResultLineAgainstCase(1, result, budgetCase); len(errs) != 0 {
 			t.Errorf("budget timing %q with score %q rejected: %v", timing, score, errs)
 		}
 		for _, wrongScore := range contract.Scores {
@@ -162,10 +165,63 @@ func TestPublicResultStateMatrixMatchesValidator(t *testing.T) {
 				continue
 			}
 			result.Score = wrongScore
-			if errs := validateResultLine(1, result); len(errs) == 0 {
+			if errs := validateResultLineAgainstCase(1, result, budgetCase); len(errs) == 0 {
 				t.Errorf("budget timing %q accepted wrong score %q", timing, wrongScore)
 			}
 		}
+	}
+	for name, evidence := range map[string]map[string]interface{}{
+		"missing": {},
+		"unknown": {"budget_block_timing": "unknown"},
+	} {
+		result := ResultLine{
+			SchemaVersion: 4, CaseID: "budget-case", Tool: "contract-tool", ToolVersion: "1",
+			CapabilityRegistry: testRegistryReference,
+			ExpectedVerdict:    "block", ActualVerdict: "block", Score: "pass",
+			Evidence: evidence, Notes: strPtr(""),
+		}
+		if errs := validateResultLineAgainstCase(1, result, budgetCase); len(errs) == 0 {
+			t.Errorf("budget timing %s evidence accepted", name)
+		}
+	}
+	nonBudgetCase := &resultCaseMetadata{ExpectedVerdict: "block"}
+	nonBudgetResult := ResultLine{
+		SchemaVersion: 4, CaseID: "ordinary-case", Tool: "contract-tool", ToolVersion: "1",
+		CapabilityRegistry: testRegistryReference,
+		ExpectedVerdict:    "block", ActualVerdict: "block", Score: "fail",
+		Evidence: map[string]interface{}{"over_budget_call_id": float64(4), "budget_block_timing": "before_over_budget"}, Notes: strPtr(""),
+	}
+	if errs := validateResultLineAgainstCase(1, nonBudgetResult, nonBudgetCase); len(errs) == 0 {
+		t.Error("non-budget case accepted budget timing override")
+	}
+	for name, tc := range map[string]struct {
+		result   ResultLine
+		metadata *resultCaseMetadata
+	}{
+		"allow case": {
+			result: ResultLine{
+				SchemaVersion: 4, CaseID: "allow-case", Tool: "contract-tool", ToolVersion: "1",
+				CapabilityRegistry: testRegistryReference,
+				ExpectedVerdict:    "allow", ActualVerdict: "allow", Score: "pass",
+				Evidence: map[string]interface{}{"budget_block_timing": "at_over_budget"}, Notes: strPtr(""),
+			},
+			metadata: &resultCaseMetadata{ExpectedVerdict: "allow"},
+		},
+		"budget case without block verdict": {
+			result: ResultLine{
+				SchemaVersion: 4, CaseID: "budget-case", Tool: "contract-tool", ToolVersion: "1",
+				CapabilityRegistry: testRegistryReference,
+				ExpectedVerdict:    "block", ActualVerdict: "allow", Score: "fail",
+				Evidence: map[string]interface{}{"budget_block_timing": "at_over_budget"}, Notes: strPtr(""),
+			},
+			metadata: budgetCase,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if errs := validateResultLineAgainstCase(1, tc.result, tc.metadata); len(errs) == 0 {
+				t.Error("result accepted stray budget timing evidence")
+			}
+		})
 	}
 	skip, ok := contract.AdapterOnlyStates["skip"]
 	if !ok || len(contract.AdapterOnlyStates) != 1 || skip.ActiveResult.ActualVerdict != "error" || skip.ActiveResult.Score != "error" {
@@ -173,5 +229,24 @@ func TestPublicResultStateMatrixMatchesValidator(t *testing.T) {
 	}
 	if got, ok := contract.HistoricalOnlyStates["not_applicable"]; !ok || len(contract.HistoricalOnlyStates) != 1 || got == "" {
 		t.Fatalf("historical-only states = %+v, want a non-empty not_applicable entry", contract.HistoricalOnlyStates)
+	}
+}
+
+func TestPublicResultValidationLoadsCanonicalCaseMetadata(t *testing.T) {
+	metadata, err := loadResultCaseMetadata(filepath.Join("..", "cases"))
+	if err != nil {
+		t.Fatalf("load case metadata: %v", err)
+	}
+	budget := metadata["mcp-chain-dow-budget-exceeded-010"]
+	if budget.ExpectedVerdict != "block" || !budget.BudgetTimingRequired {
+		t.Fatalf("budget case metadata = %+v", budget)
+	}
+	warn := metadata["mcp-drift-benign-001"]
+	if warn.ExpectedVerdict != "allow" || warn.BudgetTimingRequired {
+		t.Fatalf("warn-normalized case metadata = %+v", warn)
+	}
+	ordinary := metadata["url-dlp-aws-key-001"]
+	if ordinary.ExpectedVerdict != "block" || ordinary.BudgetTimingRequired {
+		t.Fatalf("ordinary case metadata = %+v", ordinary)
 	}
 }


### PR DESCRIPTION
Publishes machine-readable case-shape and result-state contracts and checks them against the schemas, owner docs, Go validator, runner scorer, and publication builder.

Binds result validation to canonical case metadata when a cases directory is supplied, so warning normalization and budget timing rules cannot drift between readers. Schema v4 keeps its published `warn` compatibility while active result rows remain binary.

Keeps generic WebSocket protocol closes unproven unless the adapter can attribute a policy decision to the tool under test.
