### PR TITLE
feat(release): make a downloaded release runnable and checkable

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,9 +28,34 @@ builds:
       - -X main.releaseVersion={{ .Version }}
       - -X main.releaseCommit={{ .FullCommit }}
 
+  # The result validator ships in the same archive as the runner. A release
+  # that produced results without shipping the tool that checks them would
+  # leave every downloader depending on this repository to verify its own work.
+  - id: aeb-validate
+    dir: validate
+    main: .
+    binary: aeb-validate
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.releaseVersion={{ .Version }}
+      - -X main.releaseCommit={{ .FullCommit }}
+
 archives:
   - id: aeb-gauntlet
-    ids: [aeb-gauntlet]
+    ids: [aeb-gauntlet, aeb-validate]
     formats: [tar.gz]
     format_overrides:
       - goos: windows

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -4,7 +4,12 @@ A tagged release fixes the corpus, schemas, contracts, runner source revision, a
 
 Each release contains:
 
-- One corpus data bundle.
+- One corpus data bundle. It carries the cases, the schemas, the contracts, the
+  core capability registry, and the operator kit under `examples/`: the tool
+  profile template the runner requires, the MCP gateway plugin template, the
+  runner skeleton, and the reference harness. Bundle members extract with mode
+  `0644` so the bytes stay reproducible, so run a bundled shell script as
+  `bash <script>` rather than executing it directly.
 - One commit-pinned schema catalog and schema bundle. The bundle contains the
   catalog and every schema it names, so a vendor can validate schema bytes
   after download without a network connection.
@@ -44,6 +49,28 @@ gh attestation verify aeb-release/agent-egress-bench_0.1.0_linux_amd64.tar.gz --
 ```
 
 After extracting the platform archive, run `aeb-gauntlet --version`. A tagged binary prints its release version and exact source commit. The release verifier accepts that output with `--executable` when the archive matches the current host.
+
+## Run the corpus from a downloaded release
+
+The platform archive and the data bundle together are enough to inspect and run the corpus. Neither step needs a Go toolchain, a clone, or a network connection.
+
+```bash
+tar -xzf aeb-release/agent-egress-bench_0.1.0_linux_amd64.tar.gz -C aeb-release/extracted
+cd aeb-release/extracted
+mkdir artifacts
+./aeb-gauntlet --stats --cases cases
+./aeb-gauntlet --cases cases --profile examples/runner-template/tool-profile-template.json \
+  --output artifacts/raw-summary.json > artifacts/results.jsonl
+./aeb-gauntlet --report artifacts --report-output artifacts/report.md
+```
+
+The runner writes one JSON result per case to standard output and its human summary to standard error, so redirecting standard output produces `results.jsonl` without mixing the two. `--report` reads a directory rather than a single file, and it reads the summary under the name `raw-summary.json`, so write `--output` to that name when the run is meant to be reported. A summary saved under any other name leaves the report's method, target, and score sections reading as absent even though the file is sitting in the directory.
+
+Every artifact the report reads is individually optional, so a run that produced only some of them still renders, and each missing fact is reported as absent rather than guessed.
+
+The template profile names no real product, so that run exercises the corpus and the artifact path rather than measuring anything. Copy it, set `tool` and `tool_version` to the target under test, and select the adapter that reaches it. `--adapter mcp-gateway --gateway-plugin` drives an MCP gateway from `examples/gateway-plugin-template.json`; `docs/GATEWAY-ADAPTER.md` states that plugin contract.
+
+A run that reaches no target reports `measurement_status: incomplete`, and the score covers only the cases the adapter actually routed. Pass `--require-complete` to exit nonzero on an incomplete measurement instead of reading a partial run as a result.
 
 ## Build without publishing
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -13,7 +13,15 @@ Each release contains:
 - One commit-pinned schema catalog and schema bundle. The bundle contains the
   catalog and every schema it names, so a vendor can validate schema bytes
   after download without a network connection.
-- `aeb-gauntlet` archives for Linux, macOS, and Windows on amd64 and arm64.
+- Archives for Linux, macOS, and Windows on amd64 and arm64. Each one carries
+  both `aeb-gauntlet`, which runs the corpus, and `aeb-validate`, which checks a
+  result against the contracts. The release verifier refuses an archive missing
+  either binary, carrying one built for another platform, or carrying the same
+  program under both names. That last check exists because a name, an executable
+  bit, and a machine type are all satisfied by one program copied under two
+  names, which is what a build configured to produce the same binary twice
+  produces. It does not establish which program either binary is; see the note
+  under Verify a downloaded release.
 - `checksums.txt` covering every release asset.
 - `release-identity.json` with the corpus version, active schema versions, source commit, and supported archive matrix.
 - `runner-image.ref` with the full digest-pinned OCI image reference.
@@ -48,7 +56,18 @@ An operator can also check the GitHub provenance attached to any release asset:
 gh attestation verify aeb-release/agent-egress-bench_0.1.0_linux_amd64.tar.gz --repo luckyPipewrench/agent-egress-bench
 ```
 
-After extracting the platform archive, run `aeb-gauntlet --version`. A tagged binary prints its release version and exact source commit. The release verifier accepts that output with `--executable` when the archive matches the current host.
+After extracting the platform archive, run `aeb-gauntlet --version` and `aeb-validate --version`. A tagged binary prints its release version and exact source commit. When the archive matches the current host, hand both back to the verifier so it reads the identity out of the running programs rather than off their filenames:
+
+```bash
+python3 scripts/release_build.py verify --release-dir .. \
+  --executable ./aeb-gauntlet --validator-executable ./aeb-validate
+```
+
+Be precise about what that establishes. Without those two options the verifier checks each binary's name, executable bit, machine type, and that the two archive members are different programs. Supplying them adds two things: the file you point at must be the same bytes as that binary inside a release archive, and running it must print the identity this release records. Pointing the option at some other program is refused before it runs, so the option reports on the release rather than on whatever happens to be on your path.
+
+What none of it establishes is what a program does. A binary carrying the release's own bytes and reporting its version could still behave differently from the source it claims, and the release identity naming the validator is a label rather than a proof of role. These checks catch the mistake and the swap: a build configured to produce one program twice, a member replaced with another, an archive assembled for the wrong platform.
+
+What binds the bytes is `checksums.txt` over every asset, and the GitHub attestation over those assets. Altering a binary inside an archive fails checksum verification immediately, so defeating it means regenerating the checksums, which means controlling the build. At that point a second manifest of binary digests written by the same build would be regenerated too, which is why there isn't one. Verify the attestation when the question is whether the release came from this repository's workflow.
 
 ## Run the corpus from a downloaded release
 
