### PR TITLE
chore(ci): advance the review pin and drop the retired secrets

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -47,7 +47,7 @@ jobs:
        github.event_name == 'workflow_dispatch')
     # Pinned to an immutable Pipelock commit in both positions. A branch or tag
     # here would run reviewer code that can change under the pin.
-    uses: luckyPipewrench/pipelock/.github/workflows/pr-review-reusable.yaml@3ff24b5885df799a034f61713e8ffb7a4f06b009
+    uses: luckyPipewrench/pipelock/.github/workflows/pr-review-reusable.yaml@74b3b3f1099d8d6d8ffeb67407ba7e99d1bd3119
     with:
       pr_number: >-
         ${{ github.event_name == 'issue_comment' &&
@@ -57,11 +57,9 @@ jobs:
         (github.event.comment.body == '/review deep' && 'deep' ||
          'default') ||
         inputs.review_mode }}
-      reviewer_sha: 3ff24b5885df799a034f61713e8ffb7a4f06b009
+      reviewer_sha: 74b3b3f1099d8d6d8ffeb67407ba7e99d1bd3119
     # Personal-account repositories cannot use secrets: inherit with a reusable
     # workflow, so every secret the reviewer needs is mapped by name.
     secrets:
       review_token: ${{ secrets.GITHUB_TOKEN }}
-      litellm_base_url: ${{ secrets.LITELLM_BASE_URL }}
-      litellm_api_key: ${{ secrets.LITELLM_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## What changed

The shared reviewer is pinned by commit in two positions, and both advance together here so the workflow and the reviewer source stay the same version.

The two retired LiteLLM secrets are dropped in the same commit, because the workflow at the new pin accepts only `review_token` and `openai_api_key`. A caller still passing a secret the workflow no longer declares fails at workflow load rather than at review time, so splitting the bump from the removal would break every review in this repository between the two commits.

What a reviewer should distrust here: the pin appears twice, and a mismatch would run one version's workflow against another version's reviewer code without saying so. Both occurrences and the secret list are worth checking directly against the workflow at the new pin rather than taken on trust.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated pull request review workflow to use a fixed, immutable version.
  * Removed obsolete service configuration mappings from the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->