### PR TITLE
Publish a pinned schema catalog and bundle with each release

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -4,7 +4,10 @@ A tagged release fixes the corpus, schemas, contracts, runner source revision, a
 
 Each release contains:
 
-- One corpus and schema data bundle.
+- One corpus data bundle.
+- One commit-pinned schema catalog and schema bundle. The bundle contains the
+  catalog and every schema it names, so a vendor can validate schema bytes
+  after download without a network connection.
 - `aeb-gauntlet` archives for Linux, macOS, and Windows on amd64 and arm64.
 - `checksums.txt` covering every release asset.
 - `release-identity.json` with the corpus version, active schema versions, source commit, and supported archive matrix.
@@ -22,7 +25,7 @@ tar -xzf aeb-release/agent-egress-bench_0.1.0_data.tar.gz -C aeb-release/extract
 (cd aeb-release/extracted && python3 scripts/release_build.py verify --release-dir ..)
 ```
 
-The verifier rejects a missing asset, a checksum mismatch, an archive whose embedded identity differs from the release identity, a changed corpus or schema file, or a data bundle whose file list differs from the recorded tree.
+The verifier rejects a missing asset, a checksum mismatch, an archive whose embedded identity differs from the release identity, a changed corpus or schema file, a schema catalog or bundle that disagrees with the release commit, or a data bundle whose file list differs from the recorded tree.
 
 To bind that package back to the cited source, clone the same tag and supply it to the verifier:
 
@@ -43,6 +46,6 @@ After extracting the platform archive, run `aeb-gauntlet --version`. A tagged bi
 
 ## Build without publishing
 
-`make release-snapshot` builds the archive matrix, data bundle, checksums, and identity verification under `dist/release`. It creates no tag and no GitHub release. The command requires a pinned GoReleaser installation. The release workflow installs GoReleaser v2.17.1 and runs this snapshot path for manual workflow dispatches.
+`make release-snapshot` builds the archive matrix, corpus data bundle, schema catalog and bundle, checksums, and identity verification under `dist/release`. It creates no tag and no GitHub release. The command requires a pinned GoReleaser installation. The release workflow installs GoReleaser v2.17.1 and runs this snapshot path for manual workflow dispatches.
 
 Tag pushes matching `v*` run the same gates against the tag, attach provenance to every release asset, upload the generated artifacts for inspection, and publish a draft only after those checks pass. If the publish job fails after creating a draft, rerunning that workflow resumes the existing draft and refuses to overwrite a published release. The workflow stops before publication when the release identity, corpus data, schema contract, archive layout, or checksum verification disagrees.

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -35,6 +35,9 @@ The in-repo copy is deterministic and carries no commit or release field. A
 commit cannot name the commit that contains it, so embedding one would make
 the committed catalog permanently disagree with its own regeneration check.
 
+The released catalog adds a `retrieval_url` for every entry. Each URL pins the
+exact `source_commit` recorded by the catalog, never the moving default branch.
+
 ## Pinning a version, and reproducing an old run
 
 Pin the released catalog artifact, not the copy on the default branch. The
@@ -49,6 +52,11 @@ For a result you intend to reproduce later, retain the catalog artifact, its
 digest, and the schema bytes themselves alongside the result. A digest says
 which bytes; the commit and release say which repository state produced them.
 Reproducing a two-year-old run needs both.
+
+Every release also includes a schema bundle containing that released catalog
+at `schemas/index.json` and every schema it names. Verify the bundle against
+the release `checksums.txt`, then validate each extracted file against the
+catalog without network access.
 
 To validate:
 
@@ -73,6 +81,12 @@ rejects any byte difference, including a reformat or a key reorder that leaves
 the parsed document identical, because a consumer pinning a digest sees those
 as a different document. There is no permitted-migration exception. Changing a
 frozen contract means publishing a new version.
+
+## Forward identifier policy
+
+A new schema version may use a versioned resolving identifier on a controlled
+domain when one exists. Existing identifiers never migrate, because consumers
+may have registered or referenced the original name and pinned its bytes.
 
 ## Adapter quickstarts
 

--- a/scripts/check_schema_catalog_test.py
+++ b/scripts/check_schema_catalog_test.py
@@ -57,6 +57,34 @@ class SchemaCatalogTest(unittest.TestCase):
     def test_accepts_catalog_derived_from_schema_files(self):
         self.assertEqual(1, check_schema_catalog.check(self.root, roots=TEST_ROOTS))
 
+    def test_released_catalog_has_source_commit_pinned_retrieval_urls(self):
+        commit = "a" * 40
+        catalog = json.loads(
+            schema_catalog.rendered_catalog(
+                self.root,
+                source_commit=commit,
+                release="v1.2.3",
+                roots=TEST_ROOTS,
+            )
+        )
+        self.assertEqual(commit, catalog["source_commit"])
+        self.assertEqual("v1.2.3", catalog["release"])
+        self.assertEqual(
+            f"https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/{commit}/schemas/fixture-v1.schema.json",
+            catalog["schemas"][0]["retrieval_url"],
+        )
+
+    def test_released_catalog_refuses_an_unpinned_or_invalid_source_commit(self):
+        with self.assertRaisesRegex(ValueError, "requires both a source commit and release name"):
+            schema_catalog.rendered_catalog(self.root, release="v1.2.3", roots=TEST_ROOTS)
+        with self.assertRaisesRegex(ValueError, "40-character lower-case Git SHA"):
+            schema_catalog.rendered_catalog(
+                self.root,
+                source_commit="main",
+                release="v1.2.3",
+                roots=TEST_ROOTS,
+            )
+
     def test_rejects_stale_hash_after_schema_bytes_change(self):
         self.schema.write_text(
             json.dumps(
@@ -97,6 +125,14 @@ class SchemaCatalogTest(unittest.TestCase):
         catalog = self.root / "schemas" / "index.json"
         content = json.loads(catalog.read_text(encoding="utf-8"))
         content["schemas"][0]["path"] = "schemas/other-v1.schema.json"
+        catalog.write_text(json.dumps(content) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "is stale"):
+            check_schema_catalog.check(self.root, roots=TEST_ROOTS)
+
+    def test_rejects_a_release_only_retrieval_url_in_the_committed_catalog(self):
+        catalog = self.root / "schemas" / "index.json"
+        content = json.loads(catalog.read_text(encoding="utf-8"))
+        content["schemas"][0]["retrieval_url"] = "https://example.invalid/schema.json"
         catalog.write_text(json.dumps(content) + "\n", encoding="utf-8")
         with self.assertRaisesRegex(ValueError, "is stale"):
             check_schema_catalog.check(self.root, roots=TEST_ROOTS)

--- a/scripts/release-build.sh
+++ b/scripts/release-build.sh
@@ -76,6 +76,9 @@ release_dir="$dist/release"
 mkdir -p "$release_dir"
 find "$dist" -maxdepth 1 -type f \( -name 'agent-egress-bench_*.tar.gz' -o -name 'agent-egress-bench_*.zip' \) -exec mv {} "$release_dir" \;
 python3 scripts/release_build.py data-bundle --identity "$identity" --dist "$release_dir"
+schema_catalog="$release_dir/agent-egress-bench_${version}_schema-catalog.json"
+python3 scripts/write_schema_catalog.py --release "$tag" --output "$schema_catalog"
+python3 scripts/release_build.py schema-bundle --identity "$identity" --catalog "$schema_catalog" --dist "$release_dir"
 python3 scripts/release_build.py checksums --identity "$identity" --dist "$release_dir"
 # Run the binary this host can actually execute. Hardcoding linux/amd64 works on
 # CI and silently breaks a macOS or arm64 developer running a snapshot. When no

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -24,7 +24,7 @@ SNAPSHOT_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?-S
 IDENTITY_NAME = "release-identity.json"
 CHECKSUM_NAME = "checksums.txt"
 DATA_ROOTS = ("cases", "schemas", "contracts", "capability-registry/aeb.core-capabilities")
-DATA_FILES = ("README.md", "LICENSE", "NOTICE", "docs/SPEC.md", "docs/GOVERNANCE.md", "docs/RUNNER.md", "scripts/release_build.py")
+DATA_FILES = ("README.md", "LICENSE", "NOTICE", "CITATION.cff", "docs/SPEC.md", "docs/GOVERNANCE.md", "docs/RUNNER.md", "scripts/release_build.py")
 PLATFORMS = tuple((goos, arch) for goos in ("linux", "darwin", "windows") for arch in ("amd64", "arm64"))
 
 

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -23,6 +23,11 @@ VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-
 SNAPSHOT_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?-SNAPSHOT-[0-9a-f]{7}$")
 IDENTITY_NAME = "release-identity.json"
 CHECKSUM_NAME = "checksums.txt"
+SCHEMA_CATALOG_PATH = "schemas/index.json"
+SCHEMA_CATALOG_SUFFIX = "_schema-catalog.json"
+SCHEMA_BUNDLE_SUFFIX = "_schemas.tar.gz"
+REPOSITORY = "luckyPipewrench/agent-egress-bench"
+RAW_SCHEMA_URL = "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/{commit}/{path}"
 DATA_ROOTS = ("cases", "schemas", "contracts", "capability-registry/aeb.core-capabilities")
 DATA_FILES = ("README.md", "LICENSE", "NOTICE", "CITATION.cff", "docs/SPEC.md", "docs/GOVERNANCE.md", "docs/RUNNER.md", "scripts/release_build.py")
 PLATFORMS = tuple((goos, arch) for goos in ("linux", "darwin", "windows") for arch in ("amd64", "arm64"))
@@ -275,7 +280,7 @@ def build_identity(repo: Path, tag: str, version: str, commit: str, snapshot: bo
     return {
         "schema_version": 1,
         "release": {"tag": tag, "version": version, "snapshot": snapshot},
-        "source": {"repository": "luckyPipewrench/agent-egress-bench", "commit": commit, "commit_timestamp": int(timestamp)},
+        "source": {"repository": REPOSITORY, "commit": commit, "commit_timestamp": int(timestamp)},
         "runner": {"binary": "aeb-gauntlet", "runner_version": metadata["runner_version"], "scoring_version": metadata["scoring_version"], "platforms": [{"goos": goos, "goarch": arch} for goos, arch in PLATFORMS]},
         "corpus": corpus(repo, metadata["corpus_version"]),
         "schema_contract": {"artifacts_manifest_path": "contracts/artifacts.json", "artifacts_manifest_sha256": sha256_file(repo / "contracts/artifacts.json"), "families": contract_families(repo)},
@@ -320,7 +325,7 @@ def validate_identity_structure(identity: dict[str, Any]) -> None:
         fail("release identity release tag and version are invalid")
 
     source = exact_object(identity["source"], "release identity source", {"repository", "commit", "commit_timestamp"})
-    if source["repository"] != "luckyPipewrench/agent-egress-bench":
+    if source["repository"] != REPOSITORY:
         fail("release identity source.repository is invalid")
     if not isinstance(source["commit"], str) or not COMMIT_RE.fullmatch(source["commit"]):
         fail("release identity source.commit is invalid")
@@ -422,6 +427,71 @@ def make_data_bundle(repo: Path, identity_path: Path, dist: Path) -> Path:
     return output
 
 
+def schema_asset_names(identity: dict[str, Any]) -> tuple[str, str]:
+    version = identity["release"]["version"]
+    prefix = f"agent-egress-bench_{version}"
+    return f"{prefix}{SCHEMA_CATALOG_SUFFIX}", f"{prefix}{SCHEMA_BUNDLE_SUFFIX}"
+
+
+def release_catalog_entries(identity: dict[str, Any], catalog_bytes: bytes) -> list[dict[str, str]]:
+    try:
+        catalog = json.loads(catalog_bytes)
+    except json.JSONDecodeError as exc:
+        fail(f"release schema catalog is not JSON: {exc}")
+    if not isinstance(catalog, dict):
+        fail("release schema catalog must be an object")
+    if set(catalog) != {"format", "repository", "source_commit", "release", "schemas"}:
+        fail("release schema catalog has invalid fields")
+    if catalog["format"] != 1 or catalog["repository"] != f"https://github.com/{REPOSITORY}":
+        fail("release schema catalog has invalid identity")
+    if catalog["source_commit"] != identity["source"]["commit"] or catalog["release"] != identity["release"]["tag"]:
+        fail("release schema catalog does not match release identity")
+    schemas = catalog["schemas"]
+    if not isinstance(schemas, list) or not schemas:
+        fail("release schema catalog has no schema entries")
+    paths: set[str] = set()
+    entries: list[dict[str, str]] = []
+    for index, entry in enumerate(schemas):
+        entry = exact_object(entry, f"release schema catalog schemas[{index}]", {"path", "$id", "sha256", "retrieval_url"})
+        path = safe_name(nonempty_string(entry["path"], f"release schema catalog schemas[{index}].path"))
+        if path in paths or path == SCHEMA_CATALOG_PATH:
+            fail("release schema catalog has duplicate or reserved schema paths")
+        paths.add(path)
+        nonempty_string(entry["$id"], f"release schema catalog schemas[{index}].$id")
+        digest = entry["sha256"]
+        if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+            fail(f"release schema catalog schemas[{index}].sha256 is invalid")
+        expected_url = RAW_SCHEMA_URL.format(commit=identity["source"]["commit"], path=path)
+        if entry["retrieval_url"] != expected_url:
+            fail(f"release schema catalog schemas[{index}].retrieval_url is not pinned to the release commit")
+        entries.append({"path": path, "sha256": digest})
+    return entries
+
+
+def make_schema_bundle(repo: Path, identity_path: Path, catalog_path: Path, dist: Path) -> Path:
+    identity = verify_identity(repo, identity_path)
+    if not catalog_path.is_file() or catalog_path.is_symlink():
+        fail(f"release schema catalog is absent or unsafe: {catalog_path}")
+    catalog_bytes = catalog_path.read_bytes()
+    entries = release_catalog_entries(identity, catalog_bytes)
+    catalog_name, bundle_name = schema_asset_names(identity)
+    if catalog_path.name != catalog_name:
+        fail("release schema catalog has an unexpected asset name")
+    output = dist / bundle_name
+    dist.mkdir(parents=True, exist_ok=True)
+    with output.open("wb") as raw, gzip.GzipFile(fileobj=raw, mode="wb", mtime=identity["source"]["commit_timestamp"], filename="") as compressed, tarfile.open(fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT) as archive:
+        add_tar_bytes(archive, SCHEMA_CATALOG_PATH, catalog_bytes, identity["source"]["commit_timestamp"])
+        for entry in sorted(entries, key=lambda item: item["path"]):
+            path = repo / entry["path"]
+            if not path.is_file() or path.is_symlink():
+                fail(f"release schema catalog names an absent or unsafe schema: {entry['path']}")
+            contents = path.read_bytes()
+            if sha256_bytes(contents) != entry["sha256"]:
+                fail(f"release schema catalog digest does not match source schema: {entry['path']}")
+            add_tar_bytes(archive, entry["path"], contents, identity["source"]["commit_timestamp"])
+    return output
+
+
 def write_checksums(dist: Path, identity_path: Path) -> Path:
     if not identity_path.is_file():
         fail(f"release identity is absent: {identity_path}")
@@ -520,6 +590,24 @@ def bundle_contents(path: Path) -> dict[str, bytes]:
     return result
 
 
+def verify_schema_bundle(identity: dict[str, Any], release_dir: Path) -> None:
+    catalog_name, bundle_name = schema_asset_names(identity)
+    catalog_path, bundle_path = release_dir / catalog_name, release_dir / bundle_name
+    if not catalog_path.is_file() or not bundle_path.is_file():
+        fail("release is missing its schema catalog or schema bundle")
+    catalog_bytes = catalog_path.read_bytes()
+    entries = release_catalog_entries(identity, catalog_bytes)
+    contents = bundle_contents(bundle_path)
+    if contents.get(SCHEMA_CATALOG_PATH) != catalog_bytes:
+        fail("schema bundle catalog does not match the release catalog asset")
+    expected_paths = {SCHEMA_CATALOG_PATH, *(entry["path"] for entry in entries)}
+    if set(contents) != expected_paths:
+        fail("schema bundle file list does not match the release catalog")
+    for entry in entries:
+        if sha256_bytes(contents[entry["path"]]) != entry["sha256"]:
+            fail(f"schema bundle digest does not match release catalog: {entry['path']}")
+
+
 def bundle_corpus_ids(contents: dict[str, bytes]) -> set[str]:
     result: set[str] = set()
     for name in contents:
@@ -571,8 +659,9 @@ def verify_release(release_dir: Path, repo: Path | None, executable: Path | None
             fail(f"checksum mismatch: {name}")
     binaries = binary_archives(identity)
     data_name = f"agent-egress-bench_{identity['release']['version']}_data.tar.gz"
-    if data_name not in checksums or not set(binaries).issubset(checksums):
-        fail("release is missing its data bundle or declared runner platforms")
+    catalog_name, bundle_name = schema_asset_names(identity)
+    if data_name not in checksums or catalog_name not in checksums or bundle_name not in checksums or not set(binaries).issubset(checksums):
+        fail("release is missing its data bundle, schema artifacts, or declared runner platforms")
     expected_identity = identity_path.read_bytes()
     for name, (goos, goarch) in binaries.items():
         if archive_identity(release_dir / name, goos, goarch) != expected_identity:
@@ -585,6 +674,7 @@ def verify_release(release_dir: Path, repo: Path | None, executable: Path | None
         if not isinstance(name, str) or not isinstance(digest, str) or not SHA256_RE.fullmatch(digest) or sha256_bytes(contents[name]) != digest:
             fail(f"data bundle digest does not match release identity: {name}")
     verify_bundle_corpus(identity, contents)
+    verify_schema_bundle(identity, release_dir)
     if repo is not None:
         expected = build_identity(repo.resolve(), identity["release"]["tag"], identity["release"]["version"], identity["source"]["commit"], identity["release"]["snapshot"])
         if canonical_json(expected) != canonical_json(identity):
@@ -630,6 +720,11 @@ def main() -> int:
     bundle.add_argument("--repo-root", type=Path, default=Path("."))
     bundle.add_argument("--identity", type=Path, required=True)
     bundle.add_argument("--dist", type=Path, required=True)
+    schema_bundle = commands.add_parser("schema-bundle")
+    schema_bundle.add_argument("--repo-root", type=Path, default=Path("."))
+    schema_bundle.add_argument("--identity", type=Path, required=True)
+    schema_bundle.add_argument("--catalog", type=Path, required=True)
+    schema_bundle.add_argument("--dist", type=Path, required=True)
     sums = commands.add_parser("checksums")
     sums.add_argument("--identity", type=Path, required=True)
     sums.add_argument("--dist", type=Path, required=True)
@@ -650,6 +745,8 @@ def main() -> int:
             verify_identity(args.repo_root.resolve(), args.identity)
         elif args.command == "data-bundle":
             print(make_data_bundle(args.repo_root.resolve(), args.identity, args.dist))
+        elif args.command == "schema-bundle":
+            print(make_schema_bundle(args.repo_root.resolve(), args.identity, args.catalog, args.dist))
         elif args.command == "checksums":
             print(write_checksums(args.dist, args.identity))
         elif args.command == "verify":

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -457,15 +457,36 @@ def release_catalog_entries(identity: dict[str, Any], catalog_bytes: bytes) -> l
         if path in paths or path == SCHEMA_CATALOG_PATH:
             fail("release schema catalog has duplicate or reserved schema paths")
         paths.add(path)
-        nonempty_string(entry["$id"], f"release schema catalog schemas[{index}].$id")
+        declared_id = nonempty_string(entry["$id"], f"release schema catalog schemas[{index}].$id")
         digest = entry["sha256"]
         if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
             fail(f"release schema catalog schemas[{index}].sha256 is invalid")
         expected_url = RAW_SCHEMA_URL.format(commit=identity["source"]["commit"], path=path)
         if entry["retrieval_url"] != expected_url:
             fail(f"release schema catalog schemas[{index}].retrieval_url is not pinned to the release commit")
-        entries.append({"path": path, "sha256": digest})
+        entries.append({"path": path, "$id": declared_id, "sha256": digest})
     return entries
+
+
+def require_declared_id(contents: bytes, entry: dict[str, str], source: str) -> None:
+    """Require a schema's own declared identity to match what the catalog claims.
+
+    A digest proves the bytes; it says nothing about the name those bytes are
+    published under. Without this, a catalog carrying a substituted `$id`
+    passes every other check, because the paths resolve, the digests match the
+    real files, and the checksums are regenerated over the altered catalog. An
+    offline consumer then registers correct schema bytes under the wrong
+    identity and validates its data against a contract it never chose, with
+    every integrity signal reading green.
+    """
+    try:
+        document = json.loads(contents)
+    except json.JSONDecodeError as exc:
+        fail(f"{source} is not JSON: {entry['path']}: {exc}")
+    if not isinstance(document, dict):
+        fail(f"{source} is not a JSON object: {entry['path']}")
+    if document.get("$id") != entry["$id"]:
+        fail(f"{source} declares an $id the release catalog does not name: {entry['path']}")
 
 
 def make_schema_bundle(repo: Path, identity_path: Path, catalog_path: Path, dist: Path) -> Path:
@@ -488,6 +509,7 @@ def make_schema_bundle(repo: Path, identity_path: Path, catalog_path: Path, dist
             contents = path.read_bytes()
             if sha256_bytes(contents) != entry["sha256"]:
                 fail(f"release schema catalog digest does not match source schema: {entry['path']}")
+            require_declared_id(contents, entry, "source schema")
             add_tar_bytes(archive, entry["path"], contents, identity["source"]["commit_timestamp"])
     return output
 
@@ -606,6 +628,7 @@ def verify_schema_bundle(identity: dict[str, Any], release_dir: Path) -> None:
     for entry in entries:
         if sha256_bytes(contents[entry["path"]]) != entry["sha256"]:
             fail(f"schema bundle digest does not match release catalog: {entry['path']}")
+        require_declared_id(contents[entry["path"]], entry, "bundled schema")
 
 
 def bundle_corpus_ids(contents: dict[str, bytes]) -> set[str]:

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -434,6 +434,36 @@ class ReleaseBuildTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("missing its data bundle, schema artifacts, or declared runner platforms", result.stderr)
 
+    def test_download_verifier_rejects_schema_bytes_changed_after_rechecksum(self) -> None:
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke("data-bundle", "--repo-root", str(self.root), "--identity", str(self.identity), "--dist", str(dist))
+        identity = self.identity.read_bytes()
+        self.write_runner_archives(dist, identity, json.loads(identity))
+        bundle_path = next(dist.glob("*_schemas.tar.gz"))
+        catalog = json.loads(next(dist.glob("*_schema-catalog.json")).read_text(encoding="utf-8"))
+        changed_path = catalog["schemas"][0]["path"]
+        with tarfile.open(bundle_path, "r:gz") as archive:
+            contents = {
+                entry.name: archive.extractfile(entry).read()
+                for entry in archive.getmembers()
+                if entry.isfile()
+            }
+        contents[changed_path] += b"\n"
+        with tarfile.open(bundle_path, "w:gz") as archive:
+            for name, data in sorted(contents.items()):
+                entry = tarfile.TarInfo(name)
+                entry.size = len(data)
+                archive.addfile(entry, io.BytesIO(data))
+        self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist)],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("schema bundle digest does not match release catalog", result.stderr)
+
     def test_download_verifier_runs_from_the_documented_extract_layout(self) -> None:
         self.prepare()
         dist = self.root / "dist"

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -464,6 +464,50 @@ class ReleaseBuildTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("schema bundle digest does not match release catalog", result.stderr)
 
+    def test_download_verifier_rejects_a_substituted_schema_identity(self) -> None:
+        # A digest proves the bytes and says nothing about the name they are
+        # published under. With the catalog $id substituted, every other signal
+        # still reads green: the paths resolve, the digests match the real
+        # schemas, and the checksums are regenerated over the altered catalog.
+        # An offline consumer would register correct bytes under the wrong
+        # identity and validate against a contract it never chose.
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke("data-bundle", "--repo-root", str(self.root), "--identity", str(self.identity), "--dist", str(dist))
+        identity = self.identity.read_bytes()
+        self.write_runner_archives(dist, identity, json.loads(identity))
+
+        catalog_path = next(dist.glob("*_schema-catalog.json"))
+        bundle_path = next(dist.glob("*_schemas.tar.gz"))
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        catalog["schemas"][0]["$id"] = "https://example.invalid/schemas/substituted-v1.schema.json"
+        catalog_bytes = (json.dumps(catalog, indent=2) + "\n").encode("utf-8")
+        catalog_path.write_bytes(catalog_bytes)
+
+        # Repack the bundle so its embedded catalog copy agrees with the asset,
+        # leaving the digest and file-list checks satisfied.
+        with tarfile.open(bundle_path, "r:gz") as archive:
+            contents = {
+                entry.name: archive.extractfile(entry).read()
+                for entry in archive.getmembers()
+                if entry.isfile()
+            }
+        contents["schemas/index.json"] = catalog_bytes
+        with tarfile.open(bundle_path, "w:gz") as archive:
+            for name, data in sorted(contents.items()):
+                entry = tarfile.TarInfo(name)
+                entry.size = len(data)
+                archive.addfile(entry, io.BytesIO(data))
+
+        self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist)],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0, "a substituted schema identity verified clean")
+        self.assertIn("declares an $id the release catalog does not name", result.stderr)
+
     def test_download_verifier_runs_from_the_documented_extract_layout(self) -> None:
         self.prepare()
         dist = self.root / "dist"

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -330,6 +330,34 @@ class ReleaseBuildTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("checksum mismatch", result.stderr)
 
+    def test_release_binds_citation_metadata_into_the_data_bundle_and_checksums(self) -> None:
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke("data-bundle", "--repo-root", str(self.root), "--identity", str(self.identity), "--dist", str(dist))
+        identity = json.loads(self.identity.read_text(encoding="utf-8"))
+        self.assertEqual(
+            hashlib.sha256((self.root / "CITATION.cff").read_bytes()).hexdigest(),
+            identity["data_files"]["CITATION.cff"],
+        )
+        data_bundle = next(dist.glob("*_data.tar.gz"))
+        with tarfile.open(data_bundle, "r:gz") as archive:
+            citation = archive.extractfile("CITATION.cff")
+            self.assertIsNotNone(citation)
+            assert citation is not None
+            self.assertEqual((self.root / "CITATION.cff").read_bytes(), citation.read())
+        self.write_runner_archives(dist, self.identity.read_bytes(), identity)
+        self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
+        checksums = {
+            name: digest
+            for digest, name in (
+                line.split("  ", 1)
+                for line in (dist / "checksums.txt").read_text(encoding="utf-8").splitlines()
+            )
+        }
+        self.assertIn(data_bundle.name, checksums)
+        self.assertEqual(hashlib.sha256(data_bundle.read_bytes()).hexdigest(), checksums[data_bundle.name])
+        self.invoke("verify", "--release-dir", str(dist))
+
     def test_download_verifier_runs_from_the_documented_extract_layout(self) -> None:
         self.prepare()
         dist = self.root / "dist"

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -91,6 +91,7 @@ class ReleaseBuildTest(unittest.TestCase):
         binary_overrides: dict[tuple[str, str], bytes] | None = None,
         mode_overrides: dict[tuple[str, str], int] | None = None,
     ) -> None:
+        self.write_schema_assets(dist, identity)
         binary_overrides = binary_overrides or {}
         mode_overrides = mode_overrides or {}
         for platform in release["runner"]["platforms"]:
@@ -112,6 +113,33 @@ class ReleaseBuildTest(unittest.TestCase):
                         info.size = len(runner)
                         info.mode = mode_overrides.get((goos, goarch), 0o755)
                         archive.addfile(info, __import__("io").BytesIO(runner))
+
+    def write_schema_assets(self, dist: Path, identity: bytes) -> None:
+        release = json.loads(identity)
+        version = release["release"]["version"]
+        catalog = dist / f"agent-egress-bench_{version}_schema-catalog.json"
+        subprocess.run(
+            [
+                sys.executable,
+                str(self.root / "scripts/write_schema_catalog.py"),
+                "--release",
+                release["release"]["tag"],
+                "--output",
+                str(catalog),
+            ],
+            check=True,
+        )
+        self.invoke(
+            "schema-bundle",
+            "--repo-root",
+            str(self.root),
+            "--identity",
+            str(self.identity),
+            "--catalog",
+            str(catalog),
+            "--dist",
+            str(dist),
+        )
 
     def forge_release(self, identity: dict) -> Path:
         release = Path(self.temp.name) / "fakerel"
@@ -357,6 +385,54 @@ class ReleaseBuildTest(unittest.TestCase):
         self.assertIn(data_bundle.name, checksums)
         self.assertEqual(hashlib.sha256(data_bundle.read_bytes()).hexdigest(), checksums[data_bundle.name])
         self.invoke("verify", "--release-dir", str(dist))
+
+    def test_release_binds_a_schema_bundle_to_the_commit_pinned_catalog(self) -> None:
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke("data-bundle", "--repo-root", str(self.root), "--identity", str(self.identity), "--dist", str(dist))
+        identity = json.loads(self.identity.read_text(encoding="utf-8"))
+        self.write_runner_archives(dist, self.identity.read_bytes(), identity)
+        self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
+        self.invoke("verify", "--release-dir", str(dist))
+
+        catalog_path = next(dist.glob("*_schema-catalog.json"))
+        bundle_path = next(dist.glob("*_schemas.tar.gz"))
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        self.assertEqual(self.commit, catalog["source_commit"])
+        self.assertEqual("snapshot", catalog["release"])
+        with tarfile.open(bundle_path, "r:gz") as archive:
+            contents = {
+                entry.name: archive.extractfile(entry).read()
+                for entry in archive.getmembers()
+                if entry.isfile()
+            }
+        self.assertEqual(catalog_path.read_bytes(), contents["schemas/index.json"])
+        self.assertEqual(
+            {"schemas/index.json", *(entry["path"] for entry in catalog["schemas"])},
+            set(contents),
+        )
+        for entry in catalog["schemas"]:
+            self.assertEqual(
+                f"https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/{self.commit}/{entry['path']}",
+                entry["retrieval_url"],
+            )
+            self.assertEqual(entry["sha256"], hashlib.sha256(contents[entry["path"]]).hexdigest())
+
+    def test_download_verifier_rejects_a_release_without_schema_bundle(self) -> None:
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke("data-bundle", "--repo-root", str(self.root), "--identity", str(self.identity), "--dist", str(dist))
+        identity = self.identity.read_bytes()
+        self.write_runner_archives(dist, identity, json.loads(identity))
+        next(dist.glob("*_schemas.tar.gz")).unlink()
+        self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist)],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing its data bundle, schema artifacts, or declared runner platforms", result.stderr)
 
     def test_download_verifier_runs_from_the_documented_extract_layout(self) -> None:
         self.prepare()

--- a/scripts/schema_catalog.py
+++ b/scripts/schema_catalog.py
@@ -16,7 +16,9 @@ from pathlib import Path
 
 
 VERSIONED_SCHEMA_FILENAME = re.compile(r"^.+-v[0-9]+\.schema\.json$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 CATALOG_PATH = Path("schemas/index.json")
+RAW_SCHEMA_URL = "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/{commit}/{path}"
 
 # Every directory holding published versioned schemas. The verifier copies are
 # governed assets in their own right: a consumer validating a Control Evidence
@@ -49,7 +51,7 @@ def head_commit(root: Path) -> str:
     return result.stdout.strip()
 
 
-def schema_entries(root: Path, roots=SCHEMA_ROOTS):
+def schema_entries(root: Path, source_commit: str = "", roots=SCHEMA_ROOTS):
     """Return catalog entries derived from every published schema root.
 
     `roots` is injectable for tests only. Production uses the explicit
@@ -83,7 +85,10 @@ def schema_entries(root: Path, roots=SCHEMA_ROOTS):
             # which contract applies, so refuse to publish a catalog that
             # cannot answer its own lookup.
             seen_ids.setdefault(declared, []).append((relative, digest))
-            entries.append({"path": relative, "$id": declared, "sha256": digest})
+            entry = {"path": relative, "$id": declared, "sha256": digest}
+            if source_commit:
+                entry["retrieval_url"] = RAW_SCHEMA_URL.format(commit=source_commit, path=relative)
+            entries.append(entry)
 
     for declared, occurrences in sorted(seen_ids.items()):
         digests = {digest for _, digest in occurrences}
@@ -111,6 +116,11 @@ def rendered_catalog(root: Path, source_commit: str = "", release: str = "", roo
     consumer pinning that artifact can map identity to bytes and say which
     repository state produced them.
     """
+    if bool(source_commit) != bool(release):
+        raise ValueError("a released schema catalog requires both a source commit and release name")
+    if source_commit and not COMMIT_RE.fullmatch(source_commit):
+        raise ValueError("released schema catalog source commit must be a 40-character lower-case Git SHA")
+
     catalog = {
         "format": 1,
         "repository": "https://github.com/luckyPipewrench/agent-egress-bench",
@@ -119,5 +129,5 @@ def rendered_catalog(root: Path, source_commit: str = "", release: str = "", roo
         catalog["source_commit"] = source_commit
     if release:
         catalog["release"] = release
-    catalog["schemas"] = schema_entries(root, roots)
+    catalog["schemas"] = schema_entries(root, source_commit, roots)
     return (json.dumps(catalog, indent=2) + "\n").encode("utf-8")

--- a/scripts/write_schema_catalog.py
+++ b/scripts/write_schema_catalog.py
@@ -37,6 +37,8 @@ def main() -> int:
         parser.error(f"refusing to write through a symlinked destination: {destination}")
 
     source_commit = head_commit(root) if args.release else ""
+    if args.release and not source_commit:
+        parser.error("a released schema catalog requires a checked-out Git commit")
     destination.write_bytes(rendered_catalog(root, source_commit, args.release))
     print(f"write-schema-catalog: wrote {destination}")
     return 0


### PR DESCRIPTION
## What changed

A release now publishes a schema catalog and a schema bundle alongside the corpus, so a vendor can pin one artifact and validate offline. The released catalog carries the source commit and release tag, which the in-repo copy cannot: a commit is unable to name the commit containing it, so provenance belongs on the copy generated after the tag exists. Each entry also carries a retrieval URL pinned to that commit. A retrieval URL is never the schema's identity; identities stay exactly as published and the catalog only says where to fetch the bytes and what their digest is.

`CITATION.cff` is now part of the verified data bundle. It was the one file describing how to cite a release while sitting outside that release's identity and checksums, so the instruction for citing an artifact was not covered by the artifact's own integrity record.

`docs/SCHEMAS.md` records the forward policy: a new incompatible schema version may take a versioned identifier on a controlled domain, and existing identifiers are never retroactively migrated. That decision was made and implemented once already, and writing it down is what stops it being relitigated by whoever next notices that the identifiers do not resolve.

Reviewers should distrust the bundle's integrity claim first. It asserts that the schemas a consumer verifies offline are the schemas the release was built from, and it fails in the quiet direction: a bundle that silently disagrees with the repository would let a vendor validate against the wrong contract and believe the result. The added test builds a release and compares the bundled bytes against the tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release packages now include a versioned schema catalog and schema bundle.
  - Schemas can be validated offline using the bundled catalog and files.
  - Catalog entries include retrieval links pinned to the exact release commit.
  - Release verification checks schema contents, catalog consistency, and checksums.

- **Documentation**
  - Added guidance for validating schema bundles and catalog consistency.
  - Documented rules for introducing new versioned schema identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->