@@ -67,6 +86,15 @@ mkdir artifacts
 The runner writes one JSON result per case to standard output and its human summary to standard error, so redirecting standard output produces `results.jsonl` without mixing the two. `--report` reads a directory rather than a single file, and it reads the summary under the name `raw-summary.json`, so write `--output` to that name when the run is meant to be reported. A summary saved under any other name leaves the report's method, target, and score sections reading as absent even though the file is sitting in the directory.
 
 Every artifact the report reads is individually optional, so a run that produced only some of them still renders, and each missing fact is reported as absent rather than guessed.
+
+Check the corpus and the result with the validator from the same archive. It reads the case directory alongside the results so it can bind each row back to the case it claims to answer:
+
+```bash
+./aeb-validate cases cases
+./aeb-validate results artifacts/results.jsonl cases
+```
+
+Read a validator refusal as a statement about the rows in front of it, and never suppress one to make a run look clean. Two denial-of-wallet cases, for instance, require a target to carry timing evidence for any block it claims, so a target that claims the block without producing the evidence is refused. A real target either supplies the evidence or does not claim the block.
 
 The template profile names no real product, so that run exercises the corpus and the artifact path rather than measuring anything. Copy it, set `tool` and `tool_version` to the target under test, and select the adapter that reaches it. `--adapter mcp-gateway --gateway-plugin` drives an MCP gateway from `examples/gateway-plugin-template.json`; `docs/GATEWAY-ADAPTER.md` states that plugin contract.
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -63,6 +63,13 @@ python3 scripts/release_build.py verify --release-dir .. \
   --executable ./aeb-gauntlet --validator-executable ./aeb-validate
 ```
 
+The Windows archives carry `aeb-gauntlet.exe` and `aeb-validate.exe`, so name those instead:
+
+```powershell
+python3 scripts/release_build.py verify --release-dir .. `
+  --executable .\aeb-gauntlet.exe --validator-executable .\aeb-validate.exe
+```
+
 Be precise about what that establishes. Without those two options the verifier checks each binary's name, executable bit, machine type, and that the two archive members are different programs. Supplying them adds two things: the file you point at must be the same bytes as that binary inside a release archive, and running it must print the identity this release records. Pointing the option at some other program is refused before it runs, so the option reports on the release rather than on whatever happens to be on your path.
 
 What none of it establishes is what a program does. A binary carrying the release's own bytes and reporting its version could still behave differently from the source it claims, and the release identity naming the validator is a label rather than a proof of role. These checks catch the mistake and the swap: a build configured to produce one program twice, a member replaced with another, an archive assembled for the wrong platform.

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -838,11 +838,37 @@ VERSION_OUTPUT_LIMIT = 4096
 VERSION_READ_TIMEOUT_SECONDS = 60
 
 
+def process_group_options() -> dict[str, Any]:
+    if os.name == "nt":
+        return {"creationflags": getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)}
+    return {"start_new_session": True}
+
+
+# POSIX and Windows do not share a process-group model, and the difference is
+# not cosmetic here. os.killpg does not exist on Windows at all, so calling it
+# there raises AttributeError inside the watchdog thread, the watchdog dies
+# silently, and the read this whole mechanism exists to bound blocks forever.
+# Windows terminates a tree with taskkill instead.
 def kill_process_group(process: subprocess.Popen) -> None:
     try:
-        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
-    except (ProcessLookupError, PermissionError, OSError):
-        process.kill()
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=30,
+            )
+        else:
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+    except Exception:
+        # Whatever went wrong, the process still has to die: a watchdog that
+        # raises leaves the reader waiting, which is the failure it was added
+        # to prevent.
+        try:
+            process.kill()
+        except Exception:
+            pass
 
 
 def run_bounded_version(executable: Path, binary: str) -> str:
@@ -859,7 +885,11 @@ def run_bounded_version(executable: Path, binary: str) -> str:
             # leaves that pipe open and the read still waiting: measured with a
             # script that printed a few bytes and then slept, which hung until
             # killed even with the watchdog in place.
-            start_new_session=True,
+            #
+            # The two platforms spell this differently. start_new_session is
+            # POSIX-only, and passing it on Windows does nothing for the tree,
+            # so Windows asks for its own process group through creationflags.
+            **process_group_options(),
         )
     except OSError as exc:
         fail(f"{binary} executable cannot run: {exc}")

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -8,11 +8,14 @@ import gzip
 import hashlib
 import io
 import json
+import os
+import signal
 import re
 import shutil
 import subprocess
 import sys
 import tarfile
+import threading
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -35,6 +38,12 @@ RAW_SCHEMA_URL = "https://raw.githubusercontent.com/luckyPipewrench/agent-egress
 DATA_ROOTS = ("cases", "schemas", "contracts", "capability-registry/aeb.core-capabilities", "examples")
 DATA_FILES = ("README.md", "LICENSE", "NOTICE", "CITATION.cff", "docs/SPEC.md", "docs/GOVERNANCE.md", "docs/RUNNER.md", "scripts/release_build.py", "scripts/schema_catalog.py")
 PLATFORMS = tuple((goos, arch) for goos in ("linux", "darwin", "windows") for arch in ("amd64", "arm64"))
+# Both tools ride in one platform archive. A release that shipped only the
+# runner let a downloader produce a result and gave them nothing to check it
+# with, which leaves the reproduction path depending on this repository.
+RUNNER_BINARY = "aeb-gauntlet"
+VALIDATOR_BINARY = "aeb-validate"
+RELEASE_BINARIES = (RUNNER_BINARY, VALIDATOR_BINARY)
 
 
 class ReleaseError(RuntimeError):
