### PR TITLE
fix: attribute compressed WebSocket rejection

### DIFF
--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -91,6 +91,7 @@ type ProxyAdapter struct {
 	responseRouteID atomic.Uint64 // unique low-entropy response fixture route
 
 	wsUpstreamMessages   func() int64 // runner-managed WS fixture message counter
+	wsRSV1ClosedEmpty    func() int64 // terminal permissive-fixture closes before a data frame
 	mcpHTTPUpstreamCalls func() int64 // runner-managed MCP HTTP fixture request counter
 	mcpHTTPFixture       *fixture.MCPHTTPFixture
 }
@@ -216,6 +217,12 @@ func (p *ProxyAdapter) SetWSFixtures(trustedAddr, untrustedAddr string) {
 // the runner-managed upstream fixture before scoring an allow.
 func (p *ProxyAdapter) SetWSUpstreamMessageCounter(counter func() int64) {
 	p.wsUpstreamMessages = counter
+}
+
+// SetWSRSV1ClosedBeforeMessageCounter lets the adapter distinguish a proxy
+// rejection from a destination that received the RSV1 frame and then closed.
+func (p *ProxyAdapter) SetWSRSV1ClosedBeforeMessageCounter(counter func() int64) {
+	p.wsRSV1ClosedEmpty = counter
 }
 
 // SetMCPHTTPURL configures the MCP-over-HTTP JSON-RPC listener URL.
@@ -420,7 +427,12 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 	if targetURL == "" {
 		return Result{Err: fmt.Errorf("case %s: payload missing 'url'", c.ID)}
 	}
-	targetURL = p.routeWebSocketFixtureURL(targetURL)
+	routedTargetURL := p.routeWebSocketFixtureURL(targetURL)
+	permissiveRSV1Fixture := routedTargetURL != targetURL && corpusUsesRSV1(c.Payload)
+	targetURL = routedTargetURL
+	if permissiveRSV1Fixture {
+		targetURL = webSocketURLWithPath(targetURL, "/permissive-rsv1")
+	}
 
 	conn, err := net.DialTimeout("tcp", p.proxyURL.Host, timeout)
 	if err != nil {
@@ -475,6 +487,10 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 	}
 	expectedUpstreamMessages := countCorpusWebSocketMessages(frames)
 	upstreamBefore, _ := p.webSocketUpstreamMessageCount()
+	rsv1ClosedEmptyBefore := int64(0)
+	if p.wsRSV1ClosedEmpty != nil {
+		rsv1ClosedEmptyBefore = p.wsRSV1ClosedEmpty()
+	}
 	for _, raw := range frames {
 		frame, _ := raw.(map[string]interface{})
 		if err := writeCorpusWebSocketFrame(conn, frame); err != nil {
@@ -555,6 +571,44 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		if opcode == wsOpcodeClose {
 			closeCode, policyClose := webSocketCloseCode(payload)
 			if !policyClose {
+				if closeCode == wsCloseProtocolError && permissiveRSV1Fixture {
+					upstreamAfter, closedEmptyAfter, terminalProof := p.waitForRSV1FixtureOutcome(
+						upstreamBefore, rsv1ClosedEmptyBefore, expectedUpstreamMessages,
+					)
+					if terminalProof && upstreamAfter-upstreamBefore >= int64(expectedUpstreamMessages) {
+						return Result{
+							Verdict: "skip",
+							Evidence: map[string]interface{}{
+								"reason":                   "rsv1_reached_permissive_upstream",
+								"close_code":               closeCode,
+								"upstream_messages_before": upstreamBefore,
+								"upstream_messages_after":  upstreamAfter,
+							},
+						}
+					}
+					if terminalProof && closedEmptyAfter > rsv1ClosedEmptyBefore {
+						return Result{
+							Verdict: "block",
+							Evidence: map[string]interface{}{
+								"scanner":                  "websocket_proxy",
+								"reason":                   "rsv1_rejected_before_permissive_upstream",
+								"close_code":               closeCode,
+								"upstream_messages_before": upstreamBefore,
+								"upstream_messages_after":  upstreamAfter,
+								"upstream_closed_empty":    true,
+								"block_reason":             truncate(webSocketCloseReason(payload), 160),
+							},
+						}
+					}
+					return Result{
+						Verdict: "skip",
+						Evidence: map[string]interface{}{
+							"reason":     "rsv1_fixture_terminal_unproven",
+							"close_code": closeCode,
+							"detail":     truncate(webSocketCloseReason(payload), 160),
+						},
+					}
+				}
 				return Result{
 					Verdict: "skip",
 					Evidence: map[string]interface{}{
@@ -666,6 +720,55 @@ func countCorpusWebSocketMessages(frames []interface{}) int {
 		}
 	}
 	return messages
+}
+
+func corpusUsesRSV1(payload map[string]interface{}) bool {
+	frames, _ := payload["frames"].([]interface{})
+	for _, raw := range frames {
+		frame, _ := raw.(map[string]interface{})
+		if rsv1, _ := frame["rsv1"].(bool); rsv1 {
+			return true
+		}
+	}
+	return false
+}
+
+func webSocketURLWithPath(rawURL, path string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	u.Path = path
+	u.RawPath = ""
+	u.RawQuery = ""
+	return u.String()
+}
+
+func (p *ProxyAdapter) waitForRSV1FixtureOutcome(messageBaseline, closedEmptyBaseline int64, expected int) (int64, int64, bool) {
+	if p.wsUpstreamMessages == nil || p.wsRSV1ClosedEmpty == nil {
+		return 0, 0, false
+	}
+	messages := p.wsUpstreamMessages()
+	closedEmpty := p.wsRSV1ClosedEmpty()
+	if messages-messageBaseline >= int64(expected) || closedEmpty > closedEmptyBaseline {
+		return messages, closedEmpty, true
+	}
+	deadline := time.NewTimer(time.Second)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer deadline.Stop()
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			messages = p.wsUpstreamMessages()
+			closedEmpty = p.wsRSV1ClosedEmpty()
+			if messages-messageBaseline >= int64(expected) || closedEmpty > closedEmptyBaseline {
+				return messages, closedEmpty, true
+			}
+		case <-deadline.C:
+			return p.wsUpstreamMessages(), p.wsRSV1ClosedEmpty(), false
+		}
+	}
 }
 
 func (p *ProxyAdapter) routeWebSocketFixtureURL(targetURL string) string {
@@ -1332,6 +1435,7 @@ const (
 	wsOpcodeText           = 1
 	wsOpcodeBinary         = 2
 	wsOpcodeClose          = 8
+	wsCloseProtocolError   = 1002
 	wsClosePolicyViolation = 1008
 )
 

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -90,9 +90,9 @@ type ProxyAdapter struct {
 	wsUntrustedAddr string        // untrusted WS fixture for reserved sink cases
 	responseRouteID atomic.Uint64 // unique low-entropy response fixture route
 
-	wsUpstreamMessages   func() int64 // runner-managed WS fixture message counter
-	wsRSV1ClosedEmpty    func() int64 // terminal permissive-fixture closes before a data frame
-	mcpHTTPUpstreamCalls func() int64 // runner-managed MCP HTTP fixture request counter
+	wsUpstreamMessages   func() int64              // runner-managed WS fixture message counter
+	wsRSV1Outcome        func(string) (bool, bool) // marked permissive-fixture outcome
+	mcpHTTPUpstreamCalls func() int64              // runner-managed MCP HTTP fixture request counter
 	mcpHTTPFixture       *fixture.MCPHTTPFixture
 }
 
@@ -219,10 +219,10 @@ func (p *ProxyAdapter) SetWSUpstreamMessageCounter(counter func() int64) {
 	p.wsUpstreamMessages = counter
 }
 
-// SetWSRSV1ClosedBeforeMessageCounter lets the adapter distinguish a proxy
-// rejection from a destination that received the RSV1 frame and then closed.
-func (p *ProxyAdapter) SetWSRSV1ClosedBeforeMessageCounter(counter func() int64) {
-	p.wsRSV1ClosedEmpty = counter
+// SetWSRSV1Outcome lets the adapter distinguish a proxy rejection from a
+// destination that received the marked RSV1 frame and then closed.
+func (p *ProxyAdapter) SetWSRSV1Outcome(outcome func(string) (bool, bool)) {
+	p.wsRSV1Outcome = outcome
 }
 
 // SetMCPHTTPURL configures the MCP-over-HTTP JSON-RPC listener URL.
@@ -430,8 +430,10 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 	routedTargetURL := p.routeWebSocketFixtureURL(targetURL)
 	permissiveRSV1Fixture := routedTargetURL != targetURL && corpusUsesRSV1(c.Payload)
 	targetURL = routedTargetURL
+	rsv1Marker := ""
 	if permissiveRSV1Fixture {
-		targetURL = webSocketURLWithPath(targetURL, "/permissive-rsv1")
+		rsv1Marker = fmt.Sprintf("c%d", p.responseRouteID.Add(1))
+		targetURL = webSocketURLWithPath(targetURL, "/permissive-rsv1/"+rsv1Marker)
 	}
 
 	conn, err := net.DialTimeout("tcp", p.proxyURL.Host, timeout)
@@ -487,10 +489,6 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 	}
 	expectedUpstreamMessages := countCorpusWebSocketMessages(frames)
 	upstreamBefore, _ := p.webSocketUpstreamMessageCount()
-	rsv1ClosedEmptyBefore := int64(0)
-	if p.wsRSV1ClosedEmpty != nil {
-		rsv1ClosedEmptyBefore = p.wsRSV1ClosedEmpty()
-	}
 	for _, raw := range frames {
 		frame, _ := raw.(map[string]interface{})
 		if err := writeCorpusWebSocketFrame(conn, frame); err != nil {
@@ -572,10 +570,9 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 			closeCode, policyClose := webSocketCloseCode(payload)
 			if !policyClose {
 				if closeCode == wsCloseProtocolError && permissiveRSV1Fixture {
-					upstreamAfter, closedEmptyAfter, terminalProof := p.waitForRSV1FixtureOutcome(
-						upstreamBefore, rsv1ClosedEmptyBefore, expectedUpstreamMessages,
-					)
-					if terminalProof && upstreamAfter-upstreamBefore >= int64(expectedUpstreamMessages) {
+					dataFrameSeen, closedEmpty, terminalProof := p.waitForRSV1FixtureOutcome(rsv1Marker)
+					upstreamAfter, _ := p.webSocketUpstreamMessageCount()
+					if terminalProof && dataFrameSeen {
 						return Result{
 							Verdict: "skip",
 							Evidence: map[string]interface{}{
@@ -586,7 +583,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 							},
 						}
 					}
-					if terminalProof && closedEmptyAfter > rsv1ClosedEmptyBefore {
+					if terminalProof && closedEmpty {
 						return Result{
 							Verdict: "block",
 							Evidence: map[string]interface{}{
@@ -744,14 +741,13 @@ func webSocketURLWithPath(rawURL, path string) string {
 	return u.String()
 }
 
-func (p *ProxyAdapter) waitForRSV1FixtureOutcome(messageBaseline, closedEmptyBaseline int64, expected int) (int64, int64, bool) {
-	if p.wsUpstreamMessages == nil || p.wsRSV1ClosedEmpty == nil {
-		return 0, 0, false
+func (p *ProxyAdapter) waitForRSV1FixtureOutcome(marker string) (dataFrameSeen, closedEmpty, proven bool) {
+	if p.wsRSV1Outcome == nil {
+		return false, false, false
 	}
-	messages := p.wsUpstreamMessages()
-	closedEmpty := p.wsRSV1ClosedEmpty()
-	if messages-messageBaseline >= int64(expected) || closedEmpty > closedEmptyBaseline {
-		return messages, closedEmpty, true
+	dataFrameSeen, closedEmpty = p.wsRSV1Outcome(marker)
+	if dataFrameSeen || closedEmpty {
+		return dataFrameSeen, closedEmpty, true
 	}
 	deadline := time.NewTimer(time.Second)
 	ticker := time.NewTicker(5 * time.Millisecond)
@@ -760,13 +756,13 @@ func (p *ProxyAdapter) waitForRSV1FixtureOutcome(messageBaseline, closedEmptyBas
 	for {
 		select {
 		case <-ticker.C:
-			messages = p.wsUpstreamMessages()
-			closedEmpty = p.wsRSV1ClosedEmpty()
-			if messages-messageBaseline >= int64(expected) || closedEmpty > closedEmptyBaseline {
-				return messages, closedEmpty, true
+			dataFrameSeen, closedEmpty = p.wsRSV1Outcome(marker)
+			if dataFrameSeen || closedEmpty {
+				return dataFrameSeen, closedEmpty, true
 			}
 		case <-deadline.C:
-			return p.wsUpstreamMessages(), p.wsRSV1ClosedEmpty(), false
+			dataFrameSeen, closedEmpty = p.wsRSV1Outcome(marker)
+			return dataFrameSeen, closedEmpty, false
 		}
 	}
 }

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -90,9 +90,9 @@ type ProxyAdapter struct {
 	wsUntrustedAddr string        // untrusted WS fixture for reserved sink cases
 	responseRouteID atomic.Uint64 // unique low-entropy response fixture route
 
-	wsUpstreamMessages   func() int64              // runner-managed WS fixture message counter
-	wsRSV1Outcome        func(string) (bool, bool) // marked permissive-fixture outcome
-	mcpHTTPUpstreamCalls func() int64              // runner-managed MCP HTTP fixture request counter
+	wsUpstreamMessages   func() int64             // runner-managed WS fixture message counter
+	wsRSV1Outcome        func(string) (int, bool) // marked permissive-fixture outcome
+	mcpHTTPUpstreamCalls func() int64             // runner-managed MCP HTTP fixture request counter
 	mcpHTTPFixture       *fixture.MCPHTTPFixture
 }
 
@@ -221,7 +221,7 @@ func (p *ProxyAdapter) SetWSUpstreamMessageCounter(counter func() int64) {
 
 // SetWSRSV1Outcome lets the adapter distinguish a proxy rejection from a
 // destination that received the marked RSV1 frame and then closed.
-func (p *ProxyAdapter) SetWSRSV1Outcome(outcome func(string) (bool, bool)) {
+func (p *ProxyAdapter) SetWSRSV1Outcome(outcome func(string) (int, bool)) {
 	p.wsRSV1Outcome = outcome
 }
 
@@ -423,6 +423,7 @@ func (p *ProxyAdapter) runResponseContentViaFetchProxy(c Case, timeout time.Dura
 // runWebSocketFrameViaProxy performs a real WebSocket upgrade through the
 // proxy and writes the corpus frames on the proxied connection.
 func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) Result {
+	runDeadline := time.Now().Add(timeout)
 	targetURL, _ := payloadString(c.Payload, "url")
 	if targetURL == "" {
 		return Result{Err: fmt.Errorf("case %s: payload missing 'url'", c.ID)}
@@ -442,7 +443,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 	}
 	defer func() { _ = conn.Close() }()
 
-	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+	if err := conn.SetDeadline(runDeadline); err != nil {
 		return Result{Err: fmt.Errorf("case %s: ws deadline: %w", c.ID, err)}
 	}
 	br := bufio.NewReader(conn)
@@ -488,6 +489,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		}
 	}
 	expectedUpstreamMessages := countCorpusWebSocketMessages(frames)
+	expectedRSV1Frames := countCorpusRSV1Frames(frames)
 	upstreamBefore, _ := p.webSocketUpstreamMessageCount()
 	for _, raw := range frames {
 		frame, _ := raw.(map[string]interface{})
@@ -514,7 +516,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 	// Budget: the first frame gets the full timeout (proxy may need time to
 	// reassemble fragments and run scanners). Subsequent reads use a short
 	// idle window so allow-cases don't pay the full timeout per case.
-	firstReadDeadline := time.Now().Add(timeout)
+	firstReadDeadline := runDeadline
 	const idleWindow = 500 * time.Millisecond
 	var lastFrame struct {
 		opcode       int
@@ -570,9 +572,9 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 			closeCode, policyClose := webSocketCloseCode(payload)
 			if !policyClose {
 				if closeCode == wsCloseProtocolError && permissiveRSV1Fixture {
-					dataFrameSeen, closedEmpty, terminalProof := p.waitForRSV1FixtureOutcome(rsv1Marker)
+					markedRSV1Frames, terminalClose, terminalProof := p.waitForRSV1FixtureOutcome(rsv1Marker, expectedRSV1Frames, runDeadline)
 					upstreamAfter, _ := p.webSocketUpstreamMessageCount()
-					if terminalProof && dataFrameSeen {
+					if terminalProof && markedRSV1Frames >= expectedRSV1Frames {
 						return Result{
 							Verdict: "skip",
 							Evidence: map[string]interface{}{
@@ -583,7 +585,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 							},
 						}
 					}
-					if terminalProof && closedEmpty {
+					if terminalProof && terminalClose && markedRSV1Frames < expectedRSV1Frames {
 						return Result{
 							Verdict: "block",
 							Evidence: map[string]interface{}{
@@ -730,6 +732,17 @@ func corpusUsesRSV1(payload map[string]interface{}) bool {
 	return false
 }
 
+func countCorpusRSV1Frames(frames []interface{}) int {
+	count := 0
+	for _, raw := range frames {
+		frame, _ := raw.(map[string]interface{})
+		if rsv1, _ := frame["rsv1"].(bool); rsv1 {
+			count++
+		}
+	}
+	return count
+}
+
 func webSocketURLWithPath(rawURL, path string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -741,28 +754,32 @@ func webSocketURLWithPath(rawURL, path string) string {
 	return u.String()
 }
 
-func (p *ProxyAdapter) waitForRSV1FixtureOutcome(marker string) (dataFrameSeen, closedEmpty, proven bool) {
+func (p *ProxyAdapter) waitForRSV1FixtureOutcome(marker string, expectedRSV1Frames int, runDeadline time.Time) (markedRSV1Frames int, terminalClose, proven bool) {
 	if p.wsRSV1Outcome == nil {
-		return false, false, false
+		return 0, false, false
 	}
-	dataFrameSeen, closedEmpty = p.wsRSV1Outcome(marker)
-	if dataFrameSeen || closedEmpty {
-		return dataFrameSeen, closedEmpty, true
+	markedRSV1Frames, terminalClose = p.wsRSV1Outcome(marker)
+	if markedRSV1Frames >= expectedRSV1Frames || terminalClose {
+		return markedRSV1Frames, terminalClose, true
 	}
-	deadline := time.NewTimer(time.Second)
+	remaining := time.Until(runDeadline)
+	if remaining <= 0 {
+		return markedRSV1Frames, terminalClose, false
+	}
+	deadline := time.NewTimer(remaining)
 	ticker := time.NewTicker(5 * time.Millisecond)
 	defer deadline.Stop()
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			dataFrameSeen, closedEmpty = p.wsRSV1Outcome(marker)
-			if dataFrameSeen || closedEmpty {
-				return dataFrameSeen, closedEmpty, true
+			markedRSV1Frames, terminalClose = p.wsRSV1Outcome(marker)
+			if markedRSV1Frames >= expectedRSV1Frames || terminalClose {
+				return markedRSV1Frames, terminalClose, true
 			}
 		case <-deadline.C:
-			dataFrameSeen, closedEmpty = p.wsRSV1Outcome(marker)
-			return dataFrameSeen, closedEmpty, false
+			markedRSV1Frames, terminalClose = p.wsRSV1Outcome(marker)
+			return markedRSV1Frames, terminalClose, false
 		}
 	}
 }

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -1968,18 +1968,24 @@ func TestRunWebSocketFrameViaProxy_RSV1CloseRequiresTerminalFixtureProof(t *test
 	for _, tc := range []struct {
 		name              string
 		targetURL         string
-		dataFrameSeen     bool
-		closedEmpty       bool
-		staleClosedEmpty  bool
+		markedRSV1Frames  int
+		terminalClose     bool
+		staleClose        bool
 		provideOutcome    bool
+		frames            []interface{}
+		runTimeout        time.Duration
+		maxElapsed        time.Duration
 		wantVerdict       string
 		wantReason        string
 		wantDeliveryProof bool
 	}{
-		{name: "proxy rejects before upstream", targetURL: "wss://example.com/ws", closedEmpty: true, provideOutcome: true, wantVerdict: "block", wantReason: "rsv1_rejected_before_permissive_upstream", wantDeliveryProof: true},
-		{name: "upstream saw frame", targetURL: "wss://example.com/ws", dataFrameSeen: true, provideOutcome: true, wantVerdict: "skip", wantReason: "rsv1_reached_permissive_upstream"},
-		{name: "external destination stays unproven", targetURL: "wss://outside.invalid/ws", closedEmpty: true, provideOutcome: true, wantVerdict: "skip", wantReason: "ws_close_not_policy_violation"},
-		{name: "stale close for another marker stays unproven", targetURL: "wss://example.com/ws", staleClosedEmpty: true, provideOutcome: true, wantVerdict: "skip", wantReason: "rsv1_fixture_terminal_unproven"},
+		{name: "proxy rejects before marked frame reaches upstream", targetURL: "wss://example.com/ws", terminalClose: true, provideOutcome: true, wantVerdict: "block", wantReason: "rsv1_rejected_before_permissive_upstream", wantDeliveryProof: true},
+		{name: "marked frame reached upstream", targetURL: "wss://example.com/ws", markedRSV1Frames: 1, provideOutcome: true, wantVerdict: "skip", wantReason: "rsv1_reached_permissive_upstream"},
+		{name: "ordinary frame before rejected marked frame still blocks", targetURL: "wss://example.com/ws", terminalClose: true, provideOutcome: true, frames: []interface{}{map[string]interface{}{"opcode": "text", "payload": "ordinary"}, map[string]interface{}{"opcode": "text", "payload": "probe", "rsv1": true}}, wantVerdict: "block", wantReason: "rsv1_rejected_before_permissive_upstream", wantDeliveryProof: true},
+		{name: "one of two marked frames reaching upstream still blocks", targetURL: "wss://example.com/ws", markedRSV1Frames: 1, terminalClose: true, provideOutcome: true, frames: []interface{}{map[string]interface{}{"opcode": "text", "payload": "first", "rsv1": true}, map[string]interface{}{"opcode": "text", "payload": "second", "rsv1": true}}, wantVerdict: "block", wantReason: "rsv1_rejected_before_permissive_upstream", wantDeliveryProof: true},
+		{name: "external destination stays unproven", targetURL: "wss://outside.invalid/ws", terminalClose: true, provideOutcome: true, wantVerdict: "skip", wantReason: "ws_close_not_policy_violation"},
+		{name: "stale close for another marker stays unproven", targetURL: "wss://example.com/ws", staleClose: true, provideOutcome: true, runTimeout: 40 * time.Millisecond, maxElapsed: 250 * time.Millisecond, wantVerdict: "skip", wantReason: "rsv1_fixture_terminal_unproven"},
+		{name: "pre-upstream rejection without positive fixture proof stays unproven", targetURL: "wss://example.com/ws", provideOutcome: true, runTimeout: 40 * time.Millisecond, maxElapsed: 250 * time.Millisecond, wantVerdict: "skip", wantReason: "rsv1_fixture_terminal_unproven"},
 		{name: "terminal fixture proof unavailable", targetURL: "wss://example.com/ws", wantVerdict: "skip", wantReason: "rsv1_fixture_terminal_unproven"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2014,22 +2020,34 @@ func TestRunWebSocketFrameViaProxy_RSV1CloseRequiresTerminalFixtureProof(t *test
 			a.SetWSFixture("127.0.0.1:9")
 			a.SetWSUpstreamMessageCounter(upstreamMessages.Load)
 			if tc.provideOutcome {
-				a.SetWSRSV1Outcome(func(marker string) (bool, bool) {
-					if tc.staleClosedEmpty {
-						return false, marker == "stale"
+				a.SetWSRSV1Outcome(func(marker string) (int, bool) {
+					if tc.staleClose {
+						return 0, marker == "stale"
 					}
-					return tc.dataFrameSeen, tc.closedEmpty
+					return tc.markedRSV1Frames, tc.terminalClose
 				})
+			}
+			runTimeout := tc.runTimeout
+			if runTimeout == 0 {
+				runTimeout = time.Second
+			}
+			started := time.Now()
+			frames := tc.frames
+			if len(frames) == 0 {
+				frames = []interface{}{
+					map[string]interface{}{"opcode": "text", "payload": "probe", "rsv1": true},
+				}
 			}
 			result := a.Run(Case{
 				ID: "ws-rsv1-attribution", Transport: "websocket", InputType: "websocket_frame",
 				Payload: map[string]interface{}{
-					"url": tc.targetURL,
-					"frames": []interface{}{
-						map[string]interface{}{"opcode": "text", "payload": "probe", "rsv1": true},
-					},
+					"url":    tc.targetURL,
+					"frames": frames,
 				},
-			}, time.Second)
+			}, runTimeout)
+			if tc.maxElapsed > 0 && time.Since(started) > tc.maxElapsed {
+				t.Fatalf("run exceeded attribution budget: elapsed %s, max %s", time.Since(started), tc.maxElapsed)
+			}
 			if result.Err != nil || result.Verdict != tc.wantVerdict {
 				t.Fatalf("result = %+v, want verdict %q", result, tc.wantVerdict)
 			}
@@ -2049,7 +2067,7 @@ func TestRunWebSocketFrameViaProxy_RSV1CloseRequiresTerminalFixtureProof(t *test
 // runner-owned /permissive-rsv1 endpoint, then simulates a product block by
 // closing the upstream connection before the RSV1 frame is delivered and
 // returning close 1002. The block may only be credited because the real fixture
-// positively recorded a terminal empty close.
+// positively recorded that the connection closed before the marked frame.
 func TestRunWebSocketFrameViaProxy_RSV1BlockUsesRealFixtureProof(t *testing.T) {
 	wsf, err := fixture.StartWS()
 	if err != nil {
@@ -2104,8 +2122,8 @@ func TestRunWebSocketFrameViaProxy_RSV1BlockUsesRealFixtureProof(t *testing.T) {
 			_ = up.Close()
 			return
 		}
-		// Terminate the upstream connection empty: the fixture records a
-		// terminal close before any data frame reached it.
+		// Terminate the upstream connection before forwarding the marked RSV1
+		// frame: the fixture records a marker-specific terminal outcome.
 		_ = up.Close()
 		payload := append([]byte{0x03, 0xea}, []byte("compressed frames not supported")...)
 		_ = writeServerWebSocketFrame(conn, wsOpcodeClose, payload)

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -1968,20 +1968,22 @@ func TestRunWebSocketFrameViaProxy_RSV1CloseRequiresTerminalFixtureProof(t *test
 	for _, tc := range []struct {
 		name              string
 		targetURL         string
-		markUpstream      bool
-		markClosedEmpty   bool
-		provideTerminal   bool
+		dataFrameSeen     bool
+		closedEmpty       bool
+		staleClosedEmpty  bool
+		provideOutcome    bool
 		wantVerdict       string
+		wantReason        string
 		wantDeliveryProof bool
 	}{
-		{name: "proxy rejects before upstream", targetURL: "wss://example.com/ws", markClosedEmpty: true, provideTerminal: true, wantVerdict: "block", wantDeliveryProof: true},
-		{name: "upstream saw frame", targetURL: "wss://example.com/ws", markUpstream: true, provideTerminal: true, wantVerdict: "skip"},
-		{name: "external destination stays unproven", targetURL: "wss://outside.invalid/ws", markClosedEmpty: true, provideTerminal: true, wantVerdict: "skip"},
-		{name: "terminal fixture proof unavailable", targetURL: "wss://example.com/ws", wantVerdict: "skip"},
+		{name: "proxy rejects before upstream", targetURL: "wss://example.com/ws", closedEmpty: true, provideOutcome: true, wantVerdict: "block", wantReason: "rsv1_rejected_before_permissive_upstream", wantDeliveryProof: true},
+		{name: "upstream saw frame", targetURL: "wss://example.com/ws", dataFrameSeen: true, provideOutcome: true, wantVerdict: "skip", wantReason: "rsv1_reached_permissive_upstream"},
+		{name: "external destination stays unproven", targetURL: "wss://outside.invalid/ws", closedEmpty: true, provideOutcome: true, wantVerdict: "skip", wantReason: "ws_close_not_policy_violation"},
+		{name: "stale close for another marker stays unproven", targetURL: "wss://example.com/ws", staleClosedEmpty: true, provideOutcome: true, wantVerdict: "skip", wantReason: "rsv1_fixture_terminal_unproven"},
+		{name: "terminal fixture proof unavailable", targetURL: "wss://example.com/ws", wantVerdict: "skip", wantReason: "rsv1_fixture_terminal_unproven"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var upstreamMessages atomic.Int64
-			var closedEmpty atomic.Int64
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				hj := w.(http.Hijacker)
 				conn, rw, err := hj.Hijack()
@@ -1998,12 +2000,6 @@ func TestRunWebSocketFrameViaProxy_RSV1CloseRequiresTerminalFixtureProof(t *test
 					t.Errorf("read websocket frame: %v", err)
 					return
 				}
-				if tc.markUpstream {
-					upstreamMessages.Add(1)
-				}
-				if tc.markClosedEmpty {
-					closedEmpty.Add(1)
-				}
 				payload := append([]byte{0x03, 0xea}, []byte("compressed frames not supported")...)
 				if err := writeServerWebSocketFrame(conn, wsOpcodeClose, payload); err != nil {
 					t.Errorf("write close frame: %v", err)
@@ -2017,8 +2013,13 @@ func TestRunWebSocketFrameViaProxy_RSV1CloseRequiresTerminalFixtureProof(t *test
 			}
 			a.SetWSFixture("127.0.0.1:9")
 			a.SetWSUpstreamMessageCounter(upstreamMessages.Load)
-			if tc.provideTerminal {
-				a.SetWSRSV1ClosedBeforeMessageCounter(closedEmpty.Load)
+			if tc.provideOutcome {
+				a.SetWSRSV1Outcome(func(marker string) (bool, bool) {
+					if tc.staleClosedEmpty {
+						return false, marker == "stale"
+					}
+					return tc.dataFrameSeen, tc.closedEmpty
+				})
 			}
 			result := a.Run(Case{
 				ID: "ws-rsv1-attribution", Transport: "websocket", InputType: "websocket_frame",
@@ -2035,14 +2036,8 @@ func TestRunWebSocketFrameViaProxy_RSV1CloseRequiresTerminalFixtureProof(t *test
 			if result.DeliveryProven != tc.wantDeliveryProof || result.VerdictObserved != tc.wantDeliveryProof {
 				t.Fatalf("proof = delivery:%v verdict:%v, want %v", result.DeliveryProven, result.VerdictObserved, tc.wantDeliveryProof)
 			}
-			if tc.wantVerdict == "block" && result.Evidence["reason"] != "rsv1_rejected_before_permissive_upstream" {
-				t.Fatalf("reason = %q", result.Evidence["reason"])
-			}
-			if tc.markUpstream && result.Evidence["reason"] != "rsv1_reached_permissive_upstream" {
-				t.Fatalf("upstream-delivered reason = %q", result.Evidence["reason"])
-			}
-			if !tc.provideTerminal && result.Evidence["reason"] != "rsv1_fixture_terminal_unproven" {
-				t.Fatalf("missing-terminal reason = %q", result.Evidence["reason"])
+			if result.Evidence["reason"] != tc.wantReason {
+				t.Fatalf("reason = %q, want %q", result.Evidence["reason"], tc.wantReason)
 			}
 		})
 	}
@@ -2075,7 +2070,12 @@ func TestRunWebSocketFrameViaProxy_RSV1BlockUsesRealFixtureProof(t *testing.T) {
 		}
 		defer conn.Close() //nolint:errcheck // test cleanup
 		br := bufio.NewReader(conn)
-		if _, err := http.ReadRequest(br); err != nil {
+		upgradeReq, err := http.ReadRequest(br)
+		if err != nil {
+			return
+		}
+		targetURL, err := url.Parse(upgradeReq.URL.Query().Get("url"))
+		if err != nil {
 			return
 		}
 		// Relay the upgrade to the real permissive fixture so a genuine upstream
@@ -2084,15 +2084,17 @@ func TestRunWebSocketFrameViaProxy_RSV1BlockUsesRealFixtureProof(t *testing.T) {
 		if err != nil {
 			return
 		}
-		if _, err := fmt.Fprint(up,
-			"GET /permissive-rsv1 HTTP/1.1\r\nHost: fixture\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"); err != nil {
+		if _, err := fmt.Fprintf(up,
+			"GET %s HTTP/1.1\r\nHost: fixture\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n", targetURL.RequestURI()); err != nil {
 			_ = up.Close()
 			return
 		}
-		if _, err := http.ReadResponse(bufio.NewReader(up), &http.Request{Method: http.MethodGet}); err != nil {
+		upResp, err := http.ReadResponse(bufio.NewReader(up), &http.Request{Method: http.MethodGet})
+		if err != nil {
 			_ = up.Close()
 			return
 		}
+		_ = upResp.Body.Close()
 		if _, err := fmt.Fprint(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"); err != nil {
 			_ = up.Close()
 			return
@@ -2115,7 +2117,7 @@ func TestRunWebSocketFrameViaProxy_RSV1BlockUsesRealFixtureProof(t *testing.T) {
 	}
 	a.SetWSFixture(wsf.Addr())
 	a.SetWSUpstreamMessageCounter(wsf.Messages)
-	a.SetWSRSV1ClosedBeforeMessageCounter(wsf.RSV1ClosedBeforeMessage)
+	a.SetWSRSV1Outcome(wsf.RSV1Outcome)
 
 	result := a.Run(Case{
 		ID: "ws-rsv1-real-fixture", Transport: "websocket", InputType: "websocket_frame",
@@ -2138,9 +2140,6 @@ func TestRunWebSocketFrameViaProxy_RSV1BlockUsesRealFixtureProof(t *testing.T) {
 	}
 	if result.Evidence["reason"] != "rsv1_rejected_before_permissive_upstream" {
 		t.Fatalf("reason = %q", result.Evidence["reason"])
-	}
-	if got := wsf.RSV1ClosedBeforeMessage(); got == 0 {
-		t.Fatalf("real fixture recorded no terminal empty close; got %d", got)
 	}
 	if got := wsf.Messages(); got != 0 {
 		t.Fatalf("frame reached upstream unexpectedly; messages = %d", got)

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -1964,6 +1964,189 @@ func TestRunWebSocketFrameViaProxy_CloseFrameBlocks(t *testing.T) {
 	}
 }
 
+func TestRunWebSocketFrameViaProxy_RSV1CloseRequiresTerminalFixtureProof(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		targetURL         string
+		markUpstream      bool
+		markClosedEmpty   bool
+		provideTerminal   bool
+		wantVerdict       string
+		wantDeliveryProof bool
+	}{
+		{name: "proxy rejects before upstream", targetURL: "wss://example.com/ws", markClosedEmpty: true, provideTerminal: true, wantVerdict: "block", wantDeliveryProof: true},
+		{name: "upstream saw frame", targetURL: "wss://example.com/ws", markUpstream: true, provideTerminal: true, wantVerdict: "skip"},
+		{name: "external destination stays unproven", targetURL: "wss://outside.invalid/ws", markClosedEmpty: true, provideTerminal: true, wantVerdict: "skip"},
+		{name: "terminal fixture proof unavailable", targetURL: "wss://example.com/ws", wantVerdict: "skip"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var upstreamMessages atomic.Int64
+			var closedEmpty atomic.Int64
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				hj := w.(http.Hijacker)
+				conn, rw, err := hj.Hijack()
+				if err != nil {
+					t.Errorf("hijack: %v", err)
+					return
+				}
+				defer conn.Close() //nolint:errcheck // test cleanup
+				if _, err := fmt.Fprint(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"); err != nil {
+					t.Errorf("write upgrade response: %v", err)
+					return
+				}
+				if _, _, err := readWebSocketFrame(rw.Reader); err != nil {
+					t.Errorf("read websocket frame: %v", err)
+					return
+				}
+				if tc.markUpstream {
+					upstreamMessages.Add(1)
+				}
+				if tc.markClosedEmpty {
+					closedEmpty.Add(1)
+				}
+				payload := append([]byte{0x03, 0xea}, []byte("compressed frames not supported")...)
+				if err := writeServerWebSocketFrame(conn, wsOpcodeClose, payload); err != nil {
+					t.Errorf("write close frame: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			a, err := NewProxyAdapter(srv.Listener.Addr().String(), "", "", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			a.SetWSFixture("127.0.0.1:9")
+			a.SetWSUpstreamMessageCounter(upstreamMessages.Load)
+			if tc.provideTerminal {
+				a.SetWSRSV1ClosedBeforeMessageCounter(closedEmpty.Load)
+			}
+			result := a.Run(Case{
+				ID: "ws-rsv1-attribution", Transport: "websocket", InputType: "websocket_frame",
+				Payload: map[string]interface{}{
+					"url": tc.targetURL,
+					"frames": []interface{}{
+						map[string]interface{}{"opcode": "text", "payload": "probe", "rsv1": true},
+					},
+				},
+			}, time.Second)
+			if result.Err != nil || result.Verdict != tc.wantVerdict {
+				t.Fatalf("result = %+v, want verdict %q", result, tc.wantVerdict)
+			}
+			if result.DeliveryProven != tc.wantDeliveryProof || result.VerdictObserved != tc.wantDeliveryProof {
+				t.Fatalf("proof = delivery:%v verdict:%v, want %v", result.DeliveryProven, result.VerdictObserved, tc.wantDeliveryProof)
+			}
+			if tc.wantVerdict == "block" && result.Evidence["reason"] != "rsv1_rejected_before_permissive_upstream" {
+				t.Fatalf("reason = %q", result.Evidence["reason"])
+			}
+			if tc.markUpstream && result.Evidence["reason"] != "rsv1_reached_permissive_upstream" {
+				t.Fatalf("upstream-delivered reason = %q", result.Evidence["reason"])
+			}
+			if !tc.provideTerminal && result.Evidence["reason"] != "rsv1_fixture_terminal_unproven" {
+				t.Fatalf("missing-terminal reason = %q", result.Evidence["reason"])
+			}
+		})
+	}
+}
+
+// TestRunWebSocketFrameViaProxy_RSV1BlockUsesRealFixtureProof exercises the
+// attribution decision against the real permissive fixture and the real counter
+// wiring, rather than hand-set counters. A fake proxy relays the upgrade to the
+// runner-owned /permissive-rsv1 endpoint, then simulates a product block by
+// closing the upstream connection before the RSV1 frame is delivered and
+// returning close 1002. The block may only be credited because the real fixture
+// positively recorded a terminal empty close.
+func TestRunWebSocketFrameViaProxy_RSV1BlockUsesRealFixtureProof(t *testing.T) {
+	wsf, err := fixture.StartWS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wsf.Close()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close() //nolint:errcheck // test cleanup
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close() //nolint:errcheck // test cleanup
+		br := bufio.NewReader(conn)
+		if _, err := http.ReadRequest(br); err != nil {
+			return
+		}
+		// Relay the upgrade to the real permissive fixture so a genuine upstream
+		// connection exists, then block before forwarding the client's frame.
+		up, err := net.Dial("tcp", wsf.Addr())
+		if err != nil {
+			return
+		}
+		if _, err := fmt.Fprint(up,
+			"GET /permissive-rsv1 HTTP/1.1\r\nHost: fixture\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"); err != nil {
+			_ = up.Close()
+			return
+		}
+		if _, err := http.ReadResponse(bufio.NewReader(up), &http.Request{Method: http.MethodGet}); err != nil {
+			_ = up.Close()
+			return
+		}
+		if _, err := fmt.Fprint(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"); err != nil {
+			_ = up.Close()
+			return
+		}
+		// Consume the adapter's RSV1 frame but do NOT forward it upstream.
+		if _, _, err := readWebSocketFrame(br); err != nil {
+			_ = up.Close()
+			return
+		}
+		// Terminate the upstream connection empty: the fixture records a
+		// terminal close before any data frame reached it.
+		_ = up.Close()
+		payload := append([]byte{0x03, 0xea}, []byte("compressed frames not supported")...)
+		_ = writeServerWebSocketFrame(conn, wsOpcodeClose, payload)
+	}()
+
+	a, err := NewProxyAdapter(ln.Addr().String(), "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.SetWSFixture(wsf.Addr())
+	a.SetWSUpstreamMessageCounter(wsf.Messages)
+	a.SetWSRSV1ClosedBeforeMessageCounter(wsf.RSV1ClosedBeforeMessage)
+
+	result := a.Run(Case{
+		ID: "ws-rsv1-real-fixture", Transport: "websocket", InputType: "websocket_frame",
+		Payload: map[string]interface{}{
+			"url": "wss://example.com/ws",
+			"frames": []interface{}{
+				map[string]interface{}{"opcode": "text", "payload": "probe", "rsv1": true},
+			},
+		},
+	}, 3*time.Second)
+
+	if result.Err != nil {
+		t.Fatalf("unexpected error: %v", result.Err)
+	}
+	if result.Verdict != "block" {
+		t.Fatalf("verdict = %q, want block (evidence %+v)", result.Verdict, result.Evidence)
+	}
+	if !result.DeliveryProven || !result.VerdictObserved {
+		t.Fatalf("proof = delivery:%v verdict:%v, want both true", result.DeliveryProven, result.VerdictObserved)
+	}
+	if result.Evidence["reason"] != "rsv1_rejected_before_permissive_upstream" {
+		t.Fatalf("reason = %q", result.Evidence["reason"])
+	}
+	if got := wsf.RSV1ClosedBeforeMessage(); got == 0 {
+		t.Fatalf("real fixture recorded no terminal empty close; got %d", got)
+	}
+	if got := wsf.Messages(); got != 0 {
+		t.Fatalf("frame reached upstream unexpectedly; messages = %d", got)
+	}
+}
+
 func TestRunWebSocketFrameViaProxy_ProtocolCloseIsUnproven(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/runner/fixture/ws.go
+++ b/runner/fixture/ws.go
@@ -30,8 +30,8 @@ type WSFixture struct {
 }
 
 type rsv1Outcome struct {
-	dataFrameSeen bool
-	closedEmpty   bool
+	markedRSV1Frames int
+	terminalClose    bool
 }
 
 type wsFixtureMessage struct {
@@ -80,12 +80,13 @@ func (f *WSFixture) WSURL() string {
 // Messages returns the number of application messages that reached the fixture.
 func (f *WSFixture) Messages() int64 { return f.messages.Load() }
 
-// RSV1Outcome returns runner-owned evidence for one marked permissive connection.
-func (f *WSFixture) RSV1Outcome(marker string) (dataFrameSeen, closedEmpty bool) {
+// RSV1Outcome returns how many marked RSV1 frames reached one permissive
+// connection and whether that upgraded connection reached a terminal close.
+func (f *WSFixture) RSV1Outcome(marker string) (markedRSV1Frames int, terminalClose bool) {
 	f.rsv1Mu.RLock()
 	defer f.rsv1Mu.RUnlock()
 	outcome := f.rsv1Outcomes[marker]
-	return outcome.dataFrameSeen, outcome.closedEmpty
+	return outcome.markedRSV1Frames, outcome.terminalClose
 }
 
 // StartWS creates and starts a WebSocket echo server on a random port.
@@ -117,7 +118,7 @@ func StartWS() (*WSFixture, error) {
 	// was not negotiated. That makes it unsuitable as an attribution fixture:
 	// close 1002 could then come from either the proxy or the destination. This
 	// deliberately permissive endpoint accepts the raw frame instead and records
-	// whether each connection terminated before any data reached it.
+	// whether the marked RSV1 frame reached its exact connection.
 	mux.HandleFunc("/permissive-rsv1/", f.servePermissiveRSV1)
 	// Health check for readiness.
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
@@ -149,11 +150,10 @@ func (f *WSFixture) servePermissiveRSV1(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	defer conn.Close() //nolint:errcheck // fixture connection cleanup
-	dataFrameSeen := false
 	handshakeComplete := false
 	defer func() {
-		if handshakeComplete && !dataFrameSeen {
-			f.recordRSV1ClosedEmpty(marker)
+		if handshakeComplete {
+			f.recordRSV1TerminalClose(marker)
 		}
 	}()
 	acceptInput := []byte(key + webSocketGUID)
@@ -170,18 +170,20 @@ func (f *WSFixture) servePermissiveRSV1(w http.ResponseWriter, r *http.Request) 
 		if err := conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
 			return
 		}
-		opcode, fin, payload, err := readPermissiveClientFrame(rw.Reader)
-		if err != nil || opcode == 8 {
+		opcode, fin, rsv1, payload, err := readPermissiveClientFrame(rw.Reader)
+		if err != nil {
+			return
+		}
+		if rsv1 {
+			f.recordMarkedRSV1(marker)
+		}
+		if opcode == 8 {
 			return
 		}
 		switch opcode {
 		case 1, 2:
 			if fragmentedOpcode != 0 {
 				return
-			}
-			if !dataFrameSeen {
-				dataFrameSeen = true
-				f.recordRSV1DataFrame(marker)
 			}
 			if !fin {
 				fragmentedOpcode = opcode
@@ -191,10 +193,6 @@ func (f *WSFixture) servePermissiveRSV1(w http.ResponseWriter, r *http.Request) 
 		case 0:
 			if fragmentedOpcode == 0 {
 				return
-			}
-			if !dataFrameSeen {
-				dataFrameSeen = true
-				f.recordRSV1DataFrame(marker)
 			}
 			if len(fragmentedPayload)+len(payload) > 1<<20 {
 				return
@@ -217,42 +215,43 @@ func (f *WSFixture) servePermissiveRSV1(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-func (f *WSFixture) recordRSV1DataFrame(marker string) {
+func (f *WSFixture) recordMarkedRSV1(marker string) {
 	f.rsv1Mu.Lock()
 	outcome := f.rsv1Outcomes[marker]
-	outcome.dataFrameSeen = true
+	outcome.markedRSV1Frames++
 	f.rsv1Outcomes[marker] = outcome
 	f.rsv1Mu.Unlock()
 }
 
-func (f *WSFixture) recordRSV1ClosedEmpty(marker string) {
+func (f *WSFixture) recordRSV1TerminalClose(marker string) {
 	f.rsv1Mu.Lock()
 	outcome := f.rsv1Outcomes[marker]
-	outcome.closedEmpty = true
+	outcome.terminalClose = true
 	f.rsv1Outcomes[marker] = outcome
 	f.rsv1Mu.Unlock()
 }
 
-func readPermissiveClientFrame(r *bufio.Reader) (byte, bool, []byte, error) {
+func readPermissiveClientFrame(r *bufio.Reader) (byte, bool, bool, []byte, error) {
 	header := make([]byte, 2)
 	if _, err := io.ReadFull(r, header); err != nil {
-		return 0, false, nil, err
+		return 0, false, false, nil, err
 	}
 	opcode := header[0] & 0x0f
 	fin := header[0]&0x80 != 0
+	rsv1 := header[0]&0x40 != 0
 	masked := header[1]&0x80 != 0
 	payloadLen := uint64(header[1] & 0x7f)
 	switch payloadLen {
 	case 126:
 		ext := make([]byte, 2)
 		if _, err := io.ReadFull(r, ext); err != nil {
-			return 0, false, nil, err
+			return 0, false, false, nil, err
 		}
 		payloadLen = uint64(ext[0])<<8 | uint64(ext[1])
 	case 127:
 		ext := make([]byte, 8)
 		if _, err := io.ReadFull(r, ext); err != nil {
-			return 0, false, nil, err
+			return 0, false, false, nil, err
 		}
 		payloadLen = 0
 		for _, b := range ext {
@@ -260,20 +259,20 @@ func readPermissiveClientFrame(r *bufio.Reader) (byte, bool, []byte, error) {
 		}
 	}
 	if !masked || payloadLen > 1<<20 {
-		return 0, false, nil, fmt.Errorf("invalid fixture frame")
+		return 0, false, false, nil, fmt.Errorf("invalid fixture frame")
 	}
 	mask := make([]byte, 4)
 	if _, err := io.ReadFull(r, mask); err != nil {
-		return 0, false, nil, err
+		return 0, false, false, nil, err
 	}
 	payload := make([]byte, payloadLen)
 	if _, err := io.ReadFull(r, payload); err != nil {
-		return 0, false, nil, err
+		return 0, false, false, nil, err
 	}
 	for i := range payload {
 		payload[i] ^= mask[i%len(mask)]
 	}
-	return opcode, fin, payload, nil
+	return opcode, fin, rsv1, payload, nil
 }
 
 func writePermissiveServerFrame(w io.Writer, opcode byte, payload []byte) error {

--- a/runner/fixture/ws.go
+++ b/runner/fixture/ws.go
@@ -1,7 +1,11 @@
 package fixture
 
 import (
+	"bufio"
+	"crypto/sha1" //nolint:gosec // WebSocket RFC 6455 mandates SHA-1 for the upgrade accept value.
+	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"sync/atomic"
@@ -19,6 +23,7 @@ type WSFixture struct {
 	server            *http.Server
 	untrustedServer   *http.Server
 	messages          atomic.Int64
+	rsv1ClosedEmpty   atomic.Int64
 }
 
 type wsFixtureMessage struct {
@@ -67,6 +72,10 @@ func (f *WSFixture) WSURL() string {
 // Messages returns the number of application messages that reached the fixture.
 func (f *WSFixture) Messages() int64 { return f.messages.Load() }
 
+// RSV1ClosedBeforeMessage returns the number of permissive RSV1 fixture
+// connections that reached a terminal close without receiving a data frame.
+func (f *WSFixture) RSV1ClosedBeforeMessage() int64 { return f.rsv1ClosedEmpty.Load() }
+
 // StartWS creates and starts a WebSocket echo server on a random port.
 func StartWS() (*WSFixture, error) {
 	ln, untrustedLn, err := listenLoopbackPair()
@@ -91,6 +100,12 @@ func StartWS() (*WSFixture, error) {
 			}
 		}
 	}))
+	// The ordinary WebSocket library correctly rejects RSV1 when compression
+	// was not negotiated. That makes it unsuitable as an attribution fixture:
+	// close 1002 could then come from either the proxy or the destination. This
+	// deliberately permissive endpoint accepts the raw frame instead and records
+	// whether each connection terminated before any data reached it.
+	mux.HandleFunc("/permissive-rsv1", f.servePermissiveRSV1)
 	// Health check for readiness.
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, "ok")
@@ -104,6 +119,108 @@ func StartWS() (*WSFixture, error) {
 	go func() { _ = f.server.Serve(ln) }()
 	go func() { _ = f.untrustedServer.Serve(untrustedLn) }()
 	return f, nil
+}
+
+const webSocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+func (f *WSFixture) servePermissiveRSV1(w http.ResponseWriter, r *http.Request) {
+	key := r.Header.Get("Sec-WebSocket-Key")
+	hijacker, ok := w.(http.Hijacker)
+	if key == "" || !ok {
+		http.Error(w, "websocket upgrade required", http.StatusBadRequest)
+		return
+	}
+	conn, rw, err := hijacker.Hijack()
+	if err != nil {
+		return
+	}
+	defer conn.Close() //nolint:errcheck // fixture connection cleanup
+	receivedMessage := false
+	defer func() {
+		if !receivedMessage {
+			f.rsv1ClosedEmpty.Add(1)
+		}
+	}()
+	acceptInput := []byte(key + webSocketGUID)
+	acceptSum := sha1.Sum(acceptInput) //nolint:gosec // Required by RFC 6455, not used for security.
+	if _, err := fmt.Fprintf(conn,
+		"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n",
+		base64.StdEncoding.EncodeToString(acceptSum[:])); err != nil {
+		return
+	}
+	for {
+		opcode, payload, err := readPermissiveClientFrame(rw.Reader)
+		if err != nil || opcode == 8 {
+			return
+		}
+		if opcode != 1 && opcode != 2 {
+			continue
+		}
+		receivedMessage = true
+		f.messages.Add(1)
+		if err := writePermissiveServerFrame(conn, opcode, payload); err != nil {
+			return
+		}
+	}
+}
+
+func readPermissiveClientFrame(r *bufio.Reader) (byte, []byte, error) {
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return 0, nil, err
+	}
+	opcode := header[0] & 0x0f
+	masked := header[1]&0x80 != 0
+	payloadLen := uint64(header[1] & 0x7f)
+	switch payloadLen {
+	case 126:
+		ext := make([]byte, 2)
+		if _, err := io.ReadFull(r, ext); err != nil {
+			return 0, nil, err
+		}
+		payloadLen = uint64(ext[0])<<8 | uint64(ext[1])
+	case 127:
+		ext := make([]byte, 8)
+		if _, err := io.ReadFull(r, ext); err != nil {
+			return 0, nil, err
+		}
+		payloadLen = 0
+		for _, b := range ext {
+			payloadLen = payloadLen<<8 | uint64(b)
+		}
+	}
+	if !masked || payloadLen > 1<<20 {
+		return 0, nil, fmt.Errorf("invalid fixture frame")
+	}
+	mask := make([]byte, 4)
+	if _, err := io.ReadFull(r, mask); err != nil {
+		return 0, nil, err
+	}
+	payload := make([]byte, payloadLen)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return 0, nil, err
+	}
+	for i := range payload {
+		payload[i] ^= mask[i%len(mask)]
+	}
+	return opcode, payload, nil
+}
+
+func writePermissiveServerFrame(w io.Writer, opcode byte, payload []byte) error {
+	header := []byte{0x80 | opcode}
+	switch {
+	case len(payload) < 126:
+		header = append(header, byte(len(payload)))
+	case len(payload) <= 0xffff:
+		header = append(header, 126, byte(len(payload)>>8), byte(len(payload)))
+	default:
+		return fmt.Errorf("fixture payload too large")
+	}
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
 }
 
 // Close stops both WebSocket listeners.

--- a/runner/fixture/ws.go
+++ b/runner/fixture/ws.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -23,7 +25,13 @@ type WSFixture struct {
 	server            *http.Server
 	untrustedServer   *http.Server
 	messages          atomic.Int64
-	rsv1ClosedEmpty   atomic.Int64
+	rsv1Mu            sync.RWMutex
+	rsv1Outcomes      map[string]rsv1Outcome
+}
+
+type rsv1Outcome struct {
+	dataFrameSeen bool
+	closedEmpty   bool
 }
 
 type wsFixtureMessage struct {
@@ -72,9 +80,13 @@ func (f *WSFixture) WSURL() string {
 // Messages returns the number of application messages that reached the fixture.
 func (f *WSFixture) Messages() int64 { return f.messages.Load() }
 
-// RSV1ClosedBeforeMessage returns the number of permissive RSV1 fixture
-// connections that reached a terminal close without receiving a data frame.
-func (f *WSFixture) RSV1ClosedBeforeMessage() int64 { return f.rsv1ClosedEmpty.Load() }
+// RSV1Outcome returns runner-owned evidence for one marked permissive connection.
+func (f *WSFixture) RSV1Outcome(marker string) (dataFrameSeen, closedEmpty bool) {
+	f.rsv1Mu.RLock()
+	defer f.rsv1Mu.RUnlock()
+	outcome := f.rsv1Outcomes[marker]
+	return outcome.dataFrameSeen, outcome.closedEmpty
+}
 
 // StartWS creates and starts a WebSocket echo server on a random port.
 func StartWS() (*WSFixture, error) {
@@ -86,6 +98,7 @@ func StartWS() (*WSFixture, error) {
 	f := &WSFixture{
 		listener:          ln,
 		untrustedListener: untrustedLn,
+		rsv1Outcomes:      make(map[string]rsv1Outcome),
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/echo", websocket.Handler(func(ws *websocket.Conn) {
@@ -105,7 +118,7 @@ func StartWS() (*WSFixture, error) {
 	// close 1002 could then come from either the proxy or the destination. This
 	// deliberately permissive endpoint accepts the raw frame instead and records
 	// whether each connection terminated before any data reached it.
-	mux.HandleFunc("/permissive-rsv1", f.servePermissiveRSV1)
+	mux.HandleFunc("/permissive-rsv1/", f.servePermissiveRSV1)
 	// Health check for readiness.
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, "ok")
@@ -125,8 +138,9 @@ const webSocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 func (f *WSFixture) servePermissiveRSV1(w http.ResponseWriter, r *http.Request) {
 	key := r.Header.Get("Sec-WebSocket-Key")
+	marker := strings.TrimPrefix(r.URL.Path, "/permissive-rsv1/")
 	hijacker, ok := w.(http.Hijacker)
-	if key == "" || !ok {
+	if key == "" || marker == "" || strings.Contains(marker, "/") || !ok {
 		http.Error(w, "websocket upgrade required", http.StatusBadRequest)
 		return
 	}
@@ -135,10 +149,11 @@ func (f *WSFixture) servePermissiveRSV1(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	defer conn.Close() //nolint:errcheck // fixture connection cleanup
-	receivedMessage := false
+	dataFrameSeen := false
+	handshakeComplete := false
 	defer func() {
-		if !receivedMessage {
-			f.rsv1ClosedEmpty.Add(1)
+		if handshakeComplete && !dataFrameSeen {
+			f.recordRSV1ClosedEmpty(marker)
 		}
 	}()
 	acceptInput := []byte(key + webSocketGUID)
@@ -148,15 +163,53 @@ func (f *WSFixture) servePermissiveRSV1(w http.ResponseWriter, r *http.Request) 
 		base64.StdEncoding.EncodeToString(acceptSum[:])); err != nil {
 		return
 	}
+	handshakeComplete = true
+	var fragmentedOpcode byte
+	var fragmentedPayload []byte
 	for {
-		opcode, payload, err := readPermissiveClientFrame(rw.Reader)
+		if err := conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
+			return
+		}
+		opcode, fin, payload, err := readPermissiveClientFrame(rw.Reader)
 		if err != nil || opcode == 8 {
 			return
 		}
-		if opcode != 1 && opcode != 2 {
+		switch opcode {
+		case 1, 2:
+			if fragmentedOpcode != 0 {
+				return
+			}
+			if !dataFrameSeen {
+				dataFrameSeen = true
+				f.recordRSV1DataFrame(marker)
+			}
+			if !fin {
+				fragmentedOpcode = opcode
+				fragmentedPayload = append(fragmentedPayload[:0], payload...)
+				continue
+			}
+		case 0:
+			if fragmentedOpcode == 0 {
+				return
+			}
+			if !dataFrameSeen {
+				dataFrameSeen = true
+				f.recordRSV1DataFrame(marker)
+			}
+			if len(fragmentedPayload)+len(payload) > 1<<20 {
+				return
+			}
+			fragmentedPayload = append(fragmentedPayload, payload...)
+			if !fin {
+				continue
+			}
+			opcode = fragmentedOpcode
+			payload = fragmentedPayload
+			fragmentedOpcode = 0
+			fragmentedPayload = nil
+		default:
 			continue
 		}
-		receivedMessage = true
 		f.messages.Add(1)
 		if err := writePermissiveServerFrame(conn, opcode, payload); err != nil {
 			return
@@ -164,25 +217,42 @@ func (f *WSFixture) servePermissiveRSV1(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-func readPermissiveClientFrame(r *bufio.Reader) (byte, []byte, error) {
+func (f *WSFixture) recordRSV1DataFrame(marker string) {
+	f.rsv1Mu.Lock()
+	outcome := f.rsv1Outcomes[marker]
+	outcome.dataFrameSeen = true
+	f.rsv1Outcomes[marker] = outcome
+	f.rsv1Mu.Unlock()
+}
+
+func (f *WSFixture) recordRSV1ClosedEmpty(marker string) {
+	f.rsv1Mu.Lock()
+	outcome := f.rsv1Outcomes[marker]
+	outcome.closedEmpty = true
+	f.rsv1Outcomes[marker] = outcome
+	f.rsv1Mu.Unlock()
+}
+
+func readPermissiveClientFrame(r *bufio.Reader) (byte, bool, []byte, error) {
 	header := make([]byte, 2)
 	if _, err := io.ReadFull(r, header); err != nil {
-		return 0, nil, err
+		return 0, false, nil, err
 	}
 	opcode := header[0] & 0x0f
+	fin := header[0]&0x80 != 0
 	masked := header[1]&0x80 != 0
 	payloadLen := uint64(header[1] & 0x7f)
 	switch payloadLen {
 	case 126:
 		ext := make([]byte, 2)
 		if _, err := io.ReadFull(r, ext); err != nil {
-			return 0, nil, err
+			return 0, false, nil, err
 		}
 		payloadLen = uint64(ext[0])<<8 | uint64(ext[1])
 	case 127:
 		ext := make([]byte, 8)
 		if _, err := io.ReadFull(r, ext); err != nil {
-			return 0, nil, err
+			return 0, false, nil, err
 		}
 		payloadLen = 0
 		for _, b := range ext {
@@ -190,20 +260,20 @@ func readPermissiveClientFrame(r *bufio.Reader) (byte, []byte, error) {
 		}
 	}
 	if !masked || payloadLen > 1<<20 {
-		return 0, nil, fmt.Errorf("invalid fixture frame")
+		return 0, false, nil, fmt.Errorf("invalid fixture frame")
 	}
 	mask := make([]byte, 4)
 	if _, err := io.ReadFull(r, mask); err != nil {
-		return 0, nil, err
+		return 0, false, nil, err
 	}
 	payload := make([]byte, payloadLen)
 	if _, err := io.ReadFull(r, payload); err != nil {
-		return 0, nil, err
+		return 0, false, nil, err
 	}
 	for i := range payload {
 		payload[i] ^= mask[i%len(mask)]
 	}
-	return opcode, payload, nil
+	return opcode, fin, payload, nil
 }
 
 func writePermissiveServerFrame(w io.Writer, opcode byte, payload []byte) error {

--- a/runner/fixture/ws_test.go
+++ b/runner/fixture/ws_test.go
@@ -1,0 +1,107 @@
+package fixture
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestWSFixturePermissiveRSV1AcceptsFrame(t *testing.T) {
+	f, err := StartWS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	conn, err := net.DialTimeout("tcp", f.Addr(), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close() //nolint:errcheck // test cleanup
+	if err := conn.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(conn,
+		"GET /permissive-rsv1 HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		f.Addr()); err != nil {
+		t.Fatal(err)
+	}
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want 101", resp.StatusCode)
+	}
+	_ = resp.Body.Close()
+
+	payload := []byte("rsv1 fixture probe")
+	mask := []byte{1, 2, 3, 4}
+	frame := []byte{0xc1, 0x80 | byte(len(payload))}
+	frame = append(frame, mask...)
+	for i, b := range payload {
+		frame = append(frame, b^mask[i%len(mask)])
+	}
+	if _, err := conn.Write(frame); err != nil {
+		t.Fatal(err)
+	}
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		t.Fatal(err)
+	}
+	if header[0] != 0x81 || int(header[1]) != len(payload) {
+		t.Fatalf("echo header = %x, want ordinary text frame", header)
+	}
+	echo := make([]byte, len(payload))
+	if _, err := io.ReadFull(reader, echo); err != nil {
+		t.Fatal(err)
+	}
+	if string(echo) != string(payload) {
+		t.Fatalf("echo = %q, want %q", echo, payload)
+	}
+	if got := f.Messages(); got != 1 {
+		t.Fatalf("messages = %d, want 1", got)
+	}
+}
+
+func TestWSFixturePermissiveRSV1RecordsEmptyClose(t *testing.T) {
+	f, err := StartWS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	conn, err := net.DialTimeout("tcp", f.Addr(), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(conn,
+		"GET /permissive-rsv1 HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		f.Addr()); err != nil {
+		t.Fatal(err)
+	}
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	_ = conn.Close()
+
+	deadline := time.NewTimer(time.Second)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer deadline.Stop()
+	defer ticker.Stop()
+	for f.RSV1ClosedBeforeMessage() == 0 {
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatal("permissive fixture did not record terminal empty close")
+		}
+	}
+}

--- a/runner/fixture/ws_test.go
+++ b/runner/fixture/ws_test.go
@@ -26,7 +26,7 @@ func TestWSFixturePermissiveRSV1AcceptsFrame(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := fmt.Fprintf(conn,
-		"GET /permissive-rsv1 HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		"GET /permissive-rsv1/accept HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
 		f.Addr()); err != nil {
 		t.Fatal(err)
 	}
@@ -67,6 +67,10 @@ func TestWSFixturePermissiveRSV1AcceptsFrame(t *testing.T) {
 	if got := f.Messages(); got != 1 {
 		t.Fatalf("messages = %d, want 1", got)
 	}
+	seen, closedEmpty := f.RSV1Outcome("accept")
+	if !seen || closedEmpty {
+		t.Fatalf("outcome = seen:%v closed-empty:%v, want seen only", seen, closedEmpty)
+	}
 }
 
 func TestWSFixturePermissiveRSV1RecordsEmptyClose(t *testing.T) {
@@ -81,7 +85,7 @@ func TestWSFixturePermissiveRSV1RecordsEmptyClose(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := fmt.Fprintf(conn,
-		"GET /permissive-rsv1 HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		"GET /permissive-rsv1/close HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
 		f.Addr()); err != nil {
 		t.Fatal(err)
 	}
@@ -97,11 +101,104 @@ func TestWSFixturePermissiveRSV1RecordsEmptyClose(t *testing.T) {
 	ticker := time.NewTicker(5 * time.Millisecond)
 	defer deadline.Stop()
 	defer ticker.Stop()
-	for f.RSV1ClosedBeforeMessage() == 0 {
+	for {
+		seen, closedEmpty := f.RSV1Outcome("close")
+		if closedEmpty {
+			if seen {
+				t.Fatal("empty-close outcome also reported a data frame")
+			}
+			otherSeen, otherClosedEmpty := f.RSV1Outcome("other")
+			if otherSeen || otherClosedEmpty {
+				t.Fatalf("other marker inherited outcome = seen:%v closed-empty:%v", otherSeen, otherClosedEmpty)
+			}
+			break
+		}
 		select {
 		case <-ticker.C:
 		case <-deadline.C:
 			t.Fatal("permissive fixture did not record terminal empty close")
 		}
 	}
+}
+
+func TestWSFixturePermissiveRSV1CountsOnlyCompleteFragmentedMessage(t *testing.T) {
+	f, err := StartWS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	conn, err := net.DialTimeout("tcp", f.Addr(), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close() //nolint:errcheck // test cleanup
+	if err := conn.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(conn,
+		"GET /permissive-rsv1/fragment HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		f.Addr()); err != nil {
+		t.Fatal(err)
+	}
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if err := writeMaskedFixtureTestFrame(conn, 0x41, []byte("hello ")); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.NewTimer(time.Second)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer deadline.Stop()
+	defer ticker.Stop()
+	for {
+		seen, _ := f.RSV1Outcome("fragment")
+		if seen {
+			break
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatal("fixture did not record the initial fragment")
+		}
+	}
+	if got := f.Messages(); got != 0 {
+		t.Fatalf("messages after initial fragment = %d, want 0", got)
+	}
+
+	if err := writeMaskedFixtureTestFrame(conn, 0x80, []byte("world")); err != nil {
+		t.Fatal(err)
+	}
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		t.Fatal(err)
+	}
+	if header[0] != 0x81 || header[1] != byte(len("hello world")) {
+		t.Fatalf("echo header = %x, want completed text frame", header)
+	}
+	echo := make([]byte, len("hello world"))
+	if _, err := io.ReadFull(reader, echo); err != nil {
+		t.Fatal(err)
+	}
+	if string(echo) != "hello world" {
+		t.Fatalf("echo = %q, want complete fragmented payload", echo)
+	}
+	if got := f.Messages(); got != 1 {
+		t.Fatalf("messages after final continuation = %d, want 1", got)
+	}
+}
+
+func writeMaskedFixtureTestFrame(w io.Writer, firstByte byte, payload []byte) error {
+	mask := []byte{1, 2, 3, 4}
+	frame := []byte{firstByte, 0x80 | byte(len(payload))}
+	frame = append(frame, mask...)
+	for i, b := range payload {
+		frame = append(frame, b^mask[i%len(mask)])
+	}
+	_, err := w.Write(frame)
+	return err
 }

--- a/runner/fixture/ws_test.go
+++ b/runner/fixture/ws_test.go
@@ -67,9 +67,9 @@ func TestWSFixturePermissiveRSV1AcceptsFrame(t *testing.T) {
 	if got := f.Messages(); got != 1 {
 		t.Fatalf("messages = %d, want 1", got)
 	}
-	seen, closedEmpty := f.RSV1Outcome("accept")
-	if !seen || closedEmpty {
-		t.Fatalf("outcome = seen:%v closed-empty:%v, want seen only", seen, closedEmpty)
+	markedFrames, terminalClose := f.RSV1Outcome("accept")
+	if markedFrames != 1 || terminalClose {
+		t.Fatalf("outcome = marked:%d terminal:%v, want one marked frame only", markedFrames, terminalClose)
 	}
 }
 
@@ -102,14 +102,14 @@ func TestWSFixturePermissiveRSV1RecordsEmptyClose(t *testing.T) {
 	defer deadline.Stop()
 	defer ticker.Stop()
 	for {
-		seen, closedEmpty := f.RSV1Outcome("close")
-		if closedEmpty {
-			if seen {
-				t.Fatal("empty-close outcome also reported a data frame")
+		markedFrames, terminalClose := f.RSV1Outcome("close")
+		if terminalClose {
+			if markedFrames != 0 {
+				t.Fatal("empty-close outcome also reported a marked frame")
 			}
-			otherSeen, otherClosedEmpty := f.RSV1Outcome("other")
-			if otherSeen || otherClosedEmpty {
-				t.Fatalf("other marker inherited outcome = seen:%v closed-empty:%v", otherSeen, otherClosedEmpty)
+			otherMarked, otherTerminal := f.RSV1Outcome("other")
+			if otherMarked != 0 || otherTerminal {
+				t.Fatalf("other marker inherited outcome = marked:%d terminal:%v", otherMarked, otherTerminal)
 			}
 			break
 		}
@@ -156,8 +156,8 @@ func TestWSFixturePermissiveRSV1CountsOnlyCompleteFragmentedMessage(t *testing.T
 	defer deadline.Stop()
 	defer ticker.Stop()
 	for {
-		seen, _ := f.RSV1Outcome("fragment")
-		if seen {
+		markedFrames, _ := f.RSV1Outcome("fragment")
+		if markedFrames == 1 {
 			break
 		}
 		select {
@@ -189,6 +189,85 @@ func TestWSFixturePermissiveRSV1CountsOnlyCompleteFragmentedMessage(t *testing.T
 	}
 	if got := f.Messages(); got != 1 {
 		t.Fatalf("messages after final continuation = %d, want 1", got)
+	}
+}
+
+func TestWSFixturePermissiveRSV1TracksMarkedFrameNotGenericData(t *testing.T) {
+	f, err := StartWS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	t.Run("ordinary frame before close is not marked delivery", func(t *testing.T) {
+		conn, reader := openPermissiveFixture(t, f, "ordinary-first")
+		if err := writeMaskedFixtureTestFrame(conn, 0x81, []byte("ordinary")); err != nil {
+			t.Fatal(err)
+		}
+		header := make([]byte, 2)
+		if _, err := io.ReadFull(reader, header); err != nil {
+			t.Fatal(err)
+		}
+		echo := make([]byte, int(header[1]))
+		if _, err := io.ReadFull(reader, echo); err != nil {
+			t.Fatal(err)
+		}
+		_ = conn.Close()
+		waitForRSV1Outcome(t, f, "ordinary-first", 0, true)
+	})
+
+	t.Run("marked control frame is recorded", func(t *testing.T) {
+		conn, _ := openPermissiveFixture(t, f, "control")
+		if err := writeMaskedFixtureTestFrame(conn, 0xc9, []byte("probe")); err != nil {
+			t.Fatal(err)
+		}
+		waitForRSV1Outcome(t, f, "control", 1, false)
+		_ = conn.Close()
+	})
+}
+
+func openPermissiveFixture(t *testing.T, f *WSFixture, marker string) (net.Conn, *bufio.Reader) {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", f.Addr(), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		_ = conn.Close()
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(conn,
+		"GET /permissive-rsv1/%s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		marker, f.Addr()); err != nil {
+		_ = conn.Close()
+		t.Fatal(err)
+	}
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		_ = conn.Close()
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	return conn, reader
+}
+
+func waitForRSV1Outcome(t *testing.T, f *WSFixture, marker string, wantMarked int, wantTerminal bool) {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer deadline.Stop()
+	defer ticker.Stop()
+	for {
+		marked, terminal := f.RSV1Outcome(marker)
+		if marked == wantMarked && terminal == wantTerminal {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatalf("outcome = marked:%d terminal:%v, want marked:%d terminal:%v", marked, terminal, wantMarked, wantTerminal)
+		}
 	}
 }
 

--- a/runner/main.go
+++ b/runner/main.go
@@ -204,7 +204,7 @@ func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeo
 			pa.SetTLSRequestCounter(fm.TLS().Requests)
 			pa.SetWSFixtures(fm.WS().Addr(), fm.WS().UntrustedAddr())
 			pa.SetWSUpstreamMessageCounter(fm.WS().Messages)
-			pa.SetWSRSV1ClosedBeforeMessageCounter(fm.WS().RSV1ClosedBeforeMessage)
+			pa.SetWSRSV1Outcome(fm.WS().RSV1Outcome)
 			pa.SetMCPHTTPUpstreamCallCounter(fm.MCPHTTP().Calls)
 			pa.SetMCPHTTPFixture(fm.MCPHTTP())
 			_, _ = fmt.Fprintf(os.Stderr, "Fixtures: HTTP=%s TLS=%s WS=%s DNS=%s MCP_HTTP=%s\n",

--- a/runner/main.go
+++ b/runner/main.go
@@ -204,6 +204,7 @@ func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeo
 			pa.SetTLSRequestCounter(fm.TLS().Requests)
 			pa.SetWSFixtures(fm.WS().Addr(), fm.WS().UntrustedAddr())
 			pa.SetWSUpstreamMessageCounter(fm.WS().Messages)
+			pa.SetWSRSV1ClosedBeforeMessageCounter(fm.WS().RSV1ClosedBeforeMessage)
 			pa.SetMCPHTTPUpstreamCallCounter(fm.MCPHTTP().Calls)
 			pa.SetMCPHTTPFixture(fm.MCPHTTP())
 			_, _ = fmt.Fprintf(os.Stderr, "Fixtures: HTTP=%s TLS=%s WS=%s DNS=%s MCP_HTTP=%s\n",


### PR DESCRIPTION
Closes the remaining compressed-WebSocket evidence ambiguity with a runner-owned permissive RSV1 sink.

A protocol close is credited as a block only when the sink positively reports that the connection terminated before receiving the frame. External destinations, delivered frames, and missing terminal proof remain unscored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket RSV1 policy-result attribution.
  * Blocks are now confirmed only when the connection closes before any message reaches the destination.
  * Ambiguous, upstream-delivered, or externally closed connections are reported as unproven rather than incorrectly blocked.

* **Tests**
  * Added coverage for permissive RSV1 handling, message delivery, terminal closes, and real fixture integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->