### PR TITLE
fix(runner): replay the listener-issued MCP HTTP session token

### DIFF
--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -2585,6 +2585,10 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 	}
 
 	client := &http.Client{Timeout: timeout}
+	// Establish the session before the case's own messages so a target that
+	// requires an issued token evaluates them, rather than refusing every one
+	// for want of a session and turning that refusal into a scored block.
+	sessionToken := p.establishMCPHTTPListenerSession(context.Background(), client)
 	var responses int
 	upstreamBefore, _ := p.mcpHTTPUpstreamCallCount()
 	for _, msg := range msgList {
@@ -2595,6 +2599,7 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 		}
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json, text/event-stream")
+		setListenerSessionToken(req, sessionToken)
 		resp, err := client.Do(req)
 		if err != nil {
 			return Result{Err: fmt.Errorf("case %s: MCP HTTP request: %w", c.ID, err)}
@@ -2679,7 +2684,7 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 	if err != nil {
 		return Result{Err: fmt.Errorf("case %s: prepare MCP initialize request: %w", c.ID, err)}
 	}
-	initializeResponse, initializeContentType, initializeStatus, sessionID, err := p.sendMCPHTTPGatewayRequest(ctx, client, initializeMessage, "")
+	initialize, err := p.sendMCPHTTPGatewayRequest(ctx, client, initializeMessage, "", "")
 	if err != nil {
 		return Result{Err: fmt.Errorf("case %s: send MCP initialize request: %w", c.ID, err)}
 	}
@@ -2687,23 +2692,28 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 		evidence["reason"] = "temporal_initialize_upstream_unproven"
 		return Result{Verdict: "skip", Evidence: evidence}
 	}
