### PR TITLE
fix(runner): bound WebSocket reads to the case deadline

### DIFF
--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -543,16 +543,18 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 	expectedUpstreamMessages := countCorpusWebSocketMessages(frames)
 	expectedRSV1Frames := countCorpusRSV1Frames(frames)
 	upstreamBefore, _ := p.webSocketUpstreamMessageCount()
+	var frameWriteErr error
 	for _, raw := range frames {
 		frame, _ := raw.(map[string]interface{})
 		if err := writeCorpusWebSocketFrame(conn, frame); err != nil {
-			return Result{
-				Verdict: "skip",
-				Evidence: map[string]interface{}{
-					"reason": "connection_closed_while_writing_frame",
-					"detail": truncate(err.Error(), 120),
-				},
-			}
+			// The peer can send a close frame while the remaining corpus
+			// frames are still being written. Preserve that write failure so
+			// an EOF without a close stays unproven, but first read any close
+			// already sent by the peer. RSV1 attribution requires the received
+			// protocol close and the marker-scoped fixture outcome below; a
+			// write failure alone never becomes containment proof.
+			frameWriteErr = err
+			break
 		}
 	}
 
@@ -568,8 +570,14 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 	// Budget: the first frame gets the full timeout (proxy may need time to
 	// reassemble fragments and run scanners). Subsequent reads use a short
 	// idle window so allow-cases don't pay the full timeout per case.
-	firstReadDeadline := runDeadline
 	const idleWindow = 500 * time.Millisecond
+	firstReadDeadline := runDeadline
+	if frameWriteErr != nil {
+		closeReadDeadline := time.Now().Add(idleWindow)
+		if closeReadDeadline.Before(firstReadDeadline) {
+			firstReadDeadline = closeReadDeadline
+		}
+	}
 	var lastFrame struct {
 		opcode       int
 		payloadBytes int
@@ -587,6 +595,15 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		}
 		opcode, payload, err := readWebSocketFrame(br)
 		if err != nil {
+			if frameWriteErr != nil {
+				return Result{
+					Verdict: "skip",
+					Evidence: map[string]interface{}{
+						"reason": "connection_closed_while_writing_frame",
+						"detail": truncate(frameWriteErr.Error(), 120),
+					},
+				}
+			}
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				ev := map[string]interface{}{
 					"scanner": "websocket_proxy",

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -585,9 +585,17 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 	}
 	for {
 		var dl time.Time
-		if lastFrame.seen {
+		switch {
+		case frameWriteErr != nil:
+			// After a write failure this loop exists only to collect a close
+			// the peer already sent, so it gets ONE fixed window. Renewing per
+			// frame here would let a peer that keeps talking stretch that
+			// collection out to the full case deadline, which is the opposite
+			// of the bounded read the write-failure path is supposed to be.
+			dl = firstReadDeadline
+		case lastFrame.seen:
 			dl = time.Now().Add(idleWindow)
-		} else {
+		default:
 			dl = firstReadDeadline
 		}
 		// The idle window is per-read, so a peer that sends something before

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -590,6 +590,14 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		} else {
 			dl = firstReadDeadline
 		}
+		// The idle window is per-read, so a peer that sends something before
+		// each window expires renews it forever and the loop outlives the case
+		// deadline it was given. Clamp to that deadline: a chatty target must
+		// not be able to hold a case open indefinitely, which on a benchmark
+		// stalls the whole run rather than scoring anything.
+		if dl.After(runDeadline) {
+			dl = runDeadline
+		}
 		if deadlineErr := conn.SetReadDeadline(dl); deadlineErr != nil {
 			return Result{Err: fmt.Errorf("case %s: ws read deadline: %w", c.ID, deadlineErr)}
 		}

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -5045,3 +5045,84 @@ func TestListenerSessionDeclaration_Validate(t *testing.T) {
 		})
 	}
 }