@@ -285,7 +294,7 @@ def build_identity(repo: Path, tag: str, version: str, commit: str, snapshot: bo
         "schema_version": 1,
         "release": {"tag": tag, "version": version, "snapshot": snapshot},
         "source": {"repository": REPOSITORY, "commit": commit, "commit_timestamp": int(timestamp)},
-        "runner": {"binary": "aeb-gauntlet", "runner_version": metadata["runner_version"], "scoring_version": metadata["scoring_version"], "platforms": [{"goos": goos, "goarch": arch} for goos, arch in PLATFORMS]},
+        "runner": {"binary": RUNNER_BINARY, "validator_binary": VALIDATOR_BINARY, "runner_version": metadata["runner_version"], "scoring_version": metadata["scoring_version"], "platforms": [{"goos": goos, "goarch": arch} for goos, arch in PLATFORMS]},
         "corpus": corpus(repo, metadata["corpus_version"]),
         "schema_contract": {"artifacts_manifest_path": "contracts/artifacts.json", "artifacts_manifest_sha256": sha256_file(repo / "contracts/artifacts.json"), "families": contract_families(repo)},
         "data_files": {name: sha256_file(repo / name) for name in data},
@@ -335,9 +344,11 @@ def validate_identity_structure(identity: dict[str, Any]) -> None:
         fail("release identity source.commit is invalid")
     positive_int(source["commit_timestamp"], "release identity source.commit_timestamp")
 
-    runner = exact_object(identity["runner"], "release identity runner", {"binary", "runner_version", "scoring_version", "platforms"})
-    if runner["binary"] != "aeb-gauntlet":
+    runner = exact_object(identity["runner"], "release identity runner", {"binary", "validator_binary", "runner_version", "scoring_version", "platforms"})
+    if runner["binary"] != RUNNER_BINARY:
         fail("release identity runner.binary is invalid")
+    if runner["validator_binary"] != VALIDATOR_BINARY:
+        fail("release identity runner.validator_binary is invalid")
     nonempty_string(runner["runner_version"], "release identity runner.runner_version")
     nonempty_string(runner["scoring_version"], "release identity runner.scoring_version")
     platforms = runner["platforms"]
@@ -548,58 +559,97 @@ def parse_checksums(path: Path) -> dict[str, str]:
     return result
 
 
-def verify_runner_binary(data: bytes, mode: int, goos: str, goarch: str, path: Path) -> None:
+def verify_release_binary(data: bytes, mode: int, goos: str, goarch: str, path: Path, binary: str = RUNNER_BINARY) -> None:
     platform = f"{goos} {goarch}"
     if goos != "windows" and mode & 0o111 == 0:
-        fail(f"{path.name} must mark its {platform} runner executable")
+        fail(f"{path.name} must mark its {platform} {binary} executable")
     if goos == "linux":
         machines = {"amd64": 62, "arm64": 183}
         if len(data) < 20 or data[:4] != b"\x7fELF" or data[4:6] != b"\x02\x01" or data[18:20] != machines[goarch].to_bytes(2, "little"):
-            fail(f"{path.name} must contain a 64-bit Linux {goarch} ELF runner")
+            fail(f"{path.name} must contain a 64-bit Linux {goarch} ELF {binary}")
         return
     if goos == "darwin":
         cpus = {"amd64": 0x01000007, "arm64": 0x0100000C}
         if len(data) < 8 or data[:4] != b"\xcf\xfa\xed\xfe" or data[4:8] != cpus[goarch].to_bytes(4, "little"):
-            fail(f"{path.name} must contain a 64-bit Darwin {goarch} Mach-O runner")
+            fail(f"{path.name} must contain a 64-bit Darwin {goarch} Mach-O {binary}")
         return
     if goos == "windows":
         machines = {"amd64": 0x8664, "arm64": 0xAA64}
         if len(data) < 64 or data[:2] != b"MZ":
-            fail(f"{path.name} must contain a Windows {goarch} PE runner")
+            fail(f"{path.name} must contain a Windows {goarch} PE {binary}")
         offset = int.from_bytes(data[60:64], "little")
         if offset + 6 > len(data) or data[offset:offset + 4] != b"PE\0\0" or data[offset + 4:offset + 6] != machines[goarch].to_bytes(2, "little"):
-            fail(f"{path.name} must contain a Windows {goarch} PE runner")
+            fail(f"{path.name} must contain a Windows {goarch} PE {binary}")
         return
-    fail(f"unsupported runner platform: {platform}")
+    fail(f"unsupported release platform: {platform}")
 
 
-def archive_identity(path: Path, goos: str, goarch: str) -> bytes:
-    expected_binary = "aeb-gauntlet.exe" if goos == "windows" else "aeb-gauntlet"
+def archive_binary_name(binary: str, goos: str) -> str:
+    return f"{binary}.exe" if goos == "windows" else binary
+
+
+def archive_identity(path: Path, goos: str, goarch: str, digests_out: dict[str, set[str]] | None = None) -> bytes:
+    # Every binary the release advertises is checked, not only the runner. A
+    # check that stopped at the runner would accept an archive whose validator
+    # was absent, truncated, or built for another platform, and an operator
+    # would discover that only when they tried to check a result.
+    # Each binary's digest is collected so the archive can be required to carry
+    # two DIFFERENT programs. Name, executable mode, and platform are all a
+    # substituted binary satisfies: replacing the validator with a second copy
+    # of the runner passed every other check here, and the released archive then
+    # shipped no way to check a result while reporting itself intact. A build
+    # misconfiguration that pointed both GoReleaser builds at one directory
+    # produces exactly that, which is the likelier way to reach it.
+    digests: dict[str, str] = {}
     if path.suffix == ".zip":
         with zipfile.ZipFile(path) as archive:
             entries = [item for item in archive.infolist() if item.filename == f".release/{IDENTITY_NAME}" and not item.is_dir()]
-            binaries = [item for item in archive.infolist() if item.filename == expected_binary and not item.is_dir()]
             if len(entries) != 1:
                 fail(f"{path.name} must contain exactly one regular {IDENTITY_NAME}")
-            if len(binaries) != 1:
-                fail(f"{path.name} must contain exactly one {expected_binary}")
-            verify_runner_binary(archive.read(binaries[0]), binaries[0].external_attr >> 16, goos, goarch, path)
+            for binary in RELEASE_BINARIES:
+                expected_binary = archive_binary_name(binary, goos)
+                found = [item for item in archive.infolist() if item.filename == expected_binary and not item.is_dir()]
+                if len(found) != 1:
+                    fail(f"{path.name} must contain exactly one {expected_binary}")
+                data = archive.read(found[0])
+                verify_release_binary(data, found[0].external_attr >> 16, goos, goarch, path, binary)
+                digests[binary] = sha256_bytes(data)
+            verify_distinct_binaries(digests, path)
+            record_binary_digests(digests, digests_out)
             return archive.read(entries[0])
     with tarfile.open(path, "r:*") as archive:
         entries = [item for item in archive.getmembers() if item.name == f".release/{IDENTITY_NAME}" and item.isfile()]
-        binaries = [item for item in archive.getmembers() if item.name == expected_binary and item.isfile()]
         if len(entries) != 1:
             fail(f"{path.name} must contain exactly one regular {IDENTITY_NAME}")
-        if len(binaries) != 1:
-            fail(f"{path.name} must contain exactly one {expected_binary}")
-        binary = archive.extractfile(binaries[0])
-        if binary is None:
-            fail(f"{path.name} has unreadable {expected_binary}")
-        verify_runner_binary(binary.read(), binaries[0].mode, goos, goarch, path)
+        for binary in RELEASE_BINARIES:
+            expected_binary = archive_binary_name(binary, goos)
+            found = [item for item in archive.getmembers() if item.name == expected_binary and item.isfile()]
+            if len(found) != 1:
+                fail(f"{path.name} must contain exactly one {expected_binary}")
+            member = archive.extractfile(found[0])
+            if member is None:
+                fail(f"{path.name} has unreadable {expected_binary}")
+            data = member.read()
+            verify_release_binary(data, found[0].mode, goos, goarch, path, binary)
+            digests[binary] = sha256_bytes(data)
+        verify_distinct_binaries(digests, path)
+        record_binary_digests(digests, digests_out)
         handle = archive.extractfile(entries[0])
         if handle is None:
             fail(f"{path.name} has unreadable {IDENTITY_NAME}")
         return handle.read()
+
+
+def record_binary_digests(digests: dict[str, str], digests_out: dict[str, set[str]] | None) -> None:
+    if digests_out is None:
+        return
+    for binary, digest in digests.items():
+        digests_out.setdefault(binary, set()).add(digest)
+
+
+def verify_distinct_binaries(digests: dict[str, str], path: Path) -> None:
+    if len(set(digests.values())) != len(digests):
+        fail(f"{path.name} carries the same program under more than one release binary name")
 
 
 def bundle_contents(path: Path) -> dict[str, bytes]:
@@ -705,7 +755,7 @@ def binary_archives(identity: dict[str, Any]) -> dict[str, tuple[str, str]]:
     }
 
 
