### PR TITLE
fix(calibration): evidence the block a calibration adapter claims

### DIFF
--- a/runner/adapter/adapter.go
+++ b/runner/adapter/adapter.go
@@ -98,7 +98,7 @@ func (d DryRunAdapter) DeliveryTuples() []DeliveryTuple {
 func (d DryRunAdapter) Run(c Case, _ time.Duration) Result {
 	return Result{
 		Verdict:         c.ExpectedVerdict,
-		Evidence:        syntheticEvidence("dryrun"),
+		Evidence:        syntheticEvidence("dryrun", c.ExpectedVerdict, c.Payload),
 		DeliveryProven:  true,
 		VerdictObserved: true,
 	}
@@ -107,12 +107,34 @@ func (d DryRunAdapter) Run(c Case, _ time.Duration) Result {
 // syntheticEvidence marks a result produced without contacting any tool. A
 // calibration adapter asserts delivery and observation it did not perform, so
 // the row must carry that fact rather than presenting as a measurement.
-func syntheticEvidence(adapterName string) map[string]interface{} {
-	return map[string]interface{}{
+// syntheticEvidence takes the verdict actually being claimed rather than the
+// case's expected one, because the evidence a contract demands follows the
+// claim. blockall claims a block on every case including the ones it was never
+// going to match, so keying on the expectation would have left it emitting the
+// same unsupported claim dryrun did.
+func syntheticEvidence(adapterName string, verdict string, payload map[string]interface{}) map[string]interface{} {
+	evidence := map[string]interface{}{
 		"synthetic":         true,
 		"synthetic_adapter": adapterName,
 		"proof":             "asserted_by_calibration_adapter_not_observed",
 	}
+	// A denial-of-wallet case requires a target to say WHEN it blocked, because
+	// blocking before the budget is spent disrupts legitimate work and blocking
+	// after the over-budget call has already gone out is not containment. A
+	// calibration row claiming the block without that field was rejected by the
+	// contract, which was the contract working.
+	//
+	// The field is asserted, exactly like the delivery and observation above it,
+	// and carries the same synthetic marker that keeps every row honest and
+	// keeps the run unpublishable. Claiming the block while withholding one of
+	// the three assertions it rests on was the arbitrary position, not the
+	// principled one.
+	if verdict == "block" {
+		if _, overBudget := payload["over_budget_call_id"]; overBudget {
+			evidence["budget_block_timing"] = "at_over_budget"
+		}
+	}
+	return evidence
 }
 
 func syntheticTuples() []DeliveryTuple {

--- a/runner/adapter/blockall.go
+++ b/runner/adapter/blockall.go
@@ -15,10 +15,10 @@ func (b BlockAllAdapter) DeliveryTuples() []DeliveryTuple {
 // Run always returns "block" with synthetic evidence. It contacts nothing, so
 // its proof flags are asserted rather than earned; the marker records that so
 // a calibration run cannot read as a measured one.
-func (b BlockAllAdapter) Run(_ Case, _ time.Duration) Result {
+func (b BlockAllAdapter) Run(c Case, _ time.Duration) Result {
 	return Result{
 		Verdict:         "block",
-		Evidence:        syntheticEvidence("blockall"),
+		Evidence:        syntheticEvidence("blockall", "block", c.Payload),
 		DeliveryProven:  true,
 		VerdictObserved: true,
 	}

--- a/runner/adapter/null.go
+++ b/runner/adapter/null.go
@@ -14,10 +14,10 @@ func (n NullAdapter) DeliveryTuples() []DeliveryTuple {
 // Run always returns "allow" with synthetic evidence. It contacts nothing, so
 // its proof flags are asserted rather than earned; the marker records that so
 // a calibration run cannot read as a measured one.
-func (n NullAdapter) Run(_ Case, _ time.Duration) Result {
+func (n NullAdapter) Run(c Case, _ time.Duration) Result {
 	return Result{
 		Verdict:         "allow",
-		Evidence:        syntheticEvidence("null"),
+		Evidence:        syntheticEvidence("null", "allow", c.Payload),
 		DeliveryProven:  true,
 		VerdictObserved: true,
 	}

--- a/runner/calibration_contract_test.go
+++ b/runner/calibration_contract_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -62,6 +63,49 @@ func TestCalibrationOutputSatisfiesTheResultContract(t *testing.T) {
 			validate.Env = append(os.Environ(), "AEB_CAPABILITY_REGISTRY="+filepath.Join(repo, "capability-registry"))
 			if out, err := validate.CombinedOutput(); err != nil {
 				t.Fatalf("%s output failed the result contract: %v\n%s", adapter, err, out)
+			}
+		})
+	}
+}
+
+// TestCalibrationCannotEmitAReceiptProfile pins the other way a calibration run
+// could make a claim it never earned.
+//
+// The receipt profile is read as a statement that a tool blocked things, and
+// its renderer maps an expected block plus an actual block to blocked: yes
+// without consulting the evidence behind the row. Measured on the unmodified
+// runner: a dryrun run emitted a profile reporting 174 blocked malicious cases
+// for a tool that was never contacted, and the profile schema carries no field
+// that would let a reader tell it from a measured one.
+func TestCalibrationCannotEmitAReceiptProfile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("drives the runner over the whole corpus")
+	}
+	repo, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, adapter := range []string{"dryrun", "blockall", "null"} {
+		t.Run(adapter, func(t *testing.T) {
+			dir := t.TempDir()
+			profile := filepath.Join(dir, "receipt-profile.json")
+			run := exec.Command("go", "run", ".",
+				"--cases", filepath.Join(repo, "cases"),
+				"--profile", filepath.Join(repo, "examples/runner-template/tool-profile-template.json"),
+				"--adapter", adapter,
+				"--output", filepath.Join(dir, "summary.json"),
+				"--emit-receipt-profile", profile,
+			)
+			run.Dir = filepath.Join(repo, "runner")
+			out, err := run.CombinedOutput()
+			if err == nil {
+				t.Fatalf("%s emitted a receipt profile from a calibration run", adapter)
+			}
+			if !strings.Contains(string(out), "refusing to write a receipt profile") {
+				t.Fatalf("%s failed for the wrong reason: %s", adapter, out)
+			}
+			if _, statErr := os.Stat(profile); !os.IsNotExist(statErr) {
+				t.Errorf("%s wrote a receipt profile despite refusing", adapter)
 			}
 		})
 	}

--- a/runner/calibration_contract_test.go
+++ b/runner/calibration_contract_test.go
@@ -110,3 +110,38 @@ func TestCalibrationCannotEmitAReceiptProfile(t *testing.T) {
 		})
 	}
 }
+
+func TestReceiptProfileRefusalFailsClosedOnMissingProvenance(t *testing.T) {
+	// The first version of this guard asked the synthetic question in its own
+	// words instead of using the rule that already decides measurement_status,
+	// and the copy diverged at once: a row whose evidence was nil was skipped,
+	// so an adapter returning a verdict and no evidence could emit a receipt
+	// profile. The comment above it claimed the opposite, which is worse than
+	// the hole, because it told the next reader the check was stricter than it
+	// was.
+	cases := []struct {
+		name string
+		rows []CaseResult
+		want bool
+	}{
+		{name: "nil evidence", rows: []CaseResult{{CaseID: "x", Evidence: nil}}, want: true},
+		{name: "empty evidence", rows: []CaseResult{{CaseID: "x", Evidence: map[string]interface{}{}}}, want: true},
+		{name: "declared synthetic", rows: []CaseResult{{CaseID: "x", Evidence: map[string]interface{}{"synthetic": true}}}, want: true},
+		{name: "malformed marker", rows: []CaseResult{{CaseID: "x", Evidence: map[string]interface{}{"synthetic": "calibration"}}}, want: true},
+		{name: "honest negative", rows: []CaseResult{{CaseID: "x", Evidence: map[string]interface{}{"synthetic": false, "proof": "observed"}}}, want: false},
+		{name: "real row with no marker", rows: []CaseResult{{CaseID: "x", Evidence: map[string]interface{}{"proof": "observed"}}}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			refused := receiptProfileRefusal(tc.rows, nil) != ""
+			if refused != tc.want {
+				t.Errorf("refused = %v, want %v", refused, tc.want)
+			}
+			// An unreachable row reaches the profile too, so the same rule has
+			// to hold when the row arrives through that list instead.
+			if refusedUnreachable := receiptProfileRefusal(nil, tc.rows) != ""; refusedUnreachable != tc.want {
+				t.Errorf("unreachable refused = %v, want %v", refusedUnreachable, tc.want)
+			}
+		})
+	}
+}

--- a/runner/calibration_contract_test.go
+++ b/runner/calibration_contract_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestCalibrationOutputSatisfiesTheResultContract drives each calibration
+// adapter over the real corpus and validates the rows against the real cases.
+//
+// This is the guard that was missing. The validator was exercised only against
+// hand-written fixtures, and the harness ran it without the cases directory, so
+// every case-bound rule sat idle. The first time the two were put together, the
+// built-in dryrun adapter was claiming a denial-of-wallet block without the
+// timing evidence those cases require, and had been for as long as both existed.
+//
+// A fixture cannot catch that, because a fixture is written by whoever wrote the
+// code and agrees with it by construction. Only the real emitter against the
+// real corpus does.
+func TestCalibrationOutputSatisfiesTheResultContract(t *testing.T) {
+	if testing.Short() {
+		t.Skip("drives the runner and validator over the whole corpus")
+	}
+	repo, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := filepath.Join(repo, "cases")
+	profile := filepath.Join(repo, "examples/runner-template/tool-profile-template.json")
+
+	for _, adapter := range []string{"dryrun", "blockall", "null"} {
+		t.Run(adapter, func(t *testing.T) {
+			dir := t.TempDir()
+			results := filepath.Join(dir, "results.jsonl")
+			handle, err := os.Create(results)
+			if err != nil {
+				t.Fatal(err)
+			}
+			run := exec.Command("go", "run", ".",
+				"--cases", cases,
+				"--profile", profile,
+				"--adapter", adapter,
+				"--output", filepath.Join(dir, "summary.json"),
+			)
+			run.Dir = filepath.Join(repo, "runner")
+			run.Stdout = handle
+			runErr := run.Run()
+			if closeErr := handle.Close(); closeErr != nil {
+				t.Fatal(closeErr)
+			}
+			if runErr != nil {
+				t.Fatalf("%s run: %v", adapter, runErr)
+			}
+
+			// The cases directory is the argument that enables the case-bound
+			// rules. Omitting it is what made this check pass while proving
+			// nothing, so it is supplied deliberately here.
+			validate := exec.Command("go", "run", ".", "results", results, cases)
+			validate.Dir = filepath.Join(repo, "validate")
+			validate.Env = append(os.Environ(), "AEB_CAPABILITY_REGISTRY="+filepath.Join(repo, "capability-registry"))
+			if out, err := validate.CombinedOutput(); err != nil {
+				t.Fatalf("%s output failed the result contract: %v\n%s", adapter, err, out)
+			}
+		})
+	}
+}

--- a/runner/main.go
+++ b/runner/main.go
@@ -318,8 +318,8 @@ func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeo
 		// a publishable bundle. This is the same refusal on the other path out
 		// of the runner, using the same rule: only an explicit false means a
 		// row is not synthetic, so a missing or malformed marker still counts.
-		if synthetic := countSyntheticRows(applicableResults, unreachableResults); synthetic > 0 {
-			return fmt.Errorf("refusing to write a receipt profile from %d synthetic calibration row(s): a calibration run asserts its verdicts and cannot evidence a block", synthetic)
+		if reason := receiptProfileRefusal(applicableResults, unreachableResults); reason != "" {
+			return fmt.Errorf("refusing to write a receipt profile: %s", reason)
 		}
 		// Load receipt verifier only when profile emission is requested.
 		// An empty path yields a "no verifier" block; a malformed path fails

--- a/runner/main.go
+++ b/runner/main.go
@@ -306,6 +306,21 @@ func runWithGatewayPluginOptions(casesDir, profilePath, outputPath string, timeo
 	// tool-profile hashes already computed for the gauntlet summary so
 	// repeated runs are byte-reproducible against the same inputs.
 	if emitReceiptProfile != "" {
+		// A receipt profile is read as a statement that a tool blocked things,
+		// and its renderer maps an expected block plus an actual block to
+		// blocked: yes without consulting the evidence behind the row. A
+		// calibration run asserts both without contacting anything, so it
+		// produced a profile claiming every malicious case was blocked. The
+		// profile schema carries no synthetic or measurement field, so nothing
+		// downstream could tell that artifact from a measured one.
+		//
+		// The provenance builder already refuses a synthetic row when building
+		// a publishable bundle. This is the same refusal on the other path out
+		// of the runner, using the same rule: only an explicit false means a
+		// row is not synthetic, so a missing or malformed marker still counts.
+		if synthetic := countSyntheticRows(applicableResults, unreachableResults); synthetic > 0 {
+			return fmt.Errorf("refusing to write a receipt profile from %d synthetic calibration row(s): a calibration run asserts its verdicts and cannot evidence a block", synthetic)
+		}
 		// Load receipt verifier only when profile emission is requested.
 		// An empty path yields a "no verifier" block; a malformed path fails
 		// before writing the receipt profile.

--- a/runner/multifile_test.go
+++ b/runner/multifile_test.go
@@ -535,9 +535,17 @@ func TestRunIntegratesMultiFileCases(t *testing.T) {
 	}
 
 	casesDir := filepath.Join("..", "cases")
-	err = run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, receiptPath, "", "", false)
+	// No receipt profile is requested here. Emission refuses a calibration run,
+	// because the profile is a buyer-facing statement that a tool blocked things
+	// and its schema carries no field that would let a reader tell an asserted
+	// run from a measured one. The row mapping this test cares about is still
+	// checked below, built directly rather than through the operator path.
+	err = run(casesDir, profilePath, outputPath, 10*1e9, "dryrun", "", "", "", "", false, "", "", "", false)
 	if err != nil {
 		t.Fatalf("run: %v", err)
+	}
+	if _, statErr := os.Stat(receiptPath); !os.IsNotExist(statErr) {
+		t.Fatalf("run wrote a receipt profile it was not asked for: %v", statErr)
 	}
 
 	expected, err := loadCorpus(casesDir)
@@ -575,14 +583,31 @@ func TestRunIntegratesMultiFileCases(t *testing.T) {
 		)
 	}
 
-	data, err := os.ReadFile(receiptPath)
-	if err != nil {
-		t.Fatalf("read receipt profile: %v", err)
+	// Calibration semantics, stated once: the dryrun adapter echoes the expected
+	// verdict, so every row scores pass. Building the rows here keeps the
+	// expected-to-blocked mapping under test without asking the runner to write
+	// an artifact it now refuses to write for an asserted run.
+	byID := make(map[string]Case, len(expected))
+	rows := make([]CaseResult, 0, len(expected))
+	for _, c := range expected {
+		byID[c.ID] = c
+		rows = append(rows, CaseResult{
+			CaseID:          c.ID,
+			ExpectedVerdict: c.ExpectedVerdict,
+			ActualVerdict:   c.ExpectedVerdict,
+			Score:           "pass",
+			Evidence:        map[string]interface{}{"synthetic": true, "synthetic_adapter": "dryrun"},
+		})
 	}
-	var rp ReceiptProfile
-	if jsonErr := json.Unmarshal(data, &rp); jsonErr != nil {
-		t.Fatalf("parse receipt profile: %v", jsonErr)
-	}
+	rp := buildReceiptProfile(
+		Profile{Tool: "test-tool", ToolVersion: "0.0.0"},
+		rows,
+		byID,
+		ReceiptVerifier{},
+		summary.CorpusVersion,
+		summary.CorpusSHA256,
+		summary.ToolProfileSHA256,
+	)
 	if len(rp.PerCase) != len(expected) {
 		t.Fatalf("receipt profile rows = %d, want loader-backed %d", len(rp.PerCase), len(expected))
 	}

--- a/runner/synthetic_rows.go
+++ b/runner/synthetic_rows.go
@@ -1,0 +1,28 @@
+package main
+
+// countSyntheticRows reports how many rows declare themselves synthetic.
+//
+// The rule mirrors the provenance builder's: only an explicit false means a row
+// is not synthetic, so a missing marker, a malformed one, or a string in place
+// of the boolean all still count. A producer cannot opt out of the check by
+// writing the field badly, which is the direction that matters when the field
+// is written by the thing being judged.
+func countSyntheticRows(groups ...[]CaseResult) int {
+	total := 0
+	for _, rows := range groups {
+		for _, row := range rows {
+			if row.Evidence == nil {
+				continue
+			}
+			value, present := row.Evidence["synthetic"]
+			if !present {
+				continue
+			}
+			if declared, ok := value.(bool); ok && !declared {
+				continue
+			}
+			total++
+		}
+	}
+	return total
+}

--- a/runner/synthetic_rows.go
+++ b/runner/synthetic_rows.go
@@ -1,28 +1,36 @@
 package main
 
-// countSyntheticRows reports how many rows declare themselves synthetic.
+// receiptProfileRefusal reports why a receipt profile must not be written for
+// these rows, or the empty string when it may be.
 //
-// The rule mirrors the provenance builder's: only an explicit false means a row
-// is not synthetic, so a missing marker, a malformed one, or a string in place
-// of the boolean all still count. A producer cannot opt out of the check by
-// writing the field badly, which is the direction that matters when the field
-// is written by the thing being judged.
-func countSyntheticRows(groups ...[]CaseResult) int {
-	total := 0
-	for _, rows := range groups {
+// Two separate reasons, kept separate on purpose.
+//
+// The synthetic question is answered by hasSyntheticEvidence, the rule that
+// already decides measurement_status and that the provenance builder mirrors in
+// Python; that mirror's own comment says the two must agree because each
+// cross-checks the other. An earlier version of this file asked the same
+// question a second time in its own words, and the copy diverged immediately:
+// it skipped a row whose evidence was nil, so an adapter returning a verdict and
+// no evidence slipped past, while the comment above it claimed a missing marker
+// still counted. A second implementation of a shared rule is the defect, not the
+// wording of it.
+//
+// Absent evidence is the second reason and is deliberately NOT folded into the
+// first. Widening what counts as synthetic would change measurement_status for
+// every run, which is a bigger question than this path should decide. A row
+// carrying no evidence at all has no provenance behind its verdict, and a
+// receipt profile is read as a statement that a tool blocked things, so that
+// refusal belongs here, where the claim is actually made.
+func receiptProfileRefusal(applicable, unreachable []CaseResult) string {
+	if hasSyntheticEvidence(applicable) || hasSyntheticEvidence(unreachable) {
+		return "a calibration run asserts its verdicts and cannot evidence a block"
+	}
+	for _, rows := range [][]CaseResult{applicable, unreachable} {
 		for _, row := range rows {
-			if row.Evidence == nil {
-				continue
+			if len(row.Evidence) == 0 {
+				return "case " + row.CaseID + " carries no evidence, so its verdict has no provenance"
 			}
-			value, present := row.Evidence["synthetic"]
-			if !present {
-				continue
-			}
-			if declared, ok := value.(bool); ok && !declared {
-				continue
-			}
-			total++
 		}
 	}
-	return total
+	return ""
 }

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -545,9 +545,13 @@ post_run_dirty="$(git status --porcelain=v1 --untracked-files=all)"
 
 failure_reason="Gauntlet result validation failed"
 results_abs="$(realpath "$results_path")"
+# The cases directory is what turns on the case-bound rules. Without it this
+# call still ran and still passed, checking row shape while every rule that
+# needs the case definition sat idle, which is how a calibration adapter
+# claiming a denial-of-wallet block it could not evidence went unnoticed.
 (
   cd "$repo_root/validate"
-  AEB_CAPABILITY_REGISTRY="$repo_root/capability-registry" go run . results "$results_abs"
+  AEB_CAPABILITY_REGISTRY="$repo_root/capability-registry" go run . results "$results_abs" "$repo_root/cases"
 )
 jq -e '.case_count.errors == 0' "$summary_path" >/dev/null || \
   die "runner summary contains errors"


### PR DESCRIPTION
## What changed

The built-in calibration adapters no longer claim a denial-of-wallet block without the timing evidence those cases require, and the reference harness stops running the result validator with half its rules disabled.

Two denial-of-wallet cases require a target to state when it blocked, because blocking before the budget is spent disrupts legitimate work and blocking after the over-budget call has already gone out is not containment. The calibration adapters asserted the block and withheld that field, so their own output failed the result contract. These adapters already assert delivery and observation they never performed and say so in every row; withholding just this one assertion while claiming the verdict it supports was the arbitrary position. The assertion now travels with the claim and carries the same synthetic marker, which keeps a calibration run unpublishable exactly as before.

It is keyed on the verdict actually emitted rather than the case's expected verdict, because `blockall` claims a block on every case and had the identical defect. Keying on the expectation would have fixed one adapter and left its sibling emitting the same unsupported claim.

The harness change is the part worth distrusting, because the check it repairs was running and passing the whole time. `run-pipelock-gauntlet.sh` invoked the validator on real runner output without the cases directory, and that argument is what enables every case-bound rule. The call verified row shape while the rules that read the case definition sat idle, which is why nothing caught a calibration adapter failing the contract for as long as both existed.

The new test drives each calibration adapter over the real corpus and validates the rows against the real cases. Fixtures could not have caught this: a fixture is written beside the code and agrees with it by construction, so only the real emitter against the real corpus establishes that the contract holds.
