### PR TITLE
feat(operator): add reproducible run packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: preflight check-citation check-case-immutability check-frozen-schema-immutability check-schema-catalog check-schema-copies check-docs check-contracts check-public-contracts check-claim-language check-readme-categories check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow test-release-snapshot release-snapshot validate-cases validate
+.PHONY: preflight check-citation check-case-immutability check-frozen-schema-immutability check-schema-catalog check-schema-copies check-docs check-operator-kit check-contracts check-public-contracts check-claim-language check-readme-categories check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow test-release-snapshot release-snapshot validate-cases validate
 
 TMPDIR := $(HOME)/.cache/pipelock-tmp
 GOCACHE := $(HOME)/.cache/go-build
@@ -13,7 +13,7 @@ AEB_IMMUTABILITY_BASE ?= origin/main
 # below complete comfortably inside the edit-to-push budget and it catches real
 # shared-state defects that ordinary go test would miss. It requires the Go
 # toolchain needed by runner/go.mod (currently Go 1.25 or newer).
-preflight: check-contracts check-schema-catalog check-public-contracts check-case-immutability check-frozen-schema-immutability check-schema-copies check-docs check-citation test-capability-registry check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow check-stats check-gauntlet-site check-claim-language check-readme-categories
+preflight: check-contracts check-schema-catalog check-public-contracts check-case-immutability check-frozen-schema-immutability check-schema-copies check-docs check-operator-kit check-citation test-capability-registry check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow check-stats check-gauntlet-site check-claim-language check-readme-categories
 
 check-scorecard-workflow:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/scorecard_workflow_test.py
@@ -82,6 +82,9 @@ check-citation:
 check-docs:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_docs_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_docs.py
+
+check-operator-kit:
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/operator_kit_test.py
 
 # Independent verifier modules embed governed schema copies. Missing, empty,
 # extra, symlinked, or byte-different copies fail before verifier tests.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Evidence and publication:
 - [CAPABILITY-VOCABULARY.md](docs/CAPABILITY-VOCABULARY.md): immutable reporting-label registry and profile evolution policy
 - [ARTIFACT-PROVENANCE.md](docs/ARTIFACT-PROVENANCE.md): opt-in external `schema-valid`, `authenticated-at(T)`, and `buyer-reproduced` provenance assessments
 - [RESULTS-USE.md](docs/RESULTS-USE.md): assurance labels, public-result disclosures, and correction rules
+- [Operator kit](examples/operator-kit/): run setup, evidence custody, report template, retention, and appeal routes
 
 Integration and reference:
 

--- a/docs/ADOPTION.md
+++ b/docs/ADOPTION.md
@@ -44,7 +44,7 @@ The [operator kit](../examples/operator-kit/) provides the custody checklist and
 
 ### Suggested format
 
-```
+```text
 results/
   v0.3.6/
     results.jsonl       # Raw JSONL output

--- a/docs/ADOPTION.md
+++ b/docs/ADOPTION.md
@@ -40,6 +40,7 @@ Run your runner and save the JSONL output. How you share results is up to you. S
 **Do not submit Gauntlet results to this repo.** This repo contains attack cases, scoring methodology, and optional receipt profiles under `profiles/`. There is no in-repo results table and no maintainer-awarded mark. Each vendor publishes and owns its own results.
 
 Label the run and publish every identifying fact required by [RESULTS-USE.md](RESULTS-USE.md).
+The [operator kit](../examples/operator-kit/) provides the custody checklist and report template. Use it before execution so target identity, configuration, clocks, and artifact ownership aren't reconstructed from memory afterward.
 
 ### Suggested format
 
