### PR TITLE
Cite the author as a person, not an organization

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,8 @@ title: agent-egress-bench
 message: "If you use this corpus in research, please cite it."
 type: dataset
 authors:
-  - name: Joshua Waldrep
+  - given-names: Joshua
+    family-names: Waldrep
     alias: luckyPipewrench
 repository-code: https://github.com/luckyPipewrench/agent-egress-bench
 license: Apache-2.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: preflight check-case-immutability check-frozen-schema-immutability check-schema-catalog check-schema-copies check-docs check-contracts check-public-contracts check-claim-language check-readme-categories check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow test-release-snapshot release-snapshot validate-cases validate
+.PHONY: preflight check-citation check-case-immutability check-frozen-schema-immutability check-schema-catalog check-schema-copies check-docs check-contracts check-public-contracts check-claim-language check-readme-categories check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow test-release-snapshot release-snapshot validate-cases validate
 
 TMPDIR := $(HOME)/.cache/pipelock-tmp
 GOCACHE := $(HOME)/.cache/go-build
@@ -13,7 +13,7 @@ AEB_IMMUTABILITY_BASE ?= origin/main
 # below complete comfortably inside the edit-to-push budget and it catches real
 # shared-state defects that ordinary go test would miss. It requires the Go
 # toolchain needed by runner/go.mod (currently Go 1.25 or newer).
-preflight: check-contracts check-schema-catalog check-public-contracts check-case-immutability check-frozen-schema-immutability check-schema-copies check-docs test-capability-registry check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow check-stats check-gauntlet-site check-claim-language check-readme-categories
+preflight: check-contracts check-schema-catalog check-public-contracts check-case-immutability check-frozen-schema-immutability check-schema-copies check-docs check-citation test-capability-registry check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow check-stats check-gauntlet-site check-claim-language check-readme-categories
 
 check-scorecard-workflow:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/scorecard_workflow_test.py
@@ -71,6 +71,10 @@ check-frozen-schema-immutability:
 
 # Keep contract ownership links live and prevent deleted scoring documents from
 # becoming shadow authorities again. Missing and empty inputs fail the scan.
+check-citation:
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_citation_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_citation.py
+
 check-docs:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_docs_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_docs.py

--- a/scripts/check_citation.py
+++ b/scripts/check_citation.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Check that CITATION.cff describes its authors as people.
+
+CFF 1.2.0 defines two author shapes. A person carries `given-names` and
+`family-names`; an entity, meaning an organization or team, carries `name`.
+Both validate against the schema, so a human written as `name: Jane Doe` is
+accepted and then cited as an organization by every downstream tool. Schema
+validation proves shape, not meaning, which is why this check exists.
+
+Every author in this repository is a person. If an organization is ever added
+as an author, this check fails loudly and whoever adds it updates the rule
+deliberately, which is the intended cost: a citation that misattributes
+authorship is worse than a build that stops.
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+
+CITATION_PATH = Path("CITATION.cff")
+
+
+def check(root: Path) -> int:
+    path = root / CITATION_PATH
+    if not path.is_file():
+        raise ValueError(f"missing {CITATION_PATH}")
+
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise ValueError(f"{CITATION_PATH} must be a YAML mapping")
+
+    authors = document.get("authors")
+    if not isinstance(authors, list) or not authors:
+        raise ValueError(f"{CITATION_PATH} declares no authors")
+
+    for index, author in enumerate(authors):
+        label = f"{CITATION_PATH} authors[{index}]"
+        if not isinstance(author, dict):
+            raise ValueError(f"{label} must be a mapping")
+        if "name" in author:
+            raise ValueError(
+                f"{label} uses the CFF entity field 'name', which cites a human as an "
+                "organization; use 'given-names' and 'family-names'"
+            )
+        if not author.get("family-names"):
+            raise ValueError(f"{label} has no 'family-names'")
+
+    return len(authors)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    try:
+        count = check(root)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"check-citation: FAIL - {exc}", file=sys.stderr)
+        return 1
+    print(f"check-citation: OK ({count} author(s) cited as people)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_citation_test.py
+++ b/scripts/check_citation_test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Regression tests for the citation author-identity check."""
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).parent
+spec = importlib.util.spec_from_file_location("check_citation", SCRIPTS / "check_citation.py")
+check_citation = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules["check_citation"] = check_citation
+spec.loader.exec_module(check_citation)
+
+
+PERSON = """cff-version: 1.2.0
+title: fixture
+message: "cite it"
+type: dataset
+authors:
+  - given-names: Jane
+    family-names: Doe
+    alias: jdoe
+"""
+
+ENTITY = """cff-version: 1.2.0
+title: fixture
+message: "cite it"
+type: dataset
+authors:
+  - name: Jane Doe
+    alias: jdoe
+"""
+
+
+class CitationCheckTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def write(self, content):
+        (self.root / "CITATION.cff").write_text(content, encoding="utf-8")
+
+    def test_accepts_a_person(self):
+        self.write(PERSON)
+        self.assertEqual(1, check_citation.check(self.root))
+
+    def test_rejects_the_entity_spelling_of_a_person(self):
+        # The defect this exists for. Both spellings are valid CFF, so schema
+        # validation passes either way and only this check tells them apart.
+        self.write(ENTITY)
+        with self.assertRaisesRegex(ValueError, "entity field 'name'"):
+            check_citation.check(self.root)
+
+    def test_rejects_an_author_without_family_names(self):
+        self.write(
+            "cff-version: 1.2.0\ntitle: fixture\nmessage: \"cite it\"\ntype: dataset\n"
+            "authors:\n  - given-names: Jane\n"
+        )
+        with self.assertRaisesRegex(ValueError, "family-names"):
+            check_citation.check(self.root)
+
+    def test_rejects_a_file_with_no_authors(self):
+        self.write("cff-version: 1.2.0\ntitle: fixture\nmessage: \"cite it\"\ntype: dataset\n")
+        with self.assertRaisesRegex(ValueError, "no authors"):
+            check_citation.check(self.root)
+
+    def test_rejects_a_missing_file(self):
+        with self.assertRaisesRegex(ValueError, "missing"):
+            check_citation.check(self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`CITATION.cff` cited the author as an organization. CFF 1.2.0 has two author shapes: a person carries `given-names` and `family-names`, an entity carries `name`. The file used `name`, so every tool reading it credited a human as an org.

Both spellings validate against the CFF schema, which is why this survived. Schema validation proves shape, not meaning.

Adds `check-citation` to preflight so it cannot come back silently. The check fails if an author uses the entity field, and it will also fail if a real organization is added later. That is deliberate: a citation that misattributes authorship is worse than a build that stops, so whoever adds an org author updates the rule on purpose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated citation metadata to use separate given and family names for authors.
  * Added validation to catch missing or incorrectly formatted citation author information.

* **Tests**
  * Added coverage for valid citations, missing authors, missing files, and invalid author formats.

* **Chores**
  * Added citation checks to the preflight validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->