### PR TITLE
feat(operator): add local doctor and offline run paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,11 @@ test-control-evidence-g2-authentication:
 
 test-pipelock-example:
 	@sh examples/pipelock/mcp-stdio-upstream-bridge_test.sh
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest \
+		scripts.continuous_gauntlet_workflow_test.ContinuousGauntletWorkflowTest.test_doctor_reports_every_check_as_json_without_starting_a_run \
+		scripts.continuous_gauntlet_workflow_test.ContinuousGauntletWorkflowTest.test_doctor_collects_all_missing_prerequisites_before_failing \
+		scripts.continuous_gauntlet_workflow_test.ContinuousGauntletWorkflowTest.test_doctor_rejects_a_malformed_release_pin \
+		scripts.continuous_gauntlet_workflow_test.ContinuousGauntletWorkflowTest.test_doctor_keeps_json_contract_when_release_pin_is_unreadable
 
 # Regenerate cases/MANIFEST.txt after adding or removing a case. The manifest
 # pins the logical corpus so a case cannot leave it without a visible diff;

--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ cd validate && go build -o aeb-validate .
 For the pinned Pipelock release, use the portable entry point from a clean Linux clone on `origin/main` or a tag:
 
 ```bash
+./scripts/run-pipelock-gauntlet.sh --doctor
 ./scripts/run-pipelock-gauntlet.sh
 ```
+
+Run `--doctor` before the benchmark. It checks the platform, the required commands, an MCP stdio bridge, the working directory, and the reviewed release pin, without starting a run or writing an evidence directory. `--doctor-json` returns the same checks as JSON. Both commands exit nonzero when a check fails. A ready result is not a prediction that the run will succeed: it does not check the installed Go version, the `origin` remote, whether the checkout is clean, or network reachability, and the run itself still fails on each of those.
 
 The command downloads the reviewed Pipelock release, verifies its pinned asset digest, published checksum, and reported version, then confines target writes with Landlock and denies Unix-domain sockets with seccomp. It starts the required local fixtures and managed Pipelock processes, runs the single-file and multi-file cases, and leaves one timestamped directory under `continuous-gauntlet-runs/`. That directory contains the exact internal command, stdout results, stderr, summary, case index, corpus stats, release identity, file digests, and a machine-readable execution decision.
 

--- a/docs/OCI-RUNNER.md
+++ b/docs/OCI-RUNNER.md
@@ -107,6 +107,21 @@ docker image load --input aeb-gauntlet-image.tar
 docker image inspect "$(cat aeb-gauntlet-image.ref)"
 ```
 
+Run the same offline engine locally without a GitHub Actions runner:
+
+```bash
+./scripts/run-oci-action.sh \
+  --profile examples/pipelock/tool-profile.json \
+  --adapter proxy \
+  --image "$(cat aeb-gauntlet-image.ref)" \
+  --image-metadata benchmark/release/runner-image.ref \
+  --image-attestation benchmark/release/runner-image.attestation.jsonl \
+  --attestation-trusted-root benchmark/release/runner-image.trusted-root.jsonl \
+  --runner-args '["--fixtures","--managed-proxy-cmd","/work/benchmark/start-proxy.sh","--proxy-addr","127.0.0.1:18899"]'
+```
+
+The local command uses the Action's verification and containment path. It requires the image to be loaded already, verifies the release identity with the transferred attestation material, starts Docker with network mode `none`, and writes the same strict result set to `aeb-results/`.
+
 Set the Action inputs `image` to that full digest reference and `offline` to `true`. Offline mode first requires that exact reference to exist locally, then starts the benchmark container with Docker network mode `none` and the same strict completion check used online.
 
 ```yaml

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -141,23 +141,17 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertEqual(release_pin["status"], "invalid")
         self.assertTrue(release_pin["remediation"])
 
-    def test_doctor_keeps_json_contract_when_release_pin_is_unreadable(self):
-        if os.geteuid() == 0:
-            self.skipTest("root can read mode-000 files")
+    def test_doctor_keeps_json_contract_when_release_pin_is_not_a_file(self):
         with tempfile.TemporaryDirectory() as temporary:
             pin = Path(temporary) / "release.env"
