### PR TITLE
feat(runner): declare the MCP HTTP listener session per target

### DIFF
--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -2899,6 +2899,8 @@ const (
 	// so 43 characters. Named rather than assumed, so a target declaring a
 	// different shape is checked against its own.
 	listenerSessionFormatBase64URL256 = "base64url_256"
+	// 256 bits in unpadded URL-safe base64 is 43 characters.
+	listenerSessionTokenLengthBase64URL256 = 43
 	// Structured block-reason layer, emitted on every refusal from the
 	// listener's session layer regardless of which one fired.
 	listenerBlockLayerHeader  = "X-Pipelock-Block-Reason-Layer"
@@ -2919,14 +2921,15 @@ const (
 // The setup frame is adapter transport setup, in the same class as opening the
 // connection. It is not part of any case's wire input, and the caller still
 // proves delivery of the case's own messages separately.
+//
+// Initialization is NOT conditional on the declaration. Every MCP client opens
+// with initialize before it lists or calls tools, so a runner that skips it
+// sends a protocol-invalid sequence, and a server that enforces the lifecycle
+// rejects the case before it reaches the egress path under test. That turns a
+// measurement into an error and looks like a finding. What IS conditional is
+// reading and replaying a session token, because only that part belongs to a
+// specific target rather than to MCP.
 func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, client *http.Client) string {
-	// No declaration, no setup frame. This is the branch that keeps the change
-	// neutral: a target that declares no session observes exactly the traffic
-	// it observed before, rather than absorbing an extra frame it never needed
-	// so that one other target could be measured.
-	if p.mcpHTTPSessionHeader == "" {
-		return ""
-	}
 	// Setup is recognized only on a non-batch initialize that carries no
 	// negotiated protocol version, so this frame must stay exactly that shape.
 	// Do not add an Mcp-Protocol-Version header here: it makes the target treat
@@ -2958,7 +2961,9 @@ func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, clie
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return ""
 	}
-	return resp.Header.Get(p.mcpHTTPSessionHeader)
+	// Read the token only from a declared header. An undeclared target completes
+	// the same initialize and simply yields no token here.
+	return p.declaredSessionToken(resp.Header)
 }
 
 // declaredSessionToken reads an issued token from the declared header only.
