### PR TITLE
ci: run Scorecard after CodeQL

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -14,6 +14,7 @@ permissions: read-all
 
 concurrency:
   group: scorecard-${{ github.repository }}
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -5,14 +5,29 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 5 * * 1' # Weekly Monday 5AM UTC
-  push:
+  workflow_run:
+    workflows: [Security]
+    types: [completed]
     branches: [main]
 
 permissions: read-all
 
+concurrency:
+  group: scorecard-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   analysis:
+    # A main-branch push starts Security first. Waiting for its successful
+    # CodeQL run prevents Scorecard from measuring the commit before its SAST
+    # evidence exists. Other explicit triggers remain independently runnable.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       security-events: write
       id-token: write
@@ -20,6 +35,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: preflight check-case-immutability check-schema-copies check-docs check-contracts check-public-contracts check-claim-language check-readme-categories check-capability-registry-history test-label-boundary test-runner-parity stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example validate-cases validate
+.PHONY: preflight check-case-immutability check-schema-copies check-docs check-contracts check-public-contracts check-claim-language check-readme-categories check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example validate-cases validate
 
 TMPDIR := $(HOME)/.cache/pipelock-tmp
 GOCACHE := $(HOME)/.cache/go-build
@@ -13,7 +13,10 @@ AEB_IMMUTABILITY_BASE ?= origin/main
 # below complete comfortably inside the edit-to-push budget and it catches real
 # shared-state defects that ordinary go test would miss. It requires the Go
 # toolchain needed by runner/go.mod (currently Go 1.25 or newer).
-preflight: check-contracts check-public-contracts check-case-immutability check-schema-copies check-docs test-capability-registry check-capability-registry-history test-label-boundary test-runner-parity test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example check-stats check-gauntlet-site check-claim-language check-readme-categories
+preflight: check-contracts check-public-contracts check-case-immutability check-schema-copies check-docs test-capability-registry check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example check-stats check-gauntlet-site check-claim-language check-readme-categories
+
+check-scorecard-workflow:
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/scorecard_workflow_test.py
 # Keep the machine-readable compatibility inventory tied to the schemas,
 # source constants, and frozen public records it describes. The checker
 # rejects missing and empty inputs before it compares any values, so a failed

--- a/scripts/scorecard_workflow_test.py
+++ b/scripts/scorecard_workflow_test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Structural tests for Scorecard's dependency on completed SAST evidence."""
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "scorecard.yaml"
+SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yaml"
+
+
+class ScorecardWorkflowTest(unittest.TestCase):
+    def setUp(self):
+        self.workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.triggers = self.workflow.split("permissions:", 1)[0]
+
+    def test_main_push_waits_for_security_workflow(self):
+        self.assertNotRegex(self.triggers, r"(?m)^  push:$")
+        self.assertIn("workflow_run:", self.triggers)
+        self.assertIn("workflows: [Security]", self.triggers)
+        self.assertIn("types: [completed]", self.triggers)
+        self.assertIn("branches: [main]", self.triggers)
+
+    def test_workflow_run_accepts_only_successful_main_pushes(self):
+        self.assertIn("github.event_name != 'workflow_run' ||", self.workflow)
+        self.assertIn("github.event.workflow_run.event == 'push'", self.workflow)
+        self.assertIn("github.event.workflow_run.head_branch == 'main'", self.workflow)
+        self.assertIn("github.event.workflow_run.conclusion == 'success'", self.workflow)
+
+    def test_security_dependency_exists_and_scans_main_pushes(self):
+        security = SECURITY_WORKFLOW.read_text(encoding="utf-8")
+        self.assertRegex(security, r"(?m)^name: Security$")
+        trigger_block = security.split("concurrency:", 1)[0]
+        self.assertRegex(
+            trigger_block,
+            r"(?m)^  push:\n    branches: \[main\]$",
+        )
+        self.assertRegex(
+            security,
+            r"uses: github/codeql-action/analyze@[0-9a-f]{40}",
+        )
+
+    def test_scorecard_checks_out_the_scanned_commit(self):
+        self.assertIn(
+            "ref: ${{ github.event.workflow_run.head_sha || github.sha }}",
+            self.workflow,
+        )
+
+    def test_manual_scheduled_and_branch_protection_triggers_remain(self):
+        for trigger in ("branch_protection_rule:", "workflow_dispatch:", "schedule:"):
+            with self.subTest(trigger=trigger):
+                self.assertIn(trigger, self.triggers)
+
+    def test_runs_are_serialized_without_discarding_evidence(self):
+        self.assertRegex(
+            self.workflow,
+            r"(?m)^concurrency:\n"
+            r"  group: scorecard-\$\{\{ github\.repository \}\}\n"
+            r"  cancel-in-progress: false$",
+        )
+        self.assertRegex(self.workflow, r"(?m)^    timeout-minutes: 10$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/scorecard_workflow_test.py
+++ b/scripts/scorecard_workflow_test.py
@@ -57,6 +57,7 @@ class ScorecardWorkflowTest(unittest.TestCase):
             self.workflow,
             r"(?m)^concurrency:\n"
             r"  group: scorecard-\$\{\{ github\.repository \}\}\n"
+            r"  queue: max\n"
             r"  cancel-in-progress: false$",
         )
         self.assertRegex(self.workflow, r"(?m)^    timeout-minutes: 10$")


### PR DESCRIPTION
Runs OpenSSF Scorecard after the successful main-branch Security workflow, so the commit's CodeQL evidence exists before Scorecard measures SAST coverage.

Pins the Scorecard checkout to the analyzed commit, serializes uploads, and adds workflow-contract tests for the Security dependency, trigger guards, timeout, and commit attribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved automated security checks for main-branch workflow runs.
  * Added protections against overlapping or excessively long security checks.
  * Ensured scans evaluate the appropriate triggering commit.

* **Quality Improvements**
  * Added automated validation for security workflow configuration.
  * Included these checks in the standard preflight verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->