### PR TITLE
fix(publication): bind synthetic checks to raw results

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -184,6 +184,9 @@ jobs:
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/command.txt
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/make-stats.txt
             ${{ env.GAUNTLET_ARTIFACT_DIR }}/case-index.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/tool-profile.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/capability-registry.json
+            ${{ env.GAUNTLET_ARTIFACT_DIR }}/receipt-profile.json
           retention-days: 14
 
       # Enforce only after upload. A regression must leave the candidate and

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -213,6 +213,9 @@ jobs:
             --evidence "release_checksums=$artifact_dir/checksums.txt" \
             --evidence "pipelock_version_output=$artifact_dir/pipelock-version.txt" \
             --evidence "corpus_manifest=$artifact_dir/corpus-manifest.txt" \
+            --evidence "tool_profile=$artifact_dir/tool-profile.json" \
+            --evidence "capability_registry=$artifact_dir/capability-registry.json" \
+            --evidence "receipt_profile=$artifact_dir/receipt-profile.json" \
             --evidence "execution_decision=$artifact_dir/execution-decision.json" \
             --evidence "run_bundle=$artifact_dir/run-bundle.json" || decision_exit=$?
           exit "$decision_exit"

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -27,6 +27,10 @@ try:
     from scripts import artifact_contracts
 except ModuleNotFoundError:
     import artifact_contracts
+try:
+    from scripts.result_evidence import claims_synthetic
+except ModuleNotFoundError:
+    from result_evidence import claims_synthetic
 
 
 # Scoring versions belonging to retained, frozen published records. Those
@@ -361,22 +365,6 @@ def publication_provenance(summary, metadata, command):
             raise ValueError(f"summary {field} does not match recorded runner command {option}")
 
     return fields
-
-
-def claims_synthetic(row):
-    """Report whether a result row claims synthetic calibration evidence.
-
-    An explicit boolean false is an honest negative and is honored. Every other
-    present value counts as a claim, including a non-boolean such as
-    "synthetic": "calibration". Requiring the boolean true would let a malformed
-    marker be the reason a run reads as measured and publishes, which inverts the
-    gate. Mirrors hasSyntheticEvidence in runner/summary.go; the two must agree
-    because each cross-checks the other's measurement_status.
-    """
-    evidence = row.get("evidence")
-    if not isinstance(evidence, dict) or "synthetic" not in evidence:
-        return False
-    return evidence["synthetic"] is not False
 
 
 def require_sha256(document, key, allow_null=False):

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -337,6 +337,8 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("promotion-decision.json", upload_block)
         self.assertIn("execution-decision.json", upload_block)
         self.assertIn("run-bundle.json", upload_block)
+        for filename in BUILDER.V4_RAW_EVIDENCE.values():
+            self.assertIn(filename, upload_block)
         self.assertIn("enforcement-result.json", review_upload_block)
         self.assertIn("owner-summary.md", review_upload_block)
         self.assertIn("evaluate_gauntlet_candidate.py enforce", enforce_block)

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -31,7 +31,11 @@ def load_builder():
     return module
 
 
-EVIDENCE_LABELS = tuple(load_builder().RAW_EVIDENCE) + ("execution_decision", "run_bundle")
+BUILDER = load_builder()
+EVIDENCE_LABELS = tuple(BUILDER.RAW_EVIDENCE | BUILDER.V4_RAW_EVIDENCE) + (
+    "execution_decision",
+    "run_bundle",
+)
 
 
 def step_block(workflow, name):

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -22,6 +22,10 @@ try:
     from scripts import artifact_contracts
 except ModuleNotFoundError:
     import artifact_contracts
+try:
+    from scripts.result_evidence import claims_synthetic
+except ModuleNotFoundError:
+    from result_evidence import claims_synthetic
 
 
 LEGACY_REQUIRED_FLOORS = {
@@ -308,6 +312,41 @@ def recompute_v5_measurements(case_index_path, results_path):
     }
 
 