-def verify_release(release_dir: Path, repo: Path | None, executable: Path | None) -> None:
+def verify_release(release_dir: Path, repo: Path | None, executable: Path | None, validator_executable: Path | None = None) -> None:
     release_dir = release_dir.resolve()
     identity_path, checksums_path = release_dir / IDENTITY_NAME, release_dir / CHECKSUM_NAME
     if not identity_path.is_file() or not checksums_path.is_file():
@@ -730,8 +780,9 @@ def verify_release(release_dir: Path, repo: Path | None, executable: Path | None
     if data_name not in checksums or catalog_name not in checksums or bundle_name not in checksums or not set(binaries).issubset(checksums):
         fail("release is missing its data bundle, schema artifacts, or declared runner platforms")
     expected_identity = identity_path.read_bytes()
+    archive_binary_digests: dict[str, set[str]] = {}
     for name, (goos, goarch) in binaries.items():
-        if archive_identity(release_dir / name, goos, goarch) != expected_identity:
+        if archive_identity(release_dir / name, goos, goarch, archive_binary_digests) != expected_identity:
             fail(f"binary archive identity does not match release identity: {name}")
     contents = bundle_contents(release_dir / data_name)
     data_files = identity.get("data_files")
@@ -748,21 +799,91 @@ def verify_release(release_dir: Path, repo: Path | None, executable: Path | None
         if canonical_json(expected) != canonical_json(identity):
             fail("release identity does not match the supplied source tree")
     if executable is not None:
-        if not executable.is_file() or executable.stat().st_mode & 0o111 == 0:
-            fail("runner executable is absent or is not marked executable")
-        try:
-            # Bounded: this runs a binary out of a downloaded release, so a hung
-            # or wedged executable must fail verification rather than hang it.
-            result = subprocess.run(
-                [str(executable), "--version"], text=True, capture_output=True, check=False, timeout=60
-            )
-        except subprocess.TimeoutExpired:
-            fail("runner executable did not report its version within 60 seconds")
-        except OSError as exc:
-            fail(f"runner executable cannot run: {exc}")
-        expected = f"aeb-gauntlet {identity['release']['version']} {identity['source']['commit']}"
-        if result.returncode or result.stdout.strip() != expected:
-            fail("runner version output does not match release identity")
+        verify_executable_identity(executable, RUNNER_BINARY, identity, archive_binary_digests)
+    if validator_executable is not None:
+        verify_executable_identity(validator_executable, VALIDATOR_BINARY, identity, archive_binary_digests)
+
+
+# An archive check can prove a member's name, mode, and machine type, and those
+# are all satisfied by the wrong program under the right name. Running the
+# binary and reading back what it calls itself is what separates the two, so the
+# validator gets the same treatment the runner already had.
+def verify_executable_identity(
+    executable: Path,
+    binary: str,
+    identity: dict[str, Any],
+    archive_binary_digests: dict[str, set[str]],
+) -> None:
+    if not executable.is_file() or executable.stat().st_mode & 0o111 == 0:
+        fail(f"{binary} executable is absent or is not marked executable")
+    # Bind the file about to be executed to the release before executing it.
+    # Without this the option accepted any binary that printed the expected
+    # line, so pointing it at an unrelated program made an archive appear
+    # verified while establishing nothing about the archive at all.
+    known = archive_binary_digests.get(binary, set())
+    if sha256_file(executable) not in known:
+        fail(f"{binary} executable is not the {binary} in any release archive")
+    version = run_bounded_version(executable, binary)
+    expected = f"{binary} {identity['release']['version']} {identity['source']['commit']}"
+    if version != expected:
+        fail(f"{binary} version output does not match release identity")
+
+
+# The most a released binary prints here is its name, a version, and a
+# 40-character commit. Reading without a bound let a downloaded binary emit
+# output for the whole timeout and grow the verifier's memory until it died,
+# which turns verifying a release into a way to lose the machine doing it.
+VERSION_OUTPUT_LIMIT = 4096
+# Overridable so a test can bound the wait without sitting through the real one.
+VERSION_READ_TIMEOUT_SECONDS = 60
+
+
+def kill_process_group(process: subprocess.Popen) -> None:
+    try:
+        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        process.kill()
+
+
+def run_bounded_version(executable: Path, binary: str) -> str:
+    try:
+        # stderr is discarded rather than captured: nothing reads it, and an
+        # unread pipe is another unbounded buffer a hostile binary can fill.
+        process = subprocess.Popen(
+            [str(executable), "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            # Its own process group, so the watchdog can end descendants too. A
+            # child of the binary inherits the pipe, so killing only the binary
+            # leaves that pipe open and the read still waiting: measured with a
+            # script that printed a few bytes and then slept, which hung until
+            # killed even with the watchdog in place.
+            start_new_session=True,
+        )
+    except OSError as exc:
+        fail(f"{binary} executable cannot run: {exc}")
+    # Both bounds are needed and they fail differently. The size cap alone left
+    # the read blocking: a binary that printed a few bytes and then slept never
+    # reached the limit and never closed the pipe, so the read waited and the
+    # timeout below was never consulted. Measured, that hung until killed. A
+    # watchdog kills the process instead, which closes the pipe and makes the
+    # read return, so a stalled binary ends the same way a talkative one does.
+    watchdog = threading.Timer(VERSION_READ_TIMEOUT_SECONDS, lambda: kill_process_group(process))
+    watchdog.start()
+    try:
+        captured = process.stdout.read(VERSION_OUTPUT_LIMIT) if process.stdout else ""
+        if process.stdout is not None:
+            process.stdout.close()
+        code = process.wait()
+    finally:
+        watchdog.cancel()
+        if process.poll() is None:
+            kill_process_group(process)
+            process.wait()
+    if code:
+        fail(f"{binary} executable did not report its version cleanly")
+    return captured.strip()
 
 
 def main() -> int:
@@ -800,6 +921,7 @@ def main() -> int:
     verify.add_argument("--release-dir", type=Path, required=True)
     verify.add_argument("--repo-root", type=Path)
     verify.add_argument("--executable", type=Path)
+    verify.add_argument("--validator-executable", type=Path)
     args = parser.parse_args()
     try:
         if args.command == "prepare":
@@ -818,7 +940,7 @@ def main() -> int:
         elif args.command == "checksums":
             print(write_checksums(args.dist, args.identity))
         elif args.command == "verify":
-            verify_release(args.release_dir, args.repo_root, args.executable)
+            verify_release(args.release_dir, args.repo_root, args.executable, args.validator_executable)
     except ReleaseError as exc:
         print(f"release verification failed: {exc}", file=sys.stderr)
         return 1

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -28,7 +28,11 @@ SCHEMA_CATALOG_SUFFIX = "_schema-catalog.json"
 SCHEMA_BUNDLE_SUFFIX = "_schemas.tar.gz"
 REPOSITORY = "luckyPipewrench/agent-egress-bench"
 RAW_SCHEMA_URL = "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/{commit}/{path}"
-DATA_ROOTS = ("cases", "schemas", "contracts", "capability-registry/aeb.core-capabilities")
+# "examples" carries the operator kit: the tool-profile template the runner
+# requires, the gateway plugin template, the runner skeleton, and the reference
+# harness. Without it a downloaded release can report the corpus but cannot run
+# it, because --profile is mandatory and nothing in the release satisfied it.
+DATA_ROOTS = ("cases", "schemas", "contracts", "capability-registry/aeb.core-capabilities", "examples")
 DATA_FILES = ("README.md", "LICENSE", "NOTICE", "CITATION.cff", "docs/SPEC.md", "docs/GOVERNANCE.md", "docs/RUNNER.md", "scripts/release_build.py", "scripts/schema_catalog.py")
 PLATFORMS = tuple((goos, arch) for goos in ("linux", "darwin", "windows") for arch in ("amd64", "arm64"))
 
@@ -381,7 +385,7 @@ def validate_identity_structure(identity: dict[str, Any]) -> None:
             fail("release identity data_files has an invalid entry")
         safe_name(name)
     if set(DATA_FILES) - set(data_files) or corpus_value["manifest_path"] not in data_files or any(not any(name == root or name.startswith(f"{root}/") for name in data_files) for root in DATA_ROOTS):
-        fail("release identity data_files does not contain the required corpus, schema, contract, and verifier data")
+        fail("release identity data_files does not contain the required corpus, schema, contract, operator kit, and verifier data")
 
     verification = exact_object(identity["verification"], "release identity verification", {"checksums", "command"})
     checksums = exact_object(verification["checksums"], "release identity verification.checksums", {"algorithm", "path"})

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -923,6 +923,54 @@ class ReleaseBuildTest(unittest.TestCase):
         finally:
             module.VERSION_READ_TIMEOUT_SECONDS = original
 
+    def test_process_group_termination_is_defined_for_both_platforms(self) -> None:
+        # The watchdog runs in a thread, so anything it raises is lost and the
+        # read it exists to bound waits forever. os.killpg does not exist on
+        # Windows at all, so the POSIX-only version raised AttributeError there
+        # and left the verifier hanging on exactly the input the bound was
+        # added for. Both spellings are checked here because CI runs on Linux
+        # and would never execute the Windows path.
+        module = self.release_build_module()
+        self.assertIn("start_new_session", module.process_group_options())
+        original = module.os.name
+        try:
+            module.os.name = "nt"
+            self.assertIn("creationflags", module.process_group_options())
+        finally:
+            module.os.name = original
+
+        class NeverDies:
+            pid = -1
+
+            def __init__(self) -> None:
+                self.killed = False
+
+            def kill(self) -> None:
+                self.killed = True
+
+        # A pid that cannot be signalled stands in for every way the platform
+        # call can fail. The contract is that the process still gets killed and
+        # nothing propagates out of the watchdog thread.
+        stand_in = NeverDies()
+        module.kill_process_group(stand_in)
+        self.assertTrue(stand_in.killed, "the fallback kill must still run when the group call fails")
+
+        # The Windows branch never runs on this CI, so assert the call it makes
+        # rather than the effect. Without this the branch could be deleted and
+        # every test here would still pass, which is how the POSIX-only version
+        # shipped in the first place.
+        calls = []
+        original_run = module.subprocess.run
+        module.os.name = "nt"
+        module.subprocess.run = lambda *args, **kwargs: calls.append(args[0])
+        try:
+            module.kill_process_group(NeverDies())
+        finally:
+            module.subprocess.run = original_run
+            module.os.name = original
+        self.assertEqual(len(calls), 1, "the Windows path must terminate the tree")
+        self.assertEqual(calls[0][:4], ["taskkill", "/F", "/T", "/PID"])
+
     def release_build_module(self):
         import importlib.util
 

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -411,6 +411,32 @@ class ReleaseBuildTest(unittest.TestCase):
         self.assertEqual(hashlib.sha256(data_bundle.read_bytes()).hexdigest(), checksums[data_bundle.name])
         self.invoke("verify", "--release-dir", str(dist))
 
+    def test_data_bundle_alone_can_drive_a_run(self) -> None:
+        # The release advertises a corpus an operator can run. --profile is
+        # mandatory, so a bundle that carries cases but no tool profile ships a
+        # corpus nobody outside this repository can execute. Asserting the file
+        # is present would pass for a template the runner rejects, so this runs
+        # the real runner against the extracted bundle and nothing else.
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke("data-bundle", "--repo-root", str(self.root), "--identity", str(self.identity), "--dist", str(dist))
+        extracted = self.root / "extracted"
+        extracted.mkdir()
+        with tarfile.open(next(dist.glob("*_data.tar.gz")), "r:gz") as archive:
+            archive.extractall(extracted, filter="data")
+        profile = extracted / "examples/runner-template/tool-profile-template.json"
+        self.assertTrue(profile.is_file(), "the data bundle must carry a tool profile the runner accepts")
+        summary = self.root / "bundle-run-summary.json"
+        run = subprocess.run(
+            ["go", "run", ".", "--cases", str(extracted / "cases"), "--profile", str(profile), "--output", str(summary)],
+            cwd=self.root / "runner",
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(run.returncode, 0, msg=run.stderr)
+        self.assertTrue(summary.is_file(), "a run driven by the bundle must write its summary")
+        self.assertEqual(json.loads(summary.read_text(encoding="utf-8"))["tool"], json.loads(profile.read_text(encoding="utf-8"))["tool"])
+
     def test_release_binds_a_schema_bundle_to_the_commit_pinned_catalog(self) -> None:
         self.prepare()
         dist = self.root / "dist"

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import unittest
 import zipfile
 from pathlib import Path
@@ -62,6 +63,13 @@ class ReleaseBuildTest(unittest.TestCase):
         )
 
     @staticmethod
+    def fixture_release_binary(goos: str, goarch: str, binary: str = "aeb-gauntlet") -> bytes:
+        # A real archive carries two different programs. The fixture pads each
+        # one differently so it does too; identical bytes are themselves a
+        # release defect and have their own test.
+        return ReleaseBuildTest.fixture_runner_binary(goos, goarch) + binary.encode("ascii")
+
+    @staticmethod
     def fixture_runner_binary(goos: str, goarch: str) -> bytes:
         if goos == "linux":
             machines = {"amd64": 62, "arm64": 183}
@@ -90,6 +98,7 @@ class ReleaseBuildTest(unittest.TestCase):
         include_binaries: bool = True,
         binary_overrides: dict[tuple[str, str], bytes] | None = None,
         mode_overrides: dict[tuple[str, str], int] | None = None,
+        binaries: tuple[str, ...] = ("aeb-gauntlet", "aeb-validate"),
     ) -> None:
         self.write_schema_assets(dist, identity)
         binary_overrides = binary_overrides or {}
@@ -97,22 +106,26 @@ class ReleaseBuildTest(unittest.TestCase):
         for platform in release["runner"]["platforms"]:
             goos, goarch = platform["goos"], platform["goarch"]
             name = f"agent-egress-bench_{self.snapshot_version}_{goos}_{goarch}"
-            runner = binary_overrides.get((goos, goarch), self.fixture_runner_binary(goos, goarch))
+            override = binary_overrides.get((goos, goarch))
             if goos == "windows":
                 with zipfile.ZipFile(dist / f"{name}.zip", "w") as archive:
                     archive.writestr(".release/release-identity.json", identity)
                     if include_binaries:
-                        archive.writestr("aeb-gauntlet.exe", runner)
+                        for binary in binaries:
+                            body = override if override is not None else self.fixture_release_binary(goos, goarch, binary)
+                            archive.writestr(f"{binary}.exe", body)
             else:
                 with tarfile.open(dist / f"{name}.tar.gz", "w:gz") as archive:
                     info = tarfile.TarInfo(".release/release-identity.json")
                     info.size = len(identity)
                     archive.addfile(info, __import__("io").BytesIO(identity))
                     if include_binaries:
-                        info = tarfile.TarInfo("aeb-gauntlet")
-                        info.size = len(runner)
-                        info.mode = mode_overrides.get((goos, goarch), 0o755)
-                        archive.addfile(info, __import__("io").BytesIO(runner))
+                        for binary in binaries:
+                            body = override if override is not None else self.fixture_release_binary(goos, goarch, binary)
+                            info = tarfile.TarInfo(binary)
+                            info.size = len(body)
+                            info.mode = mode_overrides.get((goos, goarch), 0o755)
+                            archive.addfile(info, __import__("io").BytesIO(body))
 
     def write_schema_assets(self, dist: Path, identity: bytes) -> None:
         release = json.loads(identity)
@@ -427,11 +440,18 @@ class ReleaseBuildTest(unittest.TestCase):
         profile = extracted / "examples/runner-template/tool-profile-template.json"
         self.assertTrue(profile.is_file(), "the data bundle must carry a tool profile the runner accepts")
         summary = self.root / "bundle-run-summary.json"
+        # /tmp is quota-constrained on the development hosts, so every Go
+        # command runs against the shared caches rather than filling it.
+        go_env = dict(os.environ)
+        for name, value in (("TMPDIR", Path.home() / ".cache/pipelock-tmp"), ("GOCACHE", Path.home() / ".cache/go-build")):
+            value.mkdir(parents=True, exist_ok=True)
+            go_env[name] = str(value)
         run = subprocess.run(
             ["go", "run", ".", "--cases", str(extracted / "cases"), "--profile", str(profile), "--output", str(summary)],
             cwd=self.root / "runner",
             text=True,
             capture_output=True,
+            env=go_env,
         )
         self.assertEqual(run.returncode, 0, msg=run.stderr)
         self.assertTrue(summary.is_file(), "a run driven by the bundle must write its summary")
@@ -744,6 +764,64 @@ class ReleaseBuildTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("must contain exactly one aeb-gauntlet", result.stderr)
 
+    def test_download_verifier_rejects_an_executable_that_is_not_in_the_release(self) -> None:
+        # --executable and --validator-executable used to accept any file that
+        # printed the expected identity line, so pointing one at an unrelated
+        # program made an archive report as verified while saying nothing about
+        # the archive. The file handed over must be the same bytes as that
+        # binary inside a release archive, checked before it is run.
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke("data-bundle", "--repo-root", str(self.root), "--identity", str(self.identity), "--dist", str(dist))
+        identity = self.identity.read_bytes()
+        release = json.loads(identity)
+        self.write_runner_archives(dist, identity, release)
+        self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
+        stranger = self.root / "stranger"
+        stranger.write_bytes(self.fixture_release_binary("linux", "amd64", "aeb-validate") + b"stranger")
+        stranger.chmod(0o755)
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist), "--validator-executable", str(stranger)],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is not the aeb-validate in any release archive", result.stderr)
+
+    def test_download_verifier_rejects_one_program_under_both_binary_names(self) -> None:
+        # Name, executable mode, and machine type are all satisfied by the wrong
+        # program under the right name. Replacing the validator with a second
+        # copy of the runner passed every one of them, so the release reported
+        # itself intact while shipping no way to check a result. A GoReleaser
+        # build pointed at one directory twice produces the same archive.
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke("data-bundle", "--repo-root", str(self.root), "--identity", str(self.identity), "--dist", str(dist))
+        identity = self.identity.read_bytes()
+        release = json.loads(identity)
+        same = {(platform["goos"], platform["goarch"]): self.fixture_runner_binary(platform["goos"], platform["goarch"]) for platform in release["runner"]["platforms"]}
+        self.write_runner_archives(dist, identity, release, binary_overrides=same)
+        self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
+        result = subprocess.run([sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist)], text=True, capture_output=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("carries the same program under more than one release binary name", result.stderr)
+
+    def test_download_verifier_rejects_an_archive_without_the_validator(self) -> None:
+        # The release advertises a runner and a result validator in one archive.
+        # A verifier that stopped at the runner would publish a package that
+        # could produce results and could not check them, and the omission would
+        # surface only when an operator tried to check somebody else's run.
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke("data-bundle", "--repo-root", str(self.root), "--identity", str(self.identity), "--dist", str(dist))
+        identity = self.identity.read_bytes()
+        release = json.loads(identity)
+        self.write_runner_archives(dist, identity, release, binaries=("aeb-gauntlet",))
+        self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
+        result = subprocess.run([sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist)], text=True, capture_output=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must contain exactly one aeb-validate", result.stderr)
+
     def test_download_verifier_rejects_a_text_runner_binary(self) -> None:
         self.prepare()
         dist = self.root / "dist"
