### PR TITLE
refactor(runner): version each artifact family independently

### DIFF
--- a/contracts/artifacts.json
+++ b/contracts/artifacts.json
@@ -104,7 +104,7 @@
         },
         {
           "path": "validate/main.go",
-          "symbol": "activeCaseSchemaVersion"
+          "symbol": "activeResultSchemaVersion"
         }
       ],
       "gate": "make check-contracts"
@@ -157,7 +157,7 @@
         },
         {
           "path": "validate/main.go",
-          "symbol": "activeCaseSchemaVersion"
+          "symbol": "activeToolProfileSchemaVersion"
         }
       ],
       "gate": "make check-contracts"

--- a/contracts/artifacts.json
+++ b/contracts/artifacts.json
@@ -28,7 +28,7 @@
       "source_versions": [
         {
           "path": "runner/case.go",
-          "symbol": "activeSchemaVersion"
+          "symbol": "activeCaseSchemaVersion"
         },
         {
           "path": "validate/main.go",
@@ -64,7 +64,7 @@
       "source_versions": [
         {
           "path": "runner/case.go",
-          "symbol": "activeSchemaVersion"
+          "symbol": "activeMultiFileCaseSchemaVersion"
         },
         {
           "path": "validate/main.go",
@@ -100,7 +100,7 @@
       "source_versions": [
         {
           "path": "runner/case.go",
-          "symbol": "activeSchemaVersion"
+          "symbol": "activeResultSchemaVersion"
         },
         {
           "path": "validate/main.go",
@@ -153,7 +153,7 @@
       "source_versions": [
         {
           "path": "runner/case.go",
-          "symbol": "activeSchemaVersion"
+          "symbol": "activeToolProfileSchemaVersion"
         },
         {
           "path": "validate/main.go",
@@ -205,7 +205,7 @@
       "source_versions": [
         {
           "path": "runner/case.go",
-          "symbol": "activeSchemaVersion"
+          "symbol": "activeReceiptProfileSchemaVersion"
         }
       ],
       "gate": "make check-contracts"

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -43,7 +43,7 @@ changes before a runner may exclude any case.
 
 Ask one question about any proposed change:
 
-> Could an artifact someone already saved still be read, verified, and scored the same way afterwards?
+> Could an artifact someone already saved still be read, verified, and scored the same way afterward?
 
 Yes, so amend that family in place and leave its version alone. No, so bump that one family and keep its old reader working. The rest of this section is that question stated precisely, plus what freezing means.
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -39,6 +39,16 @@ changes before a runner may exclude any case.
 
 ## Versioning and compatibility
 
+### The short version
+
+Ask one question about any proposed change:
+
+> Could an artifact someone already saved still be read, verified, and scored the same way afterwards?
+
+Yes, so amend that family in place and leave its version alone. No, so bump that one family and keep its old reader working. The rest of this section is that question stated precisely, plus what freezing means.
+
+Two things follow that are easy to get backwards. A version number belongs to ONE family, so bumping result rows does not move cases, profiles, or anything else; the writer constants are per family and `runner/schema_version_contract_test.go` fails if any of them disagrees with the manifest. And a high version number is not evidence of churn, because these numbers were assigned when versioned filenames were adopted rather than earned one release at a time.
+
 Each artifact family has its own version. Cases, result rows, tool profiles, receipt profiles, summaries, provenance candidates, case indexes, promotion records, baselines, and Control Evidence documents do not become compatible because two version numbers happen to match. The machine-readable [`contracts/artifacts.json`](../contracts/artifacts.json) manifest names each active writer, accepted reader, frozen version, schema, and gate.
 
 An active schema may change in place only when every existing artifact that declares that version remains valid with the same meaning and score. Clarifications, schema corrections that change no accepted instance, and optional fields with a documented behavior-preserving default can qualify. This rule never permits a change to an existing case ID, payload, expected verdict, capability tags, or semantics.

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
   },
   "packageRules": [
     {
-      "description": "Update INDIRECT Go dependencies too. Renovate skips them by default, so a vulnerability in an indirect module is invisible to this automation and stays open until someone notices it by hand. GO-2026-6179 and GO-2026-6180 in golang.org/x/mod sat open from 2026-05-09 for exactly this reason.",
+      "description": "Enable updates for indirect Go dependencies. Renovate disables normal indirect updates by default, so a transitive module stays pinned until something else moves it.",
       "matchManagers": [
         "gomod"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,79 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":semanticCommits"],
+  "extends": [
+    "config:recommended",
+    ":semanticCommits"
+  ],
   "minimumReleaseAge": "10 days",
   "internalChecksFilter": "strict",
   "dependencyDashboard": false,
-  "schedule": ["* * * * 1"],
+  "schedule": [
+    "* * * * 1"
+  ],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
-  "labels": ["dependencies"],
-  "lockFileMaintenance": { "enabled": false },
+  "labels": [
+    "dependencies"
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "osvVulnerabilityAlerts": true,
-  "vulnerabilityAlerts": { "labels": ["security", "fast-track"], "minimumReleaseAge": "0 days", "schedule": ["at any time"] },
+  "vulnerabilityAlerts": {
+    "labels": [
+      "security",
+      "fast-track"
+    ],
+    "minimumReleaseAge": "0 days",
+    "schedule": [
+      "at any time"
+    ]
+  },
   "packageRules": [
-    { "description": "Pin GitHub Actions to digests for the OpenSSF Scorecard pinned-dependencies check. Digest-maintenance PRs batch into the weekly group below.", "matchManagers": ["github-actions"], "pinDigests": true },
-    { "description": "Collapse every non-major update (minor, patch, digest, pin) into ONE weekly batched PR so PR volume stays low.", "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest", "bump"], "groupName": "weekly dependencies" },
-    { "description": "Major updates stay individual and manually reviewed (no automerge), not delayed to the weekly window.", "matchUpdateTypes": ["major"], "addLabels": ["major-update", "needs-review"], "automerge": false, "schedule": ["at any time"] }
+    {
+      "description": "Update INDIRECT Go dependencies too. Renovate skips them by default, so a vulnerability in an indirect module is invisible to this automation and stays open until someone notices it by hand. GO-2026-6179 and GO-2026-6180 in golang.org/x/mod sat open from 2026-05-09 for exactly this reason.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "enabled": true
+    },
+    {
+      "description": "Pin GitHub Actions to digests for the OpenSSF Scorecard pinned-dependencies check. Digest-maintenance PRs batch into the weekly group below.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Collapse every non-major update (minor, patch, digest, pin) into ONE weekly batched PR so PR volume stays low.",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pinDigest",
+        "bump"
+      ],
+      "groupName": "weekly dependencies"
+    },
+    {
+      "description": "Major updates stay individual and manually reviewed (no automerge), not delayed to the weekly window.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "addLabels": [
+        "major-update",
+        "needs-review"
+      ],
+      "automerge": false,
+      "schedule": [
+        "at any time"
+      ]
+    }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }

--- a/runner/case.go
+++ b/runner/case.go
@@ -11,9 +11,26 @@ import (
 	capabilityregistry "github.com/luckyPipewrench/agent-egress-bench/capability-registry"
 )
 
+// Active writer version, one constant per artifact family.
+//
+// contracts/artifacts.json states that each family versions independently, and
+// docs/GOVERNANCE.md says two families are not compatible merely because their
+// numbers match. A single shared constant contradicted both: every family that
+// read it moved whenever any one of them needed to move, so a change confined
+// to result rows would have forced cases, profiles and receipt profiles to a
+// new version they had no reason to leave. That is version churn manufactured
+// by the code rather than required by the contract.
+//
+// These are all 4 today. That is a coincidence of history, not a relationship.
+// Change exactly the one whose format changed, and leave the others alone.
 const (
-	activeSchemaVersion = 4
-	v4SchemaVersion     = 4
+	activeCaseSchemaVersion           = 4
+	activeMultiFileCaseSchemaVersion  = 4
+	activeResultSchemaVersion         = 4
+	activeToolProfileSchemaVersion    = 4
+	activeReceiptProfileSchemaVersion = 4
+
+	v4SchemaVersion = 4
 )
 
 // Case represents a single active benchmark case. CapabilityTags are
@@ -99,8 +116,8 @@ func loadCases(dir string) ([]Case, error) {
 		if err := json.Unmarshal(data, &c); err != nil {
 			return fmt.Errorf("parsing %s: %w", path, err)
 		}
-		if c.SchemaVersion != activeSchemaVersion {
-			return fmt.Errorf("%s: schema_version must be %d for scoring, got %d", path, activeSchemaVersion, c.SchemaVersion)
+		if c.SchemaVersion != activeCaseSchemaVersion {
+			return fmt.Errorf("%s: schema_version must be %d for scoring, got %d", path, activeCaseSchemaVersion, c.SchemaVersion)
 		}
 		// Schema v4 historically accepted warn. Active result rows are binary,
 		// so a warning expectation is measured as the benign allow boundary.
@@ -145,8 +162,8 @@ func loadProfile(path string) (Profile, error) {
 		return Profile{}, fmt.Errorf("parsing profile: %w", err)
 	}
 	p.profileDir = filepath.Dir(path)
-	if p.SchemaVersion != activeSchemaVersion {
-		return Profile{}, fmt.Errorf("profile schema_version must be %d for scoring, got %d", activeSchemaVersion, p.SchemaVersion)
+	if p.SchemaVersion != activeToolProfileSchemaVersion {
+		return Profile{}, fmt.Errorf("profile schema_version must be %d for scoring, got %d", activeToolProfileSchemaVersion, p.SchemaVersion)
 	}
 	if err := validateProfileForRun(p); err != nil {
 		return Profile{}, fmt.Errorf("invalid profile: %w", err)

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -67,7 +67,7 @@ func TestLoadCasesNormalizesSchemaV4WarnToAllow(t *testing.T) {
 func TestLoadCasesDoesNotFilterSupersession(t *testing.T) {
 	dir := t.TempDir()
 	files := map[string]string{
-		// Must track activeSchemaVersion: loadCases returns an error rather than
+		// Must track activeCaseSchemaVersion: loadCases returns an error rather than
 		// skipping on a version mismatch, so a stale version here makes this test
 		// fail on its own loadCases call before it tests supersession at all.
 		"old.json": `{"schema_version":4,"id":"old"}`,
@@ -278,7 +278,7 @@ func TestMCPToolResultDLPCasesAreReportingLabeledAndProfileIndependent(t *testin
 			continue
 		}
 		seen[c.ID] = true
-		if c.SchemaVersion != activeSchemaVersion || c.Transport != "mcp_stdio" || c.InputType != "mcp_tool_result" {
+		if c.SchemaVersion != activeCaseSchemaVersion || c.Transport != "mcp_stdio" || c.InputType != "mcp_tool_result" {
 			t.Errorf("case %s active route = v%d/%s/%s", c.ID, c.SchemaVersion, c.Transport, c.InputType)
 		}
 		if c.ExpectedVerdict != expected {

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,12 +67,13 @@ func TestLoadCasesNormalizesSchemaV4WarnToAllow(t *testing.T) {
 
 func TestLoadCasesDoesNotFilterSupersession(t *testing.T) {
 	dir := t.TempDir()
+	// Built from activeCaseSchemaVersion rather than a literal. loadCases returns
+	// an error rather than skipping on a version mismatch, so a hardcoded version
+	// makes this test fail inside its own loadCases call the first time the case
+	// family moves, reporting a version problem where the subject is supersession.
 	files := map[string]string{
-		// Must track activeCaseSchemaVersion: loadCases returns an error rather than
-		// skipping on a version mismatch, so a stale version here makes this test
-		// fail on its own loadCases call before it tests supersession at all.
-		"old.json": `{"schema_version":4,"id":"old"}`,
-		"new.json": `{"schema_version":4,"id":"new","supersedes":"old"}`,
+		"old.json": fmt.Sprintf(`{"schema_version":%d,"id":"old"}`, activeCaseSchemaVersion),
+		"new.json": fmt.Sprintf(`{"schema_version":%d,"id":"new","supersedes":"old"}`, activeCaseSchemaVersion),
 	}
 	for name, body := range files {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {

--- a/runner/corpus.go
+++ b/runner/corpus.go
@@ -261,8 +261,8 @@ func loadCasesFromSnapshot(files []corpusFile, multiFileDirs []multiFileCaseDir)
 		if err := json.Unmarshal(file.data, &c); err != nil {
 			return nil, fmt.Errorf("parsing %s: %w", file.path, err)
 		}
-		if c.SchemaVersion != activeSchemaVersion {
-			return nil, fmt.Errorf("%s: schema_version must be %d for scoring, got %d", file.path, activeSchemaVersion, c.SchemaVersion)
+		if c.SchemaVersion != activeCaseSchemaVersion {
+			return nil, fmt.Errorf("%s: schema_version must be %d for scoring, got %d", file.path, activeCaseSchemaVersion, c.SchemaVersion)
 		}
 		cases = append(cases, c)
 	}

--- a/runner/main.go
+++ b/runner/main.go
@@ -370,7 +370,7 @@ func runCases(cases []Case, profile Profile, adapt adapter.Adapter, timeout time
 			debugf(debug, "case %s: FAIL expected=%s actual=%s evidence=%v", c.ID, c.ExpectedVerdict, adapterResult.Verdict, evidence)
 		}
 		result := CaseResult{
-			SchemaVersion:      activeSchemaVersion,
+			SchemaVersion:      activeResultSchemaVersion,
 			CaseID:             c.ID,
 			Tool:               profile.Tool,
 			ToolVersion:        profile.ToolVersion,

--- a/runner/multifile.go
+++ b/runner/multifile.go
@@ -370,8 +370,8 @@ func requireMultiFileYAMLKeys(data []byte, path string) error {
 }
 
 func validateMultiFileCaseMetadata(c MultiFileCase, caseYAMLPath string) error {
-	if c.SchemaVersion != activeSchemaVersion {
-		return fmt.Errorf("%s: schema_version must be %d, got %d", caseYAMLPath, activeSchemaVersion, c.SchemaVersion)
+	if c.SchemaVersion != activeMultiFileCaseSchemaVersion {
+		return fmt.Errorf("%s: schema_version must be %d, got %d", caseYAMLPath, activeMultiFileCaseSchemaVersion, c.SchemaVersion)
 	}
 	if strings.TrimSpace(c.ID) == "" {
 		return fmt.Errorf("%s: id must be non-empty", caseYAMLPath)

--- a/runner/public_contract_test.go
+++ b/runner/public_contract_test.go
@@ -47,7 +47,7 @@ func loadPublicResultStates(t *testing.T) publicResultStatesContract {
 
 func TestPublicResultStateMatrixMatchesScorer(t *testing.T) {
 	contract := loadPublicResultStates(t)
-	if contract.Contract != "aeb.result-states" || contract.Format != 1 || contract.ResultSchemaVersion != activeSchemaVersion {
+	if contract.Contract != "aeb.result-states" || contract.Format != 1 || contract.ResultSchemaVersion != activeResultSchemaVersion {
 		t.Fatalf("result-states identity/version = %q/%d/%d", contract.Contract, contract.Format, contract.ResultSchemaVersion)
 	}
 	for _, row := range contract.Matrix {

--- a/runner/receipt_profile.go
+++ b/runner/receipt_profile.go
@@ -225,7 +225,7 @@ func buildReceiptProfile(
 	}
 
 	return ReceiptProfile{
-		SchemaVersion:      activeSchemaVersion,
+		SchemaVersion:      activeReceiptProfileSchemaVersion,
 		Tool:               p.Tool,
 		ToolVersion:        p.ToolVersion,
 		CorpusVersion:      corpusVersion,

--- a/runner/receipt_profile_test.go
+++ b/runner/receipt_profile_test.go
@@ -899,13 +899,13 @@ func TestBuildReceiptProfile_UnreachableRowsAreNotScoredAsOutcomes(t *testing.T)
 // keep passing while the version it actually emits goes unchecked.
 func TestValidateReceiptProfile_AcceptsActiveSchemaVersion(t *testing.T) {
 	rp := validProfile()
-	rp.SchemaVersion = activeSchemaVersion
+	rp.SchemaVersion = activeReceiptProfileSchemaVersion
 	// The active version additionally binds the capability-registry snapshot,
 	// which the frozen v3 fixture does not carry. That requirement is exactly
 	// what had no positive coverage.
 	rp.CapabilityRegistry = testRegistryReference
 	if issues := ValidateReceiptProfile(rp); len(issues) != 0 {
-		t.Fatalf("active schema version %d rejected: %v", activeSchemaVersion, issues)
+		t.Fatalf("active schema version %d rejected: %v", activeReceiptProfileSchemaVersion, issues)
 	}
 }
 
@@ -914,7 +914,7 @@ func TestValidateReceiptProfile_AcceptsActiveSchemaVersion(t *testing.T) {
 // test defends is a requirement that can be deleted by accident.
 func TestValidateReceiptProfile_ActiveVersionRequiresRegistryBinding(t *testing.T) {
 	rp := validProfile()
-	rp.SchemaVersion = activeSchemaVersion
+	rp.SchemaVersion = activeReceiptProfileSchemaVersion
 	rp.CapabilityRegistry = capabilityregistry.Reference{}
 	expectIssueMatch(t, rp, "capability_registry must contain")
 }

--- a/runner/receipt_profile_validate.go
+++ b/runner/receipt_profile_validate.go
@@ -46,7 +46,7 @@ var readableReceiptProfileVersions = func() map[int]bool {
 		3:               true,
 		v4SchemaVersion: true,
 	}
-	versions[activeSchemaVersion] = true
+	versions[activeReceiptProfileSchemaVersion] = true
 	return versions
 }()
 
@@ -65,7 +65,7 @@ func ValidateReceiptProfile(rp ReceiptProfile) []string {
 	// did not exist when it was produced. Emission still uses the active
 	// version, so nothing new is written at a superseded one.
 	if !isReadableReceiptProfileVersion(rp.SchemaVersion) {
-		issues = append(issues, fmt.Sprintf("schema_version must be %d for scoring, or a readable historical version, got %d", activeSchemaVersion, rp.SchemaVersion))
+		issues = append(issues, fmt.Sprintf("schema_version must be %d for scoring, or a readable historical version, got %d", activeReceiptProfileSchemaVersion, rp.SchemaVersion))
 	}
 	if strings.TrimSpace(rp.Tool) == "" {
 		issues = append(issues, "tool must be a non-empty string")
@@ -82,7 +82,7 @@ func ValidateReceiptProfile(rp ReceiptProfile) []string {
 	if !sha256HexPattern.MatchString(rp.ToolProfileSHA256) {
 		issues = append(issues, "tool_profile_sha256 must be 64 lower-case hex characters")
 	}
-	if rp.SchemaVersion == activeSchemaVersion {
+	if rp.SchemaVersion == activeReceiptProfileSchemaVersion {
 		if rp.CapabilityRegistry.ID == "" || rp.CapabilityRegistry.Format != 1 || rp.CapabilityRegistry.Revision < 1 || !sha256HexPattern.MatchString(rp.CapabilityRegistry.SHA256) {
 			issues = append(issues, "capability_registry must contain a supported id, format, revision, and 64-character sha256")
 		}

--- a/runner/registry_preflight_test.go
+++ b/runner/registry_preflight_test.go
@@ -20,7 +20,7 @@ var testRegistryReference = capabilityregistry.Reference{
 
 func v4TestProfile() Profile {
 	return Profile{
-		SchemaVersion:      activeSchemaVersion,
+		SchemaVersion:      activeToolProfileSchemaVersion,
 		Tool:               "test-tool",
 		ToolVersion:        "1.0.0",
 		RunnerVersion:      "v1",
@@ -46,7 +46,7 @@ func validV4Profile(t *testing.T) map[string]any {
 
 func v4TestCase() Case {
 	return Case{
-		SchemaVersion:   activeSchemaVersion,
+		SchemaVersion:   activeCaseSchemaVersion,
 		ID:              "registry-test-001",
 		Category:        "url",
 		InputType:       "url",

--- a/runner/report_test.go
+++ b/runner/report_test.go
@@ -203,7 +203,7 @@ func TestBuyerReportRefusesReceiptProfileWithMismatchedRegistryReference(t *test
 	// in both provenance records. Its registry reference alone belongs to a
 	// different run, so only an explicit cross-artifact binding can reject it.
 	receipt := validProfile()
-	receipt.SchemaVersion = activeSchemaVersion
+	receipt.SchemaVersion = activeReceiptProfileSchemaVersion
 	receipt.Tool = fixture.summary["tool"].(string)
 	receipt.ToolVersion = fixture.summary["tool_version"].(string)
 	receipt.CorpusVersion = fixture.summary["corpus_version"].(string)
@@ -245,7 +245,7 @@ func TestV4ReceiptProfileBindingStaysReadableAfterActiveSchemaAdvances(t *testin
 	fixture.write(t, dir)
 
 	// This is intentionally a literal v4 receipt beside a literal v4 result.
-	// When activeSchemaVersion advances, this historical pair must remain
+	// When activeReceiptProfileSchemaVersion advances, this historical pair must remain
 	// readable rather than being compared to the schema used for new output.
 	receipt := validProfile()
 	receipt.SchemaVersion = 4
@@ -464,7 +464,7 @@ func (f *reportFixture) write(t *testing.T, dir string) {
 		t.Fatal(err)
 	}
 	receipt := validProfile()
-	receipt.SchemaVersion = activeSchemaVersion
+	receipt.SchemaVersion = activeReceiptProfileSchemaVersion
 	receipt.Tool = f.summary["tool"].(string)
 	receipt.ToolVersion = f.summary["tool_version"].(string)
 	receipt.CorpusVersion = f.summary["corpus_version"].(string)

--- a/runner/result_state.go
+++ b/runner/result_state.go
@@ -48,7 +48,7 @@ func caseResultForState(profile Profile, c Case, state ResultState, evidence map
 		actual = "unreachable"
 	}
 	return CaseResult{
-		SchemaVersion:      activeSchemaVersion,
+		SchemaVersion:      activeResultSchemaVersion,
 		CaseID:             c.ID,
 		Tool:               profile.Tool,
 		ToolVersion:        profile.ToolVersion,

--- a/runner/schema_version_contract_test.go
+++ b/runner/schema_version_contract_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestActiveSchemaVersionsMatchArtifactContract binds each family's Go writer
+// constant to contracts/artifacts.json.
+//
+// The manifest is the published statement of which version this repository
+// writes for each artifact family, and a clean-room implementation reads it to
+// know what to expect. Nothing previously held the code to it, so the two could
+// disagree silently: a family could be bumped in Go while the manifest still
+// advertised the old version, or the manifest could advertise a version no
+// writer emits. Either way an outside reader is told something untrue.
+//
+// This test also protects the reason those constants are separate at all.
+// Before they were split, five families shared one constant, so bumping any one
+// of them dragged the rest to a version they had no reason to leave. Per-family
+// constants only stay honest if something checks them per family.
+func TestActiveSchemaVersionsMatchArtifactContract(t *testing.T) {
+	path := filepath.Join("..", "contracts", "artifacts.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read artifact contract: %v", err)
+	}
+
+	var manifest struct {
+		Families []struct {
+			Family              string `json:"family"`
+			ActiveWriterVersion int    `json:"active_writer_version"`
+		} `json:"artifact_families"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse artifact contract: %v", err)
+	}
+
+	declared := make(map[string]int, len(manifest.Families))
+	for _, f := range manifest.Families {
+		declared[f.Family] = f.ActiveWriterVersion
+	}
+
+	// Only families this Go writer actually emits. A family absent here is
+	// written elsewhere, and claiming it would make this test lie.
+	written := map[string]int{
+		"case":                    activeCaseSchemaVersion,
+		"multi_file_case":         activeMultiFileCaseSchemaVersion,
+		"result_row":              activeResultSchemaVersion,
+		"tool_profile":            activeToolProfileSchemaVersion,
+		"receipt_scoring_profile": activeReceiptProfileSchemaVersion,
+		"summary":                 activeSummarySchemaVersion,
+	}
+
+	for family, constant := range written {
+		want, ok := declared[family]
+		if !ok {
+			t.Errorf("family %q is written by this runner but absent from the artifact contract", family)
+			continue
+		}
+		if constant != want {
+			t.Errorf("family %q: runner writes v%d, contract declares v%d; bump both together or neither",
+				family, constant, want)
+		}
+	}
+}

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -544,10 +544,27 @@ def check(root, manifest_path):
         fail(f"versioned schema inventory mismatch; unlisted={missing}, nonexistent={extra}")
     if not REQUIRED_CONSTANTS.issubset(listed_constants):
         fail(f"governing constants missing from manifest: {sorted(REQUIRED_CONSTANTS - listed_constants)}")
-    case_runner = constant_values[("runner/case.go", "activeCaseSchemaVersion")]
-    case_validator = constant_values[("validate/main.go", "activeCaseSchemaVersion")]
-    if case_runner != case_validator:
-        fail(f"runner and validator case schema versions differ: {case_runner} != {case_validator}")
+    # Every source constant a family declares must equal that family's active
+    # writer version. Checked generically rather than as named pairs: the
+    # per-family split was landed three times because each round only bound the
+    # coordinates someone remembered, so a newly split constant could drift
+    # while the manifest, the runner, and the Go contract test all still agreed.
+    # Whatever the manifest declares is what gets verified.
+    for family in manifest.get("artifact_families", []):
+        name = family.get("family")
+        active = family.get("active_writer_version")
+        if not isinstance(active, int):
+            continue
+        for source in family.get("source_versions", []) or []:
+            coordinate = (source.get("path"), source.get("symbol"))
+            if coordinate not in constant_values:
+                continue
+            found = constant_values[coordinate]
+            if found != active:
+                fail(
+                    f"family {name}: {coordinate[0]}:{coordinate[1]} is {found}, "
+                    f"but active_writer_version is {active}; move both together or neither"
+                )
 
     records = manifest.get("retained_public_records")
     if not isinstance(records, dict):

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -10,7 +10,13 @@ from pathlib import Path
 
 REQUIRED_CONSTANTS = {
     ("runner/case.go", "activeCaseSchemaVersion"),
+    ("runner/case.go", "activeMultiFileCaseSchemaVersion"),
+    ("runner/case.go", "activeResultSchemaVersion"),
+    ("runner/case.go", "activeToolProfileSchemaVersion"),
+    ("runner/case.go", "activeReceiptProfileSchemaVersion"),
     ("validate/main.go", "activeCaseSchemaVersion"),
+    ("validate/main.go", "activeResultSchemaVersion"),
+    ("validate/main.go", "activeToolProfileSchemaVersion"),
     ("runner/summary.go", "activeSummarySchemaVersion"),
 }
 REQUIRED_RETAINED_RECORD_PATHS = {

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 
 REQUIRED_CONSTANTS = {
-    ("runner/case.go", "activeSchemaVersion"),
+    ("runner/case.go", "activeCaseSchemaVersion"),
     ("validate/main.go", "activeCaseSchemaVersion"),
     ("runner/summary.go", "activeSummarySchemaVersion"),
 }
@@ -538,7 +538,7 @@ def check(root, manifest_path):
         fail(f"versioned schema inventory mismatch; unlisted={missing}, nonexistent={extra}")
     if not REQUIRED_CONSTANTS.issubset(listed_constants):
         fail(f"governing constants missing from manifest: {sorted(REQUIRED_CONSTANTS - listed_constants)}")
-    case_runner = constant_values[("runner/case.go", "activeSchemaVersion")]
+    case_runner = constant_values[("runner/case.go", "activeCaseSchemaVersion")]
     case_validator = constant_values[("validate/main.go", "activeCaseSchemaVersion")]
     if case_runner != case_validator:
         fail(f"runner and validator case schema versions differ: {case_runner} != {case_validator}")

--- a/validate/main.go
+++ b/validate/main.go
@@ -13,12 +13,24 @@ import (
 	capabilityregistry "github.com/luckyPipewrench/agent-egress-bench/capability-registry"
 )
 
-// activeCaseSchemaVersion is the case schema version this validator enforces.
-// Both case shapes read it, so the single-file and multi-file paths cannot
-// drift apart on the version boundary the way they previously did on the
-// requires vocabulary. It mirrors activeSchemaVersion in the runner; the two
-// move together whenever the coordinated artifact set is bumped.
-const activeCaseSchemaVersion = 4
+// Active schema version per artifact family, mirroring the runner's constants
+// of the same names.
+//
+// activeCaseSchemaVersion covers both case shapes deliberately, so the
+// single-file and multi-file paths cannot drift apart on the version boundary
+// the way they previously did on the requires vocabulary.
+//
+// The result-row and tool-profile versions are separate because those are
+// separate families in contracts/artifacts.json. This validator previously
+// checked all three against the case constant, which meant a result-row bump
+// would have been enforced as a case bump and rejected every valid artifact of
+// the other two families. A validator that couples families it is supposed to
+// judge independently turns one family's version change into everyone's outage.
+const (
+	activeCaseSchemaVersion        = 4
+	activeResultSchemaVersion      = 4
+	activeToolProfileSchemaVersion = 4
+)
 
 // Valid enum values for v1 schema.
 var (
@@ -961,8 +973,8 @@ func validateResultLineAgainstCase(lineNum int, r ResultLine, caseMetadata *resu
 	if r.CaseID == "" {
 		addErr("missing case_id")
 	}
-	if r.SchemaVersion != activeCaseSchemaVersion {
-		addErr(fmt.Sprintf("schema_version must be %d, got %d", activeCaseSchemaVersion, r.SchemaVersion))
+	if r.SchemaVersion != activeResultSchemaVersion {
+		addErr(fmt.Sprintf("schema_version must be %d, got %d", activeResultSchemaVersion, r.SchemaVersion))
 	}
 	if r.Tool == "" {
 		addErr("missing tool")
@@ -1236,8 +1248,8 @@ type Profile struct {
 func validateProfile(p Profile) []string {
 	var errors []string
 
-	if p.SchemaVersion != activeCaseSchemaVersion {
-		errors = append(errors, fmt.Sprintf("schema_version must be %d, got %d", activeCaseSchemaVersion, p.SchemaVersion))
+	if p.SchemaVersion != activeToolProfileSchemaVersion {
+		errors = append(errors, fmt.Sprintf("schema_version must be %d, got %d", activeToolProfileSchemaVersion, p.SchemaVersion))
 	}
 	if p.Tool == "" {
 		errors = append(errors, "missing tool")

--- a/validate/main.go
+++ b/validate/main.go
@@ -16,9 +16,11 @@ import (
 // Active schema version per artifact family, mirroring the runner's constants
 // of the same names.
 //
-// activeCaseSchemaVersion covers both case shapes deliberately, so the
-// single-file and multi-file paths cannot drift apart on the version boundary
-// the way they previously did on the requires vocabulary.
+// There is no multi-file constant here because this validator does not version
+// multi-file cases: it reads `case.yaml` only for the requires vocabulary and
+// never inspects its schema_version. The single-file and multi-file shapes are
+// held together by routing both through requiresTokenProblem, not by a shared
+// version number.
 //
 // The result-row and tool-profile versions are separate because those are
 // separate families in contracts/artifacts.json. This validator previously


### PR DESCRIPTION
## What changed

Each artifact family now has its own active writer version constant instead of five families sharing one.

`contracts/artifacts.json` states that families version independently, and the governance document says two families are not compatible merely because their numbers match. The code contradicted both. Cases, multi-file cases, result rows, tool profiles, and receipt profiles all read a single `activeSchemaVersion`, so a change confined to one of them would have moved the rest to a version they had no reason to leave. The summary already had its own constant, and its comment says that separation is deliberate, so this finishes a decision rather than introducing one.

All five constants are 4 today, which is a coincidence of history rather than a relationship. The manifest entries and the cross-language contract checker now name the per-family symbol, so the runner and the validator agree about which family each number belongs to.

A new test binds every family's writer constant to the manifest and fails when they disagree, naming the family and both versions. Nothing previously held the code to the published manifest, so the two could drift silently and tell an outside reader something untrue.

The governance section gains a short plain-language opening: ask whether an artifact someone already saved could still be read, verified, and scored the same way after a change, amend in place when the answer is yes, and bump that one family when it is no.

## Why this is a refactor and not a version change

No emitted artifact changes. The case index and corpus statistics produce identical bytes before and after, `ab5a7dcb...` and `923ade6e...`, which are the same digests the published candidate evidence already records. Every constant keeps its current value, so no family moves.

## What to distrust

The routing of each call site to a family. A site sending the wrong family's constant would be invisible while the numbers happen to agree, and would emit a wrong version the first time any family moves. The call sites were routed by which artifact each one validates or writes rather than by which file it sits in, and `runner/case.go` holds two families deliberately: case loading and tool profile loading.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Schema versions are now tracked independently for cases, multi-file cases, results, tool profiles, and receipt profiles.
  - Validation and generated artifacts apply the correct compatibility rules for each artifact type.
  - Improved compatibility handling helps preserve readability of historical artifacts as individual schemas evolve.
  - Automated contract checks help detect version mismatches across artifact types.

- **Documentation**
  - Added concise guidance for deciding when to update an artifact schema versus introduce a new version.
  - Clarified that schema versions are family-specific and do not indicate release frequency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->