-	initializeBody, decodeErr := decodeGatewayResponse(initializeContentType, initializeResponse, initializeRequest.identity)
-	if decodeErr != nil || initializeStatus < http.StatusOK || initializeStatus >= http.StatusMultipleChoices || classifyMCPHTTPBlock(initializeBody) != nil || !validMCPInitializeResponse(initializeBody) {
+	initializeBody, decodeErr := decodeGatewayResponse(initialize.contentType, initialize.body, initializeRequest.identity)
+	if decodeErr != nil || initialize.status < http.StatusOK || initialize.status >= http.StatusMultipleChoices || classifyMCPHTTPBlock(initializeBody) != nil || !validMCPInitializeResponse(initializeBody) {
 		evidence["reason"] = "temporal_initialize_not_established"
 		return Result{Verdict: "skip", Evidence: evidence}
 	}
+	sessionID := initialize.sessionID
 	if sessionID == "" {
 		evidence["reason"] = "temporal_session_unbound"
 		return Result{Verdict: "skip", Evidence: evidence}
 	}
 	evidence["session_bound"] = true
+	// This initialize is itself the setup frame, so any issued token arrives on
+	// its response and is replayed on every later request in this session.
+	// Opening a second session to obtain one would abandon this one.
+	sessionToken := initialize.sessionToken
 
-	_, _, initializedStatus, _, err := p.sendMCPHTTPGatewayRequest(ctx, client, map[string]interface{}{
+	initialized, err := p.sendMCPHTTPGatewayRequest(ctx, client, map[string]interface{}{
 		"jsonrpc": "2.0",
 		"method":  "notifications/initialized",
 		"params":  map[string]interface{}{},
-	}, sessionID)
-	if err != nil || initializedStatus < http.StatusOK || initializedStatus >= http.StatusMultipleChoices {
+	}, sessionID, sessionToken)
+	if err != nil || initialized.status < http.StatusOK || initialized.status >= http.StatusMultipleChoices {
 		evidence["reason"] = "temporal_initialized_notification_failed"
 		return Result{Verdict: "skip", Evidence: evidence}
 	}
@@ -2717,7 +2727,7 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 		evidence["reason"] = "baseline_inventory_lease_timeout"
 		return Result{Verdict: "skip", Evidence: evidence}
 	}
-	baselineResponse, baselineContentType, baselineStatus, _, err := p.sendMCPHTTPGatewayRequest(ctx, client, baselineMessage, sessionID)
+	baseline, err := p.sendMCPHTTPGatewayRequest(ctx, client, baselineMessage, sessionID, sessionToken)
 	baselineRelease()
 	if err != nil {
 		return Result{Err: fmt.Errorf("case %s: send baseline tools/list request: %w", c.ID, err)}
@@ -2729,8 +2739,8 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 		evidence["reason"] = "baseline_inventory_upstream_unproven"
 		return Result{Verdict: "skip", Evidence: evidence}
 	}
-	baselineBody, err := decodeGatewayResponse(baselineContentType, baselineResponse, baselineRequest.identity)
-	if err != nil || baselineStatus < http.StatusOK || baselineStatus >= http.StatusMultipleChoices {
+	baselineBody, err := decodeGatewayResponse(baseline.contentType, baseline.body, baselineRequest.identity)
+	if err != nil || baseline.status < http.StatusOK || baseline.status >= http.StatusMultipleChoices {
 		evidence["reason"] = "baseline_inventory_not_established"
 		return Result{Verdict: "skip", Evidence: evidence}
 	}
@@ -2750,7 +2760,7 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 		evidence["reason"] = "changed_inventory_lease_timeout"
 		return Result{Verdict: "skip", Evidence: evidence}
 	}
-	changedResponse, changedContentType, changedStatus, _, err := p.sendMCPHTTPGatewayRequest(ctx, client, changedMessage, sessionID)
+	changed, err := p.sendMCPHTTPGatewayRequest(ctx, client, changedMessage, sessionID, sessionToken)
 	changedRelease()
 	if err != nil {
 		return Result{Err: fmt.Errorf("case %s: send changed tools/list request: %w", c.ID, err)}
@@ -2764,14 +2774,14 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 	}
 	evidence["upstream_reached"] = true
 
-	if changedStatus < http.StatusOK || changedStatus >= http.StatusMultipleChoices {
-		if verdict := classifyMCPHTTPBlock(changedResponse); verdict != nil {
+	if changed.status < http.StatusOK || changed.status >= http.StatusMultipleChoices {
+		if verdict := classifyMCPHTTPBlock(changed.body); verdict != nil {
 			for key, value := range evidence {
 				verdict.Evidence[key] = value
 			}
 			return *verdict
 		}
-		result := classifyResponse(changedStatus, string(changedResponse))
+		result := classifyResponse(changed.status, string(changed.body))
 		for key, value := range evidence {
 			result.Evidence[key] = value
 		}
@@ -2780,7 +2790,7 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 		}
 		return result
 	}
-	changedBody, err := decodeGatewayResponse(changedContentType, changedResponse, changedRequest.identity)
+	changedBody, err := decodeGatewayResponse(changed.contentType, changed.body, changedRequest.identity)
 	if err != nil {
 		evidence["reason"] = "malformed_or_uncorrelated_changed_inventory"
 		return Result{Verdict: "skip", Evidence: evidence}
@@ -2804,30 +2814,114 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 	return Result{Verdict: "allow", Evidence: evidence}
 }
 
-func (p *ProxyAdapter) sendMCPHTTPGatewayRequest(ctx context.Context, client *http.Client, message map[string]interface{}, sessionID string) ([]byte, string, int, string, error) {
+// mcpHTTPGatewayResponse carries one listener response. The listener-issued
+// session token is returned alongside the MCP session id because the two are
+// distinct: the id is upstream routing data the client supplies, the token is
+// the target's own proof that this client owns its state partition.
+type mcpHTTPGatewayResponse struct {
+	body         []byte
+	contentType  string
+	status       int
+	sessionID    string
+	sessionToken string
+}
+
+func (p *ProxyAdapter) sendMCPHTTPGatewayRequest(ctx context.Context, client *http.Client, message map[string]interface{}, sessionID, sessionToken string) (mcpHTTPGatewayResponse, error) {
 	body, err := json.Marshal(message)
 	if err != nil {
-		return nil, "", 0, "", fmt.Errorf("marshal request: %w", err)
+		return mcpHTTPGatewayResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.mcpHTTPURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, "", 0, "", fmt.Errorf("build request: %w", err)
+		return mcpHTTPGatewayResponse{}, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	if sessionID != "" {
 		req.Header.Set("Mcp-Session-Id", sessionID)
 	}
+	setListenerSessionToken(req, sessionToken)
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, "", 0, "", err
+		return mcpHTTPGatewayResponse{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return nil, "", 0, "", fmt.Errorf("read response: %w", err)
+		return mcpHTTPGatewayResponse{}, fmt.Errorf("read response: %w", err)
 	}
-	return responseBody, resp.Header.Get("Content-Type"), resp.StatusCode, resp.Header.Get("Mcp-Session-Id"), nil
+	return mcpHTTPGatewayResponse{
+		body:         responseBody,
+		contentType:  resp.Header.Get("Content-Type"),
+		status:       resp.StatusCode,
+		sessionID:    resp.Header.Get("Mcp-Session-Id"),
+		sessionToken: resp.Header.Get(listenerSessionTokenHeader),
+	}, nil
+}
+
+// listenerSessionTokenHeader carries a listener-issued session token. A target
+// that partitions retained per-client state by an authenticated principal
+// cannot safely key that partition on client-supplied routing data, so it
+// issues its own token during setup and requires it on later stateful
+// requests. The runner replays whatever token the target issued; it never
+// mints, guesses, or reuses one across cases.
+const listenerSessionTokenHeader = "Pipelock-Session-Token"
+
+// establishMCPHTTPListenerSession performs the listener setup handshake and
+// returns the token the target issued, or an empty string when the target
+// issues none.
+//
+// An empty result is a normal outcome, not a failure: a target that keeps no
+// per-client state, or one predating listener-issued tokens, answers setup
+// without the header and then accepts stateful requests without it. Returning
+// empty keeps those targets measurable on the same adapter, so one runner spans
+// both, and a target that DOES require a token is driven correctly instead of
+// having every stateful request refused and scored as a false positive.
+//
+// The setup frame is adapter transport setup, in the same class as opening the
+// connection. It is not part of any case's wire input, and the caller still
+// proves delivery of the case's own messages separately.
+func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, client *http.Client) string {
+	// Setup is recognized only on a non-batch initialize that carries no
+	// negotiated protocol version, so this frame must stay exactly that shape.
+	// Do not add an Mcp-Protocol-Version header here: it makes the target treat
+	// this as an already-negotiated request, skip setup, and issue no token.
+	message := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "aeb-listener-session-setup",
+		"method":  "initialize",
+		"params":  map[string]interface{}{},
+	}
+	body, err := json.Marshal(message)
+	if err != nil {
+		return ""
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.mcpHTTPURL, bytes.NewReader(body))
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// The body is drained and discarded. Only the issued token matters here,
+	// and leaving it unread would strand the connection.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return ""
+	}
+	return resp.Header.Get(listenerSessionTokenHeader)
+}
+
+// setListenerSessionToken replays an issued token on a later stateful request.
+// It is a no-op when the target issued none.
+func setListenerSessionToken(req *http.Request, token string) {
+	if token != "" {
+		req.Header.Set(listenerSessionTokenHeader, token)
+	}
 }
 
 func newMCPHTTPClient(timeout time.Duration) *http.Client {
@@ -2876,6 +2970,11 @@ func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Res
 	if err != nil {
 		return Result{Err: fmt.Errorf("case %s: prepare response request identity: %w", c.ID, err)}
 	}
+	// Establish the session before any tool-definition lease is held. The setup
+	// frame reaches the upstream fixture, so running it inside a lease window
+	// perturbs the very delivery proof the lease exists to make exact.
+	responseClient := newMCPHTTPClient(timeout)
+	sessionToken := p.establishMCPHTTPListenerSession(ctx, responseClient)
 	var (
 		request       map[string]interface{}
 		gatewayReq    gatewayRequest
@@ -2928,7 +3027,7 @@ func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Res
 	}
 	defer release()
 	if c.InputType == "mcp_tool_result" {
-		if result := p.primeMCPHTTPToolResultBaseline(ctx); result != nil {
+		if result := p.primeMCPHTTPToolResultBaseline(ctx, sessionToken); result != nil {
 			return *result
 		}
 	}
@@ -2943,7 +3042,8 @@ func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Res
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json, text/event-stream")
-	resp, err := newMCPHTTPClient(timeout).Do(httpReq)
+	setListenerSessionToken(httpReq, sessionToken)
+	resp, err := responseClient.Do(httpReq)
 	if err != nil {
 		return Result{Err: fmt.Errorf("case %s: MCP HTTP request: %w", c.ID, err)}
 	}
@@ -3003,7 +3103,10 @@ func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Res
 // it to return the fixture-owned result. This is part of the protocol path,
 // not a workaround: gateways that bind calls to the last tools/list inventory
 // must see the same ordinary discovery exchange a real MCP client performs.
-func (p *ProxyAdapter) primeMCPHTTPToolResultBaseline(ctx context.Context) *Result {
+// The caller passes the session token it already established, so one case
+// opens exactly one session. Establishing a second one here would send another
+// setup frame upstream and change the method sequence the fixture observes.
+func (p *ProxyAdapter) primeMCPHTTPToolResultBaseline(ctx context.Context, sessionToken string) *Result {
 	identity, err := nextGatewayRequestIdentity()
 	if err != nil {
 		return &Result{Err: fmt.Errorf("prepare tool-result baseline identity: %w", err)}
@@ -3018,6 +3121,7 @@ func (p *ProxyAdapter) primeMCPHTTPToolResultBaseline(ctx context.Context) *Resu
 	if err != nil {
 		return &Result{Err: fmt.Errorf("prepare tool-result baseline request: %w", err)}
 	}
+	baselineClient := newMCPHTTPClient(0)
 	tools := []json.RawMessage{json.RawMessage(`{"name":"aeb_tool_result_fixture","description":"Runner-owned benchmark fixture tool.","inputSchema":{"type":"object"}}`)}
 	release, err := p.mcpHTTPFixture.AcquireToolDefinitionLease(ctx, gatewayReq.identity, tools)
 	if err != nil {
@@ -3034,7 +3138,8 @@ func (p *ProxyAdapter) primeMCPHTTPToolResultBaseline(ctx context.Context) *Resu
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
-	resp, err := newMCPHTTPClient(0).Do(req)
+	setListenerSessionToken(req, sessionToken)
+	resp, err := baselineClient.Do(req)
 	if err != nil {
 		return &Result{Err: fmt.Errorf("send tool-result baseline request: %w", err)}
 	}

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -2608,12 +2608,18 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 		_ = resp.Body.Close()
 		if resp.StatusCode >= 400 {
 			if verdict := classifyMCPHTTPBlock(body); verdict != nil {
+				if listenerSessionRefusalIsUnproven(verdict, resp.Header) {
+					return listenerSessionUnprovenResult()
+				}
 				return *verdict
 			}
 			return classifyResponse(resp.StatusCode, string(body))
 		}
 		responses++
 		if verdict := classifyMCPHTTPBlock(body); verdict != nil {
+			if listenerSessionRefusalIsUnproven(verdict, resp.Header) {
+				return listenerSessionUnprovenResult()
+			}
 			return *verdict
 		}
 	}
@@ -2865,7 +2871,15 @@ func (p *ProxyAdapter) sendMCPHTTPGatewayRequest(ctx context.Context, client *ht
 // issues its own token during setup and requires it on later stateful
 // requests. The runner replays whatever token the target issued; it never
 // mints, guesses, or reuses one across cases.
-const listenerSessionTokenHeader = "Pipelock-Session-Token"
+const (
+	listenerSessionTokenHeader          = "Pipelock-Session-Token"
+	listenerSessionRequiredErrorCode    = -32003
+	listenerSessionRequiredErrorMessage = "stateful MCP listener request requires an authenticated principal or a legacy Pipelock session token"
+	// Structured block-reason layer, emitted on every refusal from the
+	// listener's session layer regardless of which one fired.
+	listenerBlockLayerHeader  = "X-Pipelock-Block-Reason-Layer"
+	listenerSessionBlockLayer = "mcp_listener_session"
+)
 
 // establishMCPHTTPListenerSession performs the listener setup handshake and
 // returns the token the target issued, or an empty string when the target
@@ -2919,9 +2933,63 @@ func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, clie
 // setListenerSessionToken replays an issued token on a later stateful request.
 // It is a no-op when the target issued none.
 func setListenerSessionToken(req *http.Request, token string) {
-	if token != "" {
+	if validListenerSessionToken(token) {
 		req.Header.Set(listenerSessionTokenHeader, token)
 	}
+}
+
+// validListenerSessionToken matches the listener-issued bearer format. Do not
+// replay an arbitrary response header into a later case: a malformed value is
+// not a session capability and Pipelock rejects it before the case reaches the
+// upstream fixture.
+func validListenerSessionToken(token string) bool {
+	if len(token) != 43 {
+		return false
+	}
+	for i := 0; i < len(token); i++ {
+		if (token[i] < 'A' || token[i] > 'Z') &&
+			(token[i] < 'a' || token[i] > 'z') &&
+			(token[i] < '0' || token[i] > '9') &&
+			token[i] != '-' && token[i] != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+// listenerSessionRefusalIsUnproven recognizes the listener's own refusal
+// before it forwards a case. That is transport/setup failure, not evidence
+// that the target evaluated and blocked the case.
+//
+// Match the structured layer header first and the exact message only as a
+// fallback. The header is a machine-readable contract field, so it survives a
+// reworded message and it covers EVERY refusal from this layer rather than the
+// one sentence sampled while writing this. Pipelock has at least two: a
+// missing session and a legacy token presented against current-protocol state.
+//
+// Deliberately NOT "any block that did not reach upstream": a proxy blocking
+// exfiltration before forwarding is the product working, and treating those as
+// unproven would erase real detections wholesale.
+func listenerSessionRefusalIsUnproven(result *Result, header http.Header) bool {
+	if result == nil {
+		return false
+	}
+	if header.Get(listenerBlockLayerHeader) == listenerSessionBlockLayer {
+		return true
+	}
+	code, codeOK := result.Evidence["error_code"].(int)
+	message, messageOK := result.Evidence["error_message"].(string)
+	return codeOK && messageOK && code == listenerSessionRequiredErrorCode && message == listenerSessionRequiredErrorMessage
+}
+
+func listenerSessionUnprovenResult() Result {
+	return Result{Verdict: "skip", Evidence: map[string]interface{}{
+		"product_surface":  "mcp_http_listener",
+		"reason":           "listener_session_unproven",
+		"upstream_reached": false,
+		"error_code":       listenerSessionRequiredErrorCode,
+		"error_message":    listenerSessionRequiredErrorMessage,
+	}}
 }
 
 func newMCPHTTPClient(timeout time.Duration) *http.Client {

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -3163,8 +3163,24 @@ func TestRunMCPHTTP_ResponseCasesUseFixtureRequestResponseDirection(t *testing.T
 			t.Fatalf("%s result = %+v, want fixture-proven allow", tc.ID, result)
 		}
 	}
-	if len(methods) != 3 || methods[0] != "tools/list" || methods[1] != "tools/list" || methods[2] != "tools/call" {
-		t.Fatalf("gateway methods = %v, want tools/list definition, tools/list bootstrap, tools/call result", methods)
+	// Each case opens exactly one session, so its ordinary MCP initialize leads
+	// the case's own methods. Real MCP clients always initialize before calling,
+	// and a target that issues a session token only does so during that setup.
+	// Assert the exact sequence, including the initialize count: a second
+	// initialize inside one case would mean a helper opened its own redundant
+	// session, which is what sending setup inside a tool-definition lease did
+	// before, perturbing the very delivery proof the lease exists to make exact.
+	want := []string{
+		"initialize", "tools/list", // definition case
+		"initialize", "tools/list", "tools/call", // result case: bootstrap, then the call
+	}
+	if len(methods) != len(want) {
+		t.Fatalf("gateway methods = %v, want %v", methods, want)
+	}
+	for i, method := range want {
+		if methods[i] != method {
+			t.Fatalf("gateway methods = %v, want %v", methods, want)
+		}
 	}
 }
 
@@ -4336,5 +4352,93 @@ func TestDoHTTPProxyRequestDoesNotTrustCaseURLAsPolicyEvidence(t *testing.T) {
 	}
 	if got := accepted.Load(); got != 1 {
 		t.Fatalf("reset fixture accepted %d connections, want 1", got)
+	}
+}
+
+// TestRunMCPHTTP_ReplaysListenerIssuedSessionToken proves the runner replays a
+// listener-issued session token on the case's own requests.
+//
+// A target that partitions retained per-client state by principal cannot key
+// that partition on client-supplied routing data, so it issues its own token
+// during setup and refuses later stateful requests that arrive without it. A
+// runner that ignores the token has every such request refused and scores the
+// refusal as the target blocking the case. That turns correct target behaviour
+// into a false positive on benign traffic and leaves attack cases unmeasurable.
+func TestRunMCPHTTP_ReplaysListenerIssuedSessionToken(t *testing.T) {
+	upstream, err := fixture.StartMCPHTTP()
+	if err != nil {
+		t.Fatalf("StartMCPHTTP: %v", err)
+	}
+	defer upstream.Close()
+
+	const issuedToken = "listener-issued-token-value"
+	var refusedMissing, carriedToken atomic.Int64
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		if readErr != nil {
+			t.Errorf("read listener request: %v", readErr)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode listener request: %v", err)
+			return
+		}
+		// Setup issues the token, exactly as a stateful listener does.
+		if request.Method == "initialize" {
+			w.Header().Set("Pipelock-Session-Token", issuedToken)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
+			return
+		}
+		// Every later request must carry it back, or it is refused the way a
+		// real listener refuses an unbound stateful request.
+		if r.Header.Get("Pipelock-Session-Token") != issuedToken {
+			refusedMissing.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"stateful MCP listener request requires an authenticated principal or a legacy Pipelock session token"}}`))
+			return
+		}
+		carriedToken.Add(1)
+		upstreamResp, postErr := http.Post(upstream.URL(), "application/json", bytes.NewReader(body)) //nolint:gosec,noctx // runner-owned fixture
+		if postErr != nil {
+			t.Errorf("forward to fixture: %v", postErr)
+			return
+		}
+		defer func() { _ = upstreamResp.Body.Close() }()
+		response, readErr := io.ReadAll(upstreamResp.Body)
+		if readErr != nil {
+			t.Errorf("read fixture response: %v", readErr)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(response)
+	}))
+	defer listener.Close()
+
+	a := &ProxyAdapter{}
+	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPFixture(upstream)
+
+	result := a.runMCPHTTP(Case{
+		ID: "http-tool-definition-token", Transport: "mcp_http", InputType: "mcp_tool_definition",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1, "result": map[string]interface{}{"tools": []interface{}{map[string]interface{}{
+				"name": "fixture_tool", "description": "safe", "inputSchema": map[string]interface{}{"type": "object"},
+			}}},
+		}}},
+	}, time.Second)
+
+	if result.Err != nil || result.Verdict != "allow" || result.Evidence["upstream_reached"] != true {
+		t.Fatalf("result = %+v, want fixture-proven allow", result)
+	}
+	if got := refusedMissing.Load(); got != 0 {
+		t.Fatalf("listener refused %d request(s) for a missing session token, want 0", got)
+	}
+	if carriedToken.Load() == 0 {
+		t.Fatal("no request carried the issued session token")
 	}
 }

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -4371,7 +4372,7 @@ func TestRunMCPHTTP_ReplaysListenerIssuedSessionToken(t *testing.T) {
 	}
 	defer upstream.Close()
 
-	const issuedToken = "listener-issued-token-value"
+	const issuedToken = "0123456789012345678901234567890123456789012"
 	var refusedMissing, carriedToken atomic.Int64
 	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, readErr := io.ReadAll(r.Body)
@@ -4440,5 +4441,347 @@ func TestRunMCPHTTP_ReplaysListenerIssuedSessionToken(t *testing.T) {
 	}
 	if carriedToken.Load() == 0 {
 		t.Fatal("no request carried the issued session token")
+	}
+}
+
+// A listener-session refusal is not case delivery evidence: the protected
+// upstream never received the case. If setup was unavailable or failed to
+// issue a usable token, the runner must leave that case unmeasured instead of
+// awarding the listener a block.
+func TestRunMCPHTTP_ListenerSessionRefusalIsUnproven(t *testing.T) {
+	var methods []string
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read listener request: %v", err)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode listener request: %v", err)
+			return
+		}
+		methods = append(methods, request.Method)
+		w.Header().Set("Content-Type", "application/json")
+		if request.Method == "initialize" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","error":{"code":-32003,"message":"pipelock session setup unavailable"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"stateful MCP listener request requires an authenticated principal or a legacy Pipelock session token"}}`))
+	}))
+	defer listener.Close()
+
+	a := &ProxyAdapter{}
+	a.SetMCPHTTPURL(listener.URL)
+	result := a.Run(Case{
+		ID: "listener-session-refusal", Transport: "mcp_http", InputType: "mcp_tool_call",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": map[string]interface{}{"name": "safe_tool"},
+		}}},
+	}, time.Second)
+
+	if result.Err != nil || result.Verdict != "skip" || result.Evidence["reason"] != "listener_session_unproven" || result.Evidence["upstream_reached"] != false {
+		t.Fatalf("result = %+v, want an unproven listener-session skip", result)
+	}
+	if result.DeliveryProven || result.VerdictObserved {
+		t.Fatalf("listener-session refusal proved a verdict: delivery=%v observed=%v", result.DeliveryProven, result.VerdictObserved)
+	}
+	wantMethods := []string{"initialize", "tools/call"}
+	if !slices.Equal(methods, wantMethods) {
+		t.Fatalf("listener methods = %v, want %v", methods, wantMethods)
+	}
+}
+
+func TestRunMCPHTTP_TokenlessSetupOmitsListenerSessionHeader(t *testing.T) {
+	var upstreamCalls atomic.Int64
+	var methods []string
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read listener request: %v", err)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode listener request: %v", err)
+			return
+		}
+		methods = append(methods, request.Method)
+		if got := r.Header.Get(listenerSessionTokenHeader); got != "" {
+			t.Errorf("%s = %q, want absent when setup issued no token", listenerSessionTokenHeader, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if request.Method == "initialize" {
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
+			return
+		}
+		upstreamCalls.Add(1)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`))
+	}))
+	defer listener.Close()
+
+	a := &ProxyAdapter{}
+	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPUpstreamCallCounter(upstreamCalls.Load)
+	result := a.Run(Case{
+		ID: "tokenless-listener-session", Transport: "mcp_http", InputType: "mcp_tool_call",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": map[string]interface{}{"name": "safe_tool"},
+		}}},
+	}, time.Second)
+
+	if result.Err != nil || result.Verdict != "allow" || !result.DeliveryProven || !result.VerdictObserved {
+		t.Fatalf("result = %+v, want a delivered tokenless allow", result)
+	}
+	wantMethods := []string{"initialize", "tools/call"}
+	if !slices.Equal(methods, wantMethods) {
+		t.Fatalf("listener methods = %v, want %v", methods, wantMethods)
+	}
+}
+
+func TestRunMCPHTTP_MalformedListenerSessionTokenIsUnproven(t *testing.T) {
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read listener request: %v", err)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode listener request: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if request.Method == "initialize" {
+			w.Header().Set(listenerSessionTokenHeader, "malformed-token")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
+			return
+		}
+		if got := r.Header.Get(listenerSessionTokenHeader); got != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"pipelock: upstream error: invalid Pipelock-Session-Token header"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"stateful MCP listener request requires an authenticated principal or a legacy Pipelock session token"}}`))
+	}))
+	defer listener.Close()
+
+	a := &ProxyAdapter{}
+	a.SetMCPHTTPURL(listener.URL)
+	result := a.Run(Case{
+		ID: "malformed-listener-token", Transport: "mcp_http", InputType: "mcp_tool_call",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": map[string]interface{}{"name": "safe_tool"},
+		}}},
+	}, time.Second)
+
+	if result.Err != nil || result.Verdict != "skip" || result.Evidence["reason"] != "listener_session_unproven" || result.Evidence["upstream_reached"] != false {
+		t.Fatalf("result = %+v, want an unproven malformed-token skip", result)
+	}
+}
+
+func TestRunMCPHTTP_SetupDoesNotProveCaseDelivery(t *testing.T) {
+	var upstreamCalls atomic.Int64
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read listener request: %v", err)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode listener request: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if request.Method == "initialize" {
+			upstreamCalls.Add(1)
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`))
+	}))
+	defer listener.Close()
+
+	a := &ProxyAdapter{}
+	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPUpstreamCallCounter(upstreamCalls.Load)
+	result := a.Run(Case{
+		ID: "setup-is-not-delivery", Transport: "mcp_http", InputType: "mcp_tool_call",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": map[string]interface{}{"name": "safe_tool"},
+		}}},
+	}, time.Second)
+
+	if result.Err != nil || result.Verdict != "skip" || result.Evidence["upstream_reached"] != false {
+		t.Fatalf("result = %+v, want an unproven case delivery", result)
+	}
+	if result.Evidence["upstream_calls_before"] != int64(1) || result.Evidence["upstream_calls_after"] != int64(1) {
+		t.Fatalf("upstream call proof = before=%v after=%v, want setup excluded from the case interval", result.Evidence["upstream_calls_before"], result.Evidence["upstream_calls_after"])
+	}
+	if result.DeliveryProven || result.VerdictObserved {
+		t.Fatalf("setup-only delivery proved a verdict: delivery=%v observed=%v", result.DeliveryProven, result.VerdictObserved)
+	}
+}
+
+func TestRunMCPHTTP_ConcurrentCasesKeepListenerTokensSeparate(t *testing.T) {
+	const caseCount = 2
+	var issued atomic.Int64
+	var upstreamCalls atomic.Int64
+	var tokenUses sync.Map // map[string]*atomic.Int64
+	allSetupsStarted := make(chan struct{})
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read listener request: %v", err)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode listener request: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if request.Method == "initialize" {
+			sequence := issued.Add(1)
+			if sequence == caseCount {
+				close(allSetupsStarted)
+			}
+			<-allSetupsStarted
+			token := fmt.Sprintf("%043d", sequence)
+			tokenUses.Store(token, &atomic.Int64{})
+			w.Header().Set(listenerSessionTokenHeader, token)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
+			return
+		}
+		token := r.Header.Get(listenerSessionTokenHeader)
+		value, ok := tokenUses.Load(token)
+		if !ok {
+			t.Errorf("case token %q was not issued", token)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		value.(*atomic.Int64).Add(1)
+		upstreamCalls.Add(1)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`))
+	}))
+	defer listener.Close()
+
+	a := &ProxyAdapter{}
+	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPUpstreamCallCounter(upstreamCalls.Load)
+	results := make(chan Result, caseCount)
+	var wg sync.WaitGroup
+	for i := 0; i < caseCount; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results <- a.Run(Case{
+				ID: fmt.Sprintf("concurrent-listener-token-%d", i), Transport: "mcp_http", InputType: "mcp_tool_call",
+				Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
+					"jsonrpc": "2.0", "id": i + 1, "method": "tools/call", "params": map[string]interface{}{"name": "safe_tool"},
+				}}},
+			}, time.Second)
+		}(i)
+	}
+	wg.Wait()
+	close(results)
+	for result := range results {
+		if result.Err != nil || result.Verdict != "allow" || !result.DeliveryProven || !result.VerdictObserved {
+			t.Fatalf("result = %+v, want a delivered concurrent allow", result)
+		}
+	}
+	if got := issued.Load(); got != caseCount {
+		t.Fatalf("initialize count = %d, want one per case (%d)", got, caseCount)
+	}
+	seen := 0
+	tokenUses.Range(func(token, value interface{}) bool {
+		seen++
+		if got := value.(*atomic.Int64).Load(); got != 1 {
+			t.Errorf("token %q used %d times, want once", token, got)
+		}
+		return true
+	})
+	if seen != caseCount {
+		t.Fatalf("issued token count = %d, want %d", seen, caseCount)
+	}
+}
+
+// TestRunMCPHTTP_SiblingListenerSessionRefusalIsUnproven covers the OTHER
+// refusal from the listener's session layer: a legacy token presented against
+// current-protocol state. It carries a different message from the
+// session-required refusal, so matching that one sentence does not catch it,
+// and it would otherwise be scored as the target blocking the case.
+//
+// Matching the structured layer header covers every refusal from that layer,
+// including ones added later, without the runner having to enumerate messages.
+func TestRunMCPHTTP_SiblingListenerSessionRefusalIsUnproven(t *testing.T) {
+	upstream, err := fixture.StartMCPHTTP()
+	if err != nil {
+		t.Fatalf("StartMCPHTTP: %v", err)
+	}
+	defer upstream.Close()
+
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		if readErr != nil {
+			t.Errorf("read listener request: %v", readErr)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode listener request: %v", err)
+			return
+		}
+		if request.Method == "initialize" {
+			// Issue a well-formed token so the runner replays it and reaches
+			// the refusal below, rather than stopping at format validation.
+			w.Header().Set("Pipelock-Session-Token", "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
+			return
+		}
+		// The sibling refusal: same layer, different message, never forwarded
+		// upstream. Verbatim from pipelock's rejectLegacyTokenForCurrentProtocol.
+		w.Header().Set("X-Pipelock-Block-Reason-Layer", "mcp_listener_session")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"pipelock: upstream error: legacy Pipelock session token cannot select current-protocol listener state"}}`))
+	}))
+	defer listener.Close()
+
+	a := &ProxyAdapter{}
+	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPFixture(upstream)
+
+	result := a.runMCPHTTP(Case{
+		ID: "http-sibling-session-refusal", Transport: "mcp_http", InputType: "mcp_input",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+			"params": map[string]interface{}{"name": "safe_tool", "arguments": map[string]interface{}{}},
+		}}},
+	}, time.Second)
+
+	if result.Verdict != "skip" {
+		t.Fatalf("result = %+v, want an unproven listener-session skip, not a scored verdict", result)
+	}
+	if result.Evidence["reason"] != "listener_session_unproven" {
+		t.Fatalf("evidence reason = %v, want listener_session_unproven", result.Evidence["reason"])
+	}
+	if result.Evidence["upstream_reached"] != false {
+		t.Fatalf("evidence upstream_reached = %v, want false", result.Evidence["upstream_reached"])
 	}
 }


### PR DESCRIPTION
## What changed

The MCP HTTP adapter completes the listener session handshake before it sends a case, and replays the token the listener issued on that case's own requests.

A listener that partitions retained per-client state by authenticated principal cannot key that partition on client-supplied routing data, so it issues its own token during setup and refuses later stateful requests that arrive without one. The runner already triggered setup and then discarded the token, so every stateful request came back refused, and the runner recorded that refusal as the target blocking the case.

Measured across 240 cases against a build with that listener behavior, the discarded token produced four false positives on benign traffic and left eight cases unmeasurable, one of them an attack case that an earlier build of the same target blocked correctly. With the token replayed, the run reports zero errors and a false-positive rate of zero.

A refusal from the listener session layer now records an unproven skip rather than a verdict. The runner matches the structured block-reason layer header, which covers every refusal from that layer instead of one message string, and it replays only a value in the listener's issued token format so a malformed header never becomes a request the target rejects before delivery.

## Failure direction, and what to distrust

The damaging direction is a scored verdict without delivery. A request refused before it reaches the target's scanner is transport failure, and counting it as containment or as a false positive corrupts the score in whichever direction the case happened to expect.

Distrust the discriminator that separates those two. It decides which refusals are transport failures and which are real decisions. Classifying a genuine block as transport failure would drop a real detection out of the score with no error to notice, which is the quieter and worse mistake of the two. It deliberately does not treat every undelivered block as unproven, because a proxy that blocks exfiltration before forwarding is the target working correctly.

A target that issues no token receives no token header and stays measurable on the same adapter. That target does receive one additional initialize frame per MCP HTTP case, which changes what every target observes in order to accommodate one, and that tradeoff is tracked separately for a profile-declared replacement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP-over-HTTP session handling by securely replaying listener-issued session tokens.
  * Prevented missing, malformed, or unavailable session tokens from being incorrectly reported as policy blocks.
  * Improved request tracking for temporal inventory, response-based scenarios, and tool-result checks.
  * Ensured concurrent sessions remain isolated and do not reuse one another’s tokens.
* **Reliability**
  * Improved handling of session setup and delivery failures for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->