@@ -754,7 +832,7 @@ class ReleaseBuildTest(unittest.TestCase):
         self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
         result = subprocess.run([sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist)], text=True, capture_output=True)
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("must contain a 64-bit Linux amd64 ELF runner", result.stderr)
+        self.assertIn("must contain a 64-bit Linux amd64 ELF aeb-gauntlet", result.stderr)
 
     def test_download_verifier_rejects_a_non_executable_runner_binary(self) -> None:
         self.prepare()
@@ -766,7 +844,7 @@ class ReleaseBuildTest(unittest.TestCase):
         self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
         result = subprocess.run([sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist)], text=True, capture_output=True)
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("must mark its linux amd64 runner executable", result.stderr)
+        self.assertIn("must mark its linux amd64 aeb-gauntlet executable", result.stderr)
 
     def test_download_verifier_rejects_a_wrong_platform_runner_binary(self) -> None:
         self.prepare()
@@ -778,7 +856,7 @@ class ReleaseBuildTest(unittest.TestCase):
         self.invoke("checksums", "--identity", str(self.identity), "--dist", str(dist))
         result = subprocess.run([sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist)], text=True, capture_output=True)
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("must contain a 64-bit Linux amd64 ELF runner", result.stderr)
+        self.assertIn("must contain a 64-bit Linux amd64 ELF aeb-gauntlet", result.stderr)
 
     def test_download_verifier_rejects_an_unstamped_executable(self) -> None:
         self.prepare()