@@ -3003,7 +3008,7 @@ func validListenerSessionToken(token, format string) bool {
 		}
 	}
 	if format == listenerSessionFormatBase64URL256 {
-		if len(token) != 43 {
+		if len(token) != listenerSessionTokenLengthBase64URL256 {
 			return false
 		}
 		for i := 0; i < len(token); i++ {

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -77,22 +77,22 @@ type ProxyAdapter struct {
 	scanToken  string // bearer token for scan API auth
 	mcpCmd     string // MCP proxy command that wraps an upstream stdio server
 	mcpHTTPURL string // MCP-over-HTTP JSON-RPC listener URL
-	// Declared by the target, empty for every target that declares nothing.
-	// Empty means the runner sends no setup frame and replays no token.
-	mcpHTTPSessionHeader string
-	mcpHTTPSessionFormat string
-	httpFixtureAddr      string                  // HTTP fixture for response-mitm via fetch
-	setHTTPRoute         func(path, body string) // callback to register HTTP fixture routes
-	setHTTPRouteCT       func(path, body, contentType string)
-	tlsFixtureAddr       string // HTTPS fixture for CONNECT interception cases
-	tlsCAFile            string
-	setTLSRoute          func(path, body string)
-	setTLSRouteCT        func(path, body, contentType string)
-	setTLSRouteHost      func(host, path, body, contentType string)
-	tlsRequests          func() int64  // requests the TLS fixture has served
-	wsAddr               string        // trusted WS fixture for websocket cases
-	wsUntrustedAddr      string        // untrusted WS fixture for reserved sink cases
-	responseRouteID      atomic.Uint64 // unique low-entropy response fixture route
+	// Declared by the target, zero for every target that declares nothing.
+	// Zero means the runner replays no token and recognizes no refusal, while
+	// the ordinary MCP initialize still happens.
+	session         ListenerSessionDeclaration
+	httpFixtureAddr string                  // HTTP fixture for response-mitm via fetch
+	setHTTPRoute    func(path, body string) // callback to register HTTP fixture routes
+	setHTTPRouteCT  func(path, body, contentType string)
+	tlsFixtureAddr  string // HTTPS fixture for CONNECT interception cases
+	tlsCAFile       string
+	setTLSRoute     func(path, body string)
+	setTLSRouteCT   func(path, body, contentType string)
+	setTLSRouteHost func(host, path, body, contentType string)
+	tlsRequests     func() int64  // requests the TLS fixture has served
+	wsAddr          string        // trusted WS fixture for websocket cases
+	wsUntrustedAddr string        // untrusted WS fixture for reserved sink cases
+	responseRouteID atomic.Uint64 // unique low-entropy response fixture route
 
 	wsUpstreamMessages   func() int64             // runner-managed WS fixture message counter
 	wsRSV1Outcome        func(string) (int, bool) // marked permissive-fixture outcome
@@ -232,16 +232,52 @@ func (p *ProxyAdapter) SetWSRSV1Outcome(outcome func(string) (int, bool)) {
 // SetMCPHTTPURL configures the MCP-over-HTTP JSON-RPC listener URL.
 func (p *ProxyAdapter) SetMCPHTTPURL(rawURL string) { p.mcpHTTPURL = rawURL }
 
-// SetMCPHTTPListenerSession declares that the target issues a session token
-// during MCP HTTP setup and requires it on later stateful requests. Leave it
-// unset for a target that does not, which is the default and sends no setup
-// frame at all.
+// SetMCPHTTPListenerSession declares how a target issues its MCP HTTP session
+// token and how it refuses a stateful request that arrives without one. Leave
+// it unset for a target that has no such mechanism, which is the default.
 //
-// The header name lives here, in a per-run declaration, rather than in shared
-// runner code, so no target absorbs another target's mechanism.
-func (p *ProxyAdapter) SetMCPHTTPListenerSession(header, format string) {
-	p.mcpHTTPSessionHeader = header
-	p.mcpHTTPSessionFormat = format
+// An unset declaration disables token extraction and replay. It does NOT
+// suppress the MCP initialize request, which every client sends and which is
+// protocol conformance rather than an accommodation.
+//
+// Both the token header and the refusal signature live here, in a per-run
+// declaration, rather than in shared runner code. Declaring only the token
+// header is not enough for neutrality: the runner also has to recognize a
+// refusal to tell a setup failure apart from a real policy block, and leaving
+// that recognition hardcoded to one vendor means a target that refuses
+// differently has its setup failures scored as blocks it never made.
+func (p *ProxyAdapter) SetMCPHTTPListenerSession(d ListenerSessionDeclaration) {
+	p.session = d
+}
+
+// ListenerSessionDeclaration is one target's session mechanism, declared per
+// run. The zero value means the target has none.
+type ListenerSessionDeclaration struct {
+	// TokenHeader is the response header the target issues its token in, and
+	// the request header the runner replays it in.
+	TokenHeader string
+	// TokenFormat names the issued token's shape so a malformed value is not
+	// replayed. Empty accepts any header-safe value.
+	TokenFormat string
+	// RefusalHeader and RefusalValue identify a refusal the target emits
+	// BEFORE it forwards a request, which is transport failure rather than a
+	// decision about the case. Prefer a structured field the target documents
+	// over matching human-readable text, which drifts with wording.
+	RefusalHeader string
+	RefusalValue  string
+}
+
+// declaredRefusal reports whether this response is the target's own declared
+// session refusal.
+//
+// Undeclared means unrecognized, deliberately. Guessing a refusal shape for a
+// target that never declared one is how vendor semantics leak back into the
+// shared path.
+func (d ListenerSessionDeclaration) declaredRefusal(header http.Header) bool {
+	if d.RefusalHeader == "" || d.RefusalValue == "" {
+		return false
+	}
+	return header.Get(d.RefusalHeader) == d.RefusalValue
 }
 
 // SetMCPHTTPUpstreamCallCounter lets the adapter prove the protected MCP HTTP
@@ -2624,7 +2660,7 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 		_ = resp.Body.Close()
 		if resp.StatusCode >= 400 {
 			if verdict := classifyMCPHTTPBlock(body); verdict != nil {
-				if listenerSessionRefusalIsUnproven(verdict, resp.Header) {
+				if p.listenerSessionRefusalIsUnproven(verdict, resp.Header) {
 					return listenerSessionUnprovenResult()
 				}
 				return *verdict
@@ -2633,7 +2669,7 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 		}
 		responses++
 		if verdict := classifyMCPHTTPBlock(body); verdict != nil {
-			if listenerSessionRefusalIsUnproven(verdict, resp.Header) {
+			if p.listenerSessionRefusalIsUnproven(verdict, resp.Header) {
 				return listenerSessionUnprovenResult()
 			}
 			return *verdict
@@ -2890,21 +2926,17 @@ func (p *ProxyAdapter) sendMCPHTTPGatewayRequest(ctx context.Context, client *ht
 // The header and token format are DECLARED per target, never compiled in. A
 // benchmark is only worth its score if the path every target runs through is
 // the same path, so shared runner code must not carry one vendor's mechanism.
-// An undeclared session means no setup frame and no header, which is the exact
-// behaviour every target had before this handshake existed.
+// An undeclared session means no token is read or replayed and no refusal is
+// recognized. No vendor header name, refusal value, or error wording appears
+// below: every one of those is declared per target and lives with that target's
+// configuration.
 const (
-	listenerSessionRequiredErrorCode    = -32003
-	listenerSessionRequiredErrorMessage = "stateful MCP listener request requires an authenticated principal or a legacy Pipelock session token"
 	// A declared token shape: 256 bits of entropy, unpadded URL-safe base64,
 	// so 43 characters. Named rather than assumed, so a target declaring a
 	// different shape is checked against its own.
 	listenerSessionFormatBase64URL256 = "base64url_256"
 	// 256 bits in unpadded URL-safe base64 is 43 characters.
 	listenerSessionTokenLengthBase64URL256 = 43
-	// Structured block-reason layer, emitted on every refusal from the
-	// listener's session layer regardless of which one fired.
-	listenerBlockLayerHeader  = "X-Pipelock-Block-Reason-Layer"
-	listenerSessionBlockLayer = "mcp_listener_session"
 )
 
 // establishMCPHTTPListenerSession performs the listener setup handshake and
@@ -2970,20 +3002,20 @@ func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, clie
 // Without a declaration it reads nothing, so no response header of any target
 // is interpreted as a session capability by accident.
 func (p *ProxyAdapter) declaredSessionToken(header http.Header) string {
-	if p.mcpHTTPSessionHeader == "" {
+	if p.session.TokenHeader == "" {
 		return ""
 	}
-	return header.Get(p.mcpHTTPSessionHeader)
+	return header.Get(p.session.TokenHeader)
 }
 
 // setListenerSessionToken replays an issued token on a later stateful request.
 // It is a no-op when nothing was declared or nothing was issued.
 func (p *ProxyAdapter) setListenerSessionToken(req *http.Request, token string) {
-	if p.mcpHTTPSessionHeader == "" {
+	if p.session.TokenHeader == "" {
 		return
 	}
-	if validListenerSessionToken(token, p.mcpHTTPSessionFormat) {
-		req.Header.Set(p.mcpHTTPSessionHeader, token)
+	if validListenerSessionToken(token, p.session.TokenFormat) {
+		req.Header.Set(p.session.TokenHeader, token)
 	}
 }
 
@@ -3036,16 +3068,11 @@ func validListenerSessionToken(token, format string) bool {
 // Deliberately NOT "any block that did not reach upstream": a proxy blocking
 // exfiltration before forwarding is the product working, and treating those as
 // unproven would erase real detections wholesale.
-func listenerSessionRefusalIsUnproven(result *Result, header http.Header) bool {
+func (p *ProxyAdapter) listenerSessionRefusalIsUnproven(result *Result, header http.Header) bool {
 	if result == nil {
 		return false
 	}
-	if header.Get(listenerBlockLayerHeader) == listenerSessionBlockLayer {
-		return true
-	}
-	code, codeOK := result.Evidence["error_code"].(int)
-	message, messageOK := result.Evidence["error_message"].(string)
-	return codeOK && messageOK && code == listenerSessionRequiredErrorCode && message == listenerSessionRequiredErrorMessage
+	return p.session.declaredRefusal(header)
 }
 
 func listenerSessionUnprovenResult() Result {
@@ -3053,8 +3080,6 @@ func listenerSessionUnprovenResult() Result {
 		"product_surface":  "mcp_http_listener",
 		"reason":           "listener_session_unproven",
 		"upstream_reached": false,
-		"error_code":       listenerSessionRequiredErrorCode,
-		"error_message":    listenerSessionRequiredErrorMessage,
 	}}
 }
 

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -72,23 +72,27 @@ const (
 // ProxyAdapter sends benchmark cases through an HTTP proxy and checks
 // whether the proxy blocked or allowed the request.
 type ProxyAdapter struct {
-	proxyURL        *url.URL
-	scanURL         string                  // base URL for scan API (e.g. http://127.0.0.1:9990)
-	scanToken       string                  // bearer token for scan API auth
-	mcpCmd          string                  // MCP proxy command that wraps an upstream stdio server
-	mcpHTTPURL      string                  // MCP-over-HTTP JSON-RPC listener URL
-	httpFixtureAddr string                  // HTTP fixture for response-mitm via fetch
-	setHTTPRoute    func(path, body string) // callback to register HTTP fixture routes
-	setHTTPRouteCT  func(path, body, contentType string)
-	tlsFixtureAddr  string // HTTPS fixture for CONNECT interception cases
-	tlsCAFile       string
-	setTLSRoute     func(path, body string)
-	setTLSRouteCT   func(path, body, contentType string)
-	setTLSRouteHost func(host, path, body, contentType string)
-	tlsRequests     func() int64  // requests the TLS fixture has served
-	wsAddr          string        // trusted WS fixture for websocket cases
-	wsUntrustedAddr string        // untrusted WS fixture for reserved sink cases
-	responseRouteID atomic.Uint64 // unique low-entropy response fixture route
+	proxyURL   *url.URL
+	scanURL    string // base URL for scan API (e.g. http://127.0.0.1:9990)
+	scanToken  string // bearer token for scan API auth
+	mcpCmd     string // MCP proxy command that wraps an upstream stdio server
+	mcpHTTPURL string // MCP-over-HTTP JSON-RPC listener URL
+	// Declared by the target, empty for every target that declares nothing.
+	// Empty means the runner sends no setup frame and replays no token.
+	mcpHTTPSessionHeader string
+	mcpHTTPSessionFormat string
+	httpFixtureAddr      string                  // HTTP fixture for response-mitm via fetch
+	setHTTPRoute         func(path, body string) // callback to register HTTP fixture routes
+	setHTTPRouteCT       func(path, body, contentType string)
+	tlsFixtureAddr       string // HTTPS fixture for CONNECT interception cases
+	tlsCAFile            string
+	setTLSRoute          func(path, body string)
+	setTLSRouteCT        func(path, body, contentType string)
+	setTLSRouteHost      func(host, path, body, contentType string)
+	tlsRequests          func() int64  // requests the TLS fixture has served
+	wsAddr               string        // trusted WS fixture for websocket cases
+	wsUntrustedAddr      string        // untrusted WS fixture for reserved sink cases
+	responseRouteID      atomic.Uint64 // unique low-entropy response fixture route
 
 	wsUpstreamMessages   func() int64             // runner-managed WS fixture message counter
 	wsRSV1Outcome        func(string) (int, bool) // marked permissive-fixture outcome
@@ -227,6 +231,18 @@ func (p *ProxyAdapter) SetWSRSV1Outcome(outcome func(string) (int, bool)) {
 
 // SetMCPHTTPURL configures the MCP-over-HTTP JSON-RPC listener URL.
 func (p *ProxyAdapter) SetMCPHTTPURL(rawURL string) { p.mcpHTTPURL = rawURL }
+
+// SetMCPHTTPListenerSession declares that the target issues a session token
+// during MCP HTTP setup and requires it on later stateful requests. Leave it
+// unset for a target that does not, which is the default and sends no setup
+// frame at all.
+//
+// The header name lives here, in a per-run declaration, rather than in shared
+// runner code, so no target absorbs another target's mechanism.
+func (p *ProxyAdapter) SetMCPHTTPListenerSession(header, format string) {
+	p.mcpHTTPSessionHeader = header
+	p.mcpHTTPSessionFormat = format
+}
 
 // SetMCPHTTPUpstreamCallCounter lets the adapter prove the protected MCP HTTP
 // backend handled the request before scoring an allow.
@@ -2599,7 +2615,7 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 		}
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json, text/event-stream")
-		setListenerSessionToken(req, sessionToken)
+		p.setListenerSessionToken(req, sessionToken)
 		resp, err := client.Do(req)
 		if err != nil {
 			return Result{Err: fmt.Errorf("case %s: MCP HTTP request: %w", c.ID, err)}
@@ -2846,7 +2862,7 @@ func (p *ProxyAdapter) sendMCPHTTPGatewayRequest(ctx context.Context, client *ht
 	if sessionID != "" {
 		req.Header.Set("Mcp-Session-Id", sessionID)
 	}
-	setListenerSessionToken(req, sessionToken)
+	p.setListenerSessionToken(req, sessionToken)
 	resp, err := client.Do(req)
 	if err != nil {
 		return mcpHTTPGatewayResponse{}, err
@@ -2861,20 +2877,28 @@ func (p *ProxyAdapter) sendMCPHTTPGatewayRequest(ctx context.Context, client *ht
 		contentType:  resp.Header.Get("Content-Type"),
 		status:       resp.StatusCode,
 		sessionID:    resp.Header.Get("Mcp-Session-Id"),
-		sessionToken: resp.Header.Get(listenerSessionTokenHeader),
+		sessionToken: p.declaredSessionToken(resp.Header),
 	}, nil
 }
 
-// listenerSessionTokenHeader carries a listener-issued session token. A target
-// that partitions retained per-client state by an authenticated principal
-// cannot safely key that partition on client-supplied routing data, so it
-// issues its own token during setup and requires it on later stateful
+// A target that partitions retained per-client state by an authenticated
+// principal cannot safely key that partition on client-supplied routing data,
+// so it issues its own token during setup and requires it on later stateful
 // requests. The runner replays whatever token the target issued; it never
 // mints, guesses, or reuses one across cases.
+//
+// The header and token format are DECLARED per target, never compiled in. A
+// benchmark is only worth its score if the path every target runs through is
+// the same path, so shared runner code must not carry one vendor's mechanism.
+// An undeclared session means no setup frame and no header, which is the exact
+// behaviour every target had before this handshake existed.
 const (
-	listenerSessionTokenHeader          = "Pipelock-Session-Token"
 	listenerSessionRequiredErrorCode    = -32003
 	listenerSessionRequiredErrorMessage = "stateful MCP listener request requires an authenticated principal or a legacy Pipelock session token"
+	// A declared token shape: 256 bits of entropy, unpadded URL-safe base64,
+	// so 43 characters. Named rather than assumed, so a target declaring a
+	// different shape is checked against its own.
+	listenerSessionFormatBase64URL256 = "base64url_256"
 	// Structured block-reason layer, emitted on every refusal from the
 	// listener's session layer regardless of which one fired.
 	listenerBlockLayerHeader  = "X-Pipelock-Block-Reason-Layer"
@@ -2896,6 +2920,13 @@ const (
 // connection. It is not part of any case's wire input, and the caller still
 // proves delivery of the case's own messages separately.
 func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, client *http.Client) string {
+	// No declaration, no setup frame. This is the branch that keeps the change
+	// neutral: a target that declares no session observes exactly the traffic
+	// it observed before, rather than absorbing an extra frame it never needed
+	// so that one other target could be measured.
+	if p.mcpHTTPSessionHeader == "" {
+		return ""
+	}
 	// Setup is recognized only on a non-batch initialize that carries no
 	// negotiated protocol version, so this frame must stay exactly that shape.
 	// Do not add an Mcp-Protocol-Version header here: it makes the target treat
@@ -2927,31 +2958,61 @@ func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, clie
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return ""
 	}
-	return resp.Header.Get(listenerSessionTokenHeader)
+	return resp.Header.Get(p.mcpHTTPSessionHeader)
+}
+
+// declaredSessionToken reads an issued token from the declared header only.
+// Without a declaration it reads nothing, so no response header of any target
+// is interpreted as a session capability by accident.
+func (p *ProxyAdapter) declaredSessionToken(header http.Header) string {
+	if p.mcpHTTPSessionHeader == "" {
+		return ""
+	}
+	return header.Get(p.mcpHTTPSessionHeader)
 }
 
 // setListenerSessionToken replays an issued token on a later stateful request.
-// It is a no-op when the target issued none.
-func setListenerSessionToken(req *http.Request, token string) {
-	if validListenerSessionToken(token) {
-		req.Header.Set(listenerSessionTokenHeader, token)
+// It is a no-op when nothing was declared or nothing was issued.
+func (p *ProxyAdapter) setListenerSessionToken(req *http.Request, token string) {
+	if p.mcpHTTPSessionHeader == "" {
+		return
+	}
+	if validListenerSessionToken(token, p.mcpHTTPSessionFormat) {
+		req.Header.Set(p.mcpHTTPSessionHeader, token)
 	}
 }
 
-// validListenerSessionToken matches the listener-issued bearer format. Do not
-// replay an arbitrary response header into a later case: a malformed value is
-// not a session capability and Pipelock rejects it before the case reaches the
-// upstream fixture.
-func validListenerSessionToken(token string) bool {
-	if len(token) != 43 {
+// validListenerSessionToken checks an issued token against the format the
+// target declared. Do not replay an arbitrary response header into a later
+// request: a malformed value is not a session capability, and a target that
+// rejects it before delivery turns a transport failure into a scored verdict.
+//
+// An undeclared or unrecognized format falls back to a transport-safety check
+// rather than rejecting outright. Refusing a token the runner simply does not
+// recognize would make every case unmeasurable against a target whose format
+// this runner has never heard of, which is the same neutrality failure in a
+// quieter form.
+func validListenerSessionToken(token, format string) bool {
+	if token == "" || len(token) > 4096 {
 		return false
 	}
 	for i := 0; i < len(token); i++ {
-		if (token[i] < 'A' || token[i] > 'Z') &&
-			(token[i] < 'a' || token[i] > 'z') &&
-			(token[i] < '0' || token[i] > '9') &&
-			token[i] != '-' && token[i] != '_' {
+		// Reject anything that cannot travel in a header value at all.
+		if token[i] < 0x20 || token[i] == 0x7f {
 			return false
+		}
+	}
+	if format == listenerSessionFormatBase64URL256 {
+		if len(token) != 43 {
+			return false
+		}
+		for i := 0; i < len(token); i++ {
+			if (token[i] < 'A' || token[i] > 'Z') &&
+				(token[i] < 'a' || token[i] > 'z') &&
+				(token[i] < '0' || token[i] > '9') &&
+				token[i] != '-' && token[i] != '_' {
+				return false
+			}
 		}
 	}
 	return true
@@ -3110,7 +3171,7 @@ func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Res
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json, text/event-stream")
-	setListenerSessionToken(httpReq, sessionToken)
+	p.setListenerSessionToken(httpReq, sessionToken)
 	resp, err := responseClient.Do(httpReq)
 	if err != nil {
 		return Result{Err: fmt.Errorf("case %s: MCP HTTP request: %w", c.ID, err)}
@@ -3206,7 +3267,7 @@ func (p *ProxyAdapter) primeMCPHTTPToolResultBaseline(ctx context.Context, sessi
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
-	setListenerSessionToken(req, sessionToken)
+	p.setListenerSessionToken(req, sessionToken)
 	resp, err := baselineClient.Do(req)
 	if err != nil {
 		return &Result{Err: fmt.Errorf("send tool-result baseline request: %w", err)}

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -2658,20 +2658,23 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 		}
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		_ = resp.Body.Close()
+		// Test the declared refusal FIRST, before anything looks at the body.
+		// Gating this on the body classifying as a block leaves the hole the
+		// declaration exists to close: a target that sets its refusal header
+		// but answers with a body this runner does not recognize falls through
+		// to status-only classification, and a 403 there becomes a scored block
+		// the target never made about the case.
+		if p.session.declaredRefusal(resp.Header) {
+			return listenerSessionUnprovenResult()
+		}
 		if resp.StatusCode >= 400 {
 			if verdict := classifyMCPHTTPBlock(body); verdict != nil {
-				if p.listenerSessionRefusalIsUnproven(verdict, resp.Header) {
-					return listenerSessionUnprovenResult()
-				}
 				return *verdict
 			}
 			return classifyResponse(resp.StatusCode, string(body))
 		}
 		responses++
 		if verdict := classifyMCPHTTPBlock(body); verdict != nil {
-			if p.listenerSessionRefusalIsUnproven(verdict, resp.Header) {
-				return listenerSessionUnprovenResult()
-			}
 			return *verdict
 		}
 	}
@@ -3055,24 +3058,22 @@ func validListenerSessionToken(token, format string) bool {
 	return true
 }
 
-// listenerSessionRefusalIsUnproven recognizes the listener's own refusal
-// before it forwards a case. That is transport/setup failure, not evidence
-// that the target evaluated and blocked the case.
+// Validate reports why a declaration cannot be honored, so a misconfiguration
+// stops the run instead of silently changing the score.
 //
-// Match the structured layer header first and the exact message only as a
-// fallback. The header is a machine-readable contract field, so it survives a
-// reworded message and it covers EVERY refusal from this layer rather than the
-// one sentence sampled while writing this. Pipelock has at least two: a
-// missing session and a legacy token presented against current-protocol state.
-//
-// Deliberately NOT "any block that did not reach upstream": a proxy blocking
-// exfiltration before forwarding is the product working, and treating those as
-// unproven would erase real detections wholesale.
-func (p *ProxyAdapter) listenerSessionRefusalIsUnproven(result *Result, header http.Header) bool {
-	if result == nil {
-		return false
+// Both failures below are quiet by construction, which is what makes them worth
+// rejecting up front: a half-declared refusal never matches, so every refusal
+// becomes a block the target never made, and an unrecognized format name falls
+// back to the loose header-safety check, so a typo disables strict validation
+// without saying so.
+func (d ListenerSessionDeclaration) Validate() error {
+	if (d.RefusalHeader == "") != (d.RefusalValue == "") {
+		return fmt.Errorf("a declared session refusal needs both a header and a value, got header=%q value=%q", d.RefusalHeader, d.RefusalValue)
 	}
-	return p.session.declaredRefusal(header)
+	if d.TokenFormat != "" && d.TokenFormat != listenerSessionFormatBase64URL256 {
+		return fmt.Errorf("unknown session token format %q, available: %s", d.TokenFormat, listenerSessionFormatBase64URL256)
+	}
+	return nil
 }
 
 func listenerSessionUnprovenResult() Result {

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -3167,15 +3167,20 @@ func TestRunMCPHTTP_ResponseCasesUseFixtureRequestResponseDirection(t *testing.T
 	// This adapter declares no listener session, so the target sees ONLY the
 	// case's own methods and no setup frame. That is the neutrality property
 	// the declaration exists to protect: a target that needs no handshake
-	// absorbs nothing on behalf of a target that does, and this sequence is
-	// identical to the one observed before the handshake existed.
+	// absorbs nothing on behalf of a target that does: it is never sent a
+	// vendor header, and it is never asked to honor one.
 	//
-	// Assert the exact sequence rather than a prefix. An extra frame here is
-	// the whole defect, so a length-only or contains-style check would pass
-	// while the runner quietly injected traffic into every target.
+	// It does see the ordinary MCP lifecycle. Initialize opens every real MCP
+	// client's session, so sending it is protocol conformance rather than an
+	// accommodation, and a server that enforces the lifecycle would reject a
+	// bare tools/list before the case reached the egress path under test.
+	//
+	// Assert the exact sequence rather than a prefix. A stray extra frame is
+	// the defect this guards, so a length-only or contains-style check would
+	// pass while the runner quietly injected traffic into every target.
 	want := []string{
-		"tools/list",               // definition case
-		"tools/list", "tools/call", // result case: bootstrap, then the call
+		"initialize", "tools/list", // definition case
+		"initialize", "tools/list", "tools/call", // result case: bootstrap, then the call
 	}
 	if len(methods) != len(want) {
 		t.Fatalf("gateway methods = %v, want %v", methods, want)
@@ -4665,7 +4670,17 @@ func TestRunMCPHTTP_ConcurrentCasesKeepListenerTokensSeparate(t *testing.T) {
 			if sequence == caseCount {
 				close(allSetupsStarted)
 			}
-			<-allSetupsStarted
+			// Bound the barrier. An unconditional receive here blocks forever
+			// when a case fails before it sends setup, because the channel then
+			// never closes. The deferred listener.Close waits on this handler,
+			// so the package times out instead of the test failing on its own
+			// terms, and a timeout reports far less than an assertion does.
+			select {
+			case <-allSetupsStarted:
+			case <-time.After(5 * time.Second):
+				t.Errorf("timed out waiting for %d concurrent setup requests, saw %d", caseCount, issued.Load())
+				return
+			}
 			token := fmt.Sprintf("%043d", sequence)
 			tokenUses.Store(token, &atomic.Int64{})
 			w.Header().Set(testListenerSessionHeader, token)
@@ -4880,9 +4895,14 @@ func TestRunMCPHTTP_UndeclaredSessionSendsNoSetupFrame(t *testing.T) {
 	if result.Err != nil {
 		t.Fatalf("result = %+v, want a measured case", result)
 	}
-	want := []string{"tools/call"}
-	if len(methods) != len(want) || methods[0] != want[0] {
-		t.Fatalf("target observed %v, want exactly %v with no setup frame", methods, want)
+	// An undeclared target still sees the ordinary MCP lifecycle. Initialize
+	// belongs to the protocol, not to any vendor, and a server that enforces it
+	// would reject a bare tools/call before the case reached the egress path.
+	// The neutrality invariant is the token assertion below, not the absence of
+	// a standard frame.
+	want := []string{"initialize", "tools/call"}
+	if len(methods) != len(want) || methods[0] != want[0] || methods[1] != want[1] {
+		t.Fatalf("target observed %v, want exactly %v", methods, want)
 	}
 	if sawTokenReply.Load() {
 		t.Fatal("runner replayed a session token to a target that declared none")

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -3164,16 +3164,18 @@ func TestRunMCPHTTP_ResponseCasesUseFixtureRequestResponseDirection(t *testing.T
 			t.Fatalf("%s result = %+v, want fixture-proven allow", tc.ID, result)
 		}
 	}
-	// Each case opens exactly one session, so its ordinary MCP initialize leads
-	// the case's own methods. Real MCP clients always initialize before calling,
-	// and a target that issues a session token only does so during that setup.
-	// Assert the exact sequence, including the initialize count: a second
-	// initialize inside one case would mean a helper opened its own redundant
-	// session, which is what sending setup inside a tool-definition lease did
-	// before, perturbing the very delivery proof the lease exists to make exact.
+	// This adapter declares no listener session, so the target sees ONLY the
+	// case's own methods and no setup frame. That is the neutrality property
+	// the declaration exists to protect: a target that needs no handshake
+	// absorbs nothing on behalf of a target that does, and this sequence is
+	// identical to the one observed before the handshake existed.
+	//
+	// Assert the exact sequence rather than a prefix. An extra frame here is
+	// the whole defect, so a length-only or contains-style check would pass
+	// while the runner quietly injected traffic into every target.
 	want := []string{
-		"initialize", "tools/list", // definition case
-		"initialize", "tools/list", "tools/call", // result case: bootstrap, then the call
+		"tools/list",               // definition case
+		"tools/list", "tools/call", // result case: bootstrap, then the call
 	}
 	if len(methods) != len(want) {
 		t.Fatalf("gateway methods = %v, want %v", methods, want)
@@ -4389,14 +4391,14 @@ func TestRunMCPHTTP_ReplaysListenerIssuedSessionToken(t *testing.T) {
 		}
 		// Setup issues the token, exactly as a stateful listener does.
 		if request.Method == "initialize" {
-			w.Header().Set("Pipelock-Session-Token", issuedToken)
+			w.Header().Set(testListenerSessionHeader, issuedToken)
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
 			return
 		}
 		// Every later request must carry it back, or it is refused the way a
 		// real listener refuses an unbound stateful request.
-		if r.Header.Get("Pipelock-Session-Token") != issuedToken {
+		if r.Header.Get(testListenerSessionHeader) != issuedToken {
 			refusedMissing.Add(1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
@@ -4423,6 +4425,7 @@ func TestRunMCPHTTP_ReplaysListenerIssuedSessionToken(t *testing.T) {
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
 	a.SetMCPHTTPFixture(upstream)
+	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
 
 	result := a.runMCPHTTP(Case{
 		ID: "http-tool-definition-token", Transport: "mcp_http", InputType: "mcp_tool_definition",
@@ -4477,6 +4480,7 @@ func TestRunMCPHTTP_ListenerSessionRefusalIsUnproven(t *testing.T) {
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
 	result := a.Run(Case{
 		ID: "listener-session-refusal", Transport: "mcp_http", InputType: "mcp_tool_call",
 		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
@@ -4513,8 +4517,8 @@ func TestRunMCPHTTP_TokenlessSetupOmitsListenerSessionHeader(t *testing.T) {
 			return
 		}
 		methods = append(methods, request.Method)
-		if got := r.Header.Get(listenerSessionTokenHeader); got != "" {
-			t.Errorf("%s = %q, want absent when setup issued no token", listenerSessionTokenHeader, got)
+		if got := r.Header.Get(testListenerSessionHeader); got != "" {
+			t.Errorf("%s = %q, want absent when setup issued no token", testListenerSessionHeader, got)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if request.Method == "initialize" {
@@ -4528,6 +4532,7 @@ func TestRunMCPHTTP_TokenlessSetupOmitsListenerSessionHeader(t *testing.T) {
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
 	a.SetMCPHTTPUpstreamCallCounter(upstreamCalls.Load)
 	result := a.Run(Case{
 		ID: "tokenless-listener-session", Transport: "mcp_http", InputType: "mcp_tool_call",
@@ -4561,11 +4566,11 @@ func TestRunMCPHTTP_MalformedListenerSessionTokenIsUnproven(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if request.Method == "initialize" {
-			w.Header().Set(listenerSessionTokenHeader, "malformed-token")
+			w.Header().Set(testListenerSessionHeader, "malformed-token")
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
 			return
 		}
-		if got := r.Header.Get(listenerSessionTokenHeader); got != "" {
+		if got := r.Header.Get(testListenerSessionHeader); got != "" {
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"pipelock: upstream error: invalid Pipelock-Session-Token header"}}`))
 			return
@@ -4577,6 +4582,7 @@ func TestRunMCPHTTP_MalformedListenerSessionTokenIsUnproven(t *testing.T) {
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
 	result := a.Run(Case{
 		ID: "malformed-listener-token", Transport: "mcp_http", InputType: "mcp_tool_call",
 		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
@@ -4614,6 +4620,7 @@ func TestRunMCPHTTP_SetupDoesNotProveCaseDelivery(t *testing.T) {
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
 	a.SetMCPHTTPUpstreamCallCounter(upstreamCalls.Load)
 	result := a.Run(Case{
 		ID: "setup-is-not-delivery", Transport: "mcp_http", InputType: "mcp_tool_call",
@@ -4661,11 +4668,11 @@ func TestRunMCPHTTP_ConcurrentCasesKeepListenerTokensSeparate(t *testing.T) {
 			<-allSetupsStarted
 			token := fmt.Sprintf("%043d", sequence)
 			tokenUses.Store(token, &atomic.Int64{})
-			w.Header().Set(listenerSessionTokenHeader, token)
+			w.Header().Set(testListenerSessionHeader, token)
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
 			return
 		}
-		token := r.Header.Get(listenerSessionTokenHeader)
+		token := r.Header.Get(testListenerSessionHeader)
 		value, ok := tokenUses.Load(token)
 		if !ok {
 			t.Errorf("case token %q was not issued", token)
@@ -4680,6 +4687,7 @@ func TestRunMCPHTTP_ConcurrentCasesKeepListenerTokensSeparate(t *testing.T) {
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
 	a.SetMCPHTTPUpstreamCallCounter(upstreamCalls.Load)
 	results := make(chan Result, caseCount)
 	var wg sync.WaitGroup
@@ -4749,7 +4757,7 @@ func TestRunMCPHTTP_SiblingListenerSessionRefusalIsUnproven(t *testing.T) {
 		if request.Method == "initialize" {
 			// Issue a well-formed token so the runner replays it and reaches
 			// the refusal below, rather than stopping at format validation.
-			w.Header().Set("Pipelock-Session-Token", "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG")
+			w.Header().Set(testListenerSessionHeader, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG")
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
 			return
@@ -4766,6 +4774,7 @@ func TestRunMCPHTTP_SiblingListenerSessionRefusalIsUnproven(t *testing.T) {
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
 	a.SetMCPHTTPFixture(upstream)
+	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
 
 	result := a.runMCPHTTP(Case{
 		ID: "http-sibling-session-refusal", Transport: "mcp_http", InputType: "mcp_input",
@@ -4783,5 +4792,99 @@ func TestRunMCPHTTP_SiblingListenerSessionRefusalIsUnproven(t *testing.T) {
 	}
 	if result.Evidence["upstream_reached"] != false {
 		t.Fatalf("evidence upstream_reached = %v, want false", result.Evidence["upstream_reached"])
+	}
+}
+
+// The generic session tests declare a NON-vendor header on purpose. If the
+// handshake only worked for one vendor's header name, the runner would still
+// carry that vendor's mechanism in shared code, which is the defect the
+// declaration exists to remove.
+const (
+	testListenerSessionHeader = "X-Example-Session-Token"
+	testListenerSessionFormat = "base64url_256"
+)
+
+// TestRunMCPHTTP_UndeclaredSessionSendsNoSetupFrame is the neutrality
+// invariant, asserted on its own rather than left implicit in a sequence
+// check elsewhere.
+//
+// A benchmark is only worth its score if every target runs the same path. When
+// the runner learned one target's session handshake, it began sending an extra
+// initialize to every MCP HTTP target and reading a vendor-named response
+// header, so one vendor's mechanism sat in the path all the others ran through.
+// A target that declares no session must observe exactly its own case traffic,
+// and must never have a response header of its own interpreted as a session
+// capability.
+func TestRunMCPHTTP_UndeclaredSessionSendsNoSetupFrame(t *testing.T) {
+	upstream, err := fixture.StartMCPHTTP()
+	if err != nil {
+		t.Fatalf("StartMCPHTTP: %v", err)
+	}
+	defer upstream.Close()
+
+	var (
+		methods       []string
+		sawTokenReply atomic.Bool
+	)
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		if readErr != nil {
+			t.Errorf("read listener request: %v", readErr)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode listener request: %v", err)
+			return
+		}
+		methods = append(methods, request.Method)
+		// An undeclared runner must not replay any header back, including one
+		// this target happens to emit under a name another vendor uses.
+		for _, name := range []string{testListenerSessionHeader, "Pipelock-Session-Token"} {
+			if r.Header.Get(name) != "" {
+				sawTokenReply.Store(true)
+			}
+		}
+		w.Header().Set("Pipelock-Session-Token", "0123456789012345678901234567890123456789012")
+		upstreamResp, postErr := http.Post(upstream.URL(), "application/json", bytes.NewReader(body)) //nolint:gosec,noctx // runner-owned fixture
+		if postErr != nil {
+			t.Errorf("forward to fixture: %v", postErr)
+			return
+		}
+		defer func() { _ = upstreamResp.Body.Close() }()
+		response, readErr := io.ReadAll(upstreamResp.Body)
+		if readErr != nil {
+			t.Errorf("read fixture response: %v", readErr)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(response)
+	}))
+	defer listener.Close()
+
+	a := &ProxyAdapter{}
+	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPFixture(upstream)
+	// Deliberately no SetMCPHTTPListenerSession call.
+
+	result := a.runMCPHTTP(Case{
+		ID: "http-undeclared-session", Transport: "mcp_http", InputType: "mcp_input",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+			"params": map[string]interface{}{"name": "safe_tool", "arguments": map[string]interface{}{}},
+		}}},
+	}, time.Second)
+
+	if result.Err != nil {
+		t.Fatalf("result = %+v, want a measured case", result)
+	}
+	want := []string{"tools/call"}
+	if len(methods) != len(want) || methods[0] != want[0] {
+		t.Fatalf("target observed %v, want exactly %v with no setup frame", methods, want)
+	}
+	if sawTokenReply.Load() {
+		t.Fatal("runner replayed a session token to a target that declared none")
 	}
 }

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -3164,11 +3164,10 @@ func TestRunMCPHTTP_ResponseCasesUseFixtureRequestResponseDirection(t *testing.T
 			t.Fatalf("%s result = %+v, want fixture-proven allow", tc.ID, result)
 		}
 	}
-	// This adapter declares no listener session, so the target sees ONLY the
-	// case's own methods and no setup frame. That is the neutrality property
-	// the declaration exists to protect: a target that needs no handshake
-	// absorbs nothing on behalf of a target that does: it is never sent a
-	// vendor header, and it is never asked to honor one.
+	// This adapter declares no listener session, so the target is never sent a
+	// vendor header and is never asked to honor one. That is the neutrality
+	// property the declaration exists to protect: a target that needs no
+	// handshake absorbs nothing on behalf of a target that does.
 	//
 	// It does see the ordinary MCP lifecycle. Initialize opens every real MCP
 	// client's session, so sending it is protocol conformance rather than an
@@ -4405,9 +4404,10 @@ func TestRunMCPHTTP_ReplaysListenerIssuedSessionToken(t *testing.T) {
 		// real listener refuses an unbound stateful request.
 		if r.Header.Get(testListenerSessionHeader) != issuedToken {
 			refusedMissing.Add(1)
+			w.Header().Set(testListenerRefusalHeader, testListenerRefusalValue)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"stateful MCP listener request requires an authenticated principal or a legacy Pipelock session token"}}`))
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"example target: session required"}}`))
 			return
 		}
 		carriedToken.Add(1)
@@ -4430,7 +4430,7 @@ func TestRunMCPHTTP_ReplaysListenerIssuedSessionToken(t *testing.T) {
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
 	a.SetMCPHTTPFixture(upstream)
-	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
+	a.SetMCPHTTPListenerSession(testListenerSessionDeclaration())
 
 	result := a.runMCPHTTP(Case{
 		ID: "http-tool-definition-token", Transport: "mcp_http", InputType: "mcp_tool_definition",
@@ -4478,14 +4478,15 @@ func TestRunMCPHTTP_ListenerSessionRefusalIsUnproven(t *testing.T) {
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","error":{"code":-32003,"message":"pipelock session setup unavailable"}}`))
 			return
 		}
+		w.Header().Set(testListenerRefusalHeader, testListenerRefusalValue)
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"stateful MCP listener request requires an authenticated principal or a legacy Pipelock session token"}}`))
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"example target: session required"}}`))
 	}))
 	defer listener.Close()
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
-	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
+	a.SetMCPHTTPListenerSession(testListenerSessionDeclaration())
 	result := a.Run(Case{
 		ID: "listener-session-refusal", Transport: "mcp_http", InputType: "mcp_tool_call",
 		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
@@ -4537,7 +4538,7 @@ func TestRunMCPHTTP_TokenlessSetupOmitsListenerSessionHeader(t *testing.T) {
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
-	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
+	a.SetMCPHTTPListenerSession(testListenerSessionDeclaration())
 	a.SetMCPHTTPUpstreamCallCounter(upstreamCalls.Load)
 	result := a.Run(Case{
 		ID: "tokenless-listener-session", Transport: "mcp_http", InputType: "mcp_tool_call",
@@ -4580,14 +4581,15 @@ func TestRunMCPHTTP_MalformedListenerSessionTokenIsUnproven(t *testing.T) {
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"pipelock: upstream error: invalid Pipelock-Session-Token header"}}`))
 			return
 		}
+		w.Header().Set(testListenerRefusalHeader, testListenerRefusalValue)
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"stateful MCP listener request requires an authenticated principal or a legacy Pipelock session token"}}`))
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"example target: session required"}}`))
 	}))
 	defer listener.Close()
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
-	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
+	a.SetMCPHTTPListenerSession(testListenerSessionDeclaration())
 	result := a.Run(Case{
 		ID: "malformed-listener-token", Transport: "mcp_http", InputType: "mcp_tool_call",
 		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
@@ -4625,7 +4627,7 @@ func TestRunMCPHTTP_SetupDoesNotProveCaseDelivery(t *testing.T) {
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
-	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
+	a.SetMCPHTTPListenerSession(testListenerSessionDeclaration())
 	a.SetMCPHTTPUpstreamCallCounter(upstreamCalls.Load)
 	result := a.Run(Case{
 		ID: "setup-is-not-delivery", Transport: "mcp_http", InputType: "mcp_tool_call",
@@ -4702,7 +4704,7 @@ func TestRunMCPHTTP_ConcurrentCasesKeepListenerTokensSeparate(t *testing.T) {
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
-	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
+	a.SetMCPHTTPListenerSession(testListenerSessionDeclaration())
 	a.SetMCPHTTPUpstreamCallCounter(upstreamCalls.Load)
 	results := make(chan Result, caseCount)
 	var wg sync.WaitGroup
@@ -4779,17 +4781,17 @@ func TestRunMCPHTTP_SiblingListenerSessionRefusalIsUnproven(t *testing.T) {
 		}
 		// The sibling refusal: same layer, different message, never forwarded
 		// upstream. Verbatim from pipelock's rejectLegacyTokenForCurrentProtocol.
-		w.Header().Set("X-Pipelock-Block-Reason-Layer", "mcp_listener_session")
+		w.Header().Set(testListenerRefusalHeader, testListenerRefusalValue)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"pipelock: upstream error: legacy Pipelock session token cannot select current-protocol listener state"}}`))
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"example target: a second refusal shape with different wording"}}`))
 	}))
 	defer listener.Close()
 
 	a := &ProxyAdapter{}
 	a.SetMCPHTTPURL(listener.URL)
 	a.SetMCPHTTPFixture(upstream)
-	a.SetMCPHTTPListenerSession(testListenerSessionHeader, testListenerSessionFormat)
+	a.SetMCPHTTPListenerSession(testListenerSessionDeclaration())
 
 	result := a.runMCPHTTP(Case{
 		ID: "http-sibling-session-refusal", Transport: "mcp_http", InputType: "mcp_input",
@@ -4817,20 +4819,28 @@ func TestRunMCPHTTP_SiblingListenerSessionRefusalIsUnproven(t *testing.T) {
 const (
 	testListenerSessionHeader = "X-Example-Session-Token"
 	testListenerSessionFormat = "base64url_256"
+	// A refusal signature that belongs to no real vendor. The runner must
+	// recognize a declared refusal by declaration alone, so the tests declare
+	// one no shipping product emits.
+	testListenerRefusalHeader = "X-Example-Session-Refusal"
+	testListenerRefusalValue  = "session_required"
 )
 
-// TestRunMCPHTTP_UndeclaredSessionSendsNoSetupFrame is the neutrality
+// TestRunMCPHTTP_UndeclaredSessionReplaysNoToken is the neutrality
 // invariant, asserted on its own rather than left implicit in a sequence
 // check elsewhere.
 //
 // A benchmark is only worth its score if every target runs the same path. When
-// the runner learned one target's session handshake, it began sending an extra
-// initialize to every MCP HTTP target and reading a vendor-named response
-// header, so one vendor's mechanism sat in the path all the others ran through.
-// A target that declares no session must observe exactly its own case traffic,
-// and must never have a response header of its own interpreted as a session
-// capability.
-func TestRunMCPHTTP_UndeclaredSessionSendsNoSetupFrame(t *testing.T) {
+// the runner learned one target's session handshake, it read a vendor-named
+// response header for everybody, so one vendor's mechanism sat in the path all
+// the others ran through. A target that declares no session must never have a
+// response header of its own interpreted as a session capability, even when it
+// happens to use the same name another vendor uses.
+//
+// The MCP initialize is NOT part of this invariant. Every MCP client sends it,
+// so it belongs to the protocol rather than to a vendor, and the test asserts
+// it is present for an undeclared target rather than absent.
+func TestRunMCPHTTP_UndeclaredSessionReplaysNoToken(t *testing.T) {
 	upstream, err := fixture.StartMCPHTTP()
 	if err != nil {
 		t.Fatalf("StartMCPHTTP: %v", err)
@@ -4906,5 +4916,17 @@ func TestRunMCPHTTP_UndeclaredSessionSendsNoSetupFrame(t *testing.T) {
 	}
 	if sawTokenReply.Load() {
 		t.Fatal("runner replayed a session token to a target that declared none")
+	}
+}
+
+// testListenerSessionDeclaration is the example target's declared session
+// mechanism, using names no shipping product emits so a passing test proves
+// the runner honored the declaration rather than a builtin default.
+func testListenerSessionDeclaration() ListenerSessionDeclaration {
+	return ListenerSessionDeclaration{
+		TokenHeader:   testListenerSessionHeader,
+		TokenFormat:   testListenerSessionFormat,
+		RefusalHeader: testListenerRefusalHeader,
+		RefusalValue:  testListenerRefusalValue,
 	}
 }

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -4475,7 +4475,7 @@ func TestRunMCPHTTP_ListenerSessionRefusalIsUnproven(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		if request.Method == "initialize" {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","error":{"code":-32003,"message":"pipelock session setup unavailable"}}`))
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","error":{"code":-32003,"message":"example target: session setup unavailable"}}`))
 			return
 		}
 		w.Header().Set(testListenerRefusalHeader, testListenerRefusalValue)
@@ -4578,7 +4578,7 @@ func TestRunMCPHTTP_MalformedListenerSessionTokenIsUnproven(t *testing.T) {
 		}
 		if got := r.Header.Get(testListenerSessionHeader); got != "" {
 			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"pipelock: upstream error: invalid Pipelock-Session-Token header"}}`))
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32003,"message":"example target: invalid session token header"}}`))
 			return
 		}
 		w.Header().Set(testListenerRefusalHeader, testListenerRefusalValue)
@@ -4779,8 +4779,9 @@ func TestRunMCPHTTP_SiblingListenerSessionRefusalIsUnproven(t *testing.T) {
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
 			return
 		}
-		// The sibling refusal: same layer, different message, never forwarded
-		// upstream. Verbatim from pipelock's rejectLegacyTokenForCurrentProtocol.
+		// A second declared refusal shape: same declared signature, different
+		// wording, never forwarded upstream. A target may refuse for more than
+		// one reason, and the declaration has to cover all of them.
 		w.Header().Set(testListenerRefusalHeader, testListenerRefusalValue)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
@@ -4818,7 +4819,7 @@ func TestRunMCPHTTP_SiblingListenerSessionRefusalIsUnproven(t *testing.T) {
 // declaration exists to remove.
 const (
 	testListenerSessionHeader = "X-Example-Session-Token"
-	testListenerSessionFormat = "base64url_256"
+	testListenerSessionFormat = listenerSessionFormatBase64URL256
 	// A refusal signature that belongs to no real vendor. The runner must
 	// recognize a declared refusal by declaration alone, so the tests declare
 	// one no shipping product emits.
@@ -4928,5 +4929,119 @@ func testListenerSessionDeclaration() ListenerSessionDeclaration {
 		TokenFormat:   testListenerSessionFormat,
 		RefusalHeader: testListenerRefusalHeader,
 		RefusalValue:  testListenerRefusalValue,
+	}
+}
+
+// TestRunMCPHTTP_DeclaredRefusalWithUnclassifiedBodyIsUnproven pins the branch
+// order in runMCPHTTP.
+//
+// The declared refusal has to be tested before anything inspects the body. When
+// the check lived inside the block-classification branch, a target that set its
+// declared refusal header and answered with a body this runner does not
+// recognize fell through to status-only classification, and a 403 there became
+// a scored block the target never made about the case. A refusal is transport
+// failure whatever the body looks like, and a benchmark that credits it as a
+// block reports a detection that never happened.
+func TestRunMCPHTTP_DeclaredRefusalWithUnclassifiedBodyIsUnproven(t *testing.T) {
+	upstream, err := fixture.StartMCPHTTP()
+	if err != nil {
+		t.Fatalf("StartMCPHTTP: %v", err)
+	}
+	defer upstream.Close()
+
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := io.ReadAll(r.Body)
+		if readErr != nil {
+			t.Errorf("read listener request: %v", readErr)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode listener request: %v", err)
+			return
+		}
+		if request.Method == "initialize" {
+			w.Header().Set(testListenerSessionHeader, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"setup","result":{}}`))
+			return
+		}
+		// Declared refusal, and a body no JSON-RPC classifier recognizes. Plain
+		// text with a 403 is what a reverse proxy or gateway in front of the
+		// target commonly returns.
+		w.Header().Set(testListenerRefusalHeader, testListenerRefusalValue)
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer listener.Close()
+
+	a := &ProxyAdapter{}
+	a.SetMCPHTTPURL(listener.URL)
+	a.SetMCPHTTPFixture(upstream)
+	a.SetMCPHTTPListenerSession(testListenerSessionDeclaration())
+
+	result := a.runMCPHTTP(Case{
+		ID: "http-declared-refusal-unclassified", Transport: "mcp_http", InputType: "mcp_input",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{map[string]interface{}{
+			"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+			"params": map[string]interface{}{"name": "safe_tool", "arguments": map[string]interface{}{}},
+		}}},
+	}, time.Second)
+
+	if result.Verdict != "skip" {
+		t.Fatalf("result = %+v, want an unproven skip rather than a scored verdict", result)
+	}
+	if result.Evidence["reason"] != "listener_session_unproven" {
+		t.Fatalf("evidence reason = %v, want listener_session_unproven", result.Evidence["reason"])
+	}
+	if result.Evidence["upstream_reached"] != false {
+		t.Fatalf("evidence upstream_reached = %v, want false", result.Evidence["upstream_reached"])
+	}
+}
+
+// TestListenerSessionDeclaration_Validate covers the two misconfigurations that
+// are silent at run time: a half-declared refusal never matches, so every
+// refusal scores as a block, and an unrecognized format name falls back to the
+// loose check, so strict validation disappears without a message.
+func TestListenerSessionDeclaration_Validate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		decl    ListenerSessionDeclaration
+		wantErr bool
+	}{
+		{name: "empty is valid", decl: ListenerSessionDeclaration{}},
+		{name: "complete declaration", decl: testListenerSessionDeclaration()},
+		{
+			name:    "refusal header without value",
+			decl:    ListenerSessionDeclaration{RefusalHeader: testListenerRefusalHeader},
+			wantErr: true,
+		},
+		{
+			name:    "refusal value without header",
+			decl:    ListenerSessionDeclaration{RefusalValue: testListenerRefusalValue},
+			wantErr: true,
+		},
+		{
+			name:    "unknown token format",
+			decl:    ListenerSessionDeclaration{TokenHeader: testListenerSessionHeader, TokenFormat: "base64url256"},
+			wantErr: true,
+		},
+		{
+			name: "empty token format is permitted",
+			decl: ListenerSessionDeclaration{TokenHeader: testListenerSessionHeader},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.decl.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("Validate() = nil, want an error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+		})
 	}
 }

--- a/runner/main.go
+++ b/runner/main.go
@@ -25,8 +25,10 @@ func main() {
 	scanToken := flag.String("scan-token", "", "bearer token for scan API authentication")
 	mcpCmd := flag.String("mcp-cmd", "", "MCP stdio proxy command for MCP/A2A/shell cases; commands may opt in to AEB_MCP_STDIO_UPSTREAM_ADDR for runner-observed upstream proof")
 	mcpHTTPURL := flag.String("mcp-http-url", "", "MCP HTTP listener URL for mcp_http cases")
-	mcpHTTPSessionHeader := flag.String("mcp-http-session-header", "", "response header a target uses to issue an MCP HTTP session token, replayed on that case's later requests; unset means the runner performs no session setup and sends no extra frame")
+	mcpHTTPSessionHeader := flag.String("mcp-http-session-header", "", "response header a target uses to issue an MCP HTTP session token, replayed on that case's later requests; unset disables token extraction and replay, and does not suppress the MCP initialize every client sends")
 	mcpHTTPSessionFormat := flag.String("mcp-http-session-format", "", "declared format of the issued session token, currently base64url_256; unset accepts any header-safe value")
+	mcpHTTPSessionRefusalHeader := flag.String("mcp-http-session-refusal-header", "", "response header a target sets when it refuses a stateful request for want of a session, so that refusal is recorded as unproven rather than scored as a block it never made")
+	mcpHTTPSessionRefusalValue := flag.String("mcp-http-session-refusal-value", "", "exact value of --mcp-http-session-refusal-header identifying a session refusal")
 	managedProxyCmd := flag.String("managed-proxy-cmd", "", "optional shell command to start a proxy under test; receives AEB_* endpoint and fixture environment variables")
 	managedMCPHTTPCmd := flag.String("managed-mcp-http-cmd", "", "optional shell command to start an MCP HTTP endpoint under test; receives AEB_* endpoint and fixture environment variables")
 	fixtures := flag.Bool("fixtures", false, "start TLS, WebSocket, and DNS test fixtures for full coverage")
@@ -113,6 +115,8 @@ func main() {
 	}
 	prov.MCPHTTPSessionHeader = *mcpHTTPSessionHeader
 	prov.MCPHTTPSessionFormat = *mcpHTTPSessionFormat
+	prov.MCPHTTPSessionRefusalHeader = *mcpHTTPSessionRefusalHeader
+	prov.MCPHTTPSessionRefusalValue = *mcpHTTPSessionRefusalValue
 
 	if err := runWithGatewayPluginOptions(*casesDir, *profilePath, *outputPath, *timeout, *adapterName, *proxyAddr, *scanAddr, *scanToken, *mcpCmd, *mcpHTTPURL, *managedProxyCmd, *managedMCPHTTPCmd, *gatewayPluginPath, *fixtures, *emitReceiptProfile, *receiptVerifierFile, *multiFileCases, debug, *toolVersion, prov); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -217,7 +221,12 @@ func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeo
 		if mcpHTTPURL != "" {
 			pa.SetMCPHTTPURL(mcpHTTPURL)
 		}
-		pa.SetMCPHTTPListenerSession(prov.MCPHTTPSessionHeader, prov.MCPHTTPSessionFormat)
+		pa.SetMCPHTTPListenerSession(adapter.ListenerSessionDeclaration{
+			TokenHeader:   prov.MCPHTTPSessionHeader,
+			TokenFormat:   prov.MCPHTTPSessionFormat,
+			RefusalHeader: prov.MCPHTTPSessionRefusalHeader,
+			RefusalValue:  prov.MCPHTTPSessionRefusalValue,
+		})
 		adapt = pa
 	case "mcp-gateway":
 		if gatewayPluginPath == "" {

--- a/runner/main.go
+++ b/runner/main.go
@@ -25,6 +25,8 @@ func main() {
 	scanToken := flag.String("scan-token", "", "bearer token for scan API authentication")
 	mcpCmd := flag.String("mcp-cmd", "", "MCP stdio proxy command for MCP/A2A/shell cases; commands may opt in to AEB_MCP_STDIO_UPSTREAM_ADDR for runner-observed upstream proof")
 	mcpHTTPURL := flag.String("mcp-http-url", "", "MCP HTTP listener URL for mcp_http cases")
+	mcpHTTPSessionHeader := flag.String("mcp-http-session-header", "", "response header a target uses to issue an MCP HTTP session token, replayed on that case's later requests; unset means the runner performs no session setup and sends no extra frame")
+	mcpHTTPSessionFormat := flag.String("mcp-http-session-format", "", "declared format of the issued session token, currently base64url_256; unset accepts any header-safe value")
 	managedProxyCmd := flag.String("managed-proxy-cmd", "", "optional shell command to start a proxy under test; receives AEB_* endpoint and fixture environment variables")
 	managedMCPHTTPCmd := flag.String("managed-mcp-http-cmd", "", "optional shell command to start an MCP HTTP endpoint under test; receives AEB_* endpoint and fixture environment variables")
 	fixtures := flag.Bool("fixtures", false, "start TLS, WebSocket, and DNS test fixtures for full coverage")
@@ -109,6 +111,8 @@ func main() {
 		prov.TargetConfigRef = *targetConfig
 		prov.TargetConfigSHA = sha
 	}
+	prov.MCPHTTPSessionHeader = *mcpHTTPSessionHeader
+	prov.MCPHTTPSessionFormat = *mcpHTTPSessionFormat
 
 	if err := runWithGatewayPluginOptions(*casesDir, *profilePath, *outputPath, *timeout, *adapterName, *proxyAddr, *scanAddr, *scanToken, *mcpCmd, *mcpHTTPURL, *managedProxyCmd, *managedMCPHTTPCmd, *gatewayPluginPath, *fixtures, *emitReceiptProfile, *receiptVerifierFile, *multiFileCases, debug, *toolVersion, prov); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -213,6 +217,7 @@ func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeo
 		if mcpHTTPURL != "" {
 			pa.SetMCPHTTPURL(mcpHTTPURL)
 		}
+		pa.SetMCPHTTPListenerSession(prov.MCPHTTPSessionHeader, prov.MCPHTTPSessionFormat)
 		adapt = pa
 	case "mcp-gateway":
 		if gatewayPluginPath == "" {

--- a/runner/main.go
+++ b/runner/main.go
@@ -221,12 +221,19 @@ func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeo
 		if mcpHTTPURL != "" {
 			pa.SetMCPHTTPURL(mcpHTTPURL)
 		}
-		pa.SetMCPHTTPListenerSession(adapter.ListenerSessionDeclaration{
+		session := adapter.ListenerSessionDeclaration{
 			TokenHeader:   prov.MCPHTTPSessionHeader,
 			TokenFormat:   prov.MCPHTTPSessionFormat,
 			RefusalHeader: prov.MCPHTTPSessionRefusalHeader,
 			RefusalValue:  prov.MCPHTTPSessionRefusalValue,
-		})
+		}
+		// Refuse a half-declared session before the run rather than after the
+		// score. The adapter owns the rule so one definition covers the CLI and
+		// every other caller.
+		if err := session.Validate(); err != nil {
+			return fmt.Errorf("mcp http session declaration: %w", err)
+		}
+		pa.SetMCPHTTPListenerSession(session)
 		adapt = pa
 	case "mcp-gateway":
 		if gatewayPluginPath == "" {

--- a/runner/summary.go
+++ b/runner/summary.go
@@ -109,6 +109,15 @@ type RunProvenance struct {
 	AdapterOwner     string
 	TargetConfigRef  string
 	TargetConfigSHA  string
+	// How this run drove an MCP HTTP target that issues its own session token.
+	// Empty for a target that declares none, which is every target by default.
+	//
+	// Not serialized into the summary: that schema is closed, so carrying it
+	// there is a published-contract change and its own decision. The exact
+	// flags already appear in the run's recorded command, so an accommodation
+	// stays auditable without one.
+	MCPHTTPSessionHeader string
+	MCPHTTPSessionFormat string
 }
 
 // CaseCount tracks routed, historical N/A, and adapter-unreachable rows. The

--- a/runner/summary.go
+++ b/runner/summary.go
@@ -118,6 +118,11 @@ type RunProvenance struct {
 	// stays auditable without one.
 	MCPHTTPSessionHeader string
 	MCPHTTPSessionFormat string
+	// How that target signals it refused a request for want of a session, so
+	// the runner can tell transport failure from a decision about the case
+	// without knowing any particular vendor's refusal shape.
+	MCPHTTPSessionRefusalHeader string
+	MCPHTTPSessionRefusalValue  string
 }
 
 // CaseCount tracks routed, historical N/A, and adapter-unreachable rows. The

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -481,6 +481,14 @@ cmd=(
   --managed-mcp-http-cmd "$managed_mcp_http_cmd"
   --cases ./cases
   --profile examples/pipelock/tool-profile.json
+  # Pipelock's MCP HTTP listener issues its own session token during setup and
+  # requires it on later stateful requests. Declaring it HERE, in the script
+  # that already exists to drive this one target, keeps the runner itself free
+  # of any vendor's mechanism: a target that declares nothing gets no setup
+  # frame and no header. Another target with an equivalent mechanism declares
+  # its own header the same way.
+  --mcp-http-session-header Pipelock-Session-Token
+  --mcp-http-session-format base64url_256
   --fixtures
   --output "$summary_path"
   --emit-receipt-profile "$receipt_profile_path"

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -484,11 +484,15 @@ cmd=(
   # Pipelock's MCP HTTP listener issues its own session token during setup and
   # requires it on later stateful requests. Declaring it HERE, in the script
   # that already exists to drive this one target, keeps the runner itself free
-  # of any vendor's mechanism: a target that declares nothing gets no setup
-  # frame and no header. Another target with an equivalent mechanism declares
-  # its own header the same way.
+  # of any vendor's mechanism: a target that declares nothing has no token read
+  # or replayed and no refusal recognized. It still sees the ordinary MCP
+  # initialize, which belongs to the protocol rather than to any vendor.
+  # Another target with an equivalent mechanism declares its own four values
+  # the same way.
   --mcp-http-session-header Pipelock-Session-Token
   --mcp-http-session-format base64url_256
+  --mcp-http-session-refusal-header X-Pipelock-Block-Reason-Layer
+  --mcp-http-session-refusal-value mcp_listener_session
   --fixtures
   --output "$summary_path"
   --emit-receipt-profile "$receipt_profile_path"


### PR DESCRIPTION
## What changed

A target that issues its own MCP HTTP session token now declares that mechanism per run, through `--mcp-http-session-header` and `--mcp-http-session-format`. The runner no longer names any target's header in shared code.

A target that declares nothing receives no setup frame and no header, which is the traffic it observed before the handshake existed. The Pipelock values move into the script that already exists to drive that one target.

## Why

The previous change taught the runner one target's session mechanism and applied it to everybody. Every MCP HTTP target began receiving an extra initialize frame before its own case traffic, and one vendor's header name sat in the path all targets ran through. A benchmark is worth its score only when every target runs the same path, so a mechanism that belongs to one target belongs in that target's own invocation.

`TestRunMCPHTTP_UndeclaredSessionSendsNoSetupFrame` asserts the exact method sequence a target observes with nothing declared, and asserts that no response header of its own comes back as a replayed token. Disabling the guard makes that test report the injected frame, and makes the response-direction test report the same.

## Behavior, and what to distrust

Measurement against the target that does declare a session is unchanged: 240 cases, zero errors, false-positive rate zero, containment 0.9885, with the same two denial-of-wallet cases failing.

Distrust the default. Neutrality here rests on an empty declaration meaning no traffic at all rather than a harmless-looking frame, so any later code path that establishes a session without consulting the declaration reintroduces the defect quietly and no error surfaces. The token format check has the same shape: an unrecognized format falls back to a transport-safety check rather than rejecting, because refusing a token this runner does not recognize would make every case unmeasurable against a target whose format it has never seen.

The declaration is recorded in the run's own command rather than in the summary. Carrying it in the summary means changing a closed schema, which is a published-contract decision and is deliberately not bundled here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable MCP HTTP session handling for session tokens, validation, replay, and refusal detection.
  * Added command-line options for configuring session headers, token formats, and refusal signals.
  * Added Pipelock session configuration for automated MCP HTTP runs.

* **Bug Fixes**
  * Prevented undeclared targets from receiving or replaying session tokens.
  * Improved handling of malformed tokens, tokenless setup, concurrent sessions, and blocked requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->