+
+// TestRunWebSocketFrameViaProxy_ChattyPeerCannotOutlastRunDeadline pins the read
+// loop to the case deadline.
+//
+// The per-read idle window is renewed on every iteration once any frame has
+// arrived, so a peer that sends something before each window expires renews it
+// forever. Without a clamp the loop outlives the deadline the case was given,
+// and on a benchmark one chatty target stalls the whole run instead of scoring
+// anything. A target under measurement is exactly the party that must not get to
+// decide how long measurement takes.
+func TestRunWebSocketFrameViaProxy_ChattyPeerCannotOutlastRunDeadline(t *testing.T) {
+	const runTimeout = 300 * time.Millisecond
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Errorf("test server does not support hijacking")
+			return
+		}
+		conn, rw, err := hj.Hijack()
+		if err != nil {
+			t.Errorf("hijack: %v", err)
+			return
+		}
+		defer conn.Close() //nolint:errcheck // test cleanup
+		if _, err := fmt.Fprint(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"); err != nil {
+			return
+		}
+		if _, _, err := readWebSocketFrame(rw.Reader); err != nil {
+			return
+		}
+		// Never close. Emit a frame well inside the idle window so the window is
+		// always renewed before it can expire.
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := writeServerWebSocketFrame(conn, wsOpcodeText, []byte("noise")); err != nil {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	a, _ := NewProxyAdapter(srv.Listener.Addr().String(), "", "", "")
+
+	// Run it off the test goroutine so a regression FAILS here rather than
+	// hanging until the package timeout. The bug under test is an unbounded
+	// wait, so a test that waits for it to finish inherits the same defect.
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		_ = a.runWebSocketFrameViaProxy(Case{
+			ID:        "ws-chatty-peer",
+			Transport: "websocket",
+			InputType: "websocket_frame",
+			Payload: map[string]interface{}{
+				"url":    "wss://example.com/ws",
+				"frames": []interface{}{map[string]interface{}{"opcode": "text", "payload": "probe"}},
+			},
+		}, runTimeout)
+		done <- time.Since(start)
+	}()
+
+	// Generous ceiling. The point is that the run ends on its own deadline
+	// rather than lasting as long as the peer keeps talking.
+	select {
+	case elapsed := <-done:
+		if elapsed > 5*runTimeout {
+			t.Fatalf("run took %s under a %s case timeout, want termination near the case deadline", elapsed, runTimeout)
+		}
+	case <-time.After(5 * runTimeout):
+		t.Fatalf("run outlived %s under a %s case timeout, so a talking peer controls the run length", 5*runTimeout, runTimeout)
+	}
+}


### PR DESCRIPTION
## What changed

Two fixes in the WebSocket path, both about who controls when a case ends.

A frame-write failure no longer discards a close the target already sent. The peer can close as soon as it rejects a marked frame, so the remaining corpus frames fail to write, and the runner was returning that write error without ever reading the close it was sent to observe. It now preserves the write error, reads one bounded close, and still returns an unproven skip when no close arrives.

The read loop is bounded by the case deadline. Once any frame had arrived, each iteration granted a fresh idle window, so a target that sent something before every window expired renewed it indefinitely and the run outlived the deadline it was given. With the clamp removed, a case carrying a 300ms timeout ran past 90 seconds and ended only on the Go package timeout.

## Failure direction, and what to distrust

Neither change can turn a close into containment credit. That still requires the terminal, marker-scoped fixture proof, and forcing that proof true makes exactly the three stays-unproven cases fail, which is how the assertion was checked rather than assumed. The damaging direction here is the other one: an attack case scored as blocked when the runner only observed a transport failure.

The second fix is the one to distrust. It shortens a deadline, so a target that legitimately needs longer than the case timeout now reports unproven where it previously reported a verdict. That is the correct outcome for a benchmark, because a result nobody can bound is not a measurement, but it does mean a slow target reads as unmeasured rather than as failing.

## Reproducing this class

Both failures reproduce only under full-package concurrency, never behind a `-run` filter. Roughly 480 filtered runs across several parallelism settings and load levels produced nothing, because the filter excludes the other tests whose sockets and goroutines create the race. Twelve full-package runs under load reproduced it immediately, and the same command passes with the fix in place. The new deadline test drives its case off the test goroutine, so a regression fails in about a second instead of hanging the suite until the package timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket error handling by capturing peer close information after write failures.
  * Prevented continuously active connections from extending execution beyond the configured timeout.
  * Preserved the original write error when subsequent reads also fail.

* **Tests**
  * Added coverage confirming WebSocket operations stop near the configured deadline, even when frames continue arriving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->