### PR TITLE
feat(release): gate method independence

### DIFF
--- a/contracts/method-independence-v1.json
+++ b/contracts/method-independence-v1.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "method_owner": "luckyPipewrench/agent-egress-bench",
+  "shared_target_vendor_ownership": false,
+  "verification": {
+    "bundled_verifier": "scripts/release_build.py",
+    "proprietary_verifier_required": false
+  },
+  "mandatory_external_services": {
+    "vendor_specific_registry": null,
+    "transparency_chain": null
+  },
+  "lab_control": {
+    "branding": "operator",
+    "scheduling": "operator"
+  }
+}

--- a/docs/RESULTS-USE.md
+++ b/docs/RESULTS-USE.md
@@ -8,6 +8,11 @@ Nobody needs approval from the maintainer to run the corpus, publish a result, o
 found. The point of writing the vocabulary down is that two people using the same word should mean
 the same thing.
 
+The released method also has no target-vendor co-owner, proprietary verifier dependency, mandatory
+vendor registry, or mandatory transparency chain. A lab controls its own name and schedule. These
+release invariants are machine-readable in `contracts/method-independence-v1.json`, bound into the
+release identity, shipped in the data bundle, and checked by the downloaded-release verifier.
+
 ## Scope
 
 Agent Egress Bench evaluates products that mediate the outbound traffic this corpus defines and

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -29,6 +29,7 @@ CHECKSUM_NAME = "checksums.txt"
 SCHEMA_CATALOG_PATH = "schemas/index.json"
 SCHEMA_CATALOG_SUFFIX = "_schema-catalog.json"
 SCHEMA_BUNDLE_SUFFIX = "_schemas.tar.gz"
+METHOD_INDEPENDENCE_PATH = "contracts/method-independence-v1.json"
 REPOSITORY = "luckyPipewrench/agent-egress-bench"
 RAW_SCHEMA_URL = "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/{commit}/{path}"
 # "examples" carries the operator kit: the tool-profile template the runner
@@ -311,6 +312,7 @@ def build_identity(repo: Path, tag: str, version: str, commit: str, snapshot: bo
         "runner": {"binary": RUNNER_BINARY, "validator_binary": VALIDATOR_BINARY, "runner_version": metadata["runner_version"], "scoring_version": metadata["scoring_version"], "platforms": [{"goos": goos, "goarch": arch} for goos, arch in PLATFORMS]},
         "corpus": corpus(repo, metadata["corpus_version"]),
         "schema_contract": {"artifacts_manifest_path": "contracts/artifacts.json", "artifacts_manifest_sha256": sha256_file(repo / "contracts/artifacts.json"), "families": contract_families(repo)},
+        "method_independence": method_independence_identity(repo),
         "data_files": {name: sha256_file(repo / name) for name in data},
         "verification": {"checksums": {"algorithm": "sha256", "path": CHECKSUM_NAME}, "command": "python3 scripts/release_build.py verify --release-dir <downloaded-release-directory>"},
     }
@@ -334,10 +336,58 @@ def positive_int(value: Any, label: str) -> int:
     return value
 
 
+def validate_method_independence_contract(data: bytes) -> dict[str, Any]:
+    def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                fail(f"method-independence contract contains duplicate key {key!r}")
+            value[key] = item
+        return value
+
+    try:
+        contract = json.loads(data, object_pairs_hook=unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"method-independence contract is invalid JSON: {exc}")
+    expected = {
+        "schema_version": 1,
+        "method_owner": REPOSITORY,
+        "shared_target_vendor_ownership": False,
+        "verification": {
+            "bundled_verifier": "scripts/release_build.py",
+            "proprietary_verifier_required": False,
+        },
+        "mandatory_external_services": {
+            "vendor_specific_registry": None,
+            "transparency_chain": None,
+        },
+        "lab_control": {"branding": "operator", "scheduling": "operator"},
+    }
+    if contract != expected:
+        fail("method-independence contract does not preserve the public release invariants")
+    return contract
+
+
+def method_independence_identity(repo: Path) -> dict[str, Any]:
+    contract = validate_method_independence_contract((repo / METHOD_INDEPENDENCE_PATH).read_bytes())
+    return {
+        "contract_path": METHOD_INDEPENDENCE_PATH,
+        "contract_sha256": sha256_file(repo / METHOD_INDEPENDENCE_PATH),
+        "method_owner": contract["method_owner"],
+        "shared_target_vendor_ownership": contract["shared_target_vendor_ownership"],
+        "bundled_verifier": contract["verification"]["bundled_verifier"],
+        "proprietary_verifier_required": contract["verification"]["proprietary_verifier_required"],
+        "mandatory_vendor_registry": contract["mandatory_external_services"]["vendor_specific_registry"],
+        "mandatory_transparency_chain": contract["mandatory_external_services"]["transparency_chain"],
+        "lab_branding_control": contract["lab_control"]["branding"],
+        "lab_scheduling_control": contract["lab_control"]["scheduling"],
+    }
+
+
 def validate_identity_structure(identity: dict[str, Any]) -> None:
     if identity.get("schema_version") != 1:
         fail("release identity schema_version must be 1")