+def count_synthetic_results(results_path):
+    """Count raw rows that claim synthetic calibration evidence."""
+    synthetic = 0
+    with results_path.open(encoding="utf-8") as handle:
+        for row_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise ValueError(f"results row {row_number} must be an object")
+            synthetic += claims_synthetic(row)
+    return synthetic
+
+
+def verify_observed_results(evidence_paths):
+    results_path = evidence_paths.get("results")
+    if results_path is None:
+        raise ValueError("active candidate evaluation requires results evidence")
+    synthetic = count_synthetic_results(results_path)
+    if synthetic:
+        raise ValueError(f"raw results contain {synthetic} synthetic result(s)")
+
+
+def verify_bound_results(candidate, evidence_paths, evidence_sha256):
+    advertised = candidate.get("evidence_sha256")
+    if not isinstance(advertised, dict):
+        raise ValueError("active candidate evidence_sha256 must be an object")
+    if not isinstance(advertised.get("results"), str):
+        raise ValueError("active candidate evidence_sha256.results is required")
+    if "results" not in evidence_paths or not isinstance(evidence_sha256.get("results"), str):
+        raise ValueError("active candidate evaluation requires hashable results evidence")
+    if advertised["results"] != evidence_sha256["results"]:
+        raise ValueError("candidate evidence_sha256.results does not match results evidence")
+
+
 def verify_v5_measurements(candidate, evidence_paths):
     missing = sorted({"case_index", "results"} - set(evidence_paths))
     if missing:
@@ -384,6 +423,8 @@ def evaluate(candidate_path, baseline_path, evidence_paths=None):
             raise ValueError("candidate schema_version must be 2, 4, 5, or 6")
         if candidate_schema_version in {4, 5, 6}:
             require_capability_registry(candidate)
+            verify_bound_results(candidate, evidence_paths, decision["evidence_sha256"])
+            verify_observed_results(evidence_paths)
         if candidate_schema_version in {5, 6}:
             require_sha256(
                 candidate.get("benchmark_manifest_sha256"),

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -44,6 +44,7 @@ def v5_raw_evidence():
 
 
 CASE_INDEX_BYTES, V5_RESULTS_BYTES = v5_raw_evidence()
+LEGACY_RESULTS_BYTES = b'{"id":"case-1"}\n'
 RUN_BUNDLE_BYTES = b'{"schema_version":1,"bundle_status":"complete"}\n'
 
 
@@ -104,6 +105,9 @@ def active_candidate():
         "format": 1,
         "revision": 1,
         "sha256": "d" * 64,
+    }
+    value["evidence_sha256"] = {
+        "results": hashlib.sha256(LEGACY_RESULTS_BYTES).hexdigest(),
     }
     return value
 
@@ -177,6 +181,7 @@ def v5_candidate():
             "exercised": {"transports": ["stdio"], "categories": ["prompt-injection"], "capability_tags": []},
         }
     )
+    value["evidence_sha256"]["results"] = hashlib.sha256(V5_RESULTS_BYTES).hexdigest()
     return value
 
 
@@ -241,6 +246,7 @@ class CandidateEvaluationTest(unittest.TestCase):
         missing_candidate=False,
         include_case_index_evidence=True,
         include_run_bundle_evidence=True,
+        results_bytes=None,
     ):
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
@@ -248,18 +254,26 @@ class CandidateEvaluationTest(unittest.TestCase):
         candidate_path = root / "candidate.json"
         baseline_path = root / "baseline.json"
         decision_path = root / "decision.json"
+        candidate_document = candidate_value or candidate()
+        if results_bytes is not None and candidate_document.get("schema_version") in {4, 5, 6}:
+            candidate_document = json.loads(json.dumps(candidate_document))
+            candidate_document.setdefault("evidence_sha256", {})["results"] = hashlib.sha256(
+                results_bytes
+            ).hexdigest()
         if missing_candidate:
             pass
         elif raw_candidate is None:
-            candidate_path.write_text(json.dumps(candidate_value or candidate()), encoding="utf-8")
+            candidate_path.write_text(json.dumps(candidate_document), encoding="utf-8")
         else:
             candidate_path.write_text(raw_candidate, encoding="utf-8")
         baseline_path.write_text(json.dumps(baseline_value or baseline()), encoding="utf-8")
         evidence_path = root / "results.jsonl"
