### PR TITLE
feat(operator): ship the offline doctor in release bundles

### DIFF
--- a/docs/OCI-RUNNER.md
+++ b/docs/OCI-RUNNER.md
@@ -107,6 +107,21 @@ docker image load --input aeb-gauntlet-image.tar
 docker image inspect "$(cat aeb-gauntlet-image.ref)"
 ```
 
+The release data bundle includes the local runner command and its artifact helper. Extract that bundle as the working directory, copy the image identity files into the paths below, and check the machine before starting a run:
+
+```bash
+./scripts/run-oci-action.sh \
+  --profile examples/pipelock/tool-profile.json \
+  --adapter proxy \
+  --image "$(cat aeb-gauntlet-image.ref)" \
+  --image-metadata benchmark/release/runner-image.ref \
+  --image-attestation benchmark/release/runner-image.attestation.jsonl \
+  --attestation-trusted-root benchmark/release/runner-image.trusted-root.jsonl \
+  --doctor-json
+```
+
+The doctor checks the platform, commands, profile, adapter, loaded image, and publisher material. It reports every failed check in one JSON document, returns nonzero when the machine isn't ready, and doesn't create `aeb-results` or start a container.
+
 Run the same offline engine locally without a GitHub Actions runner:
 
 ```bash

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -36,7 +36,20 @@ RAW_SCHEMA_URL = "https://raw.githubusercontent.com/luckyPipewrench/agent-egress
 # harness. Without it a downloaded release can report the corpus but cannot run
 # it, because --profile is mandatory and nothing in the release satisfied it.
 DATA_ROOTS = ("cases", "schemas", "contracts", "capability-registry/aeb.core-capabilities", "examples")
-DATA_FILES = ("README.md", "LICENSE", "NOTICE", "CITATION.cff", "docs/SPEC.md", "docs/GOVERNANCE.md", "docs/RUNNER.md", "scripts/release_build.py", "scripts/schema_catalog.py")
+DATA_FILES = (
+    "README.md",
+    "LICENSE",
+    "NOTICE",
+    "CITATION.cff",
+    "docs/SPEC.md",
+    "docs/GOVERNANCE.md",
+    "docs/RUNNER.md",
+    "docs/OCI-RUNNER.md",
+    "scripts/action_artifacts.py",
+    "scripts/release_build.py",
+    "scripts/run-oci-action.sh",
+    "scripts/schema_catalog.py",
+)
 PLATFORMS = tuple((goos, arch) for goos in ("linux", "darwin", "windows") for arch in ("amd64", "arm64"))
 # Both tools ride in one platform archive. A release that shipped only the
 # runner let a downloader produce a result and gave them nothing to check it
@@ -425,9 +438,11 @@ def verify_identity(repo: Path, path: Path) -> dict[str, Any]:
     return identity
 
 
-def add_tar_bytes(archive: tarfile.TarFile, name: str, data: bytes, timestamp: int) -> None:
+def add_tar_bytes(
+    archive: tarfile.TarFile, name: str, data: bytes, timestamp: int, mode: int = 0o644
+) -> None:
     info = tarfile.TarInfo(name)
-    info.size, info.mtime, info.mode = len(data), timestamp, 0o644
+    info.size, info.mtime, info.mode = len(data), timestamp, mode
     archive.addfile(info, io.BytesIO(data))
 
 
@@ -437,7 +452,16 @@ def make_data_bundle(repo: Path, identity_path: Path, dist: Path) -> Path:
     dist.mkdir(parents=True, exist_ok=True)
     with output.open("wb") as raw, gzip.GzipFile(fileobj=raw, mode="wb", mtime=identity["source"]["commit_timestamp"], filename="") as compressed, tarfile.open(fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT) as archive:
         for name in sorted(identity["data_files"]):
-            add_tar_bytes(archive, name, (repo / name).read_bytes(), identity["source"]["commit_timestamp"])
+            source = repo / name
+            tracked_mode = git(repo, "ls-tree", "HEAD", "--", name).split(maxsplit=1)[0]
+            mode = 0o755 if tracked_mode == "100755" else 0o644
+            add_tar_bytes(
+                archive,
+                name,
+                source.read_bytes(),
+                identity["source"]["commit_timestamp"],
+                mode,
+            )
         add_tar_bytes(archive, IDENTITY_NAME, identity_path.read_bytes(), identity["source"]["commit_timestamp"])
     return output
 

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -34,6 +34,7 @@ class ReleaseBuildTest(unittest.TestCase):
             source, destination = REPO / name, self.root / name
             destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(source, destination)