-    exact_object(identity, "release identity", {"schema_version", "release", "source", "runner", "corpus", "schema_contract", "data_files", "verification"})
+    exact_object(identity, "release identity", {"schema_version", "release", "source", "runner", "corpus", "schema_contract", "method_independence", "data_files", "verification"})
 
     release = exact_object(identity["release"], "release identity release", {"tag", "version", "snapshot"})
     tag = nonempty_string(release["tag"], "release identity release.tag")
@@ -402,6 +452,33 @@ def validate_identity_structure(identity: dict[str, Any]) -> None:
             fail(f"release identity schema_contract.families[{index}].schema_sha256 is invalid")
         nonempty_string(family["schema_id"], f"release identity schema_contract.families[{index}].schema_id")
 
+    method = exact_object(
+        identity["method_independence"],
+        "release identity method_independence",
+        {
+            "contract_path", "contract_sha256", "method_owner",
+            "shared_target_vendor_ownership", "bundled_verifier",
+            "proprietary_verifier_required", "mandatory_vendor_registry",
+            "mandatory_transparency_chain", "lab_branding_control",
+            "lab_scheduling_control",
+        },
+    )
+    expected_method = {
+        "contract_path": METHOD_INDEPENDENCE_PATH,
+        "method_owner": REPOSITORY,
+        "shared_target_vendor_ownership": False,
+        "bundled_verifier": "scripts/release_build.py",
+        "proprietary_verifier_required": False,
+        "mandatory_vendor_registry": None,
+        "mandatory_transparency_chain": None,
+        "lab_branding_control": "operator",
+        "lab_scheduling_control": "operator",
+    }
+    if any(method.get(key) != value for key, value in expected_method.items()):
+        fail("release identity method-independence invariants are invalid")
+    if not isinstance(method["contract_sha256"], str) or not SHA256_RE.fullmatch(method["contract_sha256"]):
+        fail("release identity method-independence contract digest is invalid")
+
     data_files = identity["data_files"]
     if not isinstance(data_files, dict) or not data_files:
         fail("release identity data_files must be a non-empty object")
@@ -410,8 +487,10 @@ def validate_identity_structure(identity: dict[str, Any]) -> None:
             fail("release identity data_files has an invalid entry")
         safe_name(name)
     required_operator_kit = {"examples/operator-kit/README.md", "examples/operator-kit/evidence-custody-checklist.md", "examples/operator-kit/report-template.md"}
-    if set(DATA_FILES) - set(data_files) or required_operator_kit - set(data_files) or corpus_value["manifest_path"] not in data_files or any(not any(name == root or name.startswith(f"{root}/") for name in data_files) for root in DATA_ROOTS):
+    if set(DATA_FILES) - set(data_files) or required_operator_kit - set(data_files) or METHOD_INDEPENDENCE_PATH not in data_files or corpus_value["manifest_path"] not in data_files or any(not any(name == root or name.startswith(f"{root}/") for name in data_files) for root in DATA_ROOTS):
         fail("release identity data_files does not contain the required corpus, schema, contract, operator kit, and verifier data")
