### PR TITLE
ci(scorecard): stop filing repository grades as code-scanning alerts

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -42,10 +42,11 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      # No security-events: write. This job no longer uploads SARIF, so it needs
-      # no permission to write code-scanning alerts. The codeql job above keeps
-      # its own. id-token remains because publish_results signs the result for
-      # the public Scorecard API.
+      # No security-events: write. This job no longer uploads SARIF to code
+      # scanning, so it needs no permission to write code-scanning alerts. It
+      # does still upload results.sarif as a build artifact below. The codeql
+      # job above keeps its own permission. id-token remains because
+      # publish_results signs the result for the public Scorecard API.
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -50,7 +50,8 @@ jobs:
       # scanning, so it needs no permission to write code-scanning alerts. It
       # does still upload results.sarif as a build artifact below. The codeql
       # job above keeps its own permission. id-token remains because
-      # publish_results signs the result for the public Scorecard API.
+      # publish_results uses GitHub's OIDC token to verify the result's
+      # authenticity when publishing it to the public Scorecard API.
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,8 +35,12 @@ jobs:
 
       - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
 
+  # No needs: codeql. The two jobs were ordered so their SARIF uploads could not
+  # race each other, and this job no longer uploads SARIF, so the ordering has
+  # nothing left to protect. Keeping it would make a CodeQL failure or skip take
+  # the Scorecard publication and its artifact down with it, which is a coupling
+  # that costs availability and buys nothing.
   scorecard:
-    needs: codeql
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -85,6 +89,3 @@ jobs:
       # them to the OpenSSF Scorecard API that backs the badge and the public
       # viewer, and the artifact above keeps the raw SARIF. This narrows where
       # the grade is displayed. It does not withhold it.
-      #
-      # needs: codeql above is retained. It orders the two jobs and costs
-      # nothing now that only one of them uploads SARIF.

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -42,7 +42,10 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      security-events: write
+      # No security-events: write. This job no longer uploads SARIF, so it needs
+      # no permission to write code-scanning alerts. The codeql job above keeps
+      # its own. id-token remains because publish_results signs the result for
+      # the public Scorecard API.
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -63,7 +66,24 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
-        with:
-          sarif_file: results.sarif
+      # Scorecard results are NOT uploaded to code scanning, deliberately.
+      #
+      # Scorecard grades repository practice: pinned dependencies, branch
+      # protection, what share of pull requests carried an approving review.
+      # Code scanning is the surface for defects in this repository's code, and
+      # routing a grade into it files each check as a dismissible alert with a
+      # severity attached.
+      #
+      # Those alerts also do not stay dismissed. GitHub matches results across
+      # uploads by rule and fingerprint, and a Scorecard result whose identity
+      # shifts arrives as a NEW alert that a previous dismissal does not cover.
+      # The outcome was a standing queue of security-labelled items that no code
+      # change could close.
+      #
+      # The results remain public and retrievable: publish_results above sends
+      # them to the OpenSSF Scorecard API that backs the badge and the public
+      # viewer, and the artifact above keeps the raw SARIF. This narrows where
+      # the grade is displayed. It does not withhold it.
+      #
+      # needs: codeql above is retained. It orders the two jobs and costs
+      # nothing now that only one of them uploads SARIF.

--- a/scripts/scorecard_workflow_test.py
+++ b/scripts/scorecard_workflow_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Structural tests for Scorecard's dependency on same-workflow SAST evidence."""
+"""Structural tests for the trusted Scorecard job and what it may publish."""
 
 import unittest
 from pathlib import Path
@@ -15,11 +15,37 @@ class ScorecardWorkflowTest(unittest.TestCase):
         self.workflow = SECURITY_WORKFLOW.read_text(encoding="utf-8")
         self.triggers = self.workflow.split("concurrency:", 1)[0]
 
-    def test_scorecard_runs_after_codeql_in_security_workflow(self):
+    def test_scorecard_stays_in_the_trusted_security_workflow(self):
+        # These three are the reason the job was moved here: a standalone
+        # workflow triggered by workflow_run runs privileged and then checks out
+        # the triggering run's code, which is a privilege-escalation shape.
         self.assertFalse(RETIRED_WORKFLOW.exists())
-        self.assertRegex(self.workflow, r"(?m)^  scorecard:\n    needs: codeql$")
         self.assertNotIn("workflow_run", self.workflow)
         self.assertRegex(self.workflow, r"(?m)^permissions: read-all$")