+            shutil.copymode(source, destination)
         subprocess.run(["git", "-C", str(self.root), "init", "-q"], check=True)
         subprocess.run(["git", "-C", str(self.root), "config", "user.email", "release-test@example.invalid"], check=True)
         subprocess.run(["git", "-C", str(self.root), "config", "user.name", "Release Test"], check=True)
@@ -456,6 +457,45 @@ class ReleaseBuildTest(unittest.TestCase):
         self.assertEqual(run.returncode, 0, msg=run.stderr)
         self.assertTrue(summary.is_file(), "a run driven by the bundle must write its summary")
         self.assertEqual(json.loads(summary.read_text(encoding="utf-8"))["tool"], json.loads(profile.read_text(encoding="utf-8"))["tool"])
+
+    def test_extracted_data_bundle_carries_a_runnable_offline_doctor(self) -> None:
+        self.prepare()
+        dist = self.root / "dist"
+        self.invoke(
+            "data-bundle",
+            "--repo-root", str(self.root),
+            "--identity", str(self.identity),
+            "--dist", str(dist),
+        )
+        extracted = self.root / "operator-kit"
+        extracted.mkdir()
+        with tarfile.open(next(dist.glob("*_data.tar.gz")), "r:gz") as archive:
+            archive.extractall(extracted, filter="data")
+        doctor = extracted / "scripts/run-oci-action.sh"
+        self.assertTrue(doctor.stat().st_mode & 0o111, "the released operator command must be executable")
+        bin_dir = self.root / "doctor-bin"
+        bin_dir.mkdir()
+        docker = bin_dir / "docker"
+        docker.write_text("#!/bin/sh\n[ \"$1 $2\" = \"image inspect\" ]\n", encoding="utf-8")
+        docker.chmod(0o755)
+        image = f"registry.invalid/reviewed/runner@sha256:{'a' * 64}"
+        result = subprocess.run(
+            [
+                str(doctor),
+                "--profile", "examples/runner-template/tool-profile-template.json",
+                "--adapter", "dryrun",
+                "--image", image,
+                "--allow-unverified-image",
+                "--doctor-json",
+            ],
+            cwd=extracted,
+            env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(json.loads(result.stdout)["ready"])
+        self.assertFalse((extracted / "aeb-results").exists())
 
     def test_release_binds_a_schema_bundle_to_the_commit_pinned_catalog(self) -> None:
         self.prepare()

--- a/scripts/run-oci-action.sh
+++ b/scripts/run-oci-action.sh
@@ -8,6 +8,7 @@ fail() {
 
 if (($#)); then
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+  doctor_mode=""
   export GITHUB_WORKSPACE="$(pwd -P)"
   export GITHUB_ACTION_PATH="$repo_root"
   export INPUT_OFFLINE=true
@@ -34,6 +35,8 @@ if (($#)); then
       --environment) (($# >= 2)) || fail "--environment requires a value"; export INPUT_ENVIRONMENT="$2"; shift 2 ;;
       --output-dir) (($# >= 2)) || fail "--output-dir requires a value"; export INPUT_OUTPUT_DIR="$2"; shift 2 ;;
       --allow-unverified-image) export INPUT_ALLOW_UNVERIFIED_IMAGE=true; shift ;;
+      --doctor) doctor_mode=text; shift ;;
+      --doctor-json) doctor_mode=json; shift ;;
       -h|--help)
         cat <<'EOF'
 Usage: ./scripts/run-oci-action.sh --profile FILE --adapter NAME --image REF [options]
@@ -56,12 +59,126 @@ Options:
   --output-dir DIR                  Workspace-relative output directory (default: aeb-results).
   --allow-unverified-image          Permit a reviewed mirror or custom digest-pinned image
                                     without publisher-verification inputs.
+  --doctor                          Check offline-run prerequisites without starting a run.
+  --doctor-json                     Emit the prerequisite report as JSON.
 EOF
         exit 0
         ;;
       *) fail "unknown local option: $1" ;;
     esac
   done
+fi
+
+run_doctor() {
+  local failed=0 code status remediation index value material_valid=true
+  local metadata_check="" attestation_check="" trusted_root_check=""
+  local -a codes=() statuses=() remediations=()
+
+  add_check() {
+    codes+=("$1")
+    statuses+=("$2")
+    remediations+=("$3")
+    [[ "$2" == ok ]] || failed=$((failed + 1))
+  }
+
+  if [[ "$(uname -s 2>/dev/null || true)" == Linux ]]; then
+    add_check platform_linux ok ""
+  else
+    add_check platform_linux unsupported "run the offline OCI path on Linux"
+  fi
+  for code in python3 realpath docker; do
+    if command -v "$code" >/dev/null 2>&1; then
+      add_check "command_$code" ok ""
+    else
+      add_check "command_$code" missing "install $code and retry"
+    fi
+  done
+  if [[ -z "${INPUT_PROFILE:-}" ]]; then
+    add_check profile missing "pass --profile with a workspace-relative file"
+  elif profile_check="$(realpath "$GITHUB_WORKSPACE/$INPUT_PROFILE" 2>/dev/null)" &&
+    [[ "$profile_check" == "$(realpath "$GITHUB_WORKSPACE")/"* && -f "$profile_check" && ! -L "$GITHUB_WORKSPACE/$INPUT_PROFILE" ]]; then
+    add_check profile ok ""
+  else
+    add_check profile invalid "use a regular, non-symlink file inside the workspace"
+  fi
+  if [[ -z "${INPUT_ADAPTER:-}" ]]; then
+    add_check adapter missing "pass --adapter with the target adapter name"
+  else
+    add_check adapter ok ""
+  fi
+  if [[ ! "${INPUT_IMAGE:-}" =~ @sha256:[0-9a-f]{64}$ ]]; then
+    add_check image_digest invalid "pass --image with an immutable sha256 digest"
+  elif command -v docker >/dev/null 2>&1 && docker image inspect "$INPUT_IMAGE" >/dev/null 2>&1; then
+    add_check image_loaded ok ""
+  else
+    add_check image_loaded missing "load the exact digest-pinned image and retry"
+  fi
+  if [[ "${INPUT_ALLOW_UNVERIFIED_IMAGE:-false}" == true ]]; then
+    add_check publisher_material ok ""
+  else
+    if [[ "${INPUT_IMAGE:-}" == ghcr.io/luckypipewrench/agent-egress-bench-runner@sha256:* ]]; then
+      add_check image_repository ok ""
+    else
+      add_check image_repository invalid "use the approved release repository or pass --allow-unverified-image for a reviewed mirror"
+    fi
+    if command -v gh >/dev/null 2>&1; then
+      add_check command_gh ok ""
+    else
+      add_check command_gh missing "install GitHub CLI and retry"
+    fi
+    for code in image-metadata image-attestation attestation-trusted-root; do
+      case "$code" in
+        image-metadata) value="${INPUT_IMAGE_METADATA:-}" ;;
+        image-attestation) value="${INPUT_IMAGE_ATTESTATION:-}" ;;
+        attestation-trusted-root) value="${INPUT_ATTESTATION_TRUSTED_ROOT:-}" ;;
+      esac
+      if [[ -n "$value" ]] && material_check="$(realpath "$GITHUB_WORKSPACE/$value" 2>/dev/null)" &&
+        [[ "$material_check" == "$(realpath "$GITHUB_WORKSPACE")/"* && -f "$material_check" && ! -L "$GITHUB_WORKSPACE/$value" ]]; then
+        add_check "${code//-/_}" ok ""
+        case "$code" in
+          image-metadata) metadata_check="$material_check" ;;
+          image-attestation) attestation_check="$material_check" ;;
+          attestation-trusted-root) trusted_root_check="$material_check" ;;
+        esac
+      else
+        add_check "${code//-/_}" missing "stage a regular, non-symlink $code file inside the workspace"
+        material_valid=false
+      fi
+    done
+    if command -v gh >/dev/null 2>&1 && [[ "$material_valid" == true ]] &&
+      [[ "${INPUT_IMAGE:-}" == ghcr.io/luckypipewrench/agent-egress-bench-runner@sha256:* ]] &&
+      gh attestation verify "$metadata_check" \
+        --repo luckyPipewrench/agent-egress-bench \
+        --signer-workflow github.com/luckyPipewrench/agent-egress-bench/.github/workflows/release.yaml \
+        --bundle "$attestation_check" \
+        --custom-trusted-root "$trusted_root_check" >/dev/null 2>&1 &&
+      [[ "$(<"$metadata_check")" == "${INPUT_IMAGE:-}" ]]; then
+      add_check publisher_identity ok ""
+    else
+      add_check publisher_identity invalid "stage publisher evidence that verifies and names the requested image"
+    fi
+  fi
+
+  if [[ "$doctor_mode" == json ]]; then
+    printf '{"schema_version":1,"ready":%s,"checks":[' "$([[ "$failed" == 0 ]] && printf true || printf false)"
+    for ((index = 0; index < ${#codes[@]}; index++)); do
+      ((index == 0)) || printf ','
+      printf '{"code":"%s","status":"%s","remediation":"%s"}' "${codes[$index]}" "${statuses[$index]}" "${remediations[$index]}"
+    done
+    printf ']}\n'
+  else
+    for ((index = 0; index < ${#codes[@]}; index++)); do
+      printf '%-28s %s' "${codes[$index]}" "${statuses[$index]}"
+      [[ -z "${remediations[$index]}" ]] || printf ' - %s' "${remediations[$index]}"
+      printf '\n'
+    done
+  fi
+  ((failed == 0))
+}
+
+if [[ -n "${doctor_mode:-}" ]]; then
+  run_doctor
+  exit $?
 fi
 
 [[ -n "${GITHUB_WORKSPACE:-}" ]] || fail "GITHUB_WORKSPACE is required"

--- a/scripts/run-oci-action.sh
+++ b/scripts/run-oci-action.sh
@@ -72,6 +72,7 @@ fi
 run_doctor() {
   local failed=0 code status remediation index value material_valid=true
   local metadata_check="" attestation_check="" trusted_root_check=""
+  local workspace_check
   local -a codes=() statuses=() remediations=()
 
   add_check() {
@@ -79,6 +80,11 @@ run_doctor() {
     statuses+=("$2")
     remediations+=("$3")
     [[ "$2" == ok ]] || failed=$((failed + 1))
+  }
+
+  workspace_check="$(realpath "$GITHUB_WORKSPACE" 2>/dev/null || true)"
+  inside_workspace() {
+    [[ "$workspace_check" == / && "$1" == /* ]] || [[ "$1" == "$workspace_check/"* ]]
   }
 
   if [[ "$(uname -s 2>/dev/null || true)" == Linux ]]; then
@@ -96,7 +102,7 @@ run_doctor() {
   if [[ -z "${INPUT_PROFILE:-}" ]]; then
     add_check profile missing "pass --profile with a workspace-relative file"
   elif profile_check="$(realpath "$GITHUB_WORKSPACE/$INPUT_PROFILE" 2>/dev/null)" &&
-    [[ "$profile_check" == "$(realpath "$GITHUB_WORKSPACE")/"* && -f "$profile_check" && ! -L "$GITHUB_WORKSPACE/$INPUT_PROFILE" ]]; then
+    inside_workspace "$profile_check" && [[ -f "$profile_check" && ! -L "$GITHUB_WORKSPACE/$INPUT_PROFILE" ]]; then
     add_check profile ok ""
   else
     add_check profile invalid "use a regular, non-symlink file inside the workspace"
@@ -133,7 +139,7 @@ run_doctor() {
         attestation-trusted-root) value="${INPUT_ATTESTATION_TRUSTED_ROOT:-}" ;;
       esac
       if [[ -n "$value" ]] && material_check="$(realpath "$GITHUB_WORKSPACE/$value" 2>/dev/null)" &&
-        [[ "$material_check" == "$(realpath "$GITHUB_WORKSPACE")/"* && -f "$material_check" && ! -L "$GITHUB_WORKSPACE/$value" ]]; then
+        inside_workspace "$material_check" && [[ -f "$material_check" && ! -L "$GITHUB_WORKSPACE/$value" ]]; then
         add_check "${code//-/_}" ok ""
         case "$code" in
           image-metadata) metadata_check="$material_check" ;;

--- a/scripts/runner_image_test.py
+++ b/scripts/runner_image_test.py
@@ -49,6 +49,35 @@ class RunnerImageContractTest(unittest.TestCase):
             self.assertTrue(report["ready"])
             self.assertFalse((workspace / "aeb-results").exists())
 
+    def test_local_offline_doctor_accepts_a_root_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            profile = fixture / "profile.json"
+            profile.write_text("{}\n", encoding="utf-8")
+            bin_dir = fixture / "bin"
+            bin_dir.mkdir()
+            docker = bin_dir / "docker"
+            docker.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            docker.chmod(0o755)
+            image = f"registry.invalid/reviewed/runner@sha256:{'a' * 64}"
+            result = subprocess.run(
+                [
+                    str(ROOT / "scripts" / "run-oci-action.sh"),
+                    "--profile", str(profile).removeprefix("/"),
+                    "--adapter", "proxy",
+                    "--image", image,
+                    "--allow-unverified-image",
+                    "--doctor-json",
+                ],
+                cwd="/",
+                env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertTrue(json.loads(result.stdout)["ready"])
+
     def test_local_offline_doctor_collects_missing_inputs(self) -> None:
         result = subprocess.run(
             [str(ROOT / "scripts" / "run-oci-action.sh"), "--doctor-json"],
@@ -74,10 +103,25 @@ class RunnerImageContractTest(unittest.TestCase):
                 (workspace / name).write_text("placeholder\n", encoding="utf-8")
             bin_dir = workspace / "bin"
             bin_dir.mkdir()
-            for name in ("docker", "gh"):
-                command = bin_dir / name
-                command.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-                command.chmod(0o755)
+            docker = bin_dir / "docker"
+            docker.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            docker.chmod(0o755)
+            gh = bin_dir / "gh"
+            gh.write_text(
+                "#!/usr/bin/env python3\n"
+                "import pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "if args[:2] != ['attestation', 'verify']: raise SystemExit(91)\n"
+                "if pathlib.Path(args[2]).name != 'image.ref': raise SystemExit(92)\n"
+                "pairs = {'--repo': 'luckyPipewrench/agent-egress-bench', '--signer-workflow': 'github.com/luckyPipewrench/agent-egress-bench/.github/workflows/release.yaml'}\n"
+                "for flag, value in pairs.items():\n"
+                "  if flag not in args or args[args.index(flag) + 1] != value: raise SystemExit(93)\n"
+                "for flag, name in [('--bundle', 'attestation.jsonl'), ('--custom-trusted-root', 'trusted-root.jsonl')]:\n"
+                "  if flag not in args or pathlib.Path(args[args.index(flag) + 1]).name != name: raise SystemExit(94)\n"
+                "raise SystemExit(0)\n",
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
             result = subprocess.run(
                 [
                     str(ROOT / "scripts" / "run-oci-action.sh"),
@@ -111,10 +155,25 @@ class RunnerImageContractTest(unittest.TestCase):
                 (workspace / name).write_text("placeholder\n", encoding="utf-8")
             bin_dir = workspace / "bin"
             bin_dir.mkdir()
-            for name in ("docker", "gh"):
-                command = bin_dir / name
-                command.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-                command.chmod(0o755)
+            docker = bin_dir / "docker"
+            docker.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            docker.chmod(0o755)
+            gh = bin_dir / "gh"
+            gh.write_text(
+                "#!/usr/bin/env python3\n"
+                "import pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "if args[:2] != ['attestation', 'verify']: raise SystemExit(91)\n"
+                "if pathlib.Path(args[2]).name != 'image.ref': raise SystemExit(92)\n"
+                "pairs = {'--repo': 'luckyPipewrench/agent-egress-bench', '--signer-workflow': 'github.com/luckyPipewrench/agent-egress-bench/.github/workflows/release.yaml'}\n"
+                "for flag, value in pairs.items():\n"
+                "  if flag not in args or args[args.index(flag) + 1] != value: raise SystemExit(93)\n"
+                "for flag, name in [('--bundle', 'attestation.jsonl'), ('--custom-trusted-root', 'trusted-root.jsonl')]:\n"
+                "  if flag not in args or pathlib.Path(args[args.index(flag) + 1]).name != name: raise SystemExit(94)\n"
+                "raise SystemExit(0)\n",
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
             result = subprocess.run(
                 [
                     str(ROOT / "scripts" / "run-oci-action.sh"),

--- a/scripts/runner_image_test.py
+++ b/scripts/runner_image_test.py
@@ -15,6 +15,128 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class RunnerImageContractTest(unittest.TestCase):
+    def test_local_offline_doctor_reports_ready_without_starting_a_run(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "profile.json").write_text("{}\n", encoding="utf-8")
+            bin_dir = workspace / "bin"
+            bin_dir.mkdir()
+            docker = bin_dir / "docker"
+            docker.write_text(
+                "#!/bin/sh\n"
+                "[ \"$1 $2\" = \"image inspect\" ] || exit 97\n",
+                encoding="utf-8",
+            )
+            docker.chmod(0o755)
+            image = f"registry.invalid/reviewed/runner@sha256:{'a' * 64}"
+            result = subprocess.run(
+                [
+                    str(ROOT / "scripts" / "run-oci-action.sh"),
+                    "--profile", "profile.json",
+                    "--adapter", "proxy",
+                    "--image", image,
+                    "--allow-unverified-image",
+                    "--doctor-json",
+                ],
+                cwd=workspace,
+                env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertTrue(report["ready"])
+            self.assertFalse((workspace / "aeb-results").exists())
+
+    def test_local_offline_doctor_collects_missing_inputs(self) -> None:
+        result = subprocess.run(
+            [str(ROOT / "scripts" / "run-oci-action.sh"), "--doctor-json"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(0, result.returncode)
+        report = json.loads(result.stdout)
+        statuses = {check["code"]: check["status"] for check in report["checks"]}
+        self.assertEqual("missing", statuses["profile"])
+        self.assertEqual("missing", statuses["adapter"])
+        self.assertEqual("invalid", statuses["image_digest"])
+
+    def test_local_offline_doctor_rejects_verified_mode_for_a_mirror(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "profile.json").write_text("{}\n", encoding="utf-8")
+            image = f"registry.invalid/reviewed/runner@sha256:{'a' * 64}"
+            (workspace / "image.ref").write_text(f"{image}\n", encoding="utf-8")
+            for name in ("attestation.jsonl", "trusted-root.jsonl"):
+                (workspace / name).write_text("placeholder\n", encoding="utf-8")
+            bin_dir = workspace / "bin"
+            bin_dir.mkdir()
+            for name in ("docker", "gh"):
+                command = bin_dir / name
+                command.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                command.chmod(0o755)
+            result = subprocess.run(
+                [
+                    str(ROOT / "scripts" / "run-oci-action.sh"),
+                    "--profile", "profile.json",
+                    "--adapter", "proxy",
+                    "--image", image,
+                    "--image-metadata", "image.ref",
+                    "--image-attestation", "attestation.jsonl",
+                    "--attestation-trusted-root", "trusted-root.jsonl",
+                    "--doctor-json",
+                ],
+                cwd=workspace,
+                env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(0, result.returncode)
+            report = json.loads(result.stdout)
+            statuses = {check["code"]: check["status"] for check in report["checks"]}
+            self.assertEqual("invalid", statuses["image_repository"])
+            self.assertEqual("invalid", statuses["publisher_identity"])
+
+    def test_local_offline_doctor_checks_publisher_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            image = f"ghcr.io/luckypipewrench/agent-egress-bench-runner@sha256:{'a' * 64}"
+            (workspace / "profile.json").write_text("{}\n", encoding="utf-8")
+            (workspace / "image.ref").write_text(f"{image}\n", encoding="utf-8")
+            for name in ("attestation.jsonl", "trusted-root.jsonl"):
+                (workspace / name).write_text("placeholder\n", encoding="utf-8")
+            bin_dir = workspace / "bin"
+            bin_dir.mkdir()
+            for name in ("docker", "gh"):
+                command = bin_dir / name
+                command.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                command.chmod(0o755)
+            result = subprocess.run(
+                [
+                    str(ROOT / "scripts" / "run-oci-action.sh"),
+                    "--profile", "profile.json",
+                    "--adapter", "proxy",
+                    "--image", image,
+                    "--image-metadata", "image.ref",
+                    "--image-attestation", "attestation.jsonl",
+                    "--attestation-trusted-root", "trusted-root.jsonl",
+                    "--doctor-json",
+                ],
+                cwd=workspace,
+                env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+            statuses = {check["code"]: check["status"] for check in json.loads(result.stdout)["checks"]}
+            self.assertEqual("ok", statuses["image_repository"])
+            self.assertEqual("ok", statuses["publisher_identity"])
+
     def test_local_offline_cli_is_read_only_until_required_inputs_exist(self) -> None:
         script = ROOT / "scripts" / "run-oci-action.sh"
         help_result = subprocess.run(


### PR DESCRIPTION
## What changed

- Include the local offline runner and its artifact helper in the verified data bundle with committed executable modes.
- Add text and JSON doctor modes that check the extracted bundle, loaded digest-pinned image, and publisher evidence without starting a container or creating result artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added offline readiness checks for OCI execution, available in human-readable and JSON formats.
  - Validates platform, required tools, profile and adapter settings, image availability, provenance, and verification materials.
  - Reports all detected issues and exits without starting a run or creating results.
  - Release bundles now preserve executable permissions for included scripts.

- **Bug Fixes**
  - Improved archive extraction so executable commands remain runnable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->