@@ -792,7 +870,66 @@ class ReleaseBuildTest(unittest.TestCase):
         executable.chmod(0o755)
         result = subprocess.run([sys.executable, str(SCRIPT), "verify", "--release-dir", str(dist), "--executable", str(executable)], text=True, capture_output=True)
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("runner version output does not match release identity", result.stderr)
+        # The digest gate now runs first and rejects this before it is executed,
+        # which is the stronger of the two refusals: a stand-in that printed the
+        # correct version used to pass. The version comparison itself is only
+        # reachable once the bytes match a release archive, so it is exercised
+        # directly below rather than through an archive fixture that would have
+        # to embed a runnable program.
+        self.assertIn("aeb-gauntlet executable is not the aeb-gauntlet in any release archive", result.stderr)
+
+    def test_version_mismatch_is_rejected_once_the_executable_matches_the_release(self) -> None:
+        # Reached when the supplied file IS a release archive member but reports
+        # a different release than the identity records, which is what a binary
+        # built from another commit looks like.
+        module = self.release_build_module()
+        executable = Path(self.temp.name) / "aeb-gauntlet"
+        executable.write_text("#!/usr/bin/env bash\nprintf 'aeb-gauntlet 9.9.9 " + "0" * 40 + "\\n'\n", encoding="utf-8")
+        executable.chmod(0o755)
+        identity = {"release": {"version": "1.2.3"}, "source": {"commit": "a" * 40}}
+        digests = {"aeb-gauntlet": {hashlib.sha256(executable.read_bytes()).hexdigest()}}
+        with self.assertRaises(module.ReleaseError) as caught:
+            module.verify_executable_identity(executable, "aeb-gauntlet", identity, digests)
+        self.assertIn("version output does not match release identity", str(caught.exception))
+
+    def test_version_output_is_read_under_a_bound(self) -> None:
+        # A downloaded binary that never stops printing used to be read without
+        # a limit, so verifying a release could exhaust the memory of the
+        # machine doing the verifying.
+        module = self.release_build_module()
+        executable = Path(self.temp.name) / "aeb-gauntlet"
+        executable.write_text("#!/usr/bin/env bash\nwhile :; do printf 'aaaaaaaaaaaaaaaa'; done\n", encoding="utf-8")
+        executable.chmod(0o755)
+        with self.assertRaises(module.ReleaseError):
+            module.run_bounded_version(executable, "aeb-gauntlet")
+
+    def test_version_read_is_bounded_when_a_descendant_holds_the_pipe(self) -> None:
+        # A size cap alone was not enough. A binary that printed a few bytes and
+        # then slept never reached the cap and never closed the pipe, so the
+        # read waited and the timeout was never consulted. Killing only the
+        # binary did not help either, because its child inherits the pipe and
+        # holds it open. Measured both ways: each hung until killed.
+        module = self.release_build_module()
+        executable = Path(self.temp.name) / "aeb-gauntlet"
+        executable.write_text("#!/usr/bin/env bash\nprintf 'aeb-gauntlet 1.0.0 '\nsleep 600\n", encoding="utf-8")
+        executable.chmod(0o755)
+        original = module.VERSION_READ_TIMEOUT_SECONDS
+        module.VERSION_READ_TIMEOUT_SECONDS = 3
+        try:
+            started = time.monotonic()
+            with self.assertRaises(module.ReleaseError):
+                module.run_bounded_version(executable, "aeb-gauntlet")
+            self.assertLess(time.monotonic() - started, 30, "the read was not bounded in time")
+        finally:
+            module.VERSION_READ_TIMEOUT_SECONDS = original
+
+    def release_build_module(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("release_build_under_test", SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
 
     def test_checksums_reports_an_absent_distribution_directory(self) -> None:
         self.prepare()

--- a/scripts/release_snapshot_test.py
+++ b/scripts/release_snapshot_test.py
@@ -39,8 +39,11 @@ class ReleaseSnapshotTest(unittest.TestCase):
         archive = next(release_dir.glob("agent-egress-bench_*_linux_amd64.tar.gz"))
         with tarfile.open(archive, "r:gz") as bundle:
             entries = [entry for entry in bundle.getmembers() if entry.isfile()]
+        # An exact set, not a subset. A membership check would let a stray file
+        # ride into every published archive unnoticed, and it would not notice
+        # either binary going missing.
         self.assertEqual(
-            {".release/release-identity.json", "LICENSE", "NOTICE", "aeb-gauntlet"},
+            {".release/release-identity.json", "LICENSE", "NOTICE", "aeb-gauntlet", "aeb-validate"},
             {entry.name for entry in entries},
         )
 

--- a/validate/main.go
+++ b/validate/main.go
@@ -196,12 +196,22 @@ var (
 	}
 )
 
+// releaseVersion and releaseCommit are stamped by the release build so this
+// binary can state which release produced it. Source and "go run" builds keep
+// the placeholders, which is why the release verifier only compares this output
+// for an archive built as a release.
+var (
+	releaseVersion = "dev"
+	releaseCommit  = "unknown"
+)
+
 const usageText = `usage: validate <command> <target>
 
 commands:
   cases   <dir>    validate case JSON files in a directory
   results <file> [cases-dir]   validate runner JSONL; cases-dir enables case-bound checks
   profile <file>   validate a tool profile JSON file
+  --version        print the release version and commit this binary was built from
 
 for backwards compatibility, 'validate <dir>' works as 'validate cases <dir>'.
 `
@@ -214,6 +224,12 @@ func main() {
 
 	subcmd := os.Args[1]
 	switch subcmd {
+	case "--version", "-version":
+		// A release records this binary's name in its identity. A name is not
+		// evidence of a program, so the release verifier runs this and compares
+		// the output, the same way it already does for the runner.
+		fmt.Fprintf(os.Stdout, "aeb-validate %s %s\n", releaseVersion, releaseCommit)
+		os.Exit(0)
 	case "cases":
 		if len(os.Args) < 3 {
 			fmt.Fprintf(os.Stderr, "usage: validate cases <cases-directory>\n")


### PR DESCRIPTION
## What changed

A downloaded release can now run the corpus and check the result. Two things were missing and neither had a workaround short of cloning this repository.

The corpus data bundle now carries `examples/`, so a release holds the tool profile the runner requires, the MCP gateway plugin template, the runner skeleton, and the reference harness. Before this, `--profile` was mandatory and no release asset satisfied it, so someone who downloaded a release could print corpus statistics and couldn't run the corpus against anything.

Each platform archive now carries `aeb-validate` beside `aeb-gauntlet`. GoReleaser built only the runner, so a release could produce results and shipped nothing to check them with, which left anyone reproducing a result depending on this repository to verify its own work.

Archive verification is the part to distrust, because the first version of it proved less than it appeared to. Checking a member's name, executable bit, and machine type does not distinguish one program from another: replacing the validator with a second copy of the runner satisfied every one of those and verified clean, leaving a release that reported itself intact while shipping no way to check a result. A GoReleaser build pointed at one directory twice produces the same archive, which is the likelier way to reach it. Verification now also requires the two binaries to be different programs, and `aeb-validate` reports its own release version so `--validator-executable` can confirm identity by running the program rather than reading its name. The documentation states what each level proves and what it does not.

Shipping `examples/` widens what the release contains, so the second thing to distrust is whether anything unintended rides along. The bundle is built from the tracked tree and the release identity records a digest for every member, so an added or altered file changes the identity and fails verification. The test that covers the profile runs the real runner against the extracted bundle instead of asserting a filename, because a present but invalid profile would satisfy a file-list check and leave the release just as unusable.

`docs/RELEASES.md` now states the sequence from download to report, and names both binaries. It also records that the validator refuses the calibration run, which is the evidence contract working rather than a fault to route around: two denial-of-wallet cases require timing evidence for any block a target claims, and the calibration adapter claims the verdict without producing it. A validator refusal describes the rows in front of it and should never be suppressed to make a run look clean.

Bundle members extract with mode `0644` so the bytes stay reproducible, so a bundled script runs as `bash <script>`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `aeb-validate` command-line tool for Linux, macOS, and Windows on AMD64 and ARM64.
  - The validator now supports `--version` and `-version` to display release information.
  - Release archives now include both `aeb-gauntlet` and `aeb-validate`, along with the examples operator kit.

- **Documentation**
  - Expanded release verification and usage guidance, including corpus extraction, report generation, incomplete artifacts, and validator refusals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->