### PR TITLE
chore: prepare Pipelock result ownership migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,8 @@ check-gauntlet-site:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/gauntlet_site_index_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/validate_gauntlet_records_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/validate_gauntlet_records.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/validate_pipelock_result_inventory_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/validate_pipelock_result_inventory.py
 	@node gauntlet-site/scope-render_test.js
 	@node gauntlet-site/latest-result_test.js
 	@test -f "$(GAUNTLET_SCOPE_ARTIFACT)" || { echo "check-gauntlet-site: FAIL - missing provenance artifact: $(GAUNTLET_SCOPE_ARTIFACT)"; exit 1; }

--- a/docs/RESULT-OWNERSHIP-MIGRATION.md
+++ b/docs/RESULT-OWNERSHIP-MIGRATION.md
@@ -1,0 +1,22 @@
+# Pipelock result ownership migration
+
+Agent Egress Bench owns the method, corpus, runner contracts, and portable verification tools.
+Pipelock owns its scheduled runs and release gates. PipeLab owns Pipelock's published result page and
+new immutable result bundles.
+
+The old Pipelock result bytes remain in this repository as a read-only restore copy. The migration
+inventory records commit-pinned and live GitHub URLs, the exact byte count and SHA-256 digest, the
+planned PipeLab destination, and the repository responsible for retention. `make check-gauntlet-site`
+rejects changed, missing, reordered, or symlinked snapshot evidence. It also reruns the existing
+record verifier against the live result chain.
+
+The inventory stays pinned to its recorded source commit if the old lane promotes another result
+before cutover. After migration, this repository keeps the listed bytes and the generic readers, but
+it no longer schedules Pipelock or publishes new Pipelock results.
+
+To cut a later snapshot, commit the reviewed record first, then regenerate the inventory from that
+commit:
+
+```bash
+python3 scripts/validate_pipelock_result_inventory.py --write
+```

--- a/examples/pipelock/README.md
+++ b/examples/pipelock/README.md
@@ -26,6 +26,16 @@ The default output is a unique directory under `continuous-gauntlet-runs/`. To c
 
 The destination must not already exist. The command verifies the corpus Git identity and cleanliness, downloads the release named by `release.env`, rejects draft or prerelease assets, verifies the archive against the release's `checksums.txt`, and verifies the extracted binary's version before running it. It then builds the repository runner and executes every canonical fixture and multi-file MCP drift case.
 
+A product-owned scheduler can keep its reviewed release pin in its own repository and pass that file
+without changing the benchmark checkout:
+
+```bash
+./scripts/run-pipelock-gauntlet.sh --release-pin ../pipelock/benchmark/release.env
+```
+
+The pin parser accepts only one `PIPELOCK_REPO`, `PIPELOCK_TAG`, and `PIPELOCK_VERSION` assignment.
+It rejects shell syntax, unknown keys, duplicate keys, and symlinks.
+
 Important files in the completed directory:
 
 | File | Meaning |

