### PR TITLE
feat(results): enforce public evidence contract

### DIFF
--- a/contracts/public-result-v1.json
+++ b/contracts/public-result-v1.json
@@ -1,0 +1,46 @@
+{
+  "evidence_index": "migration/pipelock-result-inventory-v1.json",
+  "record_verification": {
+    "command": "python3 scripts/validate_gauntlet_records.py",
+    "source_path": "scripts/validate_gauntlet_records.py"
+  },
+  "required_evidence": {
+    "normalized_decisions": [
+      "execution-decision.json",
+      "reviewed-baseline.json",
+      "reviewed-promotion-decision.json",
+      "source-baseline.json",
+      "source-promotion-decision.json"
+    ],
+    "pinned_inputs": [
+      "case-index.json",
+      "checksums.txt",
+      "corpus-manifest.txt",
+      "pipelock-release.json",
+      "pipelock-version.txt",
+      "run-bundle.json",
+      "run-metadata.json"
+    ],
+    "raw_evidence": [
+      "make-stats.txt",
+      "raw-summary.json",
+      "results.jsonl",
+      "runner.stderr"
+    ],
+    "reproduction": [
+      "command.txt",
+      "entrypoint-command.txt"
+    ],
+    "score_and_scope": [
+      "continuous-gauntlet-pipelock.json"
+    ]
+  },
+  "schema_required_evidence": {
+    "4-6": [
+      "capability-registry.json",
+      "receipt-profile.json",
+      "tool-profile.json"
+    ]
+  },
+  "schema_version": 1
+}

--- a/docs/RESULTS-USE.md
+++ b/docs/RESULTS-USE.md
@@ -59,6 +59,12 @@ Publish these next to any score, or the number is not reproducible.
 
 The runner writes these into the v5 summary JSON. The corpus-derived facts come from the run itself; repository and commit, adapter owner, and target configuration are operator declarations supplied with `--method-repository`, `--method-commit`, `--adapter-owner`, and `--target-config`. A local summary may omit a declaration rather than guess it. The v6 provenance candidate requires every declaration before promotion, and the buyer report names anything absent from older or local artifacts. Reproduction instructions belong beside a public result too, so a reader can run it rather than believe it.
 
+## Verify a public result
+
+The public result must include the score, its exact scope and pinned inputs, the reproduction commands, the raw evidence, the normalized decisions, and a verification path. Those categories bind any publisher. The exact filenames do not: they belong to the lane that produced the result. The [public result contract](../contracts/public-result-v1.json) names the files the first-party Pipelock lane retains, and the [Pipelock result inventory](../migration/pipelock-result-inventory-v1.json) gives each of those files a commit-pinned public URL and digest. Run `python3 scripts/validate_gauntlet_records.py` from a checkout of this repository to verify that lane's retained chain and reconstruct its decisions from the raw evidence.
+
+Paid reports may add analysis or convenience. They can't gate the evidence or verification needed to check a public result.
+
 ## Non-claims
 
 A result does not establish any of the following, and no publisher should imply otherwise:

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -280,6 +280,12 @@
     link.href = canonicalURL;
     link.textContent = 'canonical artifact';
     block.appendChild(link);
+    block.appendChild(document.createTextNode(' · '));
+
+    var evidenceLink = document.createElement('a');
+    evidenceLink.href = 'https://github.com/luckyPipewrench/agent-egress-bench/blob/main/docs/RESULTS-USE.md#verify-a-public-result';
+    evidenceLink.textContent = 'evidence and verify';
+    block.appendChild(evidenceLink);
     return block;
   }
 