+    if data_files[METHOD_INDEPENDENCE_PATH] != method["contract_sha256"]:
+        fail("release identity method-independence contract digest disagrees with data_files")
 
     verification = exact_object(identity["verification"], "release identity verification", {"checksums", "command"})
     checksums = exact_object(verification["checksums"], "release identity verification.checksums", {"algorithm", "path"})
@@ -817,6 +896,7 @@ def verify_release(release_dir: Path, repo: Path | None, executable: Path | None
     for name, digest in data_files.items():
         if not isinstance(name, str) or not isinstance(digest, str) or not SHA256_RE.fullmatch(digest) or sha256_bytes(contents[name]) != digest:
             fail(f"data bundle digest does not match release identity: {name}")
+    validate_method_independence_contract(contents[METHOD_INDEPENDENCE_PATH])
     verify_bundle_corpus(identity, contents)
     schema_entries, schema_contents = verify_schema_bundle(identity, release_dir)
     if repo is not None:

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -30,8 +30,7 @@ class ReleaseBuildTest(unittest.TestCase):
         files = subprocess.run(
             ["git", "-C", str(REPO), "ls-files", "-z"], check=True, capture_output=True
         ).stdout.decode("utf-8").split("\0")
-        if "contracts/method-independence-v1.json" not in files:
-            files.append("contracts/method-independence-v1.json")
+        self.assertIn("contracts/method-independence-v1.json", files)
         for name in filter(None, files):
             source, destination = REPO / name, self.root / name
             destination.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -30,6 +30,8 @@ class ReleaseBuildTest(unittest.TestCase):
         files = subprocess.run(
             ["git", "-C", str(REPO), "ls-files", "-z"], check=True, capture_output=True
         ).stdout.decode("utf-8").split("\0")
+        if "contracts/method-independence-v1.json" not in files:
+            files.append("contracts/method-independence-v1.json")
         for name in filter(None, files):
             source, destination = REPO / name, self.root / name
             destination.parent.mkdir(parents=True, exist_ok=True)
@@ -157,6 +159,7 @@ class ReleaseBuildTest(unittest.TestCase):
 
     def forge_release(self, identity: dict) -> Path:
         release = Path(self.temp.name) / "fakerel"
+        shutil.rmtree(release, ignore_errors=True)
         release.mkdir()
         identity_bytes = json.dumps(identity, sort_keys=True).encode("utf-8")
         identity_path = release / "release-identity.json"
@@ -802,6 +805,83 @@ class ReleaseBuildTest(unittest.TestCase):
         identity = json.loads(self.identity.read_text(encoding="utf-8"))
         del identity["corpus"]
         self.assert_forged_release_refused(identity, "release identity must contain exactly")
+
+    def test_download_verifier_rejects_method_independence_downgrades(self) -> None:
+        self.prepare()
+        mutations = {
+            "shared ownership": ("shared_target_vendor_ownership", True),
+            "proprietary verifier": ("proprietary_verifier_required", True),
+            "vendor registry": ("mandatory_vendor_registry", "registry.vendor.example"),
+            "mandatory chain": ("mandatory_transparency_chain", "chain.vendor.example"),
+            "lab branding": ("lab_branding_control", "method-owner"),
+            "lab scheduling": ("lab_scheduling_control", "method-owner"),
+        }
+        original = json.loads(self.identity.read_text(encoding="utf-8"))
+        for label, (field, value) in mutations.items():
+            with self.subTest(label=label):
+                identity = json.loads(json.dumps(original))
+                identity["method_independence"][field] = value
+                self.assert_forged_release_refused(identity, "method-independence invariants are invalid")
+
+    def test_download_verifier_rejects_method_contract_digest_disagreement(self) -> None:
+        self.prepare()
+        identity = json.loads(self.identity.read_text(encoding="utf-8"))
+        identity["method_independence"]["contract_sha256"] = "a" * 64
+        self.assert_forged_release_refused(identity, "contract digest disagrees with data_files")
+
+    def test_identity_rejects_a_vendor_owned_method_contract(self) -> None:
+        contract_path = self.root / "contracts/method-independence-v1.json"
+        contract = json.loads(contract_path.read_text(encoding="utf-8"))
+        contract["shared_target_vendor_ownership"] = True
+        contract_path.write_text(json.dumps(contract), encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", "contracts/method-independence-v1.json"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "vendor-owned method"], check=True)
+        broken_commit = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD"],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+        result = subprocess.run(
+            [
+                sys.executable, str(SCRIPT), "prepare", "--repo-root", str(self.root),
+                "--tag", "snapshot", "--version", f"1.0.0-SNAPSHOT-{broken_commit[:7]}",
+                "--commit", broken_commit, "--snapshot", "--output", str(self.identity),
+            ],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not preserve the public release invariants", result.stderr)
+        self.assertFalse(self.identity.exists())
+
+    def test_identity_rejects_duplicate_method_contract_keys(self) -> None:
+        contract_path = self.root / "contracts/method-independence-v1.json"
+        contract = contract_path.read_text(encoding="utf-8").replace(
+            '  "shared_target_vendor_ownership": false,',
+            '  "shared_target_vendor_ownership": true,\n  "shared_target_vendor_ownership": false,',
+        )
+        contract_path.write_text(contract, encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", "contracts/method-independence-v1.json"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "duplicate ownership key"], check=True)
+        broken_commit = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD"],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+        result = subprocess.run(
+            [
+                sys.executable, str(SCRIPT), "prepare", "--repo-root", str(self.root),
+                "--tag", "snapshot", "--version", f"1.0.0-SNAPSHOT-{broken_commit[:7]}",
+                "--commit", broken_commit, "--snapshot", "--output", str(self.identity),
+            ],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("contains duplicate key 'shared_target_vendor_ownership'", result.stderr)
+        self.assertFalse(self.identity.exists())
 
     def test_download_verifier_rejects_truncated_identity(self) -> None:
         self.assert_forged_release_refused({"schema_version": 1, "release": {"tag": "v9.9.9", "version": "9.9.9", "snapshot": False}}, "release identity must contain exactly")

--- a/scripts/release_snapshot_test.py
+++ b/scripts/release_snapshot_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
@@ -36,6 +37,18 @@ class ReleaseSnapshotTest(unittest.TestCase):
         self.assertEqual(verification.returncode, 0, msg=verification.stderr)
         identity = release_dir / "release-identity.json"
         self.assertTrue(identity.is_file())
+        release_identity = json.loads(identity.read_text(encoding="utf-8"))
+        self.assertEqual(release_identity["method_independence"]["method_owner"], "luckyPipewrench/agent-egress-bench")
+        self.assertFalse(release_identity["method_independence"]["shared_target_vendor_ownership"])
+        self.assertFalse(release_identity["method_independence"]["proprietary_verifier_required"])
+        self.assertIsNone(release_identity["method_independence"]["mandatory_vendor_registry"])
+        self.assertIsNone(release_identity["method_independence"]["mandatory_transparency_chain"])
+        data_archive = next(release_dir.glob("agent-egress-bench_*_data.tar.gz"))
+        with tarfile.open(data_archive, "r:gz") as bundle:
+            contract = bundle.extractfile("contracts/method-independence-v1.json")
+            self.assertIsNotNone(contract)
+            contract_value = json.load(contract)
+        self.assertEqual(contract_value["lab_control"], {"branding": "operator", "scheduling": "operator"})
         archive = next(release_dir.glob("agent-egress-bench_*_linux_amd64.tar.gz"))
         with tarfile.open(archive, "r:gz") as bundle:
             entries = [entry for entry in bundle.getmembers() if entry.isfile()]


### PR DESCRIPTION
## What changed

- Bind a machine-readable method-independence contract into the release identity and data bundle.
- Make verification fail closed when ownership, verifier, registry, chain, or lab-control invariants drift. Reviewers should distrust any packet whose bundled contract and identity disagree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release metadata describing method ownership, verification requirements, external-service dependencies, and laboratory controls.
  * Included method-independence information in release identities and bundled release data.
* **Bug Fixes**
  * Release verification now detects invalid, altered, vendor-owned, or duplicate-key contract data.
  * Added checks to ensure contract contents and recorded digests remain consistent.
* **Documentation**
  * Documented release invariants confirming independence from vendor ownership, proprietary verification, mandatory registries, and transparency chains.
* **Tests**
  * Expanded release and snapshot validation for the new independence metadata and verification rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->