--- a/migration/pipelock-result-inventory-v1.json
+++ b/migration/pipelock-result-inventory-v1.json
@@ -1,0 +1,435 @@
+{
+  "entries": [
+    {
+      "bytes": 4233,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/gauntlet-results.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/gauntlet-results.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/gauntlet-results.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/gauntlet-results.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "5d7b4fb993bed479294edbdd2cd6a796cc45a34e965eef1602313d9c2d5bc696",
+      "source_path": "gauntlet-site/gauntlet-results.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/gauntlet-results.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/gauntlet-results.json"
+      ]
+    },
+    {
+      "bytes": 862,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/latest-verified.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/latest-verified.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/latest-verified.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/latest-verified.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "31806f96af60f59f8ea0385cd893d1650d8e86b7f6bec384c91456a68728c3c4",
+      "source_path": "gauntlet-site/latest-verified.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/latest-verified.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/latest-verified.json"
+      ]
+    },
+    {
+      "bytes": 14558,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/case-index.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/case-index.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/case-index.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/case-index.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "2a36b9f2ce028055f41d8781f5da68249a34f9b42a3b09beea9dc5e98c3fafa0",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/case-index.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/case-index.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/case-index.json"
+      ]
+    },
+    {
+      "bytes": 1254,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/checksums.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/checksums.txt"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/checksums.txt",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/checksums.txt"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "e8bed22541f2660700c9a58884da3a00f0270ad437b9483015b74ba19e438877",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/checksums.txt",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/checksums.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/checksums.txt"
+      ]
+    },
+    {
+      "bytes": 820,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/command.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/command.txt"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/command.txt",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/command.txt"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "158deca442751a2ad6b371f00260f4695eb3c6affef24afc18e860871fc23948",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/command.txt",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/command.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/command.txt"
+      ]
+    },
+    {
+      "bytes": 5314,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/continuous-gauntlet-pipelock.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/continuous-gauntlet-pipelock.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/continuous-gauntlet-pipelock.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/continuous-gauntlet-pipelock.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/continuous-gauntlet-pipelock.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/continuous-gauntlet-pipelock.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/continuous-gauntlet-pipelock.json"
+      ]
+    },
+    {
+      "bytes": 5753,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/corpus-manifest.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/corpus-manifest.txt"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/corpus-manifest.txt",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/corpus-manifest.txt"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "ef82e319ad3efd7d407e15de27631f2b8fdf9f227ecc7f8253308ac44053916a",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/corpus-manifest.txt",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/corpus-manifest.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/corpus-manifest.txt"
+      ]
+    },
+    {
+      "bytes": 162,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/entrypoint-command.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/entrypoint-command.txt"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/entrypoint-command.txt",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/entrypoint-command.txt"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "5bb1e1a8b9a934a6dc818d8432ba4cba817b4da498744e80bd6610984df561d5",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/entrypoint-command.txt",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/entrypoint-command.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/entrypoint-command.txt"
+      ]
+    },
+    {
+      "bytes": 1294,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/execution-decision.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/execution-decision.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/execution-decision.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/execution-decision.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "dc5707b1151bb0a90f0a22034294fc4d9e0a831f3fe6df0dea7ef03aa3bdce35",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/execution-decision.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/execution-decision.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/execution-decision.json"
+      ]
+    },
+    {
+      "bytes": 438,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/make-stats.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/make-stats.txt"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/make-stats.txt",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/make-stats.txt"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "a43158709df0fe447c3eb2e5ff3f89d66a907b1a102ff5210e635bf841f8ecfa",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/make-stats.txt",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/make-stats.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/make-stats.txt"
+      ]
+    },
+    {
+      "bytes": 405,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-release.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-release.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-release.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-release.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "016d9287cd2a63c000b5012f7ff0f24ae7d88b28e321ad08e3dbf3c9c6d6ee7f",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-release.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-release.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-release.json"
+      ]
+    },
+    {
+      "bytes": 23,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-version.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-version.txt"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-version.txt",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-version.txt"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "f7475df97325d18fe948b25d17d390766c2a236b2c9617f0dd3b1a58db4ecfdd",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-version.txt",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-version.txt",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/pipelock-version.txt"
+      ]
+    },
+    {
+      "bytes": 4265,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/raw-summary.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/raw-summary.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/raw-summary.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/raw-summary.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "6d90c1db915a1f7623826f09a84826db14f07996931f705ce58a89ca8d605fae",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/raw-summary.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/raw-summary.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/raw-summary.json"
+      ]
+    },
+    {
+      "bytes": 2300,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/record-manifest.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/record-manifest.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/record-manifest.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/record-manifest.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "17d069ecebe70f52413cd2509aa80c551d0a0e3703385471cc406088625fabb6",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/record-manifest.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/record-manifest.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/record-manifest.json"
+      ]
+    },
+    {
+      "bytes": 74732,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/results.jsonl",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/results.jsonl"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/results.jsonl",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/results.jsonl"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "4abc24358a3107aa3b8c50304d66ba6a085f88c6b27d796b52d782b80723f16f",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/results.jsonl",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/results.jsonl",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/results.jsonl"
+      ]
+    },
+    {
+      "bytes": 1208,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-baseline.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-baseline.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-baseline.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-baseline.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "f7eed83f9f719932f50e6184d84f034dea714e28a49a309926e5d52bf5b87c6f",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-baseline.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-baseline.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-baseline.json"
+      ]
+    },
+    {
+      "bytes": 1759,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-promotion-decision.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-promotion-decision.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-promotion-decision.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-promotion-decision.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "126ee10e867821b429aaf976aed89a2e16ae61009822b9fc6eddcb5b58671a61",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-promotion-decision.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-promotion-decision.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/reviewed-promotion-decision.json"
+      ]
+    },
+    {
+      "bytes": 6528,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-bundle.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-bundle.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-bundle.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-bundle.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "e4cbce2725d7b9afeaa2f29ecf200144adb20142d76e5bca1ee537eb7580cdd6",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-bundle.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-bundle.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-bundle.json"
+      ]
+    },
+    {
+      "bytes": 357,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-metadata.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-metadata.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-metadata.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-metadata.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "b32407d7ea52794fd6dd1470a1676031c88e238ab4a7a3d20487bca625e759c3",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-metadata.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-metadata.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/run-metadata.json"
+      ]
+    },
+    {
+      "bytes": 2120,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/runner.stderr",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/runner.stderr"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/runner.stderr",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/runner.stderr"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "497bd9e0ce33d70aa35b88eac25ab3de490cec256dd7e4b75b384cfa0898b304",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/runner.stderr",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/runner.stderr",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/runner.stderr"
+      ]
+    },
+    {
+      "bytes": 1261,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-baseline.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-baseline.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-baseline.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-baseline.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "819e94a8550ddf76677ad8a6ba96c75ec1fdad54a35bfd27ed07ad3a528eb091",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-baseline.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-baseline.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-baseline.json"
+      ]
+    },
+    {
+      "bytes": 2387,
+      "legacy_live_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-promotion-decision.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/main/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-promotion-decision.json"
+      ],
+      "planned_destination": {
+        "path": "static/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-promotion-decision.json",
+        "repository": "luckyPipewrench/pipelab.org",
+        "url": "https://pipelab.org/gauntlet/evidence/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-promotion-decision.json"
+      },
+      "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+      "sha256": "4f77476769d033d57a0d9930b2c145984945e31ca0e7420ff01bf4cd0fa65d7b",
+      "source_path": "gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-promotion-decision.json",
+      "source_urls": [
+        "https://github.com/luckyPipewrench/agent-egress-bench/blob/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-promotion-decision.json",
+        "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/47e22d833f19ce0b7430fca591fb31520ee90fa4/gauntlet-site/results/pipelock/5869b18cf5027d502bc5d0fd8b8f6899872a8b379137226c617670a295222886/source-promotion-decision.json"
+      ]
+    }
+  ],
+  "migration": {
+    "execution_owner": "luckyPipewrench/pipelock",
+    "publication_owner": "luckyPipewrench/pipelab.org",
+    "source_retention_owner": "luckyPipewrench/agent-egress-bench",
+    "status": "inventory_complete"
+  },
+  "record_verification": {
+    "command": "python3 scripts/validate_gauntlet_records.py",
+    "result": "verified"
+  },
+  "schema_version": 1,
+  "source_commit": "47e22d833f19ce0b7430fca591fb31520ee90fa4",
+  "source_repository": "luckyPipewrench/agent-egress-bench"
+}

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -105,6 +105,10 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
                 "PIPELOCK_REPO=luckyPipewrench/pipelock\nPIPELOCK_TAG=v3.3.0\nPIPELOCK_VERSION=3.3.0\n",
                 True,
             ),