--- a/gauntlet-site/scope-render_test.js
+++ b/gauntlet-site/scope-render_test.js
@@ -79,6 +79,8 @@ assert.equal(rendered.className, 'denominator');
 assert.match(rendered.children[0].textContent,
   /Containment 99\.4% of 158 malicious cases in the full 213-case corpus; 100\.0% of 1 applicable malicious \(diagnostic/);
 assert.equal(rendered.children[3].href, completeArtifact().canonical_url);
+assert.equal(rendered.children[5].textContent, 'evidence and verify');
+assert.match(rendered.children[5].href, /docs\/RESULTS-USE\.md#verify-a-public-result$/);
 
 const unboundV4 = completeArtifact();
 unboundV4.schema_version = 4;

--- a/scripts/validate_pipelock_result_inventory.py
+++ b/scripts/validate_pipelock_result_inventory.py
@@ -274,6 +274,42 @@ def validate_public_result_contract(repo_root, inventory, recorded_paths):
     ):
         raise ValueError("public result contract evidence roles must contain unique filenames")
 
+    raw_evidence = promotion.provenance.RAW_EVIDENCE
+    expected_roles = {
+        "normalized_decisions": sorted(
+            {
+                promotion.BASELINE_SNAPSHOT_FILENAME,
+                promotion.EXECUTION_DECISION_FILENAME,
+                promotion.PUBLISHED_DECISION_FILENAME,
+                promotion.SOURCE_BASELINE_FILENAME,
+                promotion.SOURCE_PROMOTION_DECISION_FILENAME,
+            }
+        ),
+        "pinned_inputs": sorted(
+            raw_evidence[label]
+            for label in (
+                "case_index",
+                "corpus_manifest",
+                "pipelock_release",
+                "pipelock_version_output",
+                "release_checksums",
+                "run_metadata",
+            )
+        )
+        + [promotion.RUN_BUNDLE_FILENAME],
+        "raw_evidence": sorted(
+            raw_evidence[label]
+            for label in ("raw_summary", "results", "runner_stderr", "stats")
+        ),
+        "reproduction": sorted(
+            raw_evidence[label] for label in ("command", "entrypoint_command")
+        ),
+        "score_and_scope": [promotion.CANDIDATE_FILENAME],
+    }
+    expected_roles["pinned_inputs"] = sorted(expected_roles["pinned_inputs"])
+    if required_evidence != expected_roles:
+        raise ValueError("public result contract evidence role bindings drifted from promotion output")
+
     schema_evidence = contract["schema_required_evidence"]
     require_exact_keys(schema_evidence, ("4-6",), "public result contract schema_required_evidence")
     active_files = schema_evidence["4-6"]
@@ -284,6 +320,8 @@ def validate_public_result_contract(repo_root, inventory, recorded_paths):
         or any(not isinstance(name, str) or not name or Path(name).name != name for name in active_files)
     ):
         raise ValueError("public result contract schema evidence must contain unique sorted filenames")