-            pin.write_text("PIPELOCK_REPO=luckyPipewrench/pipelock\n", encoding="utf-8")
-            pin.chmod(0)
-            try:
-                result = subprocess.run(
-                    ["bash", str(ENTRYPOINT), "--release-pin", str(pin), "--doctor-json"],
-                    cwd=REPO_ROOT,
-                    text=True,
-                    capture_output=True,
-                    check=False,
-                )
-            finally:
-                pin.chmod(0o600)
+            pin.mkdir()
+            result = subprocess.run(
+                ["bash", str(ENTRYPOINT), "--release-pin", str(pin), "--doctor-json"],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
         self.assertNotEqual(result.returncode, 0)
         report = json.loads(result.stdout)
         release_pin = next(check for check in report["checks"] if check["code"] == "release_pin")

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -141,7 +141,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertEqual(release_pin["status"], "invalid")
         self.assertTrue(release_pin["remediation"])
 
-    def test_doctor_keeps_json_contract_when_release_pin_is_not_a_file(self):
+    def test_doctor_keeps_json_contract_when_release_pin_is_unreadable(self):
         with tempfile.TemporaryDirectory() as temporary:
             pin = Path(temporary) / "release.env"
             pin.mkdir()

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -71,6 +71,98 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertIn('${original_args[$original_arg_index]}', self.entrypoint)
         self.assertNotRegex(self.entrypoint, r"\$\{original_args\[[@*]\]")
 
+    def test_doctor_reports_every_check_as_json_without_starting_a_run(self):
+        before = set((REPO_ROOT / "continuous-gauntlet-runs").glob("*"))
+        result = subprocess.run(
+            ["bash", str(ENTRYPOINT), "--doctor-json"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["schema_version"], 1)
+        self.assertTrue(report["ready"])
+        codes = {check["code"] for check in report["checks"]}
+        self.assertIn("platform_linux", codes)
+        self.assertIn("command_jq", codes)
+        self.assertIn("mcp_stdio_bridge", codes)
+        self.assertIn("repository_root", codes)
+        self.assertIn("release_pin", codes)
+        self.assertEqual(before, set((REPO_ROOT / "continuous-gauntlet-runs").glob("*")))
+
+    def test_doctor_collects_all_missing_prerequisites_before_failing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            fake_path = Path(temporary)
+            for name in (
+                "dirname", "uname", "git", "python3", "go", "curl",
+                "sha256sum", "tar", "timeout", "realpath", "make",
+            ):
+                target = "/usr/bin/uname" if name == "uname" else "/usr/bin/true"
+                if name == "dirname":
+                    target = "/usr/bin/dirname"
+                (fake_path / name).symlink_to(target)
+            result = subprocess.run(
+                ["/bin/bash", str(ENTRYPOINT), "--doctor-json"],
+                cwd=REPO_ROOT,
+                env={**os.environ, "PATH": str(fake_path)},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        report = json.loads(result.stdout)
+        statuses = {check["code"]: check["status"] for check in report["checks"]}
+        self.assertFalse(report["ready"])
+        self.assertEqual(statuses["command_jq"], "missing")
+        self.assertEqual(statuses["mcp_stdio_bridge"], "missing")
+        self.assertIn("release_pin", statuses)
+
+    def test_doctor_rejects_a_malformed_release_pin(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            pin = Path(temporary) / "release.env"
+            pin.write_text(
+                "PIPELOCK_REPO=luckyPipewrench/pipelock\n"
+                "PIPELOCK_TAG=v3.3.0\n"
+                "PIPELOCK_VERSION=3.3.0\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                ["bash", str(ENTRYPOINT), "--release-pin", str(pin), "--doctor-json"],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        report = json.loads(result.stdout)
+        release_pin = next(check for check in report["checks"] if check["code"] == "release_pin")
+        self.assertEqual(release_pin["status"], "invalid")
+        self.assertTrue(release_pin["remediation"])
+
+    def test_doctor_keeps_json_contract_when_release_pin_is_unreadable(self):
+        if os.geteuid() == 0:
+            self.skipTest("root can read mode-000 files")
+        with tempfile.TemporaryDirectory() as temporary:
+            pin = Path(temporary) / "release.env"
+            pin.write_text("PIPELOCK_REPO=luckyPipewrench/pipelock\n", encoding="utf-8")
+            pin.chmod(0)
+            try:
+                result = subprocess.run(
+                    ["bash", str(ENTRYPOINT), "--release-pin", str(pin), "--doctor-json"],
+                    cwd=REPO_ROOT,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+            finally:
+                pin.chmod(0o600)
+        self.assertNotEqual(result.returncode, 0)
+        report = json.loads(result.stdout)
+        release_pin = next(check for check in report["checks"] if check["code"] == "release_pin")
+        self.assertEqual(release_pin["status"], "invalid")
+
     def test_canonical_entrypoint_avoids_old_bash_empty_reason_array_expansion(self):
         self.assertIn("noncanonical_reason_count=0", self.entrypoint)
         self.assertIn("reason_index < noncanonical_reason_count", self.entrypoint)
@@ -88,7 +180,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertNotIn(version, self.entrypoint)
         self.assertNotIn('source "$release_pin"', self.entrypoint)
         self.assertIn("--release-pin", self.entrypoint)
-        self.assertIn("release pin contains an invalid line", self.entrypoint)
+        self.assertIn("reviewed release pin is invalid", self.entrypoint)
 
     def test_target_runs_under_a_filesystem_restricted_environment(self):
         self.assertIn("go build -o \"$target_sandbox\" ./cmd/target-sandbox", self.entrypoint)
@@ -105,15 +197,14 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("SECCOMP_RET_ERRNO", sandbox)
 
     def test_release_pin_parser_accepts_only_the_five_data_fields(self):
-        start = self.entrypoint.index('release_pin_input="$release_pin"')
-        end = self.entrypoint.index('started_at="$(date', start)
-        parser_block = self.entrypoint[start:end]
+        start = self.entrypoint.index("parse_release_pin() {")
+        end = self.entrypoint.index("\nrequire_uint()", start)
+        parser_function = self.entrypoint[start:end]
         shell = "\n".join(
             (
                 "set -Eeuo pipefail",
-                'die() { printf "%s\\n" "$*" >&2; exit 1; }',
-                'release_pin="$1"',
-                parser_block,
+                parser_function,
+                'parse_release_pin "$1"',
             )
         )
         digests = (
@@ -195,7 +286,22 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
                 check=False,
             )
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("cannot be a symbolic link", result.stderr)
+
+    def test_run_path_rejects_release_pin_symlink_before_resolution(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "target.env"
+            target.write_text(RELEASE_PIN.read_text(encoding="utf-8"), encoding="utf-8")
+            pin = Path(temporary) / "release.env"
+            pin.symlink_to(target)
+            result = subprocess.run(
+                ["bash", str(ENTRYPOINT), "--release-pin", str(pin), "--development"],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("reviewed release pin cannot be a symbolic link", result.stderr)
 
     def test_stdio_profile_does_not_claim_unexercised_subject_budget(self):
         profile = json.loads(PIPELOCK_PROFILE.read_text(encoding="utf-8"))

--- a/scripts/run-oci-action.sh
+++ b/scripts/run-oci-action.sh
@@ -44,6 +44,8 @@ Required:
   --profile FILE                    Workspace-relative tool profile.
   --adapter NAME                    Runner adapter name.
   --image REF                       Preloaded digest-pinned image.
+
+Required for publisher verification:
   --image-metadata FILE             Signed runner-image.ref asset.
   --image-attestation FILE          Offline attestation bundle.
   --attestation-trusted-root FILE   Offline GitHub attestation trusted root.
@@ -52,7 +54,8 @@ Options:
   --runner-args JSON                Additional runner arguments as a JSON string array.
   --environment JSON                Environment variable names as a JSON string array.
   --output-dir DIR                  Workspace-relative output directory (default: aeb-results).
-  --allow-unverified-image          Permit a reviewed mirror or custom digest-pinned image.
+  --allow-unverified-image          Permit a reviewed mirror or custom digest-pinned image
+                                    without publisher-verification inputs.
 EOF
         exit 0
         ;;

--- a/scripts/run-oci-action.sh
+++ b/scripts/run-oci-action.sh
@@ -6,6 +6,61 @@ fail() {
   exit 2
 }
 
+if (($#)); then
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+  export GITHUB_WORKSPACE="$(pwd -P)"
+  export GITHUB_ACTION_PATH="$repo_root"
+  export INPUT_OFFLINE=true
+  export INPUT_RUNNER_ARGS='[]'
+  export INPUT_ENVIRONMENT='[]'
+  export INPUT_OUTPUT_DIR=aeb-results
+  export INPUT_ALLOW_UNVERIFIED_IMAGE=false
+  export INPUT_PROFILE=""
+  export INPUT_ADAPTER=""
+  export INPUT_IMAGE=""
+  export INPUT_IMAGE_METADATA=""
+  export INPUT_IMAGE_ATTESTATION=""
+  export INPUT_ATTESTATION_TRUSTED_ROOT=""
+  export AEB_ACTION_REF=local-offline
+  while (($#)); do
+    case "$1" in
+      --profile) (($# >= 2)) || fail "--profile requires a value"; export INPUT_PROFILE="$2"; shift 2 ;;
+      --adapter) (($# >= 2)) || fail "--adapter requires a value"; export INPUT_ADAPTER="$2"; shift 2 ;;
+      --image) (($# >= 2)) || fail "--image requires a value"; export INPUT_IMAGE="$2"; shift 2 ;;
+      --image-metadata) (($# >= 2)) || fail "--image-metadata requires a value"; export INPUT_IMAGE_METADATA="$2"; shift 2 ;;
+      --image-attestation) (($# >= 2)) || fail "--image-attestation requires a value"; export INPUT_IMAGE_ATTESTATION="$2"; shift 2 ;;
+      --attestation-trusted-root) (($# >= 2)) || fail "--attestation-trusted-root requires a value"; export INPUT_ATTESTATION_TRUSTED_ROOT="$2"; shift 2 ;;
+      --runner-args) (($# >= 2)) || fail "--runner-args requires a value"; export INPUT_RUNNER_ARGS="$2"; shift 2 ;;
+      --environment) (($# >= 2)) || fail "--environment requires a value"; export INPUT_ENVIRONMENT="$2"; shift 2 ;;
+      --output-dir) (($# >= 2)) || fail "--output-dir requires a value"; export INPUT_OUTPUT_DIR="$2"; shift 2 ;;
+      --allow-unverified-image) export INPUT_ALLOW_UNVERIFIED_IMAGE=true; shift ;;
+      -h|--help)
+        cat <<'EOF'
+Usage: ./scripts/run-oci-action.sh --profile FILE --adapter NAME --image REF [options]
+
+Run the pre-staged OCI benchmark locally with network access disabled.
+
+Required:
+  --profile FILE                    Workspace-relative tool profile.
+  --adapter NAME                    Runner adapter name.
+  --image REF                       Preloaded digest-pinned image.
+  --image-metadata FILE             Signed runner-image.ref asset.
+  --image-attestation FILE          Offline attestation bundle.
+  --attestation-trusted-root FILE   Offline GitHub attestation trusted root.
+
+Options:
+  --runner-args JSON                Additional runner arguments as a JSON string array.
+  --environment JSON                Environment variable names as a JSON string array.
+  --output-dir DIR                  Workspace-relative output directory (default: aeb-results).
+  --allow-unverified-image          Permit a reviewed mirror or custom digest-pinned image.
+EOF
+        exit 0
+        ;;
+      *) fail "unknown local option: $1" ;;
+    esac
+  done
+fi
+
 [[ -n "${GITHUB_WORKSPACE:-}" ]] || fail "GITHUB_WORKSPACE is required"
 [[ -n "${INPUT_PROFILE:-}" ]] || fail "profile is required"
 [[ -n "${INPUT_ADAPTER:-}" ]] || fail "adapter is required"
@@ -81,6 +136,7 @@ case "$allow_unverified_image" in
   true|false) ;;
   *) fail "allow-unverified-image must be true or false" ;;
 esac
+publisher_verified=false
 
 workspace_file() {
   local input_name=$1
@@ -129,8 +185,10 @@ if [[ -n "$image" ]]; then
   [[ "$image" =~ @sha256:[0-9a-f]{64}$ ]] || fail "image must use an immutable @sha256 digest"
   if [[ "$allow_unverified_image" == false ]]; then
     verify_image_identity
+    publisher_verified=true
   fi
   if [[ "$offline" == true ]]; then
+    command -v docker >/dev/null 2>&1 || fail "Docker is required for an offline run"
     docker image inspect "$image" >/dev/null 2>&1 || fail "offline image isn't loaded: $image"
   else
     docker pull "$image"
@@ -224,6 +282,7 @@ export AEB_ACTION_RUNNER_EXIT="$container_exit"
 export AEB_ACTION_EXIT="$run_exit"
 export AEB_ACTION_REF_VALUE="${AEB_ACTION_REF:-local}"
 export AEB_ACTION_MEASUREMENT_STATUS="$measurement_status"
+export AEB_ACTION_PUBLISHER_VERIFIED="$publisher_verified"
 python3 - <<'PY'
 import json
 import os
@@ -237,6 +296,7 @@ path.write_text(json.dumps({
     "network_mode": os.environ["AEB_ACTION_NETWORK_MODE"],
     "selinux_labeling": os.environ["AEB_ACTION_SELINUX_LABELING"],
     "measurement_status": os.environ["AEB_ACTION_MEASUREMENT_STATUS"],
+    "publisher_verified": os.environ["AEB_ACTION_PUBLISHER_VERIFIED"] == "true",
     "require_complete": True,
     "runner_exit_code": int(os.environ["AEB_ACTION_RUNNER_EXIT"]),
     "action_exit_code": int(os.environ["AEB_ACTION_EXIT"]),

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -15,6 +15,7 @@ corpus_repository="luckyPipewrench/agent-egress-bench"
 output_dir=""
 development_mode=false
 development_binary=""
+doctor_mode=""
 benchmark_timeout_seconds=$((24 * 60))
 deadline_epoch=""
 reserve_seconds=$((6 * 60))
@@ -35,6 +36,8 @@ Options:
   --release-pin FILE               Read the reviewed Pipelock release identity from FILE.
   --development                    Allow a dirty or unreviewed corpus and mark the run noncanonical.
   --development-binary PATH        Use PATH instead of a released binary and mark the run noncanonical.
+  --doctor                         Check local prerequisites without starting a run.
+  --doctor-json                    Check prerequisites and emit machine-readable JSON.
   -h, --help                       Show this help.
 EOF
 }
@@ -43,6 +46,40 @@ die() {
   failure_reason="$*"
   printf 'run-pipelock-gauntlet: %s\n' "$failure_reason" >&2
   exit 1
+}
+
+parse_release_pin() {
+  local pin_path="$1"
+  local pin_contents=""
+  local release_line release_key release_value
+  local release_repo_count=0 release_tag_count=0 release_version_count=0
+  local release_amd64_digest_count=0 release_arm64_digest_count=0
+  unset PIPELOCK_REPO PIPELOCK_TAG PIPELOCK_VERSION PIPELOCK_ASSET_SHA256_AMD64 PIPELOCK_ASSET_SHA256_ARM64
+
+  [[ -f "$pin_path" && ! -L "$pin_path" ]] || return 1
+  if ! pin_contents="$(<"$pin_path")"; then
+    return 1
+  fi
+  while IFS= read -r release_line || [[ -n "$release_line" ]]; do
+    [[ -z "$release_line" || "$release_line" == \#* ]] && continue
+    [[ "$release_line" =~ ^([A-Z0-9_]+)=([A-Za-z0-9._/-]+)$ ]] || return 1
+    release_key="${BASH_REMATCH[1]}"
+    release_value="${BASH_REMATCH[2]}"
+    case "$release_key" in
+      PIPELOCK_REPO) PIPELOCK_REPO="$release_value"; release_repo_count=$((release_repo_count + 1)) ;;
+      PIPELOCK_TAG) PIPELOCK_TAG="$release_value"; release_tag_count=$((release_tag_count + 1)) ;;
+      PIPELOCK_VERSION) PIPELOCK_VERSION="$release_value"; release_version_count=$((release_version_count + 1)) ;;
+      PIPELOCK_ASSET_SHA256_AMD64) PIPELOCK_ASSET_SHA256_AMD64="$release_value"; release_amd64_digest_count=$((release_amd64_digest_count + 1)) ;;
+      PIPELOCK_ASSET_SHA256_ARM64) PIPELOCK_ASSET_SHA256_ARM64="$release_value"; release_arm64_digest_count=$((release_arm64_digest_count + 1)) ;;
+      *) return 1 ;;
+    esac
+  done <<< "$pin_contents"
+  [[ "$release_repo_count" == 1 && "$release_tag_count" == 1 && "$release_version_count" == 1 && \
+    "$release_amd64_digest_count" == 1 && "$release_arm64_digest_count" == 1 && \
+    "${PIPELOCK_REPO:-}" == "luckyPipewrench/pipelock" && \
+    "${PIPELOCK_TAG:-}" == "v${PIPELOCK_VERSION:-}" && \
+    "${PIPELOCK_ASSET_SHA256_AMD64:-}" =~ ^[0-9a-f]{64}$ && \
+    "${PIPELOCK_ASSET_SHA256_ARM64:-}" =~ ^[0-9a-f]{64}$ ]]
 }
 
 require_uint() {
@@ -87,6 +124,14 @@ while (($#)); do
       development_binary="$2"
       shift 2
       ;;
+    --doctor)
+      doctor_mode="text"
+      shift
+      ;;
+    --doctor-json)
+      doctor_mode="json"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -96,6 +141,93 @@ while (($#)); do
       ;;
   esac
 done
+
+run_doctor() {
+  local failed=0
+  local command_name
+  local bridge_found=false
+  local repo_ok=false
+  local pin_ok=false
+  local -a codes=()
+  local -a details=()
+  local -a remediations=()
+
+  add_doctor_result() {
+    codes+=("$1")
+    details+=("$2")
+    remediations+=("$3")
+    [[ "$2" == "ok" ]] || failed=$((failed + 1))
+  }
+
+  if [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]; then
+    add_doctor_result "platform_linux" "ok" ""
+  else
+    add_doctor_result "platform_linux" "unsupported" "run this reference lane on Linux"
+  fi
+  for command_name in git python3 go curl jq sha256sum tar timeout realpath make; do
+    if command -v "$command_name" >/dev/null 2>&1; then
+      add_doctor_result "command_${command_name//-/_}" "ok" ""
+    else
+      add_doctor_result "command_${command_name//-/_}" "missing" "install $command_name and retry"
+    fi
+  done
+  for command_name in socat ncat nc; do
+    if command -v "$command_name" >/dev/null 2>&1; then
+      bridge_found=true
+      break
+    fi
+  done
+  if [[ "$bridge_found" == true ]]; then
+    add_doctor_result "mcp_stdio_bridge" "ok" ""
+  else
+    add_doctor_result "mcp_stdio_bridge" "missing" "install socat, ncat, or nc and retry"
+  fi
+  if [[ "$(pwd -P)" == "$repo_root" ]]; then
+    repo_ok=true
+  fi
+  if [[ "$repo_ok" == true ]]; then
+    add_doctor_result "repository_root" "ok" ""
+  else
+    add_doctor_result "repository_root" "wrong_directory" "run the command from the benchmark repository root"
+  fi
+  if parse_release_pin "$release_pin"; then
+    pin_ok=true
+  fi
+  if [[ "$pin_ok" == true ]]; then
+    add_doctor_result "release_pin" "ok" ""
+  else
+    add_doctor_result "release_pin" "invalid" "restore the reviewed five-field release pin and retry"
+  fi
+
+  if [[ "$doctor_mode" == "json" ]]; then
+    printf '{"schema_version":1,"ready":%s,"checks":[' "$([[ "$failed" == 0 ]] && printf true || printf false)"
+    for ((doctor_index = 0; doctor_index < ${#codes[@]}; doctor_index++)); do
+      ((doctor_index == 0)) || printf ','
+      printf '{"code":"%s","status":"%s","remediation":"%s"}' \
+        "${codes[$doctor_index]}" "${details[$doctor_index]}" "${remediations[$doctor_index]}"
+    done
+    printf ']}\n'
+  else
+    for ((doctor_index = 0; doctor_index < ${#codes[@]}; doctor_index++)); do
+      printf '%-24s %s' "${codes[$doctor_index]}" "${details[$doctor_index]}"
+      if [[ -n "${remediations[$doctor_index]}" ]]; then
+        printf ' — %s' "${remediations[$doctor_index]}"
+      fi
+      printf '\n'
+    done
+    if [[ "$failed" == 0 ]]; then
+      printf 'ready: local prerequisites are satisfied\n'
+    else
+      printf 'not ready: %d prerequisite check(s) failed\n' "$failed"
+    fi
+  fi
+  ((failed == 0))
+}
+
+if [[ -n "$doctor_mode" ]]; then
+  run_doctor
+  exit $?
+fi
 
 require_uint "--benchmark-timeout-seconds" "$benchmark_timeout_seconds"
 require_uint "--reserve-seconds" "$reserve_seconds"
@@ -109,55 +241,7 @@ release_pin_input="$release_pin"
 [[ ! -L "$release_pin_input" ]] || die "reviewed release pin cannot be a symbolic link: $release_pin_input"
 release_pin="$(realpath -e "$release_pin_input")" || \
   die "reviewed release pin does not resolve: $release_pin_input"
-[[ -f "$release_pin" ]] || die "reviewed release pin must be a regular file: $release_pin_input"
-unset PIPELOCK_REPO PIPELOCK_TAG PIPELOCK_VERSION PIPELOCK_ASSET_SHA256_AMD64 PIPELOCK_ASSET_SHA256_ARM64
-release_repo_count=0
-release_tag_count=0
-release_version_count=0
-release_amd64_digest_count=0
-release_arm64_digest_count=0
-while IFS= read -r release_line || [[ -n "$release_line" ]]; do
-  [[ -z "$release_line" || "$release_line" == \#* ]] && continue
-  [[ "$release_line" =~ ^([A-Z0-9_]+)=([A-Za-z0-9._/-]+)$ ]] || \
-    die "release pin contains an invalid line"
-  release_key="${BASH_REMATCH[1]}"
-  release_value="${BASH_REMATCH[2]}"
-  case "$release_key" in
-    PIPELOCK_REPO)
-      PIPELOCK_REPO="$release_value"
-      release_repo_count=$((release_repo_count + 1))
-      ;;
-    PIPELOCK_TAG)
-      PIPELOCK_TAG="$release_value"
-      release_tag_count=$((release_tag_count + 1))
-      ;;
-    PIPELOCK_VERSION)
-      PIPELOCK_VERSION="$release_value"
-      release_version_count=$((release_version_count + 1))
-      ;;
-    PIPELOCK_ASSET_SHA256_AMD64)
-      PIPELOCK_ASSET_SHA256_AMD64="$release_value"
-      release_amd64_digest_count=$((release_amd64_digest_count + 1))
-      ;;
-    PIPELOCK_ASSET_SHA256_ARM64)
-      PIPELOCK_ASSET_SHA256_ARM64="$release_value"
-      release_arm64_digest_count=$((release_arm64_digest_count + 1))
-      ;;
-    *) die "release pin contains an unknown key: $release_key" ;;
-  esac
-done < "$release_pin"
-[[ "$release_repo_count" == 1 && "$release_tag_count" == 1 && "$release_version_count" == 1 && \
-  "$release_amd64_digest_count" == 1 && "$release_arm64_digest_count" == 1 ]] || \
-  die "release pin must define each required key exactly once"
-: "${PIPELOCK_REPO:?release pin must define PIPELOCK_REPO}"
-: "${PIPELOCK_TAG:?release pin must define PIPELOCK_TAG}"
-: "${PIPELOCK_VERSION:?release pin must define PIPELOCK_VERSION}"
-: "${PIPELOCK_ASSET_SHA256_AMD64:?release pin must define PIPELOCK_ASSET_SHA256_AMD64}"
-: "${PIPELOCK_ASSET_SHA256_ARM64:?release pin must define PIPELOCK_ASSET_SHA256_ARM64}"
-[[ "$PIPELOCK_REPO" == "luckyPipewrench/pipelock" ]] || die "release pin names an unexpected repository"
-[[ "$PIPELOCK_TAG" == "v$PIPELOCK_VERSION" ]] || die "release tag and version do not match"
-[[ "$PIPELOCK_ASSET_SHA256_AMD64" =~ ^[0-9a-f]{64}$ ]] || die "amd64 release digest is invalid"
-[[ "$PIPELOCK_ASSET_SHA256_ARM64" =~ ^[0-9a-f]{64}$ ]] || die "arm64 release digest is invalid"
+parse_release_pin "$release_pin" || die "reviewed release pin is invalid: $release_pin_input"
 
 started_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 run_stamp="$(date -u +'%Y%m%dT%H%M%SZ')"

--- a/scripts/runner_image_test.py
+++ b/scripts/runner_image_test.py
@@ -15,6 +15,93 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class RunnerImageContractTest(unittest.TestCase):
+    def test_local_offline_cli_is_read_only_until_required_inputs_exist(self) -> None:
+        script = ROOT / "scripts" / "run-oci-action.sh"
+        help_result = subprocess.run(
+            [str(script), "--help"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, help_result.returncode, help_result.stderr)
+        self.assertIn("network access disabled", help_result.stdout)
+        self.assertIn("--attestation-trusted-root", help_result.stdout)
+
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run(
+                [str(script), "--profile", "missing.json"],
+                cwd=directory,
+                env={**os.environ, "INPUT_ADAPTER": "ambient-adapter", "INPUT_IMAGE": "ambient-image"},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(2, result.returncode)
+            self.assertIn("adapter is required", result.stderr)
+            self.assertEqual([], list(Path(directory).iterdir()))
+
+    def test_local_offline_cli_rejects_unknown_options(self) -> None:
+        result = subprocess.run(
+            [str(ROOT / "scripts" / "run-oci-action.sh"), "--online"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(2, result.returncode)
+        self.assertIn("unknown local option: --online", result.stderr)
+
+    def test_local_offline_cli_never_pulls_and_records_unverified_image(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "profile.json").write_text("{}\n", encoding="utf-8")
+            bin_dir = workspace / "bin"
+            bin_dir.mkdir()
+            docker_log = workspace / "docker.log"
+            docker = bin_dir / "docker"
+            docker.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, sys\n"
+                "args = sys.argv[1:]\n"
+                "with open(os.environ['MOCK_DOCKER_LOG'], 'a', encoding='utf-8') as log: log.write(json.dumps(args) + '\\n')\n"
+                "if args[:1] == ['pull']: raise SystemExit(97)\n"
+                "if args[:2] == ['image', 'inspect']:\n"
+                "  if '--format' in args: print('sha256:local-offline-image')\n"
+                "  raise SystemExit(0)\n"
+                "if args[:1] == ['info']: print('[]'); raise SystemExit(0)\n"
+                "if args[:1] == ['run']:\n"
+                "  volumes = [args[index + 1] for index, value in enumerate(args) if value == '--volume']\n"
+                "  output = next(value.split(':/aeb-output:', 1)[0] for value in volumes if ':/aeb-output:' in value)\n"
+                "  with open(os.path.join(output, 'summary.json'), 'w', encoding='utf-8') as summary: json.dump({'measurement_status': 'measured'}, summary)\n"
+                "  raise SystemExit(0)\n"
+                "raise SystemExit(2)\n",
+                encoding="utf-8",
+            )
+            docker.chmod(0o755)
+            image = f"registry.invalid/reviewed/runner@sha256:{'a' * 64}"
+            result = subprocess.run(
+                [
+                    str(ROOT / "scripts" / "run-oci-action.sh"),
+                    "--profile", "profile.json",
+                    "--adapter", "dryrun",
+                    "--image", image,
+                    "--allow-unverified-image",
+                ],
+                cwd=workspace,
+                env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}", "MOCK_DOCKER_LOG": str(docker_log)},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            calls = [json.loads(line) for line in docker_log.read_text(encoding="utf-8").splitlines()]
+            self.assertFalse(any(call[:1] == ["pull"] for call in calls))
+            run = next(call for call in calls if call[:1] == ["run"])
+            self.assertIn("none", run)
+            metadata = json.loads((workspace / "aeb-results" / "run-metadata.json").read_text(encoding="utf-8"))
+            self.assertFalse(metadata["publisher_verified"])
+
     def run_action(self, *, image: str, metadata: str | None = None, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as directory:
             workspace = Path(directory)
@@ -40,7 +127,7 @@ class RunnerImageContractTest(unittest.TestCase):
             env.update(extra_env or {})
             return subprocess.run([str(ROOT / "scripts" / "run-oci-action.sh")], text=True, capture_output=True, env=env)
 
-    def run_completed_action(self, security_options: str) -> tuple[subprocess.CompletedProcess[str], str]:
+    def run_completed_action(self, security_options: str, *, verified: bool = False) -> tuple[subprocess.CompletedProcess[str], str, dict[str, object]]:
         with tempfile.TemporaryDirectory() as directory:
             workspace = Path(directory)
             (workspace / "profile.json").write_text("{}\n", encoding="utf-8")
@@ -69,7 +156,14 @@ class RunnerImageContractTest(unittest.TestCase):
                 encoding="utf-8",
             )
             docker.chmod(0o755)
-            image = f"registry.invalid/reviewed/runner@sha256:{'f' * 64}"
+            if verified:
+                image = f"ghcr.io/luckypipewrench/agent-egress-bench-runner@sha256:{'f' * 64}"
+                (workspace / "runner-image.ref").write_text(image + "\n", encoding="utf-8")
+                gh = bin_dir / "gh"
+                gh.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                gh.chmod(0o755)
+            else:
+                image = f"registry.invalid/reviewed/runner@sha256:{'f' * 64}"
             env = {
                 **os.environ,
                 "PATH": f"{bin_dir}:{os.environ['PATH']}",
@@ -78,12 +172,14 @@ class RunnerImageContractTest(unittest.TestCase):
                 "INPUT_PROFILE": "profile.json",
                 "INPUT_ADAPTER": "proxy",
                 "INPUT_IMAGE": image,
-                "INPUT_ALLOW_UNVERIFIED_IMAGE": "true",
+                "INPUT_ALLOW_UNVERIFIED_IMAGE": "false" if verified else "true",
+                "INPUT_IMAGE_METADATA": "runner-image.ref" if verified else "",
                 "MOCK_DOCKER_LOG": str(docker_log),
                 "MOCK_SECURITY_OPTIONS": security_options,
             }
             result = subprocess.run([str(ROOT / "scripts" / "run-oci-action.sh")], text=True, capture_output=True, env=env)
-            return result, docker_log.read_text(encoding="utf-8")
+            metadata = json.loads((workspace / "aeb-results" / "run-metadata.json").read_text(encoding="utf-8"))
+            return result, docker_log.read_text(encoding="utf-8"), metadata
 
     def test_dockerfile_pins_multi_arch_build_and_runtime_images(self) -> None:
         text = (ROOT / "Dockerfile").read_text(encoding="utf-8")
@@ -163,15 +259,16 @@ class RunnerImageContractTest(unittest.TestCase):
         self.assertNotIn("docker-called", result.stderr)
 
     def test_selinux_and_non_selinux_daemons_get_explicit_mount_modes(self) -> None:
-        selinux_result, selinux_log = self.run_completed_action('["name=seccomp", "name=selinux"]')
+        selinux_result, selinux_log, selinux_metadata = self.run_completed_action('["name=seccomp", "name=selinux"]')
         self.assertEqual(0, selinux_result.returncode, msg=selinux_result.stderr)
         selinux_run = next(call for call in map(json.loads, selinux_log.splitlines()) if call[:1] == ["run"])
         selinux_volumes = [selinux_run[index + 1] for index, value in enumerate(selinux_run) if value == "--volume"]
         self.assertTrue(any(value.endswith(":/work:ro,z") for value in selinux_volumes))
         self.assertTrue(any(value.endswith(":/aeb-output:rw,z") for value in selinux_volumes))
         self.assertNotIn("SELinux labeling is unavailable", selinux_result.stderr)
+        self.assertFalse(selinux_metadata["publisher_verified"])
 
-        plain_result, plain_log = self.run_completed_action('["name=seccomp"]')
+        plain_result, plain_log, _ = self.run_completed_action('["name=seccomp"]')
         self.assertEqual(0, plain_result.returncode, msg=plain_result.stderr)
         plain_run = next(call for call in map(json.loads, plain_log.splitlines()) if call[:1] == ["run"])
         plain_volumes = [plain_run[index + 1] for index, value in enumerate(plain_run) if value == "--volume"]
@@ -179,6 +276,11 @@ class RunnerImageContractTest(unittest.TestCase):
         self.assertTrue(any(value.endswith(":/aeb-output:rw") for value in plain_volumes))
         self.assertFalse(any(value.endswith(",z") for value in plain_volumes))
         self.assertIn("SELinux labeling is unavailable", plain_result.stderr)
+
+    def test_successful_publisher_verification_is_recorded(self) -> None:
+        result, _, metadata = self.run_completed_action('["name=seccomp"]', verified=True)
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(metadata["publisher_verified"])
 
     def test_devcontainer_builds_the_same_pinned_runner_image(self) -> None:
         text = (ROOT / ".devcontainer" / "devcontainer.json").read_text(encoding="utf-8")

--- a/scripts/runner_image_test.py
+++ b/scripts/runner_image_test.py
@@ -127,7 +127,9 @@ class RunnerImageContractTest(unittest.TestCase):
             env.update(extra_env or {})
             return subprocess.run([str(ROOT / "scripts" / "run-oci-action.sh")], text=True, capture_output=True, env=env)
 
-    def run_completed_action(self, security_options: str, *, verified: bool = False) -> tuple[subprocess.CompletedProcess[str], str, dict[str, object]]:
+    def run_completed_action(
+        self, security_options: str, *, verified: bool = False, verifier_exit: int = 0
+    ) -> tuple[subprocess.CompletedProcess[str], str, dict[str, object] | None]:
         with tempfile.TemporaryDirectory() as directory:
             workspace = Path(directory)
             (workspace / "profile.json").write_text("{}\n", encoding="utf-8")
@@ -159,8 +161,23 @@ class RunnerImageContractTest(unittest.TestCase):
             if verified:
                 image = f"ghcr.io/luckypipewrench/agent-egress-bench-runner@sha256:{'f' * 64}"
                 (workspace / "runner-image.ref").write_text(image + "\n", encoding="utf-8")
+                (workspace / "attestation.json").write_text("offline bundle\n", encoding="utf-8")
+                (workspace / "trusted-root.json").write_text("trusted root\n", encoding="utf-8")
                 gh = bin_dir / "gh"
-                gh.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                gh.write_text(
+                    "#!/usr/bin/env python3\n"
+                    "import os, pathlib, sys\n"
+                    "args = sys.argv[1:]\n"
+                    "if args[:2] != ['attestation', 'verify']: raise SystemExit(91)\n"
+                    "if pathlib.Path(args[2]).name != 'image-metadata': raise SystemExit(92)\n"
+                    "pairs = {'--repo': 'luckyPipewrench/agent-egress-bench', '--signer-workflow': 'github.com/luckyPipewrench/agent-egress-bench/.github/workflows/release.yaml'}\n"
+                    "for flag, value in pairs.items():\n"
+                    "  if flag not in args or args[args.index(flag) + 1] != value: raise SystemExit(93)\n"
+                    "for flag, name in [('--bundle', 'image-attestation'), ('--custom-trusted-root', 'attestation-trusted-root')]:\n"
+                    "  if flag not in args or pathlib.Path(args[args.index(flag) + 1]).name != name: raise SystemExit(94)\n"
+                    "raise SystemExit(int(os.environ['MOCK_VERIFIER_EXIT']))\n",
+                    encoding="utf-8",
+                )
                 gh.chmod(0o755)
             else:
                 image = f"registry.invalid/reviewed/runner@sha256:{'f' * 64}"
@@ -172,14 +189,20 @@ class RunnerImageContractTest(unittest.TestCase):
                 "INPUT_PROFILE": "profile.json",
                 "INPUT_ADAPTER": "proxy",
                 "INPUT_IMAGE": image,
+                "INPUT_OFFLINE": "true" if verified else "false",
                 "INPUT_ALLOW_UNVERIFIED_IMAGE": "false" if verified else "true",
                 "INPUT_IMAGE_METADATA": "runner-image.ref" if verified else "",
+                "INPUT_IMAGE_ATTESTATION": "attestation.json" if verified else "",
+                "INPUT_ATTESTATION_TRUSTED_ROOT": "trusted-root.json" if verified else "",
                 "MOCK_DOCKER_LOG": str(docker_log),
                 "MOCK_SECURITY_OPTIONS": security_options,
+                "MOCK_VERIFIER_EXIT": str(verifier_exit),
             }
             result = subprocess.run([str(ROOT / "scripts" / "run-oci-action.sh")], text=True, capture_output=True, env=env)
-            metadata = json.loads((workspace / "aeb-results" / "run-metadata.json").read_text(encoding="utf-8"))
-            return result, docker_log.read_text(encoding="utf-8"), metadata
+            metadata_file = workspace / "aeb-results" / "run-metadata.json"
+            metadata = json.loads(metadata_file.read_text(encoding="utf-8")) if metadata_file.exists() else None
+            docker_calls = docker_log.read_text(encoding="utf-8") if docker_log.exists() else ""
+            return result, docker_calls, metadata
 
     def test_dockerfile_pins_multi_arch_build_and_runtime_images(self) -> None:
         text = (ROOT / "Dockerfile").read_text(encoding="utf-8")
@@ -280,7 +303,17 @@ class RunnerImageContractTest(unittest.TestCase):
     def test_successful_publisher_verification_is_recorded(self) -> None:
         result, _, metadata = self.run_completed_action('["name=seccomp"]', verified=True)
         self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIsNotNone(metadata)
         self.assertTrue(metadata["publisher_verified"])
+
+    def test_failed_publisher_verification_stops_before_docker_run(self) -> None:
+        result, docker_log, metadata = self.run_completed_action(
+            '["name=seccomp"]', verified=True, verifier_exit=1
+        )
+        self.assertEqual(2, result.returncode)
+        self.assertIn("metadata provenance verification failed", result.stderr)
+        self.assertFalse(any(call[:1] == ["run"] for call in map(json.loads, docker_log.splitlines())))
+        self.assertIsNone(metadata)
 
     def test_devcontainer_builds_the_same_pinned_runner_image(self) -> None:
         text = (ROOT / ".devcontainer" / "devcontainer.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- Add read-only text and JSON doctor modes that report missing local prerequisites and validate the shared release pin without creating run artifacts.
- Run the existing OCI Action path locally with a preloaded digest-pinned image, offline attestation verification, Docker network isolation, and metadata that records whether publisher verification ran. Missing or unverified inputs fail closed, and source-built images can't inherit a publisher-verified claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added preflight checks for platform, required commands, MCP connectivity, repository setup, and release-pin validity.
  - Added machine-readable JSON output for automated readiness checks, including all detected issues.
  - Added offline OCI benchmark options with image verification, runner configuration, and publisher-verification status in run metadata.

- **Bug Fixes**
  - Improved handling of malformed, unreadable, and symlinked release pins with clearer validation failures.

- **Documentation**
  - Updated quick-start guidance and added offline OCI benchmark instructions, including verification and expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->