@@ -47,10 +48,16 @@ Label the run and publish every identifying fact required by [RESULTS-USE.md](RE
 results/
   v0.3.6/
     results.jsonl       # Raw JSONL output
-    summary.txt         # Summary line from stderr
+    raw-summary.json    # Structured summary written by the runner
+    summary.json        # OCI-path copy of the same structured summary
+    run-metadata.json   # OCI completion, exit status, image, and verification state
+    doctor.json         # OCI prerequisites, including explicit waivers
+    runner.stderr       # Human summary and diagnostics
+    command.txt         # Exact invocation
     tool-profile.json   # Copy of your tool profile
     capability-registry.json # Exact raw registry snapshot named by the profile
-    README.md           # Verdict mapping, notes, how to reproduce
+    evidence-custody-checklist.md # Run identity, digests, interventions, transfer
+    report.md           # Outcomes, exercised coverage, limits, reproduction
 ```
 
 Tag or date your results directories by tool version so readers can track progress over time.

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -108,13 +108,15 @@ The corpus maintainer also builds a competing tool ([Pipelock](https://github.co
 
 ## Appeals
 
-If you disagree with a case's expected verdict, open a GitHub issue. Include:
+If you disagree with a case's expected verdict, open a GitHub Issue. Include:
 
 - The case ID
 - Your reasoning (why the verdict should be different)
 - Evidence if available (real-world traffic patterns, false positive data, attack feasibility analysis)
 
 Verdict changes require community discussion. They are not made unilaterally.
+
+Use a GitHub Discussion instead when the disagreement is about scoring, adapter or method application, or a published result that appears to misstate the method. [`RESULTS-USE.md`](RESULTS-USE.md) defines that result-correction path.
 
 ## Spec changes
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -7,9 +7,9 @@ Each release contains:
 - One corpus data bundle. It carries the cases, the schemas, the contracts, the
   core capability registry, and the operator kit under `examples/`: the tool
   profile template the runner requires, the MCP gateway plugin template, the
-  runner skeleton, and the reference harness. Bundle members extract with mode
-  `0644` so the bytes stay reproducible, so run a bundled shell script as
-  `bash <script>` rather than executing it directly.
+  runner skeleton, the evidence-custody checklist, the report template, and the
+  reference harness. Bundle members preserve their tracked executable bit;
+  other files extract with mode `0644`.
 - One commit-pinned schema catalog and schema bundle. The bundle contains the
   catalog and every schema it names, so a vendor can validate schema bytes
   after download without a network connection.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -7,8 +7,8 @@ Each release contains:
 - One corpus data bundle. It carries the cases, the schemas, the contracts, the
   core capability registry, and the operator kit under `examples/`: the tool
   profile template the runner requires, the MCP gateway plugin template, the
-  runner skeleton, the evidence-custody checklist, the report template, and the
-  reference harness. Bundle members preserve their tracked executable bit;
+  runner skeleton, the operator-kit README, the evidence-custody checklist, the
+  report template, and the reference harness. Bundle members preserve their tracked executable bit;
   other files extract with mode `0644`.
 - One commit-pinned schema catalog and schema bundle. The bundle contains the
   catalog and every schema it names, so a vendor can validate schema bytes

--- a/docs/RESULTS-USE.md
+++ b/docs/RESULTS-USE.md
@@ -89,8 +89,7 @@ It has no veto over execution or publication.
 
 ## Corrections and disputes
 
-Open a GitHub Discussion for a disputed case verdict, a scoring question, or a result that appears
-to misstate the method. Include the case IDs, the exact commit, and the artifacts.
+Open a GitHub Issue for a disputed case verdict or other case-semantics question. Open a GitHub Discussion for a scoring question, adapter or method application, or a result that appears to misstate the method. Include the case IDs when applicable, the exact commit, and the artifacts.
 
 The maintainer answers in the thread. A case that changes semantics becomes a new case, since case
 IDs are immutable. See [GOVERNANCE.md](GOVERNANCE.md) for the case and supersession rules.

--- a/examples/operator-kit/README.md
+++ b/examples/operator-kit/README.md
@@ -1,0 +1,65 @@
+# Operator kit
+
+This directory is the run packet for a lab, vendor, or customer operating Agent Egress Bench. It doesn't replace the runner contract. It keeps the setup record, saved evidence, report, and correction path together so another person can tell what ran and repeat it.
+
+## Start a run packet
+
+Create a directory for the run and copy these files into it:
+
+```bash
+set -e
+packet_dir="aeb-run-$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir "$packet_dir"
+cp examples/operator-kit/evidence-custody-checklist.md "$packet_dir/"
+cp examples/operator-kit/report-template.md "$packet_dir/report.md"
+cp examples/runner-template/tool-profile-template.json "$packet_dir/tool-profile.json"
+cp examples/runner-template/skeleton.sh "$packet_dir/adapter.sh"
+```
+
+The copied adapter and profile are starting points. Replace every placeholder before treating the run as a measurement. The [runner template](../runner-template/README.md) explains the adapter and profile fields. The formal behavior contract lives in [`docs/RUNNER.md`](../../docs/RUNNER.md).
+
+## Before execution
+
+Fill in the first section of `evidence-custody-checklist.md`. Record the exact benchmark commit, target version, target configuration digest, adapter owner, profile digest, command, host clock source, and who controls the run directory. The commands below use `aeb-run`; substitute the timestamped packet directory you just created.
+
+Run the bundled doctor before execution when using the OCI path:
+
+```bash
+./scripts/run-oci-action.sh \
+  --profile aeb-run/tool-profile.json \
+  --adapter dryrun \
+  --image registry.vendor.example/aeb-runner@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --allow-unverified-image \
+  --doctor-json > aeb-run/doctor.json
+```
+
+Replace `dryrun` with the adapter that reaches the target and replace the example image with the reviewed digest-pinned image you loaded. This example explicitly waives official publisher verification; `doctor.json` records that check as `waived`, not `ok`. For an official image, omit `--allow-unverified-image` and supply the release's image metadata, attestation, and trusted root as described in [OCI runner](../../docs/OCI-RUNNER.md). A doctor success means every prerequisite passed or was explicitly waived. It doesn't prove that the later run reached the target or produced a complete measurement.
+
+## After execution
+
+Keep the raw artifacts before editing a report. Record a SHA-256 digest for each retained file, make the raw directory read-only, and perform analysis on a copy. The checklist names the minimum files and explains how to record an intentional omission.
+
+Render the buyer report from the retained artifact directory:
+
+```bash
+./aeb-gauntlet --report aeb-run/artifacts --report-output aeb-run/generated-report.md
+```
+
+Use `report-template.md` for the publication page around that generated output. It keeps measured outcomes separate from exercised-control coverage, which prevents a reporting label from reading like proof that a control operated.
+
+## Publish or transfer
+
+Publish the raw artifacts, their digests, the completed checklist, the report, and the reproduction command together. If access controls prevent publishing a raw file, name the omitted file, its digest, its custodian, and how a reviewer can request it. Don't replace a missing artifact with a summary written after the run.
+
+Follow [`docs/RESULTS-USE.md`](../../docs/RESULTS-USE.md) for assurance labels and non-claims. A saved packet may be artifact-validated without being independently executed. Independent execution requires a separate operator to control the execution host and retain the artifacts.
+
+The completed checklist records what the operator declares happened. It doesn't prove the declaration or create an assurance label by itself. The retained bytes, digests, validator result, and execution arrangement determine which statements the publisher can support.
+
+## Corrections and appeals
+
+Use the public route that matches the disagreement:
+
+- Open an Issue for a case's expected verdict, payload meaning, or other case semantics. Case IDs stay immutable, so a semantic change becomes a new case.
+- Open a Discussion for scoring, method application, adapter behavior, or a published result that appears to misstate the method.
+
+Include the exact benchmark commit, case IDs when applicable, the report URL, and the relevant artifacts or digests. The original result stays available. A correction adds a visible record; it doesn't silently replace the run.

--- a/examples/operator-kit/README.md
+++ b/examples/operator-kit/README.md
@@ -20,17 +20,17 @@ The copied adapter and profile are starting points. Replace every placeholder be
 
 ## Before execution
 
-Fill in the first section of `evidence-custody-checklist.md`. Record the exact benchmark commit, target version, target configuration digest, adapter owner, profile digest, command, host clock source, and who controls the run directory. The commands below use `aeb-run`; substitute the timestamped packet directory you just created.
+Fill in the first section of `evidence-custody-checklist.md`. Record the exact benchmark commit, target version, target configuration digest, adapter owner, profile digest, command, host clock source, and who controls the run directory.
 
 Run the bundled doctor before execution when using the OCI path:
 
 ```bash
 ./scripts/run-oci-action.sh \
-  --profile aeb-run/tool-profile.json \
+  --profile "$packet_dir/tool-profile.json" \
   --adapter dryrun \
   --image registry.vendor.example/aeb-runner@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
   --allow-unverified-image \
-  --doctor-json > aeb-run/doctor.json
+  --doctor-json > "$packet_dir/doctor.json"
 ```
 
 Replace `dryrun` with the adapter that reaches the target and replace the example image with the reviewed digest-pinned image you loaded. This example explicitly waives official publisher verification; `doctor.json` records that check as `waived`, not `ok`. For an official image, omit `--allow-unverified-image` and supply the release's image metadata, attestation, and trusted root as described in [OCI runner](../../docs/OCI-RUNNER.md). A doctor success means every prerequisite passed or was explicitly waived. It doesn't prove that the later run reached the target or produced a complete measurement.

--- a/examples/operator-kit/evidence-custody-checklist.md
+++ b/examples/operator-kit/evidence-custody-checklist.md
@@ -1,0 +1,85 @@
+# Evidence custody checklist
+
+Complete this file while operating the run. Keep it beside the raw artifacts.
+
+## Run identity
+
+- Run ID:
+- Operator or lab:
+- Execution host custodian:
+- Artifact custodian:
+- Start time, timezone, and clock source:
+- End time, timezone, and clock source:
+- Benchmark repository:
+- Benchmark commit:
+- Corpus version and manifest SHA-256:
+- Target product and version:
+- Target artifact or image digest:
+- Runner release, binary digest, or OCI image reference and image ID:
+- Target configuration path and SHA-256:
+- Adapter identity, owner, and SHA-256:
+- Tool profile path and SHA-256:
+- Capability-registry path, revision, and SHA-256:
+- Exact command:
+- Publisher verification status (`verified` or `waived`) and retained doctor report:
+- Transparency start commitment, publication time, third-party log operator, and entry URL (`not claimed` if unused):
+- Challenge holdout selection and retirement rule (`not claimed` if unused):
+
+## Before execution
+
+- [ ] The benchmark source matches the recorded commit.
+- [ ] The target version came from the running target or its exact pinned artifact, not from a hand-entered label alone.
+- [ ] The target configuration, adapter, profile, registry snapshot, and command are saved before execution.
+- [ ] The operator recorded any setup help supplied by the target vendor or benchmark maintainer.
+- [ ] The run directory is new or empty, so stale output can't stand in for this run.
+- [ ] The operator recorded who can write to the execution host and artifact directory during the run.
+
+## During execution
+
+- [ ] The operator recorded the start and end clocks.
+- [ ] Standard output, standard error, the raw summary, result rows, execution decision, and run bundle were captured without manual rewriting.
+- [ ] Any retry, interruption, configuration change, or manual intervention is listed below with its time and reason.
+- [ ] The operator stopped publication if the runner or validator reported an error, unreachable row, incomplete measurement, digest mismatch, or failed contract check.
+
+Interventions and deviations:
+
+```text
+None, or list each event here.
+```
+
+## Retained files
+
+Record each file's relative path and SHA-256. Every run packet keeps the result rows, runner summary, exact command, tool profile, capability-registry snapshot, target configuration evidence, generated report, and all run-status metadata produced by the selected path. The OCI path keeps `results.jsonl`, `summary.json`, `raw-summary.json`, `run-metadata.json`, and `doctor.json`; `run-metadata.json` records `measurement_status`, exit codes, publisher verification, and the runner image. The Pipelock path also keeps `runner.stderr` and `command.txt`. Keep `case-index.json`, `receipt-profile.json`, `execution-decision.json`, and `run-bundle.json` when the selected run path produces them.
+
+```text
+SHA256  RELATIVE_PATH
+```
+
+- [ ] Digests were computed from the retained bytes before report editing.
+- [ ] The raw directory is read-only or stored in a location where later changes are visible.
+- [ ] Analysis and redaction use copies, leaving the retained raw bytes unchanged.
+- [ ] Every omitted or access-controlled file is listed below with its digest, custodian, reason, and request path.
+
+Omitted or access-controlled evidence:
+
+```text
+None, or list each item here.
+```
+
+## Transfer and publication
+
+- [ ] The report links to the raw packet or states how a reviewer can request restricted evidence.
+- [ ] The published digest list matches the retained files.
+- [ ] The reproduction command names the exact benchmark commit, target version, adapter, profile, and configuration.
+- [ ] Outcome scores and exercised-control coverage appear as separate sections.
+- [ ] The report names unreachable, historical not-applicable, and error counts instead of hiding them in one denominator.
+- [ ] The report carries the non-claims required by `docs/RESULTS-USE.md`.
+- [ ] Each declared assurance label names the retained evidence that satisfies every part of its definition in `docs/RESULTS-USE.md`.
+
+Transferred by:
+
+Received by:
+
+Transfer time and method:
+
+Recipient verification result:

--- a/examples/operator-kit/report-template.md
+++ b/examples/operator-kit/report-template.md
@@ -1,0 +1,105 @@
+# Agent Egress Bench result
+
+Replace every bracketed field. Delete instructional comments only after the report contains the underlying fact.
+
+Choose assurance labels from [`docs/RESULTS-USE.md`](../../docs/RESULTS-USE.md) only when the saved evidence and execution arrangement satisfy their definitions. A completed checklist doesn't create a label by itself.
+
+## Run identity
+
+| Field | Value |
+|---|---|
+| Assurance label or labels | `[self-run / artifact-validated / independently executed / transparency-registered / challenge-verified]` |
+| Operator or lab | `[name]` |
+| Target product and version | `[product and version read from the target or pinned artifact]` |
+| Target configuration | `[public path or retained-artifact path plus SHA-256]` |
+| Benchmark repository and commit | `[repository URL and full commit]` |
+| Corpus and scoring version | `[versions]` |
+| Benchmark manifest SHA-256 | `[digest]` |
+| Runner release, binary digest, or OCI image reference and image ID | `[identity and digest]` |
+| Publisher verification | `[verified / waived, with doctor report path]` |
+| Adapter identity, owner, and SHA-256 | `[adapter, author or organization, and digest]` |
+| Tool profile and SHA-256 | `[path or URL plus digest]` |
+| Capability registry | `[ID, format, revision, path or URL, and raw-byte digest]` |
+| Execution window | `[start and end with timezone]` |
+| Artifact packet | `[URL or request path]` |
+
+## Measured outcomes
+
+Report containment and false-positive rate separately. Don't publish a composite score.
+
+| Outcome | Count or rate |
+|---|---:|
+| Malicious cases blocked with scoreable evidence | `[count]` |
+| Malicious cases allowed with scoreable evidence | `[count]` |
+| Benign cases allowed | `[count]` |
+| Benign cases blocked | `[count]` |
+| Full-corpus containment | `[rate and full malicious corpus denominator]` |
+| Applicable-only containment diagnostic | `[rate and applicable malicious denominator]` |
+| False-positive rate | `[rate and denominator]` |
+
+## Result-state accounting
+
+| State | Count | Explanation |
+|---|---:|---|
+| Applicable and measured | `[count]` | `[scope]` |
+| Unreachable | `[count]` | `[adapter coverage gaps]` |
+| Historical not-applicable | `[count]` | `[frozen-record reason]` |
+| Error | `[count]` | `[errors]` |
+
+State whether `measurement_status` is `measured` or `incomplete`. An incomplete run isn't a publishable full-corpus result. Keep it as diagnostic evidence and say why it's incomplete.
+
+## Exercised-control coverage
+
+List only transports, categories, and capability tags observed in scoreable rows. A declaration in the tool profile is a reporting label and isn't evidence that the run exercised that control.
+
+| Surface | Observed coverage |
+|---|---|
+| Transports | `[observed transports]` |
+| Categories | `[observed categories]` |
+| Capability tags | `[observed tags / not recorded]` |
+
+## Method and reproduction
+
+Exact command:
+
+```text
+[command]
+```
+
+Setup notes needed to repeat the run:
+
+```text
+[notes, including any vendor or maintainer guidance]
+```
+
+Validator command and result:
+
+```text
+[command and exit status]
+```
+
+## Evidence and custody
+
+Link the completed `evidence-custody-checklist.md` and the digest inventory. Name any file that isn't public, why access is restricted, who holds it, and how a reviewer can request it.
+
+## Limits and non-claims
+
+This result covers the named target version, configuration, adapter, exercised profile, corpus, and scoring version. It doesn't establish certification, legal or regulatory compliance, insurance eligibility, security outside the exercised profile, or the absence of bypasses. <!-- claim-ok: required non-claims for a result report -->
+
+Record any additional limitation discovered during the run:
+
+```text
+[limitations]
+```
+
+## Corrections and disputes
+
+Case semantics and expected-verdict appeals: `[Issue URL or "none"]`
+
+Scoring, method, adapter, or result dispute: `[Discussion URL or "none"]`
+
+Correction history:
+
+```text
+None, or append dated corrections without replacing the original result.
+```

--- a/scripts/action_artifacts.py
+++ b/scripts/action_artifacts.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 
 
-ARTIFACT_NAMES = ("results.jsonl", "summary.json", "run-metadata.json")
+ARTIFACT_NAMES = ("results.jsonl", "summary.json", "raw-summary.json", "run-metadata.json")
 
 
 class ArtifactError(RuntimeError):
@@ -137,6 +137,7 @@ def publish(workspace: Path, output_dir: str, results: Path, metadata: Path, sum
         copy_regular(results, output_fd, "results.jsonl")
         if summary is not None:
             copy_regular(summary, output_fd, "summary.json")
+            copy_regular(summary, output_fd, "raw-summary.json")
         copy_regular(metadata, output_fd, "run-metadata.json")
     finally:
         os.close(output_fd)

--- a/scripts/action_artifacts_test.py
+++ b/scripts/action_artifacts_test.py
@@ -66,6 +66,7 @@ class ActionArtifactsTest(unittest.TestCase):
         published = self.workspace / "aeb-results" / "run-metadata.json"
         self.assertFalse(published.is_symlink())
         self.assertEqual(metadata.read_text(encoding="utf-8"), published.read_text(encoding="utf-8"))
+        self.assertEqual(summary.read_bytes(), (self.workspace / "aeb-results" / "raw-summary.json").read_bytes())
 
     def test_publish_refuses_a_symlinked_container_artifact(self) -> None:
         self.assertEqual(0, self.prepare().returncode)

--- a/scripts/operator_kit_test.py
+++ b/scripts/operator_kit_test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Keep the released operator kit tied to the publication contract."""
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+KIT = ROOT / "examples" / "operator-kit"
+
+
+class OperatorKitTest(unittest.TestCase):
+    def test_kit_covers_setup_custody_reporting_and_appeals(self):
+        readme = (KIT / "README.md").read_text(encoding="utf-8")
+        custody = (KIT / "evidence-custody-checklist.md").read_text(encoding="utf-8")
+        report = (KIT / "report-template.md").read_text(encoding="utf-8")
+
+        for required in (
+            "examples/runner-template/tool-profile-template.json",
+            "examples/runner-template/skeleton.sh",
+            "evidence-custody-checklist.md",
+            "report-template.md",
+            "Open an Issue",
+            "Open a Discussion",
+            "doesn't prove the declaration or create an assurance label",
+        ):
+            self.assertIn(required, readme)
+
+        for required in (
+            "Target artifact or image digest",
+            "Target configuration path and SHA-256",
+            "Capability-registry path, revision, and SHA-256",
+            "The run directory is new or empty",
+            "incomplete measurement",
+            "Omitted or access-controlled evidence",
+            "Each declared assurance label names the retained evidence",
+            "run-metadata.json",
+        ):
+            self.assertIn(required, custody)
+
+        for required in (
+            "## Measured outcomes",
+            "## Result-state accounting",
+            "## Exercised-control coverage",
+            "containment",
+            "False-positive rate",
+            "Unreachable",
+            "Historical not-applicable",
+            "Error",
+            "## Limits and non-claims",
+            "only when the saved evidence and execution arrangement satisfy their definitions",
+        ):
+            self.assertIn(required, report)
+
+    def test_public_appeal_routes_are_consistent(self):
+        governance = (ROOT / "docs" / "GOVERNANCE.md").read_text(encoding="utf-8")
+        results_use = (ROOT / "docs" / "RESULTS-USE.md").read_text(encoding="utf-8")
+        self.assertIn("disagree with a case's expected verdict, open a GitHub Issue", governance)
+        self.assertIn("Use a GitHub Discussion instead when the disagreement is about scoring", governance)
+        self.assertIn("Open a GitHub Issue for a disputed case verdict", results_use)
+        self.assertIn("Open a GitHub Discussion for a scoring question", results_use)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -45,6 +45,7 @@ DATA_FILES = (
     "docs/GOVERNANCE.md",
     "docs/RUNNER.md",
     "docs/OCI-RUNNER.md",
+    "docs/RESULTS-USE.md",
     "scripts/action_artifacts.py",
     "scripts/release_build.py",
     "scripts/run-oci-action.sh",
@@ -408,7 +409,8 @@ def validate_identity_structure(identity: dict[str, Any]) -> None:
         if not isinstance(name, str) or not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
             fail("release identity data_files has an invalid entry")
         safe_name(name)
-    if set(DATA_FILES) - set(data_files) or corpus_value["manifest_path"] not in data_files or any(not any(name == root or name.startswith(f"{root}/") for name in data_files) for root in DATA_ROOTS):
+    required_operator_kit = {"examples/operator-kit/README.md", "examples/operator-kit/evidence-custody-checklist.md", "examples/operator-kit/report-template.md"}
+    if set(DATA_FILES) - set(data_files) or required_operator_kit - set(data_files) or corpus_value["manifest_path"] not in data_files or any(not any(name == root or name.startswith(f"{root}/") for name in data_files) for root in DATA_ROOTS):
         fail("release identity data_files does not contain the required corpus, schema, contract, operator kit, and verifier data")
 
     verification = exact_object(identity["verification"], "release identity verification", {"checksums", "command"})

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -506,6 +506,7 @@ class ReleaseBuildTest(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         doctor_report = json.loads(result.stdout)
         self.assertTrue(doctor_report["ready"])
+        self.assertFalse(doctor_report["publisher_verified"])
         publisher_check = next(check for check in doctor_report["checks"] if check["code"] == "publisher_material")
         self.assertEqual("waived", publisher_check["status"])
         self.assertFalse((extracted / "aeb-results").exists())

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -440,6 +440,16 @@ class ReleaseBuildTest(unittest.TestCase):
             archive.extractall(extracted, filter="data")
         profile = extracted / "examples/runner-template/tool-profile-template.json"
         self.assertTrue(profile.is_file(), "the data bundle must carry a tool profile the runner accepts")
+        for relative in (
+            "docs/RESULTS-USE.md",
+            "examples/operator-kit/README.md",
+            "examples/operator-kit/evidence-custody-checklist.md",
+            "examples/operator-kit/report-template.md",
+        ):
+            self.assertTrue(
+                (extracted / relative).is_file(),
+                f"the data bundle must carry {relative}",
+            )
         summary = self.root / "bundle-run-summary.json"
         # /tmp is quota-constrained on the development hosts, so every Go
         # command runs against the shared caches rather than filling it.
@@ -494,7 +504,10 @@ class ReleaseBuildTest(unittest.TestCase):
             capture_output=True,
         )
         self.assertEqual(0, result.returncode, result.stderr)
-        self.assertTrue(json.loads(result.stdout)["ready"])
+        doctor_report = json.loads(result.stdout)
+        self.assertTrue(doctor_report["ready"])
+        publisher_check = next(check for check in doctor_report["checks"] if check["code"] == "publisher_material")
+        self.assertEqual("waived", publisher_check["status"])
         self.assertFalse((extracted / "aeb-results").exists())
 
     def test_release_binds_a_schema_bundle_to_the_commit_pinned_catalog(self) -> None:

--- a/scripts/run-oci-action.sh
+++ b/scripts/run-oci-action.sh
@@ -79,7 +79,7 @@ run_doctor() {
     codes+=("$1")
     statuses+=("$2")
     remediations+=("$3")
-    [[ "$2" == ok ]] || failed=$((failed + 1))
+    [[ "$2" == ok || "$2" == waived ]] || failed=$((failed + 1))
   }
 
   workspace_check="$(realpath "$GITHUB_WORKSPACE" 2>/dev/null || true)"
@@ -120,7 +120,7 @@ run_doctor() {
     add_check image_loaded missing "load the exact digest-pinned image and retry"
   fi
   if [[ "${INPUT_ALLOW_UNVERIFIED_IMAGE:-false}" == true ]]; then
-    add_check publisher_material ok ""
+    add_check publisher_material waived "publisher identity was not verified; retain this waiver in the run packet"
   else
     if [[ "${INPUT_IMAGE:-}" == ghcr.io/luckypipewrench/agent-egress-bench-runner@sha256:* ]]; then
       add_check image_repository ok ""

--- a/scripts/run-oci-action.sh
+++ b/scripts/run-oci-action.sh
@@ -70,7 +70,7 @@ EOF
 fi
 
 run_doctor() {
-  local failed=0 code status remediation index value material_valid=true
+  local failed=0 code status remediation index value material_valid=true publisher_verified=false
   local metadata_check="" attestation_check="" trusted_root_check=""
   local workspace_check
   local -a codes=() statuses=() remediations=()
@@ -160,13 +160,15 @@ run_doctor() {
         --custom-trusted-root "$trusted_root_check" >/dev/null 2>&1 &&
       [[ "$(<"$metadata_check")" == "${INPUT_IMAGE:-}" ]]; then
       add_check publisher_identity ok ""
+      publisher_verified=true
     else
       add_check publisher_identity invalid "stage publisher evidence that verifies and names the requested image"
     fi
   fi
 
   if [[ "$doctor_mode" == json ]]; then
-    printf '{"schema_version":1,"ready":%s,"checks":[' "$([[ "$failed" == 0 ]] && printf true || printf false)"
+    printf '{"schema_version":1,"ready":%s,"publisher_verified":%s,"checks":[' \
+      "$([[ "$failed" == 0 ]] && printf true || printf false)" "$publisher_verified"
     for ((index = 0; index < ${#codes[@]}; index++)); do
       ((index == 0)) || printf ','
       printf '{"code":"%s","status":"%s","remediation":"%s"}' "${codes[$index]}" "${statuses[$index]}" "${remediations[$index]}"

--- a/scripts/runner_image_test.py
+++ b/scripts/runner_image_test.py
@@ -47,6 +47,7 @@ class RunnerImageContractTest(unittest.TestCase):
             self.assertEqual(0, result.returncode, result.stderr)
             report = json.loads(result.stdout)
             self.assertTrue(report["ready"])
+            self.assertFalse(report["publisher_verified"])
             self.assertFalse((workspace / "aeb-results").exists())
 
     def test_local_offline_doctor_accepts_a_root_workspace(self) -> None:
@@ -192,7 +193,9 @@ class RunnerImageContractTest(unittest.TestCase):
                 check=False,
             )
             self.assertEqual(0, result.returncode, result.stderr)
-            statuses = {check["code"]: check["status"] for check in json.loads(result.stdout)["checks"]}
+            report = json.loads(result.stdout)
+            self.assertTrue(report["publisher_verified"])
+            statuses = {check["code"]: check["status"] for check in report["checks"]}
             self.assertEqual("ok", statuses["image_repository"])
             self.assertEqual("ok", statuses["publisher_identity"])
 


### PR DESCRIPTION
## What changed

- Add a released operator packet for setup, evidence custody, reporting, and public corrections.
- Make OCI run artifacts directly reportable while preserving incomplete-run and publisher-verification status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an operator kit with setup guidance, evidence-custody checklists, reporting templates, and appeal procedures.
  - Release bundles now include operator documentation and structured result metadata.
  - Published artifacts retain both processed and original summary data.

- **Documentation**
  - Clarified adoption, governance, release, and results-use guidance.
  - Added requirements for provenance, execution details, retained evidence, corrections, and dispute routing.

- **Bug Fixes**
  - Diagnostic checks now treat waived conditions appropriately, including unverified publisher scenarios.

- **Tests**
  - Expanded validation for operator-kit content, release contents, artifact preservation, and diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->