+    if active_files != sorted(promotion.provenance.V4_RAW_EVIDENCE.values()):
+        raise ValueError("public result contract schema evidence drifted from promotion output")
 
     producer_files = set(promotion.evidence_files_for({"schema_version": 6}).values())
     producer_files.update(

--- a/scripts/validate_pipelock_result_inventory.py
+++ b/scripts/validate_pipelock_result_inventory.py
@@ -9,7 +9,15 @@ import sys
 from pathlib import Path
 
 
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+import promote_gauntlet_candidate as promotion
+
+
 INVENTORY_PATH = Path("migration/pipelock-result-inventory-v1.json")
+PUBLIC_RESULT_CONTRACT_PATH = Path("contracts/public-result-v1.json")
 PUBLIC_POINTERS = (
     Path("gauntlet-site/gauntlet-results.json"),
     Path("gauntlet-site/latest-verified.json"),
@@ -218,6 +226,135 @@ def verify_record_store(repo_root):
         raise ValueError(f"retained record verification failed: {detail}")
 
 
+def validate_public_result_contract(repo_root, inventory, recorded_paths):
+    contract = json.loads((repo_root / PUBLIC_RESULT_CONTRACT_PATH).read_text(encoding="utf-8"))
+    require_exact_keys(
+        contract,
+        (
+            "evidence_index",
+            "record_verification",
+            "required_evidence",
+            "schema_required_evidence",
+            "schema_version",
+        ),
+        "public result contract",
+    )
+    if contract["schema_version"] != 1:
+        raise ValueError("public result contract schema_version must be 1")
+    if contract["evidence_index"] != INVENTORY_PATH.as_posix():
+        raise ValueError("public result contract evidence_index is not canonical")
+    require_exact_keys(
+        contract["record_verification"],
+        ("command", "source_path"),
+        "public result contract record_verification",
+    )
+    if contract["record_verification"]["command"] != inventory["record_verification"]["command"]:
+        raise ValueError("public result contract verification command drifted from inventory")
+    verifier_path = Path(contract["record_verification"]["source_path"])
+    verifier = repo_root / verifier_path
+    if (
+        verifier_path != Path("scripts/validate_gauntlet_records.py")
+        or verifier.is_symlink()
+        or not verifier.is_file()
+    ):
+        raise ValueError("public result contract verifier source is missing or not canonical")
+
+    required_evidence = contract["required_evidence"]
+    require_exact_keys(
+        required_evidence,
+        ("normalized_decisions", "pinned_inputs", "raw_evidence", "reproduction", "score_and_scope"),
+        "public result contract required_evidence",
+    )
+    if any(not isinstance(names, list) or not names for names in required_evidence.values()):
+        raise ValueError("public result contract evidence roles must contain unique filenames")
+    required_files = sorted(name for names in required_evidence.values() for name in names)
+    if (
+        required_files != sorted(set(required_files))
+        or any(not isinstance(name, str) or not name or Path(name).name != name for name in required_files)
+    ):
+        raise ValueError("public result contract evidence roles must contain unique filenames")
+
+    schema_evidence = contract["schema_required_evidence"]
+    require_exact_keys(schema_evidence, ("4-6",), "public result contract schema_required_evidence")
+    active_files = schema_evidence["4-6"]
+    if (
+        not isinstance(active_files, list)
+        or not active_files
+        or active_files != sorted(set(active_files))
+        or any(not isinstance(name, str) or not name or Path(name).name != name for name in active_files)
+    ):
+        raise ValueError("public result contract schema evidence must contain unique sorted filenames")
+
+    producer_files = set(promotion.evidence_files_for({"schema_version": 6}).values())
+    producer_files.update(
+        {
+            promotion.BASELINE_SNAPSHOT_FILENAME,
+            promotion.CANDIDATE_FILENAME,
+            promotion.PUBLISHED_DECISION_FILENAME,
+            promotion.SOURCE_BASELINE_FILENAME,
+            promotion.SOURCE_PROMOTION_DECISION_FILENAME,
+        }
+    )
+    contracted_files = set(required_files) | set(active_files)
+    if contracted_files != producer_files:
+        missing = sorted(producer_files - contracted_files)
+        unexpected = sorted(contracted_files - producer_files)
+        raise ValueError(
+            f"public result contract drifted from promotion output: "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+    recorded_path_set = set(recorded_paths)
+    manifest_paths = [path for path in recorded_paths if path.name == "record-manifest.json"]
+    if not manifest_paths:
+        raise ValueError("public result contract has no retained record manifests")
+    for manifest_path in manifest_paths:
+        manifest = json.loads(git_file_bytes(repo_root, inventory["source_commit"], manifest_path))
+        files = manifest.get("files") if isinstance(manifest, dict) else None
+        if not isinstance(files, dict):
+            raise ValueError(f"retained record manifest has no file inventory: {manifest_path}")
+        candidate_path = manifest_path.parent / promotion.CANDIDATE_FILENAME
+        candidate = json.loads(git_file_bytes(repo_root, inventory["source_commit"], candidate_path))
+        record_required_files = set(required_files)
+        if isinstance(candidate, dict) and candidate.get("schema_version") in {4, 5, 6}:
+            record_required_files.update(active_files)
+        missing = sorted(record_required_files - set(files))
+        if missing:
+            raise ValueError(f"retained record is missing public-result evidence: {manifest_path}: {missing}")
+        record_root = manifest_path.parent
+        missing_urls = sorted(name for name in record_required_files if record_root / name not in recorded_path_set)
+        if missing_urls:
+            raise ValueError(
+                f"public result evidence is absent from the commit-pinned inventory: "
+                f"{manifest_path}: {missing_urls}"
+            )
+
+    current_paths = public_paths(repo_root)
+    current_path_set = set(current_paths)
+    for manifest_path in (path for path in current_paths if path.name == "record-manifest.json"):
+        manifest = json.loads((repo_root / manifest_path).read_text(encoding="utf-8"))
+        files = manifest.get("files") if isinstance(manifest, dict) else None
+        if not isinstance(files, dict):
+            raise ValueError(f"current record manifest has no file inventory: {manifest_path}")
+        candidate = json.loads(
+            (repo_root / manifest_path.parent / promotion.CANDIDATE_FILENAME).read_text(encoding="utf-8")
+        )
+        record_required_files = set(required_files)
+        if isinstance(candidate, dict) and candidate.get("schema_version") in {4, 5, 6}:
+            record_required_files.update(active_files)
+        missing = sorted(record_required_files - set(files))
+        if missing:
+            raise ValueError(f"current record is missing public-result evidence: {manifest_path}: {missing}")
+        missing_paths = sorted(
+            name for name in record_required_files if manifest_path.parent / name not in current_path_set
+        )
+        if missing_paths:
+            raise ValueError(
+                f"current public result evidence is missing from the repository: "
+                f"{manifest_path}: {missing_paths}"
+            )
+
+
 def validate(repo_root, inventory_path, verify_records=True):
     inventory = json.loads(inventory_path.read_text(encoding="utf-8"))
     require_exact_keys(
@@ -268,6 +405,7 @@ def validate(repo_root, inventory_path, verify_records=True):
         missing = sorted(set(actual_paths) - set(recorded_paths))
         unexpected = sorted(set(recorded_paths) - set(actual_paths))
         raise ValueError(f"inventory path set differs: missing={missing}, unexpected={unexpected}")
+    validate_public_result_contract(repo_root, inventory, recorded_paths)
     if verify_records:
         verify_record_store(repo_root)
 

--- a/scripts/validate_pipelock_result_inventory_test.py
+++ b/scripts/validate_pipelock_result_inventory_test.py
@@ -19,15 +19,35 @@ class InventoryTest(unittest.TestCase):
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory(prefix="pipelock-result-inventory-")
         self.root = Path(self.temporary.name)
+        contract = json.loads(
+            (MODULE_PATH.parents[1] / inventory.PUBLIC_RESULT_CONTRACT_PATH).read_text(encoding="utf-8")
+        )
+        contract_path = self.root / inventory.PUBLIC_RESULT_CONTRACT_PATH
+        contract_path.parent.mkdir(parents=True)
+        contract_path.write_text(json.dumps(contract) + "\n", encoding="utf-8")
+        verifier = self.root / contract["record_verification"]["source_path"]
+        verifier.parent.mkdir(parents=True)
+        verifier.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
         paths = [
             Path("gauntlet-site/gauntlet-results.json"),
             Path("gauntlet-site/latest-verified.json"),
-            Path("gauntlet-site/results/pipelock/digest/record-manifest.json"),
         ]
         for index, path in enumerate(paths):
             absolute = self.root / path
             absolute.parent.mkdir(parents=True, exist_ok=True)
             absolute.write_text(json.dumps({"value": index}) + "\n", encoding="utf-8")
+        record_root = self.root / "gauntlet-site/results/pipelock/digest"
+        record_root.mkdir(parents=True)
+        self.required_files = sorted(
+            name for names in contract["required_evidence"].values() for name in names
+        )
+        for name in self.required_files:
+            (record_root / name).write_text("{}\n", encoding="utf-8")
+        (record_root / "record-manifest.json").write_text(
+            json.dumps({"files": {name: "0" * 64 for name in self.required_files}})
+            + "\n",
+            encoding="utf-8",
+        )
         subprocess.run(["git", "init", "-q", str(self.root)], check=True)
         subprocess.run(["git", "-C", str(self.root), "config", "user.name", "Test"], check=True)
         subprocess.run(
@@ -91,9 +111,14 @@ class InventoryTest(unittest.TestCase):
             self.validate()
 
     def test_allows_newer_records_outside_the_historical_snapshot(self):
-        extra = self.root / "gauntlet-site/results/pipelock/new-digest/record-manifest.json"
-        extra.parent.mkdir()
-        extra.write_text("{}\n", encoding="utf-8")
+        record_root = self.root / "gauntlet-site/results/pipelock/new-digest"
+        record_root.mkdir()
+        for name in self.required_files:
+            (record_root / name).write_text("{}\n", encoding="utf-8")
+        (record_root / "record-manifest.json").write_text(
+            json.dumps({"files": {name: "0" * 64 for name in self.required_files}}) + "\n",
+            encoding="utf-8",
+        )
         self.validate()
 
     def test_allows_live_pointer_to_advance_after_the_snapshot(self):
@@ -129,8 +154,10 @@ class InventoryTest(unittest.TestCase):
 
     def test_rejects_missing_result_tree_at_source_commit(self):
         value = self.load_inventory()
-        record = self.root / "gauntlet-site/results/pipelock/digest/record-manifest.json"
-        record.unlink()
+        record_root = self.root / "gauntlet-site/results/pipelock/digest"
+        for record in record_root.iterdir():
+            record.unlink()
+        record_root.rmdir()
         subprocess.run(["git", "-C", str(self.root), "add", "-u"], check=True)
         subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "remove records"], check=True)
         value["source_commit"] = subprocess.run(
@@ -179,6 +206,78 @@ class InventoryTest(unittest.TestCase):
         source.unlink()
         source.symlink_to(self.root / "gauntlet-site/latest-verified.json")
         with self.assertRaisesRegex(ValueError, "missing or not a regular file"):
+            self.validate()
+
+    def test_rejects_record_missing_required_public_evidence(self):
+        value = self.load_inventory()
+        manifest_entry = next(
+            entry for entry in value["entries"] if entry["source_path"].endswith("record-manifest.json")
+        )
+        manifest = json.loads(
+            inventory.git_file_bytes(self.root, value["source_commit"], Path(manifest_entry["source_path"]))
+        )
+        manifest["files"].pop("results.jsonl")
+        manifest_path = self.root / manifest_entry["source_path"]
+        manifest_path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", manifest_entry["source_path"]], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "remove evidence label"], check=True)
+        self.write_inventory(inventory.build_inventory(self.root))
+        with self.assertRaisesRegex(ValueError, "missing public-result evidence"):
+            self.validate()
+
+    def test_rejects_verification_command_drift(self):
+        contract_path = self.root / inventory.PUBLIC_RESULT_CONTRACT_PATH
+        contract = json.loads(contract_path.read_text(encoding="utf-8"))
+        contract["record_verification"]["command"] = "python3 scripts/not-the-verifier.py"
+        contract_path.write_text(json.dumps(contract) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "verification command drifted"):
+            self.validate()
+
+    def test_rejects_contract_weakened_below_promotion_output(self):
+        contract_path = self.root / inventory.PUBLIC_RESULT_CONTRACT_PATH
+        contract = json.loads(contract_path.read_text(encoding="utf-8"))
+        contract["required_evidence"]["raw_evidence"].remove("results.jsonl")
+        contract_path.write_text(json.dumps(contract) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "drifted from promotion output"):
+            self.validate()
+
+    def test_rejects_required_file_absent_from_commit_pinned_inventory(self):
+        source = self.root / "gauntlet-site/results/pipelock/digest/results.jsonl"
+        source.unlink()
+        subprocess.run(["git", "-C", str(self.root), "add", "-u"], check=True)
+        subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "remove evidence file"], check=True)
+        self.write_inventory(inventory.build_inventory(self.root))
+        with self.assertRaisesRegex(ValueError, "absent from the commit-pinned inventory"):
+            self.validate()
+
+    def test_rejects_incomplete_record_added_after_historical_snapshot(self):
+        record_root = self.root / "gauntlet-site/results/pipelock/new-digest"
+        record_root.mkdir()
+        for name in self.required_files:
+            if name != "results.jsonl":
+                (record_root / name).write_text("{}\n", encoding="utf-8")
+        (record_root / "record-manifest.json").write_text(
+            json.dumps({"files": {name: "0" * 64 for name in self.required_files}}) + "\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "missing from the repository"):
+            self.validate()
+
+    def test_active_record_requires_schema_specific_profiles(self):
+        record_root = self.root / "gauntlet-site/results/pipelock/active-digest"
+        record_root.mkdir()
+        for name in self.required_files:
+            content = (
+                '{"schema_version":6}\n'
+                if name == inventory.promotion.CANDIDATE_FILENAME
+                else "{}\n"
+            )
+            (record_root / name).write_text(content, encoding="utf-8")
+        (record_root / "record-manifest.json").write_text(
+            json.dumps({"files": {name: "0" * 64 for name in self.required_files}}) + "\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "missing public-result evidence"):
             self.validate()
 
 

--- a/scripts/validate_pipelock_result_inventory_test.py
+++ b/scripts/validate_pipelock_result_inventory_test.py
@@ -241,6 +241,16 @@ class InventoryTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "drifted from promotion output"):
             self.validate()
 
+    def test_rejects_evidence_moved_to_wrong_role(self):
+        contract_path = self.root / inventory.PUBLIC_RESULT_CONTRACT_PATH
+        contract = json.loads(contract_path.read_text(encoding="utf-8"))
+        contract["required_evidence"]["raw_evidence"].remove("results.jsonl")
+        contract["required_evidence"]["pinned_inputs"].append("results.jsonl")
+        contract["required_evidence"]["pinned_inputs"].sort()
+        contract_path.write_text(json.dumps(contract) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "role bindings drifted"):
+            self.validate()
+
     def test_rejects_required_file_absent_from_commit_pinned_inventory(self):
         source = self.root / "gauntlet-site/results/pipelock/digest/results.jsonl"
         source.unlink()


### PR DESCRIPTION
## What changed

- Bind every public Pipelock result to its score and scope, pinned inputs, reproduction commands, raw evidence, normalized decisions, and verifier. The check fails closed if the contract weakens, evidence disappears, or an active schema loses its profiles.
- Link the result card to the evidence and keep verification public even when paid reports add analysis. Reviewers should distrust any verified card whose package doesn't match the promotion output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public-result contract defining required evidence, verification commands, sources, and schema requirements.
  - Added guidance for verifying public results, including required contents, pinned inputs, reproduction steps, and verification paths.
  - Added an “Evidence and verify” link to rendered result pages.

- **Bug Fixes**
  - Improved validation of public results, retained records, evidence files, manifests, and commit-pinned artifacts.
  - Added checks for missing evidence, outdated verification commands, incomplete records, and weakened contracts.

- **Tests**
  - Expanded coverage for evidence validation, schema-specific results, and rendered verification links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->