+
+    def test_scorecard_does_not_upload_sarif_or_wait_on_codeql(self):
+        # This replaces an assertion that required `needs: codeql`. That
+        # ordering existed so the two jobs could not upload SARIF concurrently.
+        # Scorecard no longer uploads SARIF at all, so the ordering has nothing
+        # left to protect, and keeping it would let a CodeQL failure take the
+        # Scorecard publication down with it.
+        #
+        # Both halves are asserted together on purpose: dropping the dependency
+        # is only safe while this job uploads no SARIF, so re-adding an upload
+        # without restoring the ordering must fail here.
+        self.assertNotIn("upload-sarif", self.workflow)
+        self.assertNotRegex(self.workflow, r"(?m)^  scorecard:\n    needs:")
+        jobs = self.workflow.split("jobs:\n", 1)[1]
+        _, scorecard = jobs.split("\n  scorecard:\n", 1)
+        # Match a permission LINE, not the phrase. The workflow comment explains
+        # why the permission is absent and contains the same words, so a
+        # substring check passes for the wrong reason and then fails when the
+        # explanation is written.
+        self.assertNotRegex(
+            scorecard.split("steps:", 1)[0],
+            r"(?m)^\s+security-events:\s*write\s*$",
+        )
+        self.assertIn("publish_results: true", scorecard)
 
     def test_pull_request_code_never_reaches_scorecard(self):
         self.assertRegex(

--- a/scripts/scorecard_workflow_test.py
+++ b/scripts/scorecard_workflow_test.py
@@ -34,9 +34,16 @@ class ScorecardWorkflowTest(unittest.TestCase):
         # is only safe while this job uploads no SARIF, so re-adding an upload
         # without restoring the ordering must fail here.
         self.assertNotIn("upload-sarif", self.workflow)
-        self.assertNotRegex(self.workflow, r"(?m)^  scorecard:\n    needs:")
+
         jobs = self.workflow.split("jobs:\n", 1)[1]
         _, scorecard = jobs.split("\n  scorecard:\n", 1)
+
+        # Search the whole job body, not the line right after `scorecard:`.
+        # YAML does not fix key order, so `needs` placed after `if` or
+        # `permissions` would slip past an anchored two-line pattern and the
+        # guard would report clean while the dependency was back.
+        self.assertNotRegex(scorecard, r"(?m)^\s+needs\s*:")
+
         # Match a permission LINE, not the phrase. The workflow comment explains
         # why the permission is absent and contains the same words, so a
         # substring check passes for the wrong reason and then fails when the
@@ -45,7 +52,18 @@ class ScorecardWorkflowTest(unittest.TestCase):
             scorecard.split("steps:", 1)[0],
             r"(?m)^\s+security-events:\s*write\s*$",
         )
-        self.assertIn("publish_results: true", scorecard)
+
+        # Publication and raw retention are the two things that make dropping
+        # the code-scanning upload honest rather than a quiet removal. Assert
+        # both, anchored, so deleting the artifact step fails here instead of
+        # leaving the grade unreadable while this test still passes.
+        self.assertRegex(scorecard, r"(?m)^\s+publish_results:\s*true\s*$")
+        self.assertRegex(scorecard, r"(?m)^\s+results_file:\s*results\.sarif\s*$")
+        self.assertRegex(scorecard, r"(?m)^\s+results_format:\s*sarif\s*$")
+        # The step is written as `- name:` followed by `uses:`, so the action
+        # reference does not sit on the dash line.
+        self.assertRegex(scorecard, r"(?m)^\s+uses: actions/upload-artifact@")
+        self.assertRegex(scorecard, r"(?m)^\s+path:\s*results\.sarif\s*$")
 
     def test_pull_request_code_never_reaches_scorecard(self):
         self.assertRegex(


### PR DESCRIPTION
## What changed

The OpenSSF Scorecard job no longer uploads its results to code scanning. It still runs, still publishes to the public Scorecard API that backs the badge and viewer, and still keeps the raw SARIF as a build artifact. The job's `security-events: write` permission is dropped because nothing in it writes alerts now.

## Why

Scorecard grades repository practice: whether actions are pinned to digests, whether branch protection is on, what share of pull requests carried an approving review. Code scanning is the surface for defects in this repository's code. Uploading the grade into that surface files each check as a dismissible alert carrying a severity, which is a different claim from the one Scorecard makes.

Those alerts also do not stay dismissed. GitHub matches results across uploads by rule and fingerprint, and a result whose identity shifts arrives as a new alert that an earlier dismissal does not cover. Two alerts in this repository reported the same finding at the same file and line on consecutive days. One rule accumulated 25 separate alert numbers over five months, and a false positive was dismissed under four different numbers. The result was a standing queue of security-labelled items that no code change could close, which trains a reader to clear the queue without reading it.

## What this does not do

It does not hide the grade. `publish_results` continues to send results to the public OpenSSF Scorecard API, so anyone can read this repository's score and its per-check detail without asking. The artifact keeps the raw SARIF for the run.

It also does not claim that code scanning now holds only genuine findings. Scorecard's own vulnerability check reports advisories that remain worth reading; they are read from the Scorecard result rather than from an alert list. Anyone auditing this repository should look at both.

CodeQL is unaffected. It uploads its own SARIF from a separate job with its own permission, and it remains a required check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated security scanning permissions to follow least-privilege practices.
  * Security analysis results continue to be published through the existing reporting service.
  * Raw security analysis results remain available as downloadable artifacts.
  * Removed CodeQL dependency and direct code-scanning uploads from this security analysis process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->