### PR TITLE
fix(release): cross-bind identity digests

### DIFF
--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -489,7 +489,14 @@ def validate_identity_structure(identity: dict[str, Any]) -> None:
     required_operator_kit = {"examples/operator-kit/README.md", "examples/operator-kit/evidence-custody-checklist.md", "examples/operator-kit/report-template.md"}
     if set(DATA_FILES) - set(data_files) or required_operator_kit - set(data_files) or METHOD_INDEPENDENCE_PATH not in data_files or corpus_value["manifest_path"] not in data_files or any(not any(name == root or name.startswith(f"{root}/") for name in data_files) for root in DATA_ROOTS):
         fail("release identity data_files does not contain the required corpus, schema, contract, operator kit, and verifier data")
-    if data_files[METHOD_INDEPENDENCE_PATH] != method["contract_sha256"]:
+    if data_files.get(corpus_value["manifest_path"]) != corpus_value["manifest_sha256"]:
+        fail("release identity corpus manifest digest disagrees with data_files")
+    if data_files.get(schema_contract["artifacts_manifest_path"]) != schema_contract["artifacts_manifest_sha256"]:
+        fail("release identity artifacts manifest digest disagrees with data_files")
+    for index, family in enumerate(families):
+        if data_files.get(family["schema_path"]) != family["schema_sha256"]:
+            fail(f"release identity schema_contract.families[{index}] digest disagrees with data_files")
+    if data_files.get(METHOD_INDEPENDENCE_PATH) != method["contract_sha256"]:
         fail("release identity method-independence contract digest disagrees with data_files")
 
     verification = exact_object(identity["verification"], "release identity verification", {"checksums", "command"})

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -207,7 +207,7 @@ class ReleaseBuildTest(unittest.TestCase):
         self.identity.write_text(json.dumps(identity), encoding="utf-8")
         result = subprocess.run([sys.executable, str(SCRIPT), "check-identity", "--repo-root", str(self.root), "--identity", str(self.identity)], text=True, capture_output=True)
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("disagrees with the checked-out source tree", result.stderr)
+        self.assertIn("schema_contract.families[0] digest disagrees with data_files", result.stderr)
 
     def test_identity_rejects_changed_corpus_version(self) -> None:
         self.prepare()
@@ -827,6 +827,48 @@ class ReleaseBuildTest(unittest.TestCase):
         identity = json.loads(self.identity.read_text(encoding="utf-8"))
         identity["method_independence"]["contract_sha256"] = "a" * 64
         self.assert_forged_release_refused(identity, "contract digest disagrees with data_files")
+
+    def test_download_verifier_rejects_release_contract_digest_disagreements(self) -> None:
+        self.prepare()
+        original = json.loads(self.identity.read_text(encoding="utf-8"))
+        last_family = len(original["schema_contract"]["families"]) - 1
+        mutations = (
+            (
+                "corpus manifest",
+                lambda identity: identity["corpus"].__setitem__("manifest_sha256", "a" * 64),
+                "corpus manifest digest disagrees with data_files",
+            ),
+            (
+                "corpus manifest data file",
+                lambda identity: identity["data_files"].__setitem__(identity["corpus"]["manifest_path"], "a" * 64),
+                "corpus manifest digest disagrees with data_files",
+            ),
+            (
+                "artifacts manifest",
+                lambda identity: identity["schema_contract"].__setitem__("artifacts_manifest_sha256", "a" * 64),
+                "artifacts manifest digest disagrees with data_files",
+            ),
+            (
+                "artifacts manifest data file",
+                lambda identity: identity["data_files"].__setitem__(identity["schema_contract"]["artifacts_manifest_path"], "a" * 64),
+                "artifacts manifest digest disagrees with data_files",
+            ),
+            (
+                "active schema",
+                lambda identity: identity["schema_contract"]["families"][last_family].__setitem__("schema_sha256", "a" * 64),
+                f"schema_contract.families[{last_family}] digest disagrees with data_files",
+            ),
+            (
+                "active schema data file",
+                lambda identity: identity["data_files"].__setitem__(identity["schema_contract"]["families"][last_family]["schema_path"], "a" * 64),
+                f"schema_contract.families[{last_family}] digest disagrees with data_files",
+            ),
+        )
+        for label, mutate, message in mutations:
+            with self.subTest(label=label):
+                identity = json.loads(json.dumps(original))
+                mutate(identity)
+                self.assert_forged_release_refused(identity, message)
 
     def test_identity_rejects_a_vendor_owned_method_contract(self) -> None:
         contract_path = self.root / "contracts/method-independence-v1.json"


### PR DESCRIPTION
## What changed

Cross-bind the corpus, artifacts manifest, and active schema digests in the release identity to the bundled data-file map so download-only verification rejects conflicting integrity claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened release validation to detect mismatched manifest, artifact, schema, and method-independence digests.
  * Improved error handling when required digest entries are missing or invalid.

* **Tests**
  * Added coverage for rejecting forged release identities and updated validation error expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->