-        if (candidate_value or {}).get("schema_version") in {5, 6}:
+        if results_bytes is not None:
+            evidence_path.write_bytes(results_bytes)
+        elif (candidate_value or {}).get("schema_version") in {5, 6}:
             evidence_path.write_bytes(V5_RESULTS_BYTES)
         else:
-            evidence_path.write_text('{"id":"case-1"}\n', encoding="utf-8")
+            evidence_path.write_bytes(LEGACY_RESULTS_BYTES)
         case_index_path = root / "case-index.json"
         case_index_path.write_bytes(CASE_INDEX_BYTES)
         run_bundle_path = root / "run-bundle.json"
@@ -505,6 +519,53 @@ class CandidateEvaluationTest(unittest.TestCase):
                 decision, _, _, _, _ = self.run_evaluate(value)
                 self.assertTrue(decision["blocked"])
                 self.assertTrue(any("measurement_status" in item for item in decision["failures"]))
+
+    def test_active_candidate_rejects_synthetic_raw_results(self):
+        for name, marker in (("true", True), ("null", None), ("string", "calibration")):
+            with self.subTest(name=name):
+                raw_results = (
+                    json.dumps(
+                        {
+                            "case_id": "case-1",
+                            "evidence": {"synthetic": marker},
+                        }
+                    )
+                    + "\n"
+                ).encode()
+                decision, _, _, _, _ = self.run_evaluate(
+                    active_candidate(),
+                    results_bytes=raw_results,
+                )
+                self.assertTrue(decision["blocked"])
+                self.assertIn("raw results contain 1 synthetic result(s)", decision["failures"])
+
+    def test_active_candidate_rejects_substituted_results_evidence(self):
+        value = active_candidate()
+        value["evidence_sha256"]["results"] = "0" * 64
+        decision, _, _, _, _ = self.run_evaluate(value)
+        self.assertTrue(decision["blocked"])
+        self.assertIn(
+            "candidate evidence_sha256.results does not match results evidence",
+            decision["failures"],
+        )
+
+    def test_active_candidate_honors_an_explicit_non_synthetic_marker(self):
+        raw_results = (
+            json.dumps({"case_id": "case-1", "evidence": {"synthetic": False}}) + "\n"
+        ).encode()
+        decision, _, _, _, _ = self.run_evaluate(
+            active_candidate(),
+            results_bytes=raw_results,
+        )
+        self.assertFalse(decision["blocked"], decision["failures"])
+
+    def test_active_candidate_rejects_a_non_object_raw_row(self):
+        decision, _, _, _, _ = self.run_evaluate(
+            active_candidate(),
+            results_bytes=b'[]\n',
+        )
+        self.assertTrue(decision["blocked"])
+        self.assertIn("results row 1 must be an object", decision["failures"])
 
     def test_active_error_and_unreachable_each_block_publication(self):
         for name, mutate in (

--- a/scripts/result_evidence.py
+++ b/scripts/result_evidence.py
@@ -1,0 +1,15 @@
+"""Shared result-evidence predicates for publication gates."""
+
+
+def claims_synthetic(row):
+    """Report whether a result row claims synthetic calibration evidence.
+
+    An explicit boolean false is an honest negative and is honored. Every other
+    present value counts as a claim, including a non-boolean such as
+    ``"synthetic": "calibration"``. Requiring the boolean true would let a
+    malformed marker make a run read as measured, which inverts the gate.
+    """
+    evidence = row.get("evidence")
+    if not isinstance(evidence, dict) or "synthetic" not in evidence:
+        return False
+    return evidence["synthetic"] is not False


### PR DESCRIPTION
## What changed

- Bind each active publication candidate to the exact raw results file, then check those rows directly for synthetic evidence before publication.
- Give evaluation and enforcement the same evidence files so the enforcement pass can reproduce the recorded decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Candidate evaluations now verify that submitted results are authentic and match their declared evidence.
  * Synthetic or substituted results are rejected during active evaluations.
  * Additional evidence files are included in enforcement checks.

* **Bug Fixes**
  * Improved handling of legacy and versioned evaluation evidence.
  * Added validation for missing, malformed, and explicitly non-synthetic result records.

* **Tests**
  * Expanded coverage for synthetic results, evidence mismatches, and varied result formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->