### PR TITLE
Catch known vulnerabilities in called code

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Run portable canonical benchmark
         shell: bash

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
@@ -63,6 +64,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
@@ -80,6 +83,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
@@ -97,6 +102,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       # The pinned toolchain of the result-producing lane, so this job fails on
       # exactly the exposure a published Gauntlet run would have carried. Keep

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -90,3 +90,29 @@ jobs:
           mkdir -p "$HOME/.cache/pipelock-tmp" "$HOME/.cache/go-build"
           cd validate
           TMPDIR="$HOME/.cache/pipelock-tmp" GOCACHE="$HOME/.cache/go-build" go test -race -count=1 ./...
+
+  govulncheck:
+    name: Known vulnerabilities in called code
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      # The pinned toolchain of the result-producing lane, so this job fails on
+      # exactly the exposure a published Gauntlet run would have carried. Keep
+      # this in step with continuous-gauntlet.yaml.
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.25.13"
+
+      - name: Scan both modules for called vulnerabilities
+        run: |
+          set -euo pipefail
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+          status=0
+          for module in runner validate; do
+            echo "::group::govulncheck $module"
+            ( cd "$module" && "$(go env GOPATH)/bin/govulncheck" ./... ) || status=1
+            echo "::endgroup::"
+          done
+          exit "$status"

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -274,7 +274,24 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
 
     def test_runner_and_artifacts_are_pinned_to_one_attempt(self):
         self.assertRegex(self.workflow, r"(?m)^    runs-on: ubuntu-24\.04$")
-        self.assertIn('go-version: "1.25.12"', self.workflow)
+        # Pinned to an exact patch for reproducibility. Asserting the literal
+        # version here is what let the pin fall behind a security patch without
+        # anything objecting, so require the exact-patch SHAPE and require it to
+        # equal the toolchain the govulncheck job scans. A bump then moves both.
+        pins = re.findall(r'go-version: "(\d+\.\d+\.\d+)"', self.workflow)
+        self.assertEqual(len(pins), 1, f"expected exactly one exact-patch Go pin, found {pins}")
+        validate_workflow = (
+            Path(__file__).resolve().parent.parent / ".github" / "workflows" / "validate.yaml"
+        ).read_text(encoding="utf-8")
+        scanned = re.findall(r'go-version: "(\d+\.\d+\.\d+)"', validate_workflow)
+        self.assertEqual(
+            len(scanned), 1, f"expected exactly one exact-patch Go pin in validate.yaml, found {scanned}"
+        )
+        self.assertEqual(
+            pins[0],
+            scanned[0],
+            "the benchmark toolchain and the vulnerability-scanned toolchain must match",
+        )
         upload = step_block(self.workflow, "Upload provenance artifact")
         owner_upload = step_block(self.workflow, "Upload owner review artifact")
         self.assertIn("continuous-gauntlet-pipelock-${{ github.run_attempt }}", upload)


### PR DESCRIPTION
## What changed

The continuous Gauntlet workflow, which produces published benchmark results, pinned Go 1.25.12. Eight standard-library advisories that the runner's own code paths call are fixed in 1.25.13, including ones in `net/url`, `crypto/tls`, `net/http` and `encoding/asn1`. That pin is bumped to 1.25.13.

A `govulncheck` job now scans both the `runner` and `validate` modules on the same pinned toolchain the result-producing lane uses, so the check fails on exactly the exposure a published run would have carried.

Repository grades were previously the only vulnerability signal in this repository, and they arrived as dismissible alerts carrying no file or line, so a stale toolchain pin could sit unnoticed. This replaces a graded score with a job that names the advisory and the calling line and fails closed.

Reviewers should distrust the availability direction here. A scanner wired into required CI can red the repository on an upstream advisory that has nothing to do with the change under review. `govulncheck` reports only vulnerabilities reachable from called code rather than every advisory in the dependency graph, which keeps that surface narrow, and both modules were confirmed clean on 1.25.13 before this landed. The failure mode remains a genuine one to watch.

The scanner itself is pinned to `govulncheck@v1.7.0` rather than a floating tag, so this does not add an unpinned dependency to a repository that is graded on pinning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated vulnerability scanning for the runner and validation components.
  * Scans now report all results before failing when vulnerabilities are detected.

* **Chores**
  * Updated the project’s Go toolchain to version 1.25.13.
  * Added validation to keep Go version settings consistent across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->