+            (
+                "PIPELOCK_REPO=luckyPipewrench/pipelock\nPIPELOCK_TAG=v3.3.1\nPIPELOCK_VERSION=3.3.1\n",
+                True,
+            ),
             ("PIPELOCK_REPO=luckyPipewrench/pipelock\nPIPELOCK_TAG=v3.3.0\n", False),
             (
                 "PIPELOCK_REPO=luckyPipewrench/pipelock\nPIPELOCK_REPO=luckyPipewrench/pipelock\n"

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -84,7 +84,78 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         version = re.search(r"(?m)^PIPELOCK_VERSION=([^\s]+)$", release_pin).group(1)
         self.assertNotIn(version, self.workflow)
         self.assertNotIn(version, self.entrypoint)
-        self.assertIn('source "$release_pin"', self.entrypoint)
+        self.assertNotIn('source "$release_pin"', self.entrypoint)
+        self.assertIn("--release-pin", self.entrypoint)
+        self.assertIn("release pin contains an invalid line", self.entrypoint)
+
+    def test_release_pin_parser_accepts_only_the_three_data_fields(self):
+        start = self.entrypoint.index('release_pin_input="$release_pin"')
+        end = self.entrypoint.index('started_at="$(date', start)
+        parser_block = self.entrypoint[start:end]
+        shell = "\n".join(
+            (
+                "set -Eeuo pipefail",
+                'die() { printf "%s\\n" "$*" >&2; exit 1; }',
+                'release_pin="$1"',
+                parser_block,
+            )
+        )
+        cases = (
+            (
+                "PIPELOCK_REPO=luckyPipewrench/pipelock\nPIPELOCK_TAG=v3.3.0\nPIPELOCK_VERSION=3.3.0\n",
+                True,
+            ),
+            ("PIPELOCK_REPO=luckyPipewrench/pipelock\nPIPELOCK_TAG=v3.3.0\n", False),
+            (
+                "PIPELOCK_REPO=luckyPipewrench/pipelock\nPIPELOCK_REPO=luckyPipewrench/pipelock\n"
+                "PIPELOCK_TAG=v3.3.0\nPIPELOCK_VERSION=3.3.0\n",
+                False,
+            ),
+            (
+                "PIPELOCK_REPO=luckyPipewrench/pipelock\nPIPELOCK_TAG=$(touch /tmp/not-run)\n"
+                "PIPELOCK_VERSION=3.3.0\n",
+                False,
+            ),
+            (
+                "PIPELOCK_REPO=other/tool\nPIPELOCK_TAG=v3.3.0\nPIPELOCK_VERSION=3.3.0\n",
+                False,
+            ),
+            (
+                "PIPELOCK_REPO=luckyPipewrench/pipelock\nPIPELOCK_TAG=v3.3.1\n"
+                "PIPELOCK_VERSION=3.3.0\n",
+                False,
+            ),
+            (
+                "PIPELOCK_REPO=luckyPipewrench/pipelock\nUNKNOWN=value\n"
+                "PIPELOCK_TAG=v3.3.0\nPIPELOCK_VERSION=3.3.0\n",
+                False,
+            ),
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            pin = Path(temporary) / "release.env"
+            for payload, accepted in cases:
+                with self.subTest(payload=payload):
+                    pin.write_text(payload, encoding="utf-8")
+                    result = subprocess.run(
+                        ["bash", "-c", shell, "bash", str(pin)],
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    self.assertEqual(result.returncode == 0, accepted, result.stderr)
+
+            target = Path(temporary) / "target.env"
+            target.write_text(cases[0][0], encoding="utf-8")
+            pin.unlink()
+            pin.symlink_to(target)
+            result = subprocess.run(
+                ["bash", "-c", shell, "bash", str(pin)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("cannot be a symbolic link", result.stderr)
 
     def test_stdio_profile_does_not_claim_unexercised_subject_budget(self):
         profile = json.loads(PIPELOCK_PROFILE.read_text(encoding="utf-8"))

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -32,6 +32,7 @@ Options:
   --deadline-epoch SECONDS         Stop early enough to preserve finalization time.
   --reserve-seconds SECONDS        Keep this many seconds before the deadline (default: 360).
   --benchmark-timeout-seconds N    Maximum runner time without a deadline (default: 1440).
+  --release-pin FILE               Read the reviewed Pipelock release identity from FILE.
   --development                    Allow a dirty or unreviewed corpus and mark the run noncanonical.
   --development-binary PATH        Use PATH instead of a released binary and mark the run noncanonical.
   -h, --help                       Show this help.
@@ -72,6 +73,11 @@ while (($#)); do
       benchmark_timeout_seconds="$2"
       shift 2
       ;;
+    --release-pin)
+      (($# >= 2)) || die "--release-pin requires a value"
+      release_pin="$2"
+      shift 2
+      ;;
     --development)
       development_mode=true
       shift
@@ -99,10 +105,39 @@ fi
 ((benchmark_timeout_seconds > 0)) || die "--benchmark-timeout-seconds must be greater than zero"
 
 [[ "$(pwd -P)" == "$repo_root" ]] || die "run this command from the repository root: $repo_root"
-[[ -f "$release_pin" ]] || die "missing reviewed release pin: $release_pin"
+release_pin_input="$release_pin"
+[[ ! -L "$release_pin_input" ]] || die "reviewed release pin cannot be a symbolic link: $release_pin_input"
+release_pin="$(realpath -e "$release_pin_input")" || \
+  die "reviewed release pin does not resolve: $release_pin_input"
+[[ -f "$release_pin" ]] || die "reviewed release pin must be a regular file: $release_pin_input"
 unset PIPELOCK_REPO PIPELOCK_TAG PIPELOCK_VERSION
-# shellcheck disable=SC1090
-source "$release_pin"
+release_repo_count=0
+release_tag_count=0
+release_version_count=0
+while IFS= read -r release_line || [[ -n "$release_line" ]]; do
+  [[ -z "$release_line" || "$release_line" == \#* ]] && continue
+  [[ "$release_line" =~ ^([A-Z_]+)=([A-Za-z0-9._/-]+)$ ]] || \
+    die "release pin contains an invalid line"
+  release_key="${BASH_REMATCH[1]}"
+  release_value="${BASH_REMATCH[2]}"
+  case "$release_key" in
+    PIPELOCK_REPO)
+      PIPELOCK_REPO="$release_value"
+      release_repo_count=$((release_repo_count + 1))
+      ;;
+    PIPELOCK_TAG)
+      PIPELOCK_TAG="$release_value"
+      release_tag_count=$((release_tag_count + 1))
+      ;;
+    PIPELOCK_VERSION)
+      PIPELOCK_VERSION="$release_value"
+      release_version_count=$((release_version_count + 1))
+      ;;
+    *) die "release pin contains an unknown key: $release_key" ;;
+  esac
+done < "$release_pin"
+[[ "$release_repo_count" == 1 && "$release_tag_count" == 1 && "$release_version_count" == 1 ]] || \
+  die "release pin must define each required key exactly once"
 : "${PIPELOCK_REPO:?release pin must define PIPELOCK_REPO}"
 : "${PIPELOCK_TAG:?release pin must define PIPELOCK_TAG}"
 : "${PIPELOCK_VERSION:?release pin must define PIPELOCK_VERSION}"

--- a/scripts/validate_pipelock_result_inventory.py
+++ b/scripts/validate_pipelock_result_inventory.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Build and validate the historical Pipelock result migration inventory."""
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+INVENTORY_PATH = Path("migration/pipelock-result-inventory-v1.json")
+PUBLIC_POINTERS = (
+    Path("gauntlet-site/gauntlet-results.json"),
+    Path("gauntlet-site/latest-verified.json"),
+)
+RESULTS_ROOT = Path("gauntlet-site/results/pipelock")
+SOURCE_REPOSITORY = "luckyPipewrench/agent-egress-bench"
+DESTINATION_REPOSITORY = "luckyPipewrench/pipelab.org"
+DESTINATION_PREFIX = Path("static/gauntlet/evidence")
+
+
+def sha256_bytes(value):
+    return hashlib.sha256(value).hexdigest()
+
+
+def git(repo_root, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def git_file_bytes(repo_root, commit, source_path):
+    completed = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{commit}:{source_path.as_posix()}"],
+        check=False,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        raise ValueError(f"inventory source is missing from source_commit: {source_path}")
+    return completed.stdout
+
+
+def public_paths(repo_root):
+    paths = list(PUBLIC_POINTERS)
+    result_root = repo_root / RESULTS_ROOT
+    if result_root.is_symlink() or not result_root.is_dir():
+        raise ValueError("Pipelock result store must be a real directory")
+    for path in sorted(result_root.rglob("*")):
+        if path.is_symlink():
+            raise ValueError(f"inventory source cannot be a symlink: {path.relative_to(repo_root)}")
+        if path.is_file():
+            paths.append(path.relative_to(repo_root))
+    for path in paths:
+        absolute = repo_root / path
+        if absolute.is_symlink() or not absolute.is_file():
+            raise ValueError(f"inventory source must be a regular file: {path}")
+    return sorted(paths, key=lambda path: path.as_posix())
+
+
+def public_paths_at_commit(repo_root, source_commit):
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "ls-tree",
+            "-r",
+            "-z",
+            "--name-only",
+            source_commit,
+            "--",
+            RESULTS_ROOT.as_posix(),
+        ],
+        check=False,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        raise ValueError("inventory source_commit is not retained by the repository")
+    paths = [*PUBLIC_POINTERS]
+    paths.extend(Path(value.decode()) for value in completed.stdout.split(b"\0") if value)
+    for source_path in paths:
+        git_file_bytes(repo_root, source_commit, source_path)
+    return sorted(paths, key=lambda path: path.as_posix())
+
+
+def destination_path(source_path):
+    return DESTINATION_PREFIX / source_path.relative_to("gauntlet-site")
+
+
+def entry_for(repo_root, source_path, source_commit):
+    source_bytes = git_file_bytes(repo_root, source_commit, source_path)
+    destination = destination_path(source_path)
+    return {
+        "bytes": len(source_bytes),
+        "legacy_live_urls": [
+            f"https://github.com/{SOURCE_REPOSITORY}/blob/main/{source_path.as_posix()}",
+            f"https://raw.githubusercontent.com/{SOURCE_REPOSITORY}/main/{source_path.as_posix()}",
+        ],
+        "planned_destination": {
+            "path": destination.as_posix(),
+            "repository": DESTINATION_REPOSITORY,
+            "url": f"https://pipelab.org/{destination.relative_to('static').as_posix()}",
+        },
+        "retention": "keep the commit-pinned source bytes as a read-only restore copy",
+        "sha256": sha256_bytes(source_bytes),
+        "source_path": source_path.as_posix(),
+        "source_urls": [
+            f"https://github.com/{SOURCE_REPOSITORY}/blob/{source_commit}/{source_path.as_posix()}",
+            f"https://raw.githubusercontent.com/{SOURCE_REPOSITORY}/{source_commit}/{source_path.as_posix()}",
+        ],
+    }
+
+
+def build_inventory(repo_root):
+    source_commit = git(repo_root, "rev-parse", "HEAD")
+    return {
+        "entries": [entry_for(repo_root, path, source_commit) for path in public_paths(repo_root)],
+        "migration": {
+            "execution_owner": "luckyPipewrench/pipelock",
+            "publication_owner": DESTINATION_REPOSITORY,
+            "source_retention_owner": SOURCE_REPOSITORY,
+            "status": "inventory_complete",
+        },
+        "record_verification": {
+            "command": "python3 scripts/validate_gauntlet_records.py",
+            "result": "verified",
+        },
+        "schema_version": 1,
+        "source_commit": source_commit,
+        "source_repository": SOURCE_REPOSITORY,
+    }
+
+
+def require_exact_keys(value, expected, label):
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    actual = set(value)
+    if actual != set(expected):
+        raise ValueError(
+            f"{label} keys differ: missing={sorted(set(expected) - actual)}, "
+            f"unknown={sorted(actual - set(expected))}"
+        )
+
+
+def validate_entry(repo_root, entry, source_commit):
+    require_exact_keys(
+        entry,
+        (
+            "bytes",
+            "legacy_live_urls",
+            "planned_destination",
+            "retention",
+            "sha256",
+            "source_path",
+            "source_urls",
+        ),
+        "inventory entry",
+    )
+    source_path = Path(entry["source_path"])
+    if source_path.is_absolute() or ".." in source_path.parts:
+        raise ValueError(f"inventory source path is unsafe: {source_path}")
+    expected = entry_for(repo_root, source_path, source_commit)
+    if entry != expected:
+        raise ValueError(f"inventory entry drifted from source bytes or URL contract: {source_path}")
+    if source_path.is_relative_to(RESULTS_ROOT):
+        current = repo_root / source_path
+        if current.is_symlink() or not current.is_file():
+            raise ValueError(f"immutable inventory source is missing or not a regular file: {source_path}")
+        if current.read_bytes() != git_file_bytes(repo_root, source_commit, source_path):
+            raise ValueError(f"immutable inventory source changed after source_commit: {source_path}")
+    return source_path
+
+
+def verify_record_store(repo_root):
+    completed = subprocess.run(
+        [sys.executable, "scripts/validate_gauntlet_records.py"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stdout.strip() or completed.stderr.strip()
+        raise ValueError(f"retained record verification failed: {detail}")
+
+
+def validate(repo_root, inventory_path, verify_records=True):
+    inventory = json.loads(inventory_path.read_text(encoding="utf-8"))
+    require_exact_keys(
+        inventory,
+        (
+            "entries",
+            "migration",
+            "record_verification",
+            "schema_version",
+            "source_commit",
+            "source_repository",
+        ),
+        "inventory",
+    )
+    if inventory["schema_version"] != 1:
+        raise ValueError("inventory schema_version must be 1")
+    if inventory["source_repository"] != SOURCE_REPOSITORY:
+        raise ValueError("inventory source_repository is not canonical")
+    if (
+        not isinstance(inventory["source_commit"], str)
+        or len(inventory["source_commit"]) != 40
+        or any(character not in "0123456789abcdef" for character in inventory["source_commit"])
+    ):
+        raise ValueError("inventory source_commit must be a full Git commit")
+    if inventory["migration"] != {
+        "execution_owner": "luckyPipewrench/pipelock",
+        "publication_owner": DESTINATION_REPOSITORY,
+        "source_retention_owner": SOURCE_REPOSITORY,
+        "status": "inventory_complete",
+    }:
+        raise ValueError("inventory migration ownership contract drifted")
+    if inventory["record_verification"] != {
+        "command": "python3 scripts/validate_gauntlet_records.py",
+        "result": "verified",
+    }:
+        raise ValueError("inventory record verification claim drifted")
+    if not isinstance(inventory["entries"], list) or not inventory["entries"]:
+        raise ValueError("inventory entries must be a non-empty array")
+
+    actual_paths = public_paths_at_commit(repo_root, inventory["source_commit"])
+    recorded_paths = [
+        validate_entry(repo_root, entry, inventory["source_commit"])
+        for entry in inventory["entries"]
+    ]
+    if recorded_paths != sorted(set(recorded_paths), key=lambda path: path.as_posix()):
+        raise ValueError("inventory entries must be unique and sorted by source_path")
+    if recorded_paths != actual_paths:
+        missing = sorted(set(actual_paths) - set(recorded_paths))
+        unexpected = sorted(set(recorded_paths) - set(actual_paths))
+        raise ValueError(f"inventory path set differs: missing={missing}, unexpected={unexpected}")
+    if verify_records:
+        verify_record_store(repo_root)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--inventory", type=Path, default=INVENTORY_PATH)
+    parser.add_argument("--write", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    inventory_path = args.inventory
+    if not inventory_path.is_absolute():
+        inventory_path = repo_root / inventory_path
+    try:
+        if args.write:
+            verify_record_store(repo_root)
+            inventory_path.parent.mkdir(parents=True, exist_ok=True)
+            inventory_path.write_text(
+                json.dumps(build_inventory(repo_root), indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        validate(repo_root, inventory_path)
+    except (OSError, json.JSONDecodeError, subprocess.CalledProcessError, TypeError, ValueError) as exc:
+        print(f"Pipelock result inventory: BLOCKED: {exc}")
+        return 1
+    print("Pipelock result inventory: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_pipelock_result_inventory.py
+++ b/scripts/validate_pipelock_result_inventory.py
@@ -44,6 +44,37 @@ def git_file_bytes(repo_root, commit, source_path):
     return completed.stdout
 
 
+def git_object_type(repo_root, object_name):
+    completed = subprocess.run(
+        ["git", "-C", str(repo_root), "cat-file", "-t", object_name],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def git_tree_entries(repo_root, source_commit, source_path, recursive=False):
+    command = ["git", "-C", str(repo_root), "ls-tree"]
+    if recursive:
+        command.append("-r")
+    command.extend(["-z", source_commit, "--", source_path.as_posix()])
+    completed = subprocess.run(command, check=False, capture_output=True)
+    if completed.returncode != 0:
+        raise ValueError("inventory source_commit is not retained by the repository")
+
+    entries = []
+    for record in completed.stdout.split(b"\0"):
+        if not record:
+            continue
+        metadata, raw_path = record.split(b"\t", 1)
+        mode, object_type, _object_id = metadata.decode("ascii").split(" ", 2)
+        entries.append((mode, object_type, Path(raw_path.decode("utf-8"))))
+    return entries
+
+
 def public_paths(repo_root):
     paths = list(PUBLIC_POINTERS)
     result_root = repo_root / RESULTS_ROOT
@@ -62,28 +93,27 @@ def public_paths(repo_root):
 
 
 def public_paths_at_commit(repo_root, source_commit):
-    completed = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(repo_root),
-            "ls-tree",
-            "-r",
-            "-z",
-            "--name-only",
-            source_commit,
-            "--",
-            RESULTS_ROOT.as_posix(),
-        ],
-        check=False,
-        capture_output=True,
-    )
-    if completed.returncode != 0:
-        raise ValueError("inventory source_commit is not retained by the repository")
-    paths = [*PUBLIC_POINTERS]
-    paths.extend(Path(value.decode()) for value in completed.stdout.split(b"\0") if value)
-    for source_path in paths:
+    if git_object_type(repo_root, source_commit) != "commit":
+        raise ValueError("inventory source_commit must resolve to a commit object")
+    if git_object_type(repo_root, f"{source_commit}:{RESULTS_ROOT.as_posix()}") != "tree":
+        raise ValueError("Pipelock result store must resolve to a tree at source_commit")
+
+    entries = []
+    for source_path in PUBLIC_POINTERS:
+        pointer_entries = git_tree_entries(repo_root, source_commit, source_path)
+        if len(pointer_entries) != 1 or pointer_entries[0][2] != source_path:
+            raise ValueError(f"inventory source is missing from source_commit: {source_path}")
+        entries.extend(pointer_entries)
+    result_entries = git_tree_entries(repo_root, source_commit, RESULTS_ROOT, recursive=True)
+    if not result_entries:
+        raise ValueError("Pipelock result store must contain retained records at source_commit")
+    entries.extend(result_entries)
+
+    for mode, object_type, source_path in entries:
+        if object_type != "blob" or mode not in {"100644", "100755"}:
+            raise ValueError(f"inventory source must be a regular file at source_commit: {source_path}")
         git_file_bytes(repo_root, source_commit, source_path)
+    paths = [source_path for _mode, _object_type, source_path in entries]
     return sorted(paths, key=lambda path: path.as_posix())
 
 

--- a/scripts/validate_pipelock_result_inventory_test.py
+++ b/scripts/validate_pipelock_result_inventory_test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for the historical Pipelock result migration inventory."""
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("validate_pipelock_result_inventory.py")
+SPEC = importlib.util.spec_from_file_location("inventory", MODULE_PATH)
+inventory = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(inventory)
+
+
+class InventoryTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="pipelock-result-inventory-")
+        self.root = Path(self.temporary.name)
+        paths = [
+            Path("gauntlet-site/gauntlet-results.json"),
+            Path("gauntlet-site/latest-verified.json"),
+            Path("gauntlet-site/results/pipelock/digest/record-manifest.json"),
+        ]
+        for index, path in enumerate(paths):
+            absolute = self.root / path
+            absolute.parent.mkdir(parents=True, exist_ok=True)
+            absolute.write_text(json.dumps({"value": index}) + "\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-q", str(self.root)], check=True)
+        subprocess.run(["git", "-C", str(self.root), "config", "user.name", "Test"], check=True)
+        subprocess.run(
+            ["git", "-C", str(self.root), "config", "user.email", "test@example.invalid"],
+            check=True,
+        )
+        subprocess.run(["git", "-C", str(self.root), "add", "."], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "fixture"], check=True)
+        self.inventory_path = self.root / "migration/inventory.json"
+        self.inventory_path.parent.mkdir()
+        self.write_inventory(inventory.build_inventory(self.root))
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def write_inventory(self, value):
+        self.inventory_path.write_text(json.dumps(value) + "\n", encoding="utf-8")
+
+    def load_inventory(self):
+        return json.loads(self.inventory_path.read_text(encoding="utf-8"))
+
+    def validate(self):
+        inventory.validate(self.root, self.inventory_path, verify_records=False)
+
+    def test_accepts_complete_inventory(self):
+        self.validate()
+
+    def test_rejects_changed_source_bytes(self):
+        original = self.load_inventory()
+        source = self.root / "gauntlet-site/latest-verified.json"
+        source.write_text('{"changed":true}\n', encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", source.relative_to(self.root)], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "change bytes"], check=True)
+        value = inventory.build_inventory(self.root)
+        stale = next(
+            entry
+            for entry in original["entries"]
+            if entry["source_path"] == source.relative_to(self.root).as_posix()
+        )
+        value["entries"] = [
+            stale if entry["source_path"] == stale["source_path"] else entry
+            for entry in value["entries"]
+        ]
+        self.write_inventory(value)
+        with self.assertRaisesRegex(ValueError, "drifted from source bytes"):
+            self.validate()
+
+    def test_rejects_unlisted_record_file(self):
+        extra = self.root / "gauntlet-site/results/pipelock/digest/new-evidence.json"
+        extra.write_text("{}\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", extra.relative_to(self.root)], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "add evidence"], check=True)
+        value = inventory.build_inventory(self.root)
+        value["entries"] = [
+            entry
+            for entry in value["entries"]
+            if entry["source_path"] != extra.relative_to(self.root).as_posix()
+        ]
+        self.write_inventory(value)
+        with self.assertRaisesRegex(ValueError, "path set differs"):
+            self.validate()
+
+    def test_allows_newer_records_outside_the_historical_snapshot(self):
+        extra = self.root / "gauntlet-site/results/pipelock/new-digest/record-manifest.json"
+        extra.parent.mkdir()
+        extra.write_text("{}\n", encoding="utf-8")
+        self.validate()
+
+    def test_allows_live_pointer_to_advance_after_the_snapshot(self):
+        source = self.root / "gauntlet-site/latest-verified.json"
+        source.write_text('{"new_pointer":true}\n', encoding="utf-8")
+        self.validate()
+
+    def test_rejects_entry_removed_from_inventory(self):
+        value = self.load_inventory()
+        value["entries"].pop()
+        self.write_inventory(value)
+        with self.assertRaisesRegex(ValueError, "path set differs"):
+            self.validate()
+
+    def test_rejects_source_commit_that_does_not_own_bytes(self):
+        value = self.load_inventory()
+        value["source_commit"] = "0" * 40
+        self.write_inventory(value)
+        with self.assertRaisesRegex(ValueError, "not retained by the repository"):
+            self.validate()
+
+    def test_rejects_non_hex_source_commit(self):
+        value = self.load_inventory()
+        value["source_commit"] = "z" * 40
+        self.write_inventory(value)
+        with self.assertRaisesRegex(ValueError, "full Git commit"):
+            self.validate()
+
+    def test_rejects_reordered_entries(self):
+        value = self.load_inventory()
+        value["entries"].reverse()
+        self.write_inventory(value)
+        with self.assertRaisesRegex(ValueError, "unique and sorted"):
+            self.validate()
+
+    def test_rejects_symlinked_record(self):
+        source = self.root / "gauntlet-site/results/pipelock/digest/record-manifest.json"
+        source.unlink()
+        source.symlink_to(self.root / "gauntlet-site/latest-verified.json")
+        with self.assertRaisesRegex(ValueError, "missing or not a regular file"):
+            self.validate()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_pipelock_result_inventory_test.py
+++ b/scripts/validate_pipelock_result_inventory_test.py
@@ -112,7 +112,52 @@ class InventoryTest(unittest.TestCase):
         value = self.load_inventory()
         value["source_commit"] = "0" * 40
         self.write_inventory(value)
-        with self.assertRaisesRegex(ValueError, "not retained by the repository"):
+        with self.assertRaisesRegex(ValueError, "must resolve to a commit object"):
+            self.validate()
+
+    def test_rejects_tree_object_as_source_commit(self):
+        value = self.load_inventory()
+        value["source_commit"] = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD^{tree}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self.write_inventory(value)
+        with self.assertRaisesRegex(ValueError, "must resolve to a commit object"):
+            self.validate()
+
+    def test_rejects_missing_result_tree_at_source_commit(self):
+        value = self.load_inventory()
+        record = self.root / "gauntlet-site/results/pipelock/digest/record-manifest.json"
+        record.unlink()
+        subprocess.run(["git", "-C", str(self.root), "add", "-u"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "remove records"], check=True)
+        value["source_commit"] = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self.write_inventory(value)
+        with self.assertRaisesRegex(ValueError, "must resolve to a tree"):
+            self.validate()
+
+    def test_rejects_symlinked_record_in_source_commit(self):
+        value = self.load_inventory()
+        record = self.root / "gauntlet-site/results/pipelock/digest/record-manifest.json"
+        record.unlink()
+        record.symlink_to("../../../latest-verified.json")
+        subprocess.run(["git", "-C", str(self.root), "add", record.relative_to(self.root)], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "replace with symlink"], check=True)
+        value["source_commit"] = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self.write_inventory(value)
+        with self.assertRaisesRegex(ValueError, "must be a regular file at source_commit"):
             self.validate()
 
     def test_rejects_non_hex_source_commit(self):


### PR DESCRIPTION
This prepares the first safe slice of moving Pipelock-specific benchmark operations to their owning repositories.

- Records a commit-pinned inventory of the historical Pipelock result bytes, URLs, digests, destinations, and retention ownership.
- Lets a product-owned scheduler supply a strictly parsed release pin without changing the benchmark checkout.

The existing scheduled and promotion lanes remain operational until their replacements pass end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for securely pinning Pipelock Gauntlet releases through a validated release configuration file.
  - Added inventory and validation tooling for historical Pipelock results, including checksums, source commits, ownership, and migration destinations.
  - Added a versioned migration inventory covering existing Gauntlet evidence.
  - Integrated inventory validation and unit tests into Gauntlet site verification.

- **Documentation**
  - Documented result ownership, migration responsibilities, retention, verification, and release-pin usage.

- **Tests**
  - Expanded verification for invalid release pins, tampered or missing records, symlinks, and inventory consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->