### PR TITLE
contracts: publish the result-state vocabulary

### DIFF
--- a/contracts/result-states-v4.json
+++ b/contracts/result-states-v4.json
@@ -2,18 +2,70 @@
   "contract": "aeb.result-states",
   "format": 1,
   "result_schema_version": 4,
-  "expected_verdicts": ["allow", "block"],
-  "actual_verdicts": ["allow", "block", "error", "unreachable"],
-  "scores": ["error", "fail", "pass"],
+  "expected_verdicts": [
+    "allow",
+    "block"
+  ],
+  "actual_verdicts": [
+    "allow",
+    "block",
+    "error",
+    "unreachable"
+  ],
+  "scores": [
+    "error",
+    "fail",
+    "pass"
+  ],
+  "evidence_result_states": {
+    "observed": "The adapter proved delivery and observed a request-correlated allow or block.",
+    "unreachable": "The route was declared but the adapter could not reach the target, so the case never became a measurement.",
+    "adapter_error": "The adapter itself failed before a verdict could be observed.",
+    "delivery_unavailable": "The adapter did not prove delivery of the exact wire input.",
+    "verdict_unobservable": "Delivery was proven, but no request-correlated verdict was observable.",
+    "invalid_verdict": "A verdict was observed that is neither allow nor block."
+  },
   "matrix": [
-    {"expected_verdict": "allow", "actual_verdict": "allow", "score": "pass"},
-    {"expected_verdict": "allow", "actual_verdict": "block", "score": "fail"},
-    {"expected_verdict": "allow", "actual_verdict": "error", "score": "error"},
-    {"expected_verdict": "allow", "actual_verdict": "unreachable", "score": "error"},
-    {"expected_verdict": "block", "actual_verdict": "allow", "score": "fail"},
-    {"expected_verdict": "block", "actual_verdict": "block", "score": "pass"},
-    {"expected_verdict": "block", "actual_verdict": "error", "score": "error"},
-    {"expected_verdict": "block", "actual_verdict": "unreachable", "score": "error"}
+    {
+      "expected_verdict": "allow",
+      "actual_verdict": "allow",
+      "score": "pass"
+    },
+    {
+      "expected_verdict": "allow",
+      "actual_verdict": "block",
+      "score": "fail"
+    },
+    {
+      "expected_verdict": "allow",
+      "actual_verdict": "error",
+      "score": "error"
+    },
+    {
+      "expected_verdict": "allow",
+      "actual_verdict": "unreachable",
+      "score": "error"
+    },
+    {
+      "expected_verdict": "block",
+      "actual_verdict": "allow",
+      "score": "fail"
+    },
+    {
+      "expected_verdict": "block",
+      "actual_verdict": "block",
+      "score": "pass"
+    },
+    {
+      "expected_verdict": "block",
+      "actual_verdict": "error",
+      "score": "error"
+    },
+    {
+      "expected_verdict": "block",
+      "actual_verdict": "unreachable",
+      "score": "error"
+    }
   ],
   "case_specific_overrides": [
     {
@@ -21,8 +73,12 @@
       "when": {
         "expected_verdict": "block",
         "actual_verdict": "block",
-        "case_payload_fields": ["budget_limit_calls"],
-        "required_evidence_fields": ["budget_block_timing"]
+        "case_payload_fields": [
+          "budget_limit_calls"
+        ],
+        "required_evidence_fields": [
+          "budget_block_timing"
+        ]
       },
       "scores_by_budget_block_timing": {
         "at_over_budget": "pass",
@@ -34,7 +90,10 @@
   "adapter_only_states": {
     "skip": {
       "meaning": "A declared route could not prove delivery or observe a verdict.",
-      "active_result": {"actual_verdict": "error", "score": "error"}
+      "active_result": {
+        "actual_verdict": "error",
+        "score": "error"
+      }
     }
   },
   "historical_only_states": {

--- a/runner/public_contract_test.go
+++ b/runner/public_contract_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -28,6 +29,7 @@ type publicResultStatesContract struct {
 	Contract              string                      `json:"contract"`
 	Format                int                         `json:"format"`
 	ResultSchemaVersion   int                         `json:"result_schema_version"`
+	EvidenceResultStates  map[string]string           `json:"evidence_result_states"`
 	Matrix                []publicResultMatrixRow     `json:"matrix"`
 	CaseSpecificOverrides []publicResultStateOverride `json:"case_specific_overrides"`
 }
@@ -73,6 +75,45 @@ func TestPublicBudgetTimingOverrideMatchesScorer(t *testing.T) {
 		evidence := map[string]interface{}{override.When.RequiredEvidenceFields[0]: timing}
 		if got := scoreCaseWithEvidence(budgetCase, "block", evidence); got != want {
 			t.Errorf("budget timing %q score = %q, public contract wants %q", timing, got, want)
+		}
+	}
+}
+
+// TestPublicResultStatesMatchEmitter binds the published state vocabulary to
+// the states this runner actually writes.
+//
+// Every row carries evidence.result_state, added by evidenceWithResultState.
+// The result schema describes evidence as freeform and the validator never
+// reads it, so contracts/result-states-v4.json is the only place an outside
+// implementer can learn that the field exists, what its values mean, and that
+// the parity reader rejects a row without one. A published vocabulary that
+// drifts from the emitter is worse than none, because it is followed.
+func TestPublicResultStatesMatchEmitter(t *testing.T) {
+	contract := loadPublicResultStates(t)
+
+	emitted := map[string]bool{
+		string(ResultStateObserved):            true,
+		string(ResultStateUnreachable):         true,
+		string(ResultStateAdapterError):        true,
+		string(ResultStateDeliveryUnavailable): true,
+		string(ResultStateVerdictUnobservable): true,
+		string(ResultStateInvalidVerdict):      true,
+	}
+
+	if len(contract.EvidenceResultStates) == 0 {
+		t.Fatal("public contract publishes no evidence_result_states")
+	}
+	for name, meaning := range contract.EvidenceResultStates {
+		if !emitted[name] {
+			t.Errorf("public contract publishes result state %q that this runner never emits", name)
+		}
+		if strings.TrimSpace(meaning) == "" {
+			t.Errorf("public contract publishes result state %q with no stated meaning", name)
+		}
+	}
+	for name := range emitted {
+		if _, ok := contract.EvidenceResultStates[name]; !ok {
+			t.Errorf("this runner emits result state %q that the public contract does not publish", name)
 		}
 	}
 }

--- a/scripts/check_public_contracts.py
+++ b/scripts/check_public_contracts.py
@@ -6,6 +6,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import runner_parity  # noqa: E402  (path set above so the sibling module resolves)
+
 
 BACKTICK_VALUE = re.compile(r"`([^`]+)`")
 
@@ -128,6 +131,25 @@ def check_result_states(root):
     ):
         if set(contract.get(field, [])) != set(schema_property(schema, schema_field).get("enum", [])):
             fail(f"result schema {schema_field} enum differs from result-states {field}")
+    # evidence.result_state is emitted on every row by the runner and required
+    # by scripts/runner_parity.py. The result schema calls evidence freeform and
+    # the validator does not read it, so the published contract is the only
+    # place an outside implementer can learn the field and its vocabulary. Bind
+    # the two so they cannot drift apart silently.
+    published_states = contract.get("evidence_result_states")
+    if not isinstance(published_states, dict) or not published_states:
+        fail("result-states must publish a non-empty evidence_result_states object")
+    for name, meaning in published_states.items():
+        if not isinstance(meaning, str) or not meaning.strip():
+            fail(f"evidence_result_states.{name} must document what the state means")
+    if set(published_states) != set(runner_parity.RESULT_STATES):
+        missing = sorted(set(runner_parity.RESULT_STATES) - set(published_states))
+        extra = sorted(set(published_states) - set(runner_parity.RESULT_STATES))
+        fail(
+            "evidence_result_states differs from the parity reader's RESULT_STATES; "
+            f"unpublished={missing}, unenforced={extra}"
+        )
+
     matrix = contract.get("matrix")
     if not isinstance(matrix, list):
         fail("result-states matrix must be an array")


### PR DESCRIPTION
## What changed

The public result-states contract now publishes `evidence.result_state`: its six values and what each one means. Two checks bind that list to the code, one against the runner that emits the field and one against the parity reader that requires it.

## Why

Every result row already carries `evidence.result_state`, added by the runner on the way out, and `scripts/runner_parity.py` rejects a row that lacks a valid one. Nothing published said so. The result schema describes evidence as a freeform object, the validator never reads the field, and the contract that documents result states did not mention it.

An outside implementer could therefore satisfy the schema, pass the validator, read the contract end to end, and still fail parity on a field they had no way to know existed. That is the failure this corpus exists to avoid, because a clean-room implementation is how a reader checks the score without trusting the author.

## What this is not

This does not require the field in the result schema, so no previously valid artifact becomes invalid and no family changes version. The runner already emits it on every row, and parity already enforces it; publishing the vocabulary closes the gap between what is required and what is knowable.

Requiring it in the schema is a separate decision with a version bump attached, and it is not made here.

## What to distrust

The binding, in both directions. A published vocabulary that drifts from the emitter is worse than none, because an implementer follows it. Each check was verified by breaking it: dropping a published state makes both the Go test and the contract script fail and name the missing state, and publishing a state nothing emits fails both and names the extra one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a published mapping of evidence result states, including clear descriptions for observed, unreachable, adapter error, delivery unavailable, unobservable verdict, and invalid verdict outcomes.
  - Improved transparency and consistency when interpreting result states across the product.

- **Bug Fixes**
  - Added validation to ensure all emitted result states are documented and have meaningful descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->