### PR TITLE
feat(schemas): publish an outward schema discovery surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: preflight check-citation check-case-immutability check-frozen-schema-immutability check-schema-catalog check-schema-copies check-docs check-operator-kit check-contracts check-public-contracts check-claim-language check-readme-categories check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow test-release-snapshot release-snapshot validate-cases validate
+.PHONY: preflight check-citation check-case-immutability check-frozen-schema-immutability check-schema-catalog check-schema-discovery-feed check-schema-copies check-docs check-operator-kit check-contracts check-public-contracts check-claim-language check-readme-categories check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image stats stats-update check-stats cases-manifest check-gauntlet-site test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow test-release-snapshot release-snapshot validate-cases validate
 
 TMPDIR := $(HOME)/.cache/pipelock-tmp
 GOCACHE := $(HOME)/.cache/go-build
@@ -13,7 +13,7 @@ AEB_IMMUTABILITY_BASE ?= origin/main
 # below complete comfortably inside the edit-to-push budget and it catches real
 # shared-state defects that ordinary go test would miss. It requires the Go
 # toolchain needed by runner/go.mod (currently Go 1.25 or newer).
-preflight: check-contracts check-schema-catalog check-public-contracts check-case-immutability check-frozen-schema-immutability check-schema-copies check-docs check-operator-kit check-citation test-capability-registry check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow check-stats check-gauntlet-site check-claim-language check-readme-categories
+preflight: check-contracts check-schema-catalog check-schema-discovery-feed check-public-contracts check-case-immutability check-frozen-schema-immutability check-schema-copies check-docs check-operator-kit check-citation test-capability-registry check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image test-validate validate-cases test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow check-stats check-gauntlet-site check-claim-language check-readme-categories
 
 check-scorecard-workflow:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/scorecard_workflow_test.py
@@ -33,6 +33,12 @@ check-contracts:
 check-schema-catalog:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_schema_catalog_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_schema_catalog.py
+
+# The outward feed is generated from schemas/index.json. Keeping this as a
+# separate gate catches a discovery surface that has fallen behind the catalog.
+check-schema-discovery-feed:
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_schema_discovery_feed_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_schema_discovery_feed.py
 
 # Keep the human tables, machine-readable cross-field contracts, JSON Schemas,
 # scorer, and validator on one active definition.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ The [loader-backed statistics](cases/STATS.md) include the block, allow, and war
 
 Most cases are self-contained JSON files with the attack payload, expected verdict (`block` or `allow`), severity, capability tags, and a machine-readable reason for the expected outcome. MCP drift cases under `cases/mcp-drift/` are multi-file before/after fixtures with `case.yaml` metadata.
 
-## Quick start
-
 ## Schema discovery and adapter quickstarts
 
 Machine readers can start with the generated [schema discovery feed](schemas/discovery.json). It lists every declared schema identity and its repository path, then points to the [schema catalog](schemas/index.json) for SHA-256 digests. Schema identifiers remain names, not download URLs. Released catalogs add commit-pinned retrieval URLs and an offline schema bundle.
@@ -75,6 +73,8 @@ The offline validation walkthrough and copy/paste commands live in [Schema ident
 - [CONNECT-capable forward proxy](docs/SCHEMAS.md#connect-capable-forward-proxy)
 - [MCP Streamable HTTP listener](docs/SCHEMAS.md#mcp-streamable-http-listener)
 - [MCP gateway](docs/SCHEMAS.md#mcp-gateway)
+
+## Quick start
 
 **Prerequisites:** [Go 1.25+](https://go.dev/dl/) for the validator and portable runner. The runner uses its own Go module dependencies for fixtures and multi-file case parsing.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Most cases are self-contained JSON files with the attack payload, expected verdi
 
 ## Quick start
 
+## Schema discovery and adapter quickstarts
+
+Machine readers can start with the generated [schema discovery feed](schemas/discovery.json). It lists every declared schema identity and its repository path, then points to the [schema catalog](schemas/index.json) for SHA-256 digests. Schema identifiers remain names, not download URLs. Released catalogs add commit-pinned retrieval URLs and an offline schema bundle.
+
+The offline validation walkthrough and copy/paste commands live in [Schema identifiers and discovery](docs/SCHEMAS.md). Pick the adapter that matches the target:
+
+- [Fetch-style forward proxy](docs/SCHEMAS.md#fetch-style-forward-proxy)
+- [CONNECT-capable forward proxy](docs/SCHEMAS.md#connect-capable-forward-proxy)
+- [MCP Streamable HTTP listener](docs/SCHEMAS.md#mcp-streamable-http-listener)
+- [MCP gateway](docs/SCHEMAS.md#mcp-gateway)
+
 **Prerequisites:** [Go 1.25+](https://go.dev/dl/) for the validator and portable runner. The runner uses its own Go module dependencies for fixtures and multi-file case parsing.
 
 **Build the validator:**
@@ -196,7 +207,9 @@ Integration and reference:
 - [ADOPTION.md](docs/ADOPTION.md): guide for vendors adopting the benchmark
 - [GLOSSARY.md](docs/GLOSSARY.md): definitions of key terms (agent firewall, egress security, etc.)
 - [OWASP-MAPPING.md](docs/OWASP-MAPPING.md): case categories mapped to OWASP Agentic Top 10
-- [schemas/](schemas/): JSON Schema files for cases, tool profiles, and results
+- [schemas/discovery.json](schemas/discovery.json): generated schema-identity feed
+- [schemas/index.json](schemas/index.json): schema paths and SHA-256 digests
+- [SCHEMAS.md](docs/SCHEMAS.md): identity policy, released retrieval, offline validation, and adapter quickstarts
 
 ## Contributing
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -13,6 +13,9 @@ Each release contains:
 - One commit-pinned schema catalog and schema bundle. The bundle contains the
   catalog and every schema it names, so a vendor can validate schema bytes
   after download without a network connection.
+- `release-notes.md`, used as the GitHub Release body. It lists every schema
+  identity and version carried by that release and links to the offline
+  validation walkthrough and adapter quickstarts.
 - Archives for Linux, macOS, and Windows on amd64 and arm64. Each one carries
   both `aeb-gauntlet`, which runs the corpus, and `aeb-validate`, which checks a
   result against the contracts. The release verifier refuses an archive missing

--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -4,364 +4,314 @@
   "catalog_sha256": "a18c6574833b9a29a8b28c03250e996e6f87fa6580982203336b40b392bccb68",
   "schemas": [
     {
-      "path": "schemas/case-index-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-index-v1.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-index-v1.schema.json",
+      "path": "schemas/case-index-v1.schema.json"
     },
     {
-      "path": "schemas/case-index-v2.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-index-v2.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-index-v2.schema.json",
+      "path": "schemas/case-index-v2.schema.json"
     },
     {
-      "path": "schemas/case-index-v3.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-index-v3.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-index-v3.schema.json",
+      "path": "schemas/case-index-v3.schema.json"
     },
     {
-      "path": "schemas/case-v4.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-v4.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-v4.schema.json",
+      "path": "schemas/case-v4.schema.json"
     },
     {
-      "path": "schemas/control-evidence-assessment-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-assessment-v1.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-assessment-v1.schema.json",
+      "path": "schemas/control-evidence-assessment-v1.schema.json"
     },
     {
-      "path": "schemas/control-evidence-assessment-v2.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-assessment-v2.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-assessment-v2.schema.json",
+      "path": "schemas/control-evidence-assessment-v2.schema.json"
     },
     {
-      "path": "schemas/control-evidence-authentication-context-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-authentication-context-v1.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-authentication-context-v1.schema.json",
+      "path": "schemas/control-evidence-authentication-context-v1.schema.json"
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v0.schema.json",
       "path": "schemas/control-evidence-buyer-reproduction-statement-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v0.schema.json"
+      "copies": [
+        "control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-statement-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v1.schema.json",
       "path": "schemas/control-evidence-buyer-reproduction-statement-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-buyer-reproduction-statement-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json",
       "path": "schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json"
+      "copies": [
+        "control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json",
       "path": "schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v0.schema.json",
       "path": "schemas/control-evidence-buyer-reproduction-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v0.schema.json"
+      "copies": [
+        "control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v1.schema.json",
       "path": "schemas/control-evidence-buyer-reproduction-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-buyer-reproduction-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v0.schema.json",
       "path": "schemas/control-evidence-clock-evidence-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v0.schema.json"
+      "copies": [
+        "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-clock-evidence-v0.schema.json",
+        "control-evidence/v0/verifier/schemas/control-evidence-clock-evidence-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v1.schema.json",
       "path": "schemas/control-evidence-clock-evidence-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-clock-evidence-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v0.schema.json",
       "path": "schemas/control-evidence-context-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v0.schema.json"
+      "copies": [
+        "control-evidence/v0/verifier/schemas/control-evidence-context-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v1.schema.json",
       "path": "schemas/control-evidence-context-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-context-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v0.schema.json",
       "path": "schemas/control-evidence-dsse-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v0.schema.json"
+      "copies": [
+        "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-dsse-v0.schema.json",
+        "control-evidence/v0/verifier/schemas/control-evidence-dsse-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v1.schema.json",
       "path": "schemas/control-evidence-dsse-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-dsse-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v0.schema.json",
       "path": "schemas/control-evidence-health-control-material-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v0.schema.json"
+      "copies": [
+        "control-evidence/v0/verifier/schemas/control-evidence-health-control-material-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v1.schema.json",
       "path": "schemas/control-evidence-health-control-material-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-health-control-material-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v0.schema.json",
       "path": "schemas/control-evidence-manifest-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v0.schema.json"
+      "copies": [
+        "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-manifest-v0.schema.json",
+        "control-evidence/v0/verifier/schemas/control-evidence-manifest-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v1.schema.json",
       "path": "schemas/control-evidence-manifest-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-manifest-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v0.schema.json",
       "path": "schemas/control-evidence-observer-evidence-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v0.schema.json"
+      "copies": [
+        "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-observer-evidence-v0.schema.json",
+        "control-evidence/v0/verifier/schemas/control-evidence-observer-evidence-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v1.schema.json",
       "path": "schemas/control-evidence-observer-evidence-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-observer-evidence-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v0.schema.json",
       "path": "schemas/control-evidence-outcomes-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v0.schema.json"
+      "copies": [
+        "control-evidence/v0/verifier/schemas/control-evidence-outcomes-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v1.schema.json",
       "path": "schemas/control-evidence-outcomes-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-outcomes-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v0.schema.json",
       "path": "schemas/control-evidence-requirement-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v0.schema.json"
+      "copies": [
+        "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-requirement-v0.schema.json",
+        "control-evidence/v0/verifier/schemas/control-evidence-requirement-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v1.schema.json",
       "path": "schemas/control-evidence-requirement-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-requirement-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v0.schema.json",
       "path": "schemas/control-evidence-run-envelope-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v0.schema.json"
+      "copies": [
+        "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-run-envelope-v0.schema.json",
+        "control-evidence/v0/verifier/schemas/control-evidence-run-envelope-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v1.schema.json",
       "path": "schemas/control-evidence-run-envelope-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-run-envelope-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v0.schema.json",
       "path": "schemas/control-evidence-token-material-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v0.schema.json"
+      "copies": [
+        "control-evidence/v0/verifier/schemas/control-evidence-token-material-v0.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v1.schema.json",
       "path": "schemas/control-evidence-token-material-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v1.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/control-evidence-token-material-v1.schema.json"
+      ]
     },
     {
-      "path": "schemas/control-evidence-trust-policy-dsse-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-trust-policy-dsse-v1.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-trust-policy-dsse-v1.schema.json",
+      "path": "schemas/control-evidence-trust-policy-dsse-v1.schema.json"
     },
     {
-      "path": "schemas/control-evidence-trust-policy-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-trust-policy-v1.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-trust-policy-v1.schema.json",
+      "path": "schemas/control-evidence-trust-policy-v1.schema.json"
     },
     {
-      "path": "schemas/multi-file-case-v4.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/multi-file-case-v4.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/multi-file-case-v4.schema.json",
+      "path": "schemas/multi-file-case-v4.schema.json"
     },
     {
-      "path": "schemas/promoted-record-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v1.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v1.schema.json",
+      "path": "schemas/promoted-record-v1.schema.json"
     },
     {
-      "path": "schemas/promoted-record-v2.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v2.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v2.schema.json",
+      "path": "schemas/promoted-record-v2.schema.json"
     },
     {
-      "path": "schemas/promotion-baseline-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promotion-baseline-v1.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promotion-baseline-v1.schema.json",
+      "path": "schemas/promotion-baseline-v1.schema.json"
     },
     {
-      "path": "schemas/provenance-candidate-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v1.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v1.schema.json",
+      "path": "schemas/provenance-candidate-v1.schema.json"
     },
     {
-      "path": "schemas/provenance-candidate-v2.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v2.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v2.schema.json",
+      "path": "schemas/provenance-candidate-v2.schema.json"
     },
     {
-      "path": "schemas/provenance-candidate-v4.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v4.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v4.schema.json",
+      "path": "schemas/provenance-candidate-v4.schema.json"
     },
     {
-      "path": "schemas/provenance-candidate-v5.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v5.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v5.schema.json",
+      "path": "schemas/provenance-candidate-v5.schema.json"
     },
     {
-      "path": "schemas/provenance-candidate-v6.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v6.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v6.schema.json",
+      "path": "schemas/provenance-candidate-v6.schema.json"
     },
     {
-      "path": "schemas/receipt-scoring-profile-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/receipt-scoring-profile-v1.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/receipt-scoring-profile-v1.schema.json",
+      "path": "schemas/receipt-scoring-profile-v1.schema.json"
     },
     {
-      "path": "schemas/receipt-scoring-profile-v3.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/receipt-scoring-profile-v3.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/receipt-scoring-profile-v3.schema.json",
+      "path": "schemas/receipt-scoring-profile-v3.schema.json"
     },
     {
-      "path": "schemas/receipt-scoring-profile-v4.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/receipt-scoring-profile-v4.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/receipt-scoring-profile-v4.schema.json",
+      "path": "schemas/receipt-scoring-profile-v4.schema.json"
     },
     {
-      "path": "schemas/result-v4.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/result-v4.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/result-v4.schema.json",
+      "path": "schemas/result-v4.schema.json"
     },
     {
-      "path": "schemas/result-v5.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/result-v5.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/result-v5.schema.json",
+      "path": "schemas/result-v5.schema.json"
     },
     {
-      "path": "schemas/summary-v4.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/summary-v4.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/summary-v4.schema.json",
+      "path": "schemas/summary-v4.schema.json"
     },
     {
-      "path": "schemas/summary-v5.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/summary-v5.schema.json"
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/summary-v5.schema.json",
+      "path": "schemas/summary-v5.schema.json"
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v1.schema.json",
       "path": "schemas/tool-profile-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v1.schema.json"
+      "copies": [
+        "control-evidence/v0/verifier/schemas/tool-profile-v1.schema.json",
+        "control-evidence/v1/verifier/schemas/tool-profile-v1.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v3.schema.json",
       "path": "schemas/tool-profile-v3.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v3.schema.json"
+      "copies": [
+        "control-evidence/v0/verifier/schemas/tool-profile-v3.schema.json"
+      ]
     },
     {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v4.schema.json",
       "path": "schemas/tool-profile-v4.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v4.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-statement-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-clock-evidence-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-context-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-dsse-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-health-control-material-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-manifest-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-observer-evidence-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-outcomes-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-requirement-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-run-envelope-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/control-evidence-token-material-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/tool-profile-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v0/verifier/schemas/tool-profile-v3.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v3.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-buyer-reproduction-statement-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-buyer-reproduction-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-clock-evidence-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-context-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-dsse-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-health-control-material-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-manifest-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-observer-evidence-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-outcomes-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-requirement-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-run-envelope-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/control-evidence-token-material-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/tool-profile-v1.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v1.schema.json"
-    },
-    {
-      "path": "control-evidence/v1/verifier/schemas/tool-profile-v4.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v4.schema.json"
-    },
-    {
-      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-clock-evidence-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-dsse-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-manifest-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-observer-evidence-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-requirement-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v0.schema.json"
-    },
-    {
-      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-run-envelope-v0.schema.json",
-      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v0.schema.json"
+      "copies": [
+        "control-evidence/v1/verifier/schemas/tool-profile-v4.schema.json"
+      ]
     }
   ]
 }

--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -1,0 +1,367 @@
+{
+  "format": 1,
+  "catalog": "schemas/index.json",
+  "catalog_sha256": "a18c6574833b9a29a8b28c03250e996e6f87fa6580982203336b40b392bccb68",
+  "schemas": [
+    {
+      "path": "schemas/case-index-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-index-v1.schema.json"
+    },
+    {
+      "path": "schemas/case-index-v2.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-index-v2.schema.json"
+    },
+    {
+      "path": "schemas/case-index-v3.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-index-v3.schema.json"
+    },
+    {
+      "path": "schemas/case-v4.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-v4.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-assessment-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-assessment-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-assessment-v2.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-assessment-v2.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-authentication-context-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-authentication-context-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-buyer-reproduction-statement-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-buyer-reproduction-statement-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-buyer-reproduction-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-buyer-reproduction-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-clock-evidence-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-clock-evidence-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-context-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-context-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-dsse-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-dsse-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-health-control-material-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-health-control-material-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-manifest-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-manifest-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-observer-evidence-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-observer-evidence-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-outcomes-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-outcomes-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-requirement-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-requirement-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-run-envelope-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-run-envelope-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-token-material-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v0.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-token-material-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-trust-policy-dsse-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-trust-policy-dsse-v1.schema.json"
+    },
+    {
+      "path": "schemas/control-evidence-trust-policy-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-trust-policy-v1.schema.json"
+    },
+    {
+      "path": "schemas/multi-file-case-v4.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/multi-file-case-v4.schema.json"
+    },
+    {
+      "path": "schemas/promoted-record-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v1.schema.json"
+    },
+    {
+      "path": "schemas/promoted-record-v2.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v2.schema.json"
+    },
+    {
+      "path": "schemas/promotion-baseline-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promotion-baseline-v1.schema.json"
+    },
+    {
+      "path": "schemas/provenance-candidate-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v1.schema.json"
+    },
+    {
+      "path": "schemas/provenance-candidate-v2.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v2.schema.json"
+    },
+    {
+      "path": "schemas/provenance-candidate-v4.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v4.schema.json"
+    },
+    {
+      "path": "schemas/provenance-candidate-v5.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v5.schema.json"
+    },
+    {
+      "path": "schemas/provenance-candidate-v6.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/provenance-candidate-v6.schema.json"
+    },
+    {
+      "path": "schemas/receipt-scoring-profile-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/receipt-scoring-profile-v1.schema.json"
+    },
+    {
+      "path": "schemas/receipt-scoring-profile-v3.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/receipt-scoring-profile-v3.schema.json"
+    },
+    {
+      "path": "schemas/receipt-scoring-profile-v4.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/receipt-scoring-profile-v4.schema.json"
+    },
+    {
+      "path": "schemas/result-v4.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/result-v4.schema.json"
+    },
+    {
+      "path": "schemas/result-v5.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/result-v5.schema.json"
+    },
+    {
+      "path": "schemas/summary-v4.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/summary-v4.schema.json"
+    },
+    {
+      "path": "schemas/summary-v5.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/summary-v5.schema.json"
+    },
+    {
+      "path": "schemas/tool-profile-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v1.schema.json"
+    },
+    {
+      "path": "schemas/tool-profile-v3.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v3.schema.json"
+    },
+    {
+      "path": "schemas/tool-profile-v4.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v4.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-statement-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-buyer-reproduction-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-clock-evidence-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-context-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-dsse-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-health-control-material-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-manifest-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-observer-evidence-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-outcomes-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-requirement-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-run-envelope-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/control-evidence-token-material-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/tool-profile-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v0/verifier/schemas/tool-profile-v3.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v3.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-buyer-reproduction-statement-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-statement-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-transcript-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-buyer-reproduction-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-buyer-reproduction-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-clock-evidence-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-context-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-context-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-dsse-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-health-control-material-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-health-control-material-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-manifest-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-observer-evidence-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-outcomes-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-outcomes-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-requirement-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-run-envelope-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/control-evidence-token-material-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-token-material-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/tool-profile-v1.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v1.schema.json"
+    },
+    {
+      "path": "control-evidence/v1/verifier/schemas/tool-profile-v4.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/tool-profile-v4.schema.json"
+    },
+    {
+      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-clock-evidence-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-clock-evidence-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-dsse-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-dsse-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-manifest-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-manifest-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-observer-evidence-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-observer-evidence-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-requirement-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-requirement-v0.schema.json"
+    },
+    {
+      "path": "control-evidence/g2/authentication/schemas/cee-v0/control-evidence-run-envelope-v0.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/control-evidence-run-envelope-v0.schema.json"
+    }
+  ]
+}

--- a/scripts/check_schema_discovery_feed.py
+++ b/scripts/check_schema_discovery_feed.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Require the outward schema-discovery feed to match schemas/index.json."""
+
+import json
+import sys
+from pathlib import Path
+
+from schema_discovery_feed import FEED_PATH, rendered_feed
+
+
+def check(root: Path) -> int:
+    path = root / FEED_PATH
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"schema discovery feed must be a regular file: {FEED_PATH}")
+    actual = path.read_bytes()
+    if not actual:
+        raise ValueError(f"schema discovery feed is empty: {FEED_PATH}")
+    expected = rendered_feed(root)
+    if actual != expected:
+        raise ValueError(
+            f"{FEED_PATH} is stale; regenerate it from schemas/index.json with "
+            "python3 scripts/write_schema_discovery_feed.py"
+        )
+    return len(json.loads(actual)["schemas"])
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    try:
+        count = check(root)
+    except (OSError, ValueError) as exc:
+        print(f"check-schema-discovery-feed: FAIL - {exc}", file=sys.stderr)
+        return 1
+    print(f"check-schema-discovery-feed: OK ({count} schema entries indexed)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_schema_discovery_feed_test.py
+++ b/scripts/check_schema_discovery_feed_test.py
@@ -75,6 +75,37 @@ class SchemaDiscoveryFeedTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must be a regular file"):
             check_schema_discovery_feed.check(self.root)
 
+    def _catalog_bytes_with_path(self, path):
+        return json.dumps(
+            {
+                "format": 1,
+                "repository": "luckyPipewrench/agent-egress-bench",
+                "schemas": [{"path": path, "$id": "https://example.invalid/x", "sha256": "0" * 64}],
+            }
+        ).encode("utf-8")
+
+    def test_missing_schema_target_is_refused(self):
+        with self.assertRaisesRegex(ValueError, "does not exist"):
+            schema_discovery_feed.catalog_entries(
+                self.root, self._catalog_bytes_with_path("schemas/not-a-real-file.schema.json")
+            )
+
+    def test_directory_schema_target_is_refused(self):
+        (self.root / "schemas" / "subdir").mkdir()
+        with self.assertRaisesRegex(ValueError, "not a regular file"):
+            schema_discovery_feed.catalog_entries(self.root, self._catalog_bytes_with_path("schemas/subdir"))
+
+    def test_symlinked_schema_target_is_refused(self):
+        link = self.root / "schemas" / "linked-probe.schema.json"
+        link.symlink_to("/etc/hostname")
+        try:
+            with self.assertRaisesRegex(ValueError, "is a symlink"):
+                schema_discovery_feed.catalog_entries(
+                    self.root, self._catalog_bytes_with_path("schemas/linked-probe.schema.json")
+                )
+        finally:
+            link.unlink()
+
     def test_feed_keeps_identity_separate_from_retrieval(self):
         feed = json.loads((self.root / "schemas/discovery.json").read_text(encoding="utf-8"))
         self.assertEqual({"format", "catalog", "catalog_sha256", "schemas"}, set(feed))

--- a/scripts/check_schema_discovery_feed_test.py
+++ b/scripts/check_schema_discovery_feed_test.py
@@ -48,11 +48,21 @@ class SchemaDiscoveryFeedTest(unittest.TestCase):
         self.assertEqual(1, check_schema_discovery_feed.check(self.root))
 
     def test_rejects_feed_when_catalog_changes(self):
+        # Change the identity, not the digest. A forged digest is refused earlier by the file-hash
+        # check below, so mutating it here would test that guard instead of staleness.
+        catalog_path = self.root / "schemas/index.json"
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        catalog["schemas"][0]["$id"] = "https://example.invalid/renamed-v1.schema.json"
+        catalog_path.write_text(json.dumps(catalog) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "is stale"):
+            check_schema_discovery_feed.check(self.root)
+
+    def test_forged_catalog_digest_is_refused(self):
         catalog_path = self.root / "schemas/index.json"
         catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
         catalog["schemas"][0]["sha256"] = "0" * 64
         catalog_path.write_text(json.dumps(catalog) + "\n", encoding="utf-8")
-        with self.assertRaisesRegex(ValueError, "is stale"):
+        with self.assertRaisesRegex(ValueError, "digest does not match"):
             check_schema_discovery_feed.check(self.root)
 
     def test_missing_feed_is_refused(self):

--- a/scripts/check_schema_discovery_feed_test.py
+++ b/scripts/check_schema_discovery_feed_test.py
@@ -55,6 +55,26 @@ class SchemaDiscoveryFeedTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "is stale"):
             check_schema_discovery_feed.check(self.root)
 
+    def test_missing_feed_is_refused(self):
+        (self.root / "schemas/discovery.json").unlink()
+        with self.assertRaisesRegex(ValueError, "must be a regular file"):
+            check_schema_discovery_feed.check(self.root)
+
+    def test_empty_feed_is_refused(self):
+        (self.root / "schemas/discovery.json").write_bytes(b"")
+        with self.assertRaisesRegex(ValueError, "is empty"):
+            check_schema_discovery_feed.check(self.root)
+
+    def test_symlinked_feed_is_refused(self):
+        feed = self.root / "schemas/discovery.json"
+        contents = feed.read_bytes()
+        target = self.root / "schemas/real-discovery.json"
+        target.write_bytes(contents)
+        feed.unlink()
+        feed.symlink_to(target)
+        with self.assertRaisesRegex(ValueError, "must be a regular file"):
+            check_schema_discovery_feed.check(self.root)
+
     def test_feed_keeps_identity_separate_from_retrieval(self):
         feed = json.loads((self.root / "schemas/discovery.json").read_text(encoding="utf-8"))
         self.assertEqual({"format", "catalog", "catalog_sha256", "schemas"}, set(feed))

--- a/scripts/check_schema_discovery_feed_test.py
+++ b/scripts/check_schema_discovery_feed_test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Regression tests for the generated outward schema-discovery feed."""
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).parent
+
+
+def load_module(name):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+schema_catalog = load_module("schema_catalog")
+schema_discovery_feed = load_module("schema_discovery_feed")
+check_schema_discovery_feed = load_module("check_schema_discovery_feed")
+
+
+class SchemaDiscoveryFeedTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        schemas = self.root / "schemas"
+        schemas.mkdir()
+        (schemas / "fixture-v1.schema.json").write_text(
+            json.dumps({"$id": "https://example.invalid/fixture-v1.schema.json"}) + "\n",
+            encoding="utf-8",
+        )
+        (schemas / "index.json").write_bytes(
+            schema_catalog.rendered_catalog(self.root, roots=("schemas",))
+        )
+        (schemas / "discovery.json").write_bytes(schema_discovery_feed.rendered_feed(self.root))
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_accepts_feed_generated_from_catalog(self):
+        self.assertEqual(1, check_schema_discovery_feed.check(self.root))
+
+    def test_rejects_feed_when_catalog_changes(self):
+        catalog_path = self.root / "schemas/index.json"
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+        catalog["schemas"][0]["sha256"] = "0" * 64
+        catalog_path.write_text(json.dumps(catalog) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "is stale"):
+            check_schema_discovery_feed.check(self.root)
+
+    def test_feed_keeps_identity_separate_from_retrieval(self):
+        feed = json.loads((self.root / "schemas/discovery.json").read_text(encoding="utf-8"))
+        self.assertEqual({"format", "catalog", "catalog_sha256", "schemas"}, set(feed))
+        self.assertEqual({"path", "$id"}, set(feed["schemas"][0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release-build.sh
+++ b/scripts/release-build.sh
@@ -79,6 +79,7 @@ python3 scripts/release_build.py data-bundle --identity "$identity" --dist "$rel
 schema_catalog="$release_dir/agent-egress-bench_${version}_schema-catalog.json"
 python3 scripts/write_schema_catalog.py --release "$tag" --output "$schema_catalog"
 python3 scripts/release_build.py schema-bundle --identity "$identity" --catalog "$schema_catalog" --dist "$release_dir"
+python3 scripts/release_build.py release-notes --identity "$identity" --catalog "$schema_catalog" --output "$release_dir/release-notes.md"
 python3 scripts/release_build.py checksums --identity "$identity" --dist "$release_dir"
 # Run the binary this host can actually execute. Hardcoding linux/amd64 works on
 # CI and silently breaks a macOS or arm64 developer running a snapshot. When no

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -610,7 +610,7 @@ def rendered_release_notes(identity: dict[str, Any], catalog_bytes: bytes) -> by
         f"{tag} carries these schema identities and versions from `{commit}`:",
         "",
     ]
-    for entry in entries:
+    for entry in sorted(entries, key=lambda entry: entry["path"]):
         lines.append(f"- `{entry['$id']}` (`{entry['path']}`)")
     lines.extend(
         [

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -29,6 +29,8 @@ CHECKSUM_NAME = "checksums.txt"
 SCHEMA_CATALOG_PATH = "schemas/index.json"
 SCHEMA_CATALOG_SUFFIX = "_schema-catalog.json"
 SCHEMA_BUNDLE_SUFFIX = "_schemas.tar.gz"
+RELEASE_NOTES_NAME = "release-notes.md"
+RELEASE_NOTES_MARKER = "<!-- agent-egress-bench-release-workflow-v1 -->"
 METHOD_INDEPENDENCE_PATH = "contracts/method-independence-v1.json"
 REPOSITORY = "luckyPipewrench/agent-egress-bench"
 RAW_SCHEMA_URL = "https://raw.githubusercontent.com/luckyPipewrench/agent-egress-bench/{commit}/{path}"
@@ -595,6 +597,41 @@ def release_catalog_entries(identity: dict[str, Any], catalog_bytes: bytes) -> l
     return entries
 
 
+def rendered_release_notes(identity: dict[str, Any], catalog_bytes: bytes) -> bytes:
+    """Render the GitHub release body from its checked release catalog."""
+    entries = release_catalog_entries(identity, catalog_bytes)
+    tag = identity["release"]["tag"]
+    commit = identity["source"]["commit"]
+    lines = [
+        RELEASE_NOTES_MARKER,
+        "",
+        "## Schema contracts",
+        "",
+        f"{tag} carries these schema identities and versions from `{commit}`:",
+        "",
+    ]
+    for entry in entries:
+        lines.append(f"- `{entry['$id']}` (`{entry['path']}`)")
+    lines.extend(
+        [
+            "",
+            "The release schema catalog contains commit-pinned retrieval URLs and SHA-256 digests. The schema bundle supports offline validation. See [Schema identifiers and discovery](https://github.com/luckyPipewrench/agent-egress-bench/blob/"
+            + tag
+            + "/docs/SCHEMAS.md) for the validation walkthrough and adapter quickstarts.",
+            "",
+        ]
+    )
+    return "\n".join(lines).encode("utf-8")
+
+
+def write_release_notes(identity_path: Path, catalog_path: Path, output: Path) -> Path:
+    identity = read_identity(identity_path)
+    if not catalog_path.is_file() or catalog_path.is_symlink():
+        fail(f"release schema catalog is absent or unsafe: {catalog_path}")
+    output.write_bytes(rendered_release_notes(identity, catalog_path.read_bytes()))
+    return output
+
+
 def require_declared_id(contents: bytes, entry: dict[str, str], source: str) -> None:
     """Require a schema's own declared identity to match what the catalog claims.
 
@@ -906,6 +943,11 @@ def verify_release(release_dir: Path, repo: Path | None, executable: Path | None
     validate_method_independence_contract(contents[METHOD_INDEPENDENCE_PATH])
     verify_bundle_corpus(identity, contents)
     schema_entries, schema_contents = verify_schema_bundle(identity, release_dir)
+    if RELEASE_NOTES_NAME not in checksums:
+        fail("release is missing generated release notes")
+    notes = release_dir / RELEASE_NOTES_NAME
+    if notes.read_bytes() != rendered_release_notes(identity, (release_dir / catalog_name).read_bytes()):
+        fail("release notes do not match the release schema catalog")
     if repo is not None:
         verify_repo_schema_surface(repo.resolve(), schema_entries, schema_contents)
         expected = build_identity(repo.resolve(), identity["release"]["tag"], identity["release"]["version"], identity["source"]["commit"], identity["release"]["snapshot"])
@@ -1057,6 +1099,10 @@ def main() -> int:
     schema_bundle.add_argument("--identity", type=Path, required=True)
     schema_bundle.add_argument("--catalog", type=Path, required=True)
     schema_bundle.add_argument("--dist", type=Path, required=True)
+    release_notes = commands.add_parser("release-notes")
+    release_notes.add_argument("--identity", type=Path, required=True)
+    release_notes.add_argument("--catalog", type=Path, required=True)
+    release_notes.add_argument("--output", type=Path, required=True)
     sums = commands.add_parser("checksums")
     sums.add_argument("--identity", type=Path, required=True)
     sums.add_argument("--dist", type=Path, required=True)
@@ -1080,6 +1126,8 @@ def main() -> int:
             print(make_data_bundle(args.repo_root.resolve(), args.identity, args.dist))
         elif args.command == "schema-bundle":
             print(make_schema_bundle(args.repo_root.resolve(), args.identity, args.catalog, args.dist))
+        elif args.command == "release-notes":
+            print(write_release_notes(args.identity, args.catalog, args.output))
         elif args.command == "checksums":
             print(write_checksums(args.dist, args.identity))
         elif args.command == "verify":

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -615,8 +615,10 @@ def rendered_release_notes(identity: dict[str, Any], catalog_bytes: bytes) -> by
     lines.extend(
         [
             "",
+            # The commit, not the tag. A snapshot build has the literal tag "snapshot", which is not a
+            # ref a reader can resolve, and a tag can be moved after the fact while a commit cannot.
             "The release schema catalog contains commit-pinned retrieval URLs and SHA-256 digests. The schema bundle supports offline validation. See [Schema identifiers and discovery](https://github.com/luckyPipewrench/agent-egress-bench/blob/"
-            + tag
+            + commit
             + "/docs/SCHEMAS.md) for the validation walkthrough and adapter quickstarts.",
             "",
         ]

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -155,6 +155,15 @@ class ReleaseBuildTest(unittest.TestCase):
             "--dist",
             str(dist),
         )
+        self.invoke(
+            "release-notes",
+            "--identity",
+            str(self.identity),
+            "--catalog",
+            str(catalog),
+            "--output",
+            str(dist / "release-notes.md"),
+        )
 
     def forge_release(self, identity: dict) -> Path:
         release = Path(self.temp.name) / "fakerel"

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -131,10 +131,39 @@ def _verified_notes_snapshot(dist: Path, stack: contextlib.ExitStack) -> tuple[P
         fail(f"release distribution is missing {RELEASE_NOTES_NAME}")
     if DRAFT_MARKER not in text:
         fail(f"{RELEASE_NOTES_NAME} is missing the release workflow ownership marker")
+    _require_notes_match_release(dist, raw)
     directory = stack.enter_context(tempfile.TemporaryDirectory())
     snapshot = Path(directory) / RELEASE_NOTES_NAME
     snapshot.write_bytes(raw)
     return snapshot, text
+
+
+def _require_notes_match_release(dist: Path, raw: bytes) -> None:
+    """Require the notes to be exactly what this release's identity and catalog generate.
+
+    The ownership marker only says the workflow wrote a notes file at some point. It cannot say the
+    bytes are still the generated ones, so on its own it accepts an edited body carrying arbitrary
+    release metadata. Regenerating from the identity and catalog and comparing byte for byte is what
+    makes the published body a property of the release rather than of whoever last wrote the file.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    try:
+        import release_build
+    except ImportError as exc:  # pragma: no cover - a broken checkout, not a release condition
+        fail(f"cannot load the release builder to verify {RELEASE_NOTES_NAME}: {exc}")
+    identity_path = dist / release_build.IDENTITY_NAME
+    try:
+        identity = json.loads(identity_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        fail(f"cannot read {release_build.IDENTITY_NAME} to verify {RELEASE_NOTES_NAME}: {exc}")
+    try:
+        catalog_name, _ = release_build.schema_asset_names(identity)
+        catalog_bytes = (dist / catalog_name).read_bytes()
+        expected = release_build.rendered_release_notes(identity, catalog_bytes)
+    except (OSError, KeyError, TypeError, ValueError) as exc:
+        fail(f"cannot regenerate {RELEASE_NOTES_NAME} from the release catalog: {exc}")
+    if raw != expected:
+        fail(f"{RELEASE_NOTES_NAME} does not match the notes generated from this release")
 
 
 def publish(tag: str, dist: Path, gh: str) -> None:

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -15,6 +15,7 @@ from typing import Any
 # was made by this workflow rather than being an unrelated draft for the tag.
 DRAFT_OWNER = "agent-egress-bench-release-workflow-v1"
 DRAFT_MARKER = f"<!-- {DRAFT_OWNER} -->"
+RELEASE_NOTES_NAME = "release-notes.md"
 
 
 class PublishError(RuntimeError):
@@ -91,13 +92,20 @@ def actual_asset_names(release: dict[str, Any]) -> list[str]:
 def publish(tag: str, dist: Path, gh: str) -> None:
     assets = release_assets(dist)
     expected_names = [asset.name for asset in assets]
+    notes = dist / RELEASE_NOTES_NAME
+    if not notes.is_file() or notes.is_symlink() or not notes.read_text(encoding="utf-8").strip():
+        fail(f"release distribution is missing {RELEASE_NOTES_NAME}")
+    if DRAFT_MARKER not in notes.read_text(encoding="utf-8"):
+        fail(f"{RELEASE_NOTES_NAME} is missing the release workflow ownership marker")
     release = inspect_draft(gh, tag)
     asset_arguments = [str(asset) for asset in assets]
     if release is None:
-        command(gh, "release", "create", tag, *asset_arguments, "--title", tag, "--verify-tag", "--draft", "--notes", DRAFT_MARKER)
+        command(gh, "release", "create", tag, *asset_arguments, "--title", tag, "--verify-tag", "--draft", "--notes-file", str(notes))
     else:
         require_owned_draft(release, tag)
         command(gh, "release", "upload", tag, *asset_arguments, "--clobber")
+
+    command(gh, "release", "edit", tag, "--notes-file", str(notes))
 
     release = inspect_draft(gh, tag)
     if release is None:

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -8,6 +8,7 @@ import contextlib
 import json
 import os
 import subprocess
+import stat
 import sys
 import tempfile
 from pathlib import Path
@@ -18,6 +19,8 @@ from typing import Any
 # was made by this workflow rather than being an unrelated draft for the tag.
 DRAFT_OWNER = "agent-egress-bench-release-workflow-v1"
 DRAFT_MARKER = f"<!-- {DRAFT_OWNER} -->"
+# A release notes body is prose. Anything approaching this size is a wrong or hostile file.
+MAX_NOTES_BYTES = 1 << 20
 RELEASE_NOTES_NAME = "release-notes.md"
 
 
@@ -102,11 +105,28 @@ def _verified_notes_snapshot(dist: Path, stack: contextlib.ExitStack) -> tuple[P
     """
     notes = dist / RELEASE_NOTES_NAME
     try:
-        with open(notes, "rb", opener=lambda path, flags: os.open(path, flags | os.O_NOFOLLOW)) as handle:
-            raw = handle.read()
+        descriptor = os.open(notes, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
     except OSError:
         fail(f"release distribution is missing {RELEASE_NOTES_NAME}")
-    text = raw.decode("utf-8", errors="strict")
+    try:
+        status = os.fstat(descriptor)
+        # Check the object actually opened, not the name. A FIFO would otherwise block the release on
+        # a read that never returns, and a device file would supply unbounded input.
+        if not stat.S_ISREG(status.st_mode):
+            fail(f"{RELEASE_NOTES_NAME} is not a regular file")
+        if status.st_size > MAX_NOTES_BYTES:
+            fail(f"{RELEASE_NOTES_NAME} is larger than {MAX_NOTES_BYTES} bytes")
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            raw = handle.read(MAX_NOTES_BYTES + 1)
+    finally:
+        os.close(descriptor)
+    if len(raw) > MAX_NOTES_BYTES:
+        fail(f"{RELEASE_NOTES_NAME} is larger than {MAX_NOTES_BYTES} bytes")
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        # A traceback here would be an uncontrolled exit from a publication path; refuse instead.
+        fail(f"{RELEASE_NOTES_NAME} is not valid UTF-8")
     if not text.strip():
         fail(f"release distribution is missing {RELEASE_NOTES_NAME}")
     if DRAFT_MARKER not in text:
@@ -151,9 +171,19 @@ def _publish_with_notes(tag, dist, gh, assets, expected_names, notes, notes_text
     # The snapshot proves what was SENT. This proves what the release actually carries, so a body
     # replaced between the edit and publication cannot be undrafted.
     body = release.get("body")
-    if not isinstance(body, str) or body.strip() != notes_text.strip():
+    # Exact comparison. Accepting a body that differs only at its boundaries would weaken the check
+    # into "looks close enough", which is not what a published release body needs.
+    if not isinstance(body, str) or body != notes_text:
         fail(f"draft {tag} body does not match the verified release notes")
-    command(gh, "release", "edit", tag, "--draft=false")
+    # One update sets the verified body AND clears the draft. Doing those separately leaves a window
+    # in which another editor can replace the body between the check and publication.
+    command(gh, "release", "edit", tag, "--notes-file", str(notes), "--draft=false")
+    published = inspect_draft(gh, tag)
+    if published is None:
+        fail(f"release {tag} disappeared during publication")
+    published_body = published.get("body")
+    if not isinstance(published_body, str) or published_body != notes_text:
+        fail(f"published release {tag} body does not match the verified release notes")
 
 
 def main() -> int:

--- a/scripts/release_publish.py
+++ b/scripts/release_publish.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -89,14 +92,40 @@ def actual_asset_names(release: dict[str, Any]) -> list[str]:
     return sorted(names)
 
 
+def _verified_notes_snapshot(dist: Path, stack: contextlib.ExitStack) -> tuple[Path, str]:
+    """Return a path holding the exact notes bytes that were validated.
+
+    Validating the notes file and then handing its PATHNAME to gh leaves a window: gh re-reads the
+    file later, so a write or a symlink swap in between publishes bytes nobody checked. Read once,
+    validate those bytes, and copy them into a file this process owns, so what gh publishes is
+    exactly what passed validation.
+    """
+    notes = dist / RELEASE_NOTES_NAME
+    try:
+        with open(notes, "rb", opener=lambda path, flags: os.open(path, flags | os.O_NOFOLLOW)) as handle:
+            raw = handle.read()
+    except OSError:
+        fail(f"release distribution is missing {RELEASE_NOTES_NAME}")
+    text = raw.decode("utf-8", errors="strict")
+    if not text.strip():
+        fail(f"release distribution is missing {RELEASE_NOTES_NAME}")
+    if DRAFT_MARKER not in text:
+        fail(f"{RELEASE_NOTES_NAME} is missing the release workflow ownership marker")
+    directory = stack.enter_context(tempfile.TemporaryDirectory())
+    snapshot = Path(directory) / RELEASE_NOTES_NAME
+    snapshot.write_bytes(raw)
+    return snapshot, text
+
+
 def publish(tag: str, dist: Path, gh: str) -> None:
     assets = release_assets(dist)
     expected_names = [asset.name for asset in assets]
-    notes = dist / RELEASE_NOTES_NAME
-    if not notes.is_file() or notes.is_symlink() or not notes.read_text(encoding="utf-8").strip():
-        fail(f"release distribution is missing {RELEASE_NOTES_NAME}")
-    if DRAFT_MARKER not in notes.read_text(encoding="utf-8"):
-        fail(f"{RELEASE_NOTES_NAME} is missing the release workflow ownership marker")
+    with contextlib.ExitStack() as stack:
+        notes, notes_text = _verified_notes_snapshot(dist, stack)
+        _publish_with_notes(tag, dist, gh, assets, expected_names, notes, notes_text)
+
+
+def _publish_with_notes(tag, dist, gh, assets, expected_names, notes, notes_text) -> None:
     release = inspect_draft(gh, tag)
     asset_arguments = [str(asset) for asset in assets]
     if release is None:
@@ -119,6 +148,11 @@ def publish(tag: str, dist: Path, gh: str) -> None:
     # attestation set, which is precisely what a consumer's verification refuses.
     if actual_names != sorted(expected_names):
         fail(f"draft {tag} assets do not exactly match dist/release: expected={sorted(expected_names)}, actual={actual_names}")
+    # The snapshot proves what was SENT. This proves what the release actually carries, so a body
+    # replaced between the edit and publication cannot be undrafted.
+    body = release.get("body")
+    if not isinstance(body, str) or body.strip() != notes_text.strip():
+        fail(f"draft {tag} body does not match the verified release notes")
     command(gh, "release", "edit", tag, "--draft=false")
 
 

--- a/scripts/release_publish_test.py
+++ b/scripts/release_publish_test.py
@@ -92,6 +92,36 @@ class ReleasePublishTest(unittest.TestCase):
             env={"MOCK_GH_STATE": str(self.state_path), "MOCK_GH_CALLS": str(self.calls_path)},
         )
 
+    def test_missing_release_notes_is_refused_before_any_gh_call(self) -> None:
+        (self.dist / "release-notes.md").unlink()
+        result = self.publish()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing release-notes.md", result.stderr)
+        self.assertEqual([], self.calls())
+
+    def test_empty_release_notes_is_refused_before_any_gh_call(self) -> None:
+        (self.dist / "release-notes.md").write_text("   \n", encoding="utf-8")
+        result = self.publish()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing release-notes.md", result.stderr)
+        self.assertEqual([], self.calls())
+
+    def test_release_notes_without_ownership_marker_is_refused(self) -> None:
+        (self.dist / "release-notes.md").write_text("## Schema contracts\n", encoding="utf-8")
+        result = self.publish()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ownership marker", result.stderr)
+        self.assertEqual([], self.calls())
+
+    def test_release_notes_marker_matches_the_generator(self) -> None:
+        # The build and publish modules each hardcode the marker. If they drift, publish refuses
+        # every generated notes file, and nothing else would catch it until release day.
+        sys.path.insert(0, str(SCRIPT.parent))
+        import release_build
+        import release_publish
+
+        self.assertEqual(release_build.RELEASE_NOTES_MARKER, release_publish.DRAFT_MARKER)
+
     def test_creates_marked_draft_with_exact_assets_before_publication(self) -> None:
         result = self.publish()
         self.assertEqual(result.returncode, 0, msg=result.stderr)

--- a/scripts/release_publish_test.py
+++ b/scripts/release_publish_test.py
@@ -65,7 +65,7 @@ class ReleasePublishTest(unittest.TestCase):
             "elif args[:2] == ['release', 'edit']:\n"
             "  if '--notes-file' in args:\n"
             "    state['body'] = Path(args[args.index('--notes-file') + 1]).read_text(encoding='utf-8')\n"
-            "  else:\n"
+            "  if '--draft=false' in args:\n"
             "    state['isDraft'] = False\n"
             "  save()\n"
             "else:\n"
@@ -145,7 +145,7 @@ class ReleasePublishTest(unittest.TestCase):
         result = self.publish()
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("assets do not exactly match", result.stderr)
-        self.assertNotIn(["release", "edit", "v1.0.0", "--draft=false"], self.calls())
+        self.assertFalse([call for call in self.calls() if "--draft=false" in call])
         state = json.loads(self.state_path.read_text(encoding="utf-8"))
         self.assertTrue(state["isDraft"])
         self.assertIn("extra.bin", [asset["name"] for asset in state["assets"]])

--- a/scripts/release_publish_test.py
+++ b/scripts/release_publish_test.py
@@ -21,11 +21,37 @@ class ReleasePublishTest(unittest.TestCase):
         self.root = Path(self.temp.name)
         self.dist = self.root / "dist"
         self.dist.mkdir()
-        for name in ("archive.tar.gz", "checksums.txt", "release-identity.json"):
+        for name in ("archive.tar.gz", "checksums.txt"):
             (self.dist / name).write_text(name, encoding="utf-8")
-        (self.dist / "release-notes.md").write_text(
-            "<!-- agent-egress-bench-release-workflow-v1 -->\n\n## Schema contracts\n",
-            encoding="utf-8",
+        sys.path.insert(0, str(SCRIPT.parent))
+        import release_build
+
+        identity = {
+            "release": {"version": "1.0.0", "tag": "v1.0.0"},
+            "source": {"commit": "0" * 40},
+        }
+        catalog = {
+            "format": 1,
+            "repository": f"https://github.com/{release_build.REPOSITORY}",
+            "source_commit": "0" * 40,
+            "release": "v1.0.0",
+            "schemas": [
+                {
+                    "path": "schemas/fixture-v1.schema.json",
+                    "$id": "https://example.invalid/fixture-v1.schema.json",
+                    "sha256": "0" * 64,
+                    "retrieval_url": release_build.RAW_SCHEMA_URL.format(
+                        commit="0" * 40, path="schemas/fixture-v1.schema.json"
+                    ),
+                }
+            ],
+        }
+        catalog_name, _ = release_build.schema_asset_names(identity)
+        catalog_bytes = json.dumps(catalog).encode("utf-8")
+        (self.dist / "release-identity.json").write_text(json.dumps(identity), encoding="utf-8")
+        (self.dist / catalog_name).write_bytes(catalog_bytes)
+        (self.dist / "release-notes.md").write_bytes(
+            release_build.rendered_release_notes(identity, catalog_bytes)
         )
         self.state_path = self.root / "release.json"
         self.calls_path = self.root / "calls.json"
@@ -122,13 +148,30 @@ class ReleasePublishTest(unittest.TestCase):
 
         self.assertEqual(release_build.RELEASE_NOTES_MARKER, release_publish.DRAFT_MARKER)
 
+    def test_edited_release_notes_are_refused_despite_the_marker(self) -> None:
+        notes = self.dist / "release-notes.md"
+        notes.write_text(notes.read_text(encoding="utf-8") + "\nan added claim\n", encoding="utf-8")
+        result = self.publish()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not match the notes generated", result.stderr)
+        self.assertEqual([], self.calls())
+
     def test_creates_marked_draft_with_exact_assets_before_publication(self) -> None:
         result = self.publish()
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         state = json.loads(self.state_path.read_text(encoding="utf-8"))
         self.assertFalse(state["isDraft"])
         self.assertIn("agent-egress-bench-release-workflow-v1", state["body"])
-        self.assertEqual(["archive.tar.gz", "checksums.txt", "release-identity.json", "release-notes.md"], sorted(asset["name"] for asset in state["assets"]))
+        self.assertEqual(
+            [
+                "agent-egress-bench_1.0.0_schema-catalog.json",
+                "archive.tar.gz",
+                "checksums.txt",
+                "release-identity.json",
+                "release-notes.md",
+            ],
+            sorted(asset["name"] for asset in state["assets"]),
+        )
 
     def test_unrelated_draft_is_refused_before_upload_or_publication(self) -> None:
         self.write_state(body="draft written elsewhere", assets=["extra.bin"])

--- a/scripts/release_publish_test.py
+++ b/scripts/release_publish_test.py
@@ -23,6 +23,10 @@ class ReleasePublishTest(unittest.TestCase):
         self.dist.mkdir()
         for name in ("archive.tar.gz", "checksums.txt", "release-identity.json"):
             (self.dist / name).write_text(name, encoding="utf-8")
+        (self.dist / "release-notes.md").write_text(
+            "<!-- agent-egress-bench-release-workflow-v1 -->\n\n## Schema contracts\n",
+            encoding="utf-8",
+        )
         self.state_path = self.root / "release.json"
         self.calls_path = self.root / "calls.json"
         self.gh = self.root / "gh"
@@ -49,8 +53,8 @@ class ReleasePublishTest(unittest.TestCase):
             "  print(json.dumps(state))\n"
             "elif args[:2] == ['release', 'create']:\n"
             "  files = [Path(item).name for item in args[3:args.index('--title')]]\n"
-            "  marker = args[args.index('--notes') + 1]\n"
-            "  state = {'isDraft': True, 'body': marker, 'assets': [{'name': name} for name in files]}\n"
+            "  notes = Path(args[args.index('--notes-file') + 1]).read_text(encoding='utf-8')\n"
+            "  state = {'isDraft': True, 'body': notes, 'assets': [{'name': name} for name in files]}\n"
             "  save()\n"
             "elif args[:2] == ['release', 'upload']:\n"
             "  files = [Path(item).name for item in args[3:args.index('--clobber')]]\n"
@@ -59,7 +63,10 @@ class ReleasePublishTest(unittest.TestCase):
             "  state['assets'] = list(by_name.values())\n"
             "  save()\n"
             "elif args[:2] == ['release', 'edit']:\n"
-            "  state['isDraft'] = False\n"
+            "  if '--notes-file' in args:\n"
+            "    state['body'] = Path(args[args.index('--notes-file') + 1]).read_text(encoding='utf-8')\n"
+            "  else:\n"
+            "    state['isDraft'] = False\n"
             "  save()\n"
             "else:\n"
             "  print('unsupported mock gh call', args, file=sys.stderr)\n"
@@ -91,7 +98,7 @@ class ReleasePublishTest(unittest.TestCase):
         state = json.loads(self.state_path.read_text(encoding="utf-8"))
         self.assertFalse(state["isDraft"])
         self.assertIn("agent-egress-bench-release-workflow-v1", state["body"])
-        self.assertEqual(["archive.tar.gz", "checksums.txt", "release-identity.json"], sorted(asset["name"] for asset in state["assets"]))
+        self.assertEqual(["archive.tar.gz", "checksums.txt", "release-identity.json", "release-notes.md"], sorted(asset["name"] for asset in state["assets"]))
 
     def test_unrelated_draft_is_refused_before_upload_or_publication(self) -> None:
         self.write_state(body="draft written elsewhere", assets=["extra.bin"])

--- a/scripts/schema_discovery_feed.py
+++ b/scripts/schema_discovery_feed.py
@@ -41,6 +41,7 @@ def catalog_entries(root: Path, contents: bytes) -> list[dict[str, str]]:
         raise ValueError("schema catalog has no schema entries")
     entries: list[dict[str, str]] = []
     digests: dict[str, str] = {}
+    seen_paths: set[str] = set()
     copies: dict[str, list[str]] = {}
     canonical: dict[str, str] = {}
     for index, entry in enumerate(schemas):
@@ -53,11 +54,21 @@ def catalog_entries(root: Path, contents: bytes) -> list[dict[str, str]]:
         digest = entry["sha256"]
         if not isinstance(digest, str) or not digest:
             raise ValueError(f"schema catalog entry {index} has an invalid digest")
+        # Hash the FILE. Comparing the catalog's own digest strings only proves the catalog agrees
+        # with itself, so a manipulated catalog could declare two divergent files equivalent and this
+        # feed would publish that claim. The bytes on disk are the only thing worth trusting here.
+        actual = hashlib.sha256((root / path).read_bytes()).hexdigest()
+        if actual != digest:
+            raise ValueError(f"schema catalog entry {index} digest does not match {path!r}")
         # An identity that names two DIFFERENT files is a contradiction, not a duplicate. Refuse it
         # rather than silently picking one, because either choice publishes a wrong answer.
         if schema_id in digests and digests[schema_id] != digest:
             raise ValueError(f"schema catalog lists identity {schema_id!r} with differing content")
         digests[schema_id] = digest
+        # A repeated path is a contradiction in the catalog, not something to emit twice.
+        if path in seen_paths:
+            raise ValueError(f"schema catalog lists path {path!r} more than once")
+        seen_paths.add(path)
         if path.startswith("schemas/"):
             if schema_id in canonical:
                 raise ValueError(f"schema catalog lists two canonical paths for identity {schema_id!r}")

--- a/scripts/schema_discovery_feed.py
+++ b/scripts/schema_discovery_feed.py
@@ -11,7 +11,9 @@ import hashlib
 import json
 from pathlib import Path
 
-from schema_catalog import CATALOG_PATH
+from pathlib import PurePosixPath
+
+from schema_catalog import CATALOG_PATH, SCHEMA_ROOTS
 
 
 FEED_PATH = Path("schemas/discovery.json")
@@ -27,9 +29,9 @@ def catalog_bytes(root: Path) -> bytes:
     return contents
 
 
-def catalog_entries(root: Path) -> list[dict[str, str]]:
+def catalog_entries(contents: bytes) -> list[dict[str, str]]:
     try:
-        catalog = json.loads(catalog_bytes(root))
+        catalog = json.loads(contents)
     except json.JSONDecodeError as exc:
         raise ValueError(f"schema catalog is not JSON: {exc}") from exc
     if not isinstance(catalog, dict) or set(catalog) != {"format", "repository", "schemas"}:
@@ -44,17 +46,36 @@ def catalog_entries(root: Path) -> list[dict[str, str]]:
         path, schema_id = entry["path"], entry["$id"]
         if not isinstance(path, str) or not path or not isinstance(schema_id, str) or not schema_id:
             raise ValueError(f"schema catalog entry {index} has an invalid identity")
+        _require_contained_path(index, path)
         entries.append({"path": path, "$id": schema_id})
     return entries
 
 
+def _require_contained_path(index: int, path: str) -> None:
+    """Refuse any catalog path that would resolve outside the published schema roots.
+
+    The feed is consumed by readers that join these values onto a checkout root, so an absolute
+    path or a parent-traversal segment would send them outside the repository. Validate here rather
+    than trusting the catalog, because the feed is the artifact published outward.
+    """
+    if path != PurePosixPath(path).as_posix() or path.startswith("/") or "\\" in path:
+        raise ValueError(f"schema catalog entry {index} path is not a normalised relative path: {path!r}")
+    parts = PurePosixPath(path).parts
+    if not parts or any(part in ("..", ".") for part in parts):
+        raise ValueError(f"schema catalog entry {index} path is not a normalised relative path: {path!r}")
+    if not any(path.startswith(f"{allowed}/") for allowed in SCHEMA_ROOTS):
+        raise ValueError(f"schema catalog entry {index} path is outside the published schema roots: {path!r}")
+
 def rendered_feed(root: Path) -> bytes:
     """Render a deterministic feed that points consumers to the catalog."""
+    # One read, one snapshot. The digest and the advertised identities must describe the SAME bytes,
+    # or a concurrent catalog replacement produces a feed whose checksum silently refers to a
+    # different catalog than the entries it lists.
     catalog = catalog_bytes(root)
     feed = {
         "format": 1,
         "catalog": CATALOG_PATH.as_posix(),
         "catalog_sha256": hashlib.sha256(catalog).hexdigest(),
-        "schemas": catalog_entries(root),
+        "schemas": catalog_entries(catalog),
     }
     return (json.dumps(feed, indent=2) + "\n").encode("utf-8")

--- a/scripts/schema_discovery_feed.py
+++ b/scripts/schema_discovery_feed.py
@@ -29,7 +29,7 @@ def catalog_bytes(root: Path) -> bytes:
     return contents
 
 
-def catalog_entries(contents: bytes) -> list[dict[str, str]]:
+def catalog_entries(root: Path, contents: bytes) -> list[dict[str, str]]:
     try:
         catalog = json.loads(contents)
     except json.JSONDecodeError as exc:
@@ -46,25 +46,39 @@ def catalog_entries(contents: bytes) -> list[dict[str, str]]:
         path, schema_id = entry["path"], entry["$id"]
         if not isinstance(path, str) or not path or not isinstance(schema_id, str) or not schema_id:
             raise ValueError(f"schema catalog entry {index} has an invalid identity")
-        _require_contained_path(index, path)
+        _require_contained_path(root, index, path)
         entries.append({"path": path, "$id": schema_id})
     return entries
 
 
-def _require_contained_path(index: int, path: str) -> None:
-    """Refuse any catalog path that would resolve outside the published schema roots.
+def _require_contained_path(root: Path, index: int, path: str) -> None:
+    """Refuse any catalog path that does not RESOLVE inside the published schema roots.
 
-    The feed is consumed by readers that join these values onto a checkout root, so an absolute
-    path or a parent-traversal segment would send them outside the repository. Validate here rather
-    than trusting the catalog, because the feed is the artifact published outward.
+    The feed is published outward and consumers join these values onto their own checkout, so a
+    value that escapes the schema roots escapes on their machine. A lexical check alone cannot
+    establish that: a component such as ``.. `` is normalised to a parent traversal by Win32 path
+    rules, and a symlink inside an allowed root resolves wherever its target points. So this rejects
+    the non-portable spellings first and then resolves the real target and requires it to sit beneath
+    a resolved allowed root.
     """
     if path != PurePosixPath(path).as_posix() or path.startswith("/") or "\\" in path:
         raise ValueError(f"schema catalog entry {index} path is not a normalised relative path: {path!r}")
     parts = PurePosixPath(path).parts
     if not parts or any(part in ("..", ".") for part in parts):
         raise ValueError(f"schema catalog entry {index} path is not a normalised relative path: {path!r}")
+    for part in parts:
+        # Trailing dots and spaces, drive letters, and alternate data stream syntax all mean
+        # something other than a plain name once a consumer resolves them on Windows.
+        if part != part.strip() or part.endswith(".") or ":" in part:
+            raise ValueError(f"schema catalog entry {index} path component is not portable: {path!r}")
     if not any(path.startswith(f"{allowed}/") for allowed in SCHEMA_ROOTS):
         raise ValueError(f"schema catalog entry {index} path is outside the published schema roots: {path!r}")
+    target = (root / path).resolve()
+    for allowed in SCHEMA_ROOTS:
+        allowed_root = (root / allowed).resolve()
+        if target == allowed_root or allowed_root in target.parents:
+            return
+    raise ValueError(f"schema catalog entry {index} path resolves outside the published schema roots: {path!r}")
 
 def rendered_feed(root: Path) -> bytes:
     """Render a deterministic feed that points consumers to the catalog."""
@@ -76,6 +90,6 @@ def rendered_feed(root: Path) -> bytes:
         "format": 1,
         "catalog": CATALOG_PATH.as_posix(),
         "catalog_sha256": hashlib.sha256(catalog).hexdigest(),
-        "schemas": catalog_entries(catalog),
+        "schemas": catalog_entries(root, catalog),
     }
     return (json.dumps(feed, indent=2) + "\n").encode("utf-8")

--- a/scripts/schema_discovery_feed.py
+++ b/scripts/schema_discovery_feed.py
@@ -73,7 +73,18 @@ def _require_contained_path(root: Path, index: int, path: str) -> None:
             raise ValueError(f"schema catalog entry {index} path component is not portable: {path!r}")
     if not any(path.startswith(f"{allowed}/") for allowed in SCHEMA_ROOTS):
         raise ValueError(f"schema catalog entry {index} path is outside the published schema roots: {path!r}")
-    target = (root / path).resolve()
+    candidate = root / path
+    # Containment says where a path LANDS, not that anything is there. A missing path or a directory
+    # satisfies the root check and still publishes a feed entry a consumer cannot fetch, so require a
+    # real regular file before resolving. Reject a symlink by its own status rather than by where it
+    # points, so a link inside an allowed root cannot pass simply by resolving back inside.
+    if candidate.is_symlink():
+        raise ValueError(f"schema catalog entry {index} path is a symlink: {path!r}")
+    if not candidate.exists():
+        raise ValueError(f"schema catalog entry {index} path does not exist: {path!r}")
+    if not candidate.is_file():
+        raise ValueError(f"schema catalog entry {index} path is not a regular file: {path!r}")
+    target = candidate.resolve()
     for allowed in SCHEMA_ROOTS:
         allowed_root = (root / allowed).resolve()
         if target == allowed_root or allowed_root in target.parents:

--- a/scripts/schema_discovery_feed.py
+++ b/scripts/schema_discovery_feed.py
@@ -40,6 +40,9 @@ def catalog_entries(root: Path, contents: bytes) -> list[dict[str, str]]:
     if not isinstance(schemas, list) or not schemas:
         raise ValueError("schema catalog has no schema entries")
     entries: list[dict[str, str]] = []
+    digests: dict[str, str] = {}
+    copies: dict[str, list[str]] = {}
+    canonical: dict[str, str] = {}
     for index, entry in enumerate(schemas):
         if not isinstance(entry, dict) or set(entry) != {"path", "$id", "sha256"}:
             raise ValueError(f"schema catalog entry {index} has invalid fields")
@@ -47,7 +50,30 @@ def catalog_entries(root: Path, contents: bytes) -> list[dict[str, str]]:
         if not isinstance(path, str) or not path or not isinstance(schema_id, str) or not schema_id:
             raise ValueError(f"schema catalog entry {index} has an invalid identity")
         _require_contained_path(root, index, path)
-        entries.append({"path": path, "$id": schema_id})
+        digest = entry["sha256"]
+        if not isinstance(digest, str) or not digest:
+            raise ValueError(f"schema catalog entry {index} has an invalid digest")
+        # An identity that names two DIFFERENT files is a contradiction, not a duplicate. Refuse it
+        # rather than silently picking one, because either choice publishes a wrong answer.
+        if schema_id in digests and digests[schema_id] != digest:
+            raise ValueError(f"schema catalog lists identity {schema_id!r} with differing content")
+        digests[schema_id] = digest
+        if path.startswith("schemas/"):
+            if schema_id in canonical:
+                raise ValueError(f"schema catalog lists two canonical paths for identity {schema_id!r}")
+            canonical[schema_id] = path
+        else:
+            copies.setdefault(schema_id, []).append(path)
+    for schema_id in sorted(digests):
+        if schema_id not in canonical:
+            raise ValueError(f"schema catalog has no canonical schemas/ path for identity {schema_id!r}")
+        record = {"$id": schema_id, "path": canonical[schema_id]}
+        duplicates = sorted(copies.get(schema_id, ()))
+        if duplicates:
+            # Named, not dropped. These are byte-identical vendored copies; a consumer resolving by
+            # identity uses `path`, and anyone auditing the tree can still see where the copies live.
+            record["copies"] = duplicates
+        entries.append(record)
     return entries
 
 

--- a/scripts/schema_discovery_feed.py
+++ b/scripts/schema_discovery_feed.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Build the outward schema-discovery feed from the checked-in catalog.
+
+This feed makes schema identities easy to enumerate from a stable repository
+path. It deliberately contains repository paths rather than retrieval URLs:
+an ``$id`` remains an identifier, while a release catalog supplies immutable
+commit-pinned retrieval locations.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+from schema_catalog import CATALOG_PATH
+
+
+FEED_PATH = Path("schemas/discovery.json")
+
+
+def catalog_bytes(root: Path) -> bytes:
+    path = root / CATALOG_PATH
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"schema catalog must be a regular file: {CATALOG_PATH}")
+    contents = path.read_bytes()
+    if not contents:
+        raise ValueError(f"schema catalog is empty: {CATALOG_PATH}")
+    return contents
+
+
+def catalog_entries(root: Path) -> list[dict[str, str]]:
+    try:
+        catalog = json.loads(catalog_bytes(root))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"schema catalog is not JSON: {exc}") from exc
+    if not isinstance(catalog, dict) or set(catalog) != {"format", "repository", "schemas"}:
+        raise ValueError("schema catalog has invalid fields")
+    schemas = catalog.get("schemas")
+    if not isinstance(schemas, list) or not schemas:
+        raise ValueError("schema catalog has no schema entries")
+    entries: list[dict[str, str]] = []
+    for index, entry in enumerate(schemas):
+        if not isinstance(entry, dict) or set(entry) != {"path", "$id", "sha256"}:
+            raise ValueError(f"schema catalog entry {index} has invalid fields")
+        path, schema_id = entry["path"], entry["$id"]
+        if not isinstance(path, str) or not path or not isinstance(schema_id, str) or not schema_id:
+            raise ValueError(f"schema catalog entry {index} has an invalid identity")
+        entries.append({"path": path, "$id": schema_id})
+    return entries
+
+
+def rendered_feed(root: Path) -> bytes:
+    """Render a deterministic feed that points consumers to the catalog."""
+    catalog = catalog_bytes(root)
+    feed = {
+        "format": 1,
+        "catalog": CATALOG_PATH.as_posix(),
+        "catalog_sha256": hashlib.sha256(catalog).hexdigest(),
+        "schemas": catalog_entries(root),
+    }
+    return (json.dumps(feed, indent=2) + "\n").encode("utf-8")

--- a/scripts/write_schema_discovery_feed.py
+++ b/scripts/write_schema_discovery_feed.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Write the generated outward schema-discovery feed."""
 
+import os
+import tempfile
 from pathlib import Path
 
 from schema_discovery_feed import FEED_PATH, rendered_feed
@@ -11,7 +13,21 @@ def main() -> int:
     destination = root / FEED_PATH
     if destination.is_symlink():
         raise SystemExit(f"write-schema-discovery-feed: refusing symlinked destination: {FEED_PATH}")
-    destination.write_bytes(rendered_feed(root))
+    payload = rendered_feed(root)
+    # Checking the destination and then writing to it are two operations, so a replacement in between
+    # would redirect this write. Create an exclusive temporary file in the same directory and replace
+    # the destination atomically instead, which never writes through whatever the name points at.
+    handle, temporary = tempfile.mkstemp(dir=destination.parent, prefix=".discovery-", suffix=".json")
+    try:
+        with os.fdopen(handle, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, destination)
+    except BaseException:
+        os.unlink(temporary)
+        raise
     print(f"write-schema-discovery-feed: wrote {FEED_PATH}")
     return 0
 

--- a/scripts/write_schema_discovery_feed.py
+++ b/scripts/write_schema_discovery_feed.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Write the generated outward schema-discovery feed."""
+
+from pathlib import Path
+
+from schema_discovery_feed import FEED_PATH, rendered_feed
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    destination = root / FEED_PATH
+    if destination.is_symlink():
+        raise SystemExit(f"write-schema-discovery-feed: refusing symlinked destination: {FEED_PATH}")
+    destination.write_bytes(rendered_feed(root))
+    print(f"write-schema-discovery-feed: wrote {FEED_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

Published schema identities are now discoverable from outside the repository. `schemas/discovery.json` is generated from the existing schema catalog and lists every declared identity with its repository path, release notes state which schema identities and versions a release carries, and the README links the per-adapter offline validation quickstarts that previously existed only inside `docs/SCHEMAS.md`.

A `$id` stays an identifier and never becomes a download location. The feed carries identities and repository paths only; commit-pinned retrieval URLs remain release-catalog fields. This is the distinction PR #183 established, and the generator, its test, and the README wording each hold that line independently.

The generated feed is guarded by a drift check wired into `make preflight`, which CI already runs. It re-renders the feed from the catalog and compares bytes, so a discovery surface cannot fall behind the catalog it describes. It refuses a missing, empty, or symlinked feed rather than skipping, because a surface that silently reports success on unreadable input is worse than no surface at all.

Reviewers should distrust the release path most. If the schema inventory in the release notes were wrong or stale, the failure would be publishing a confident and false claim about what a release contains. `verify_release` re-derives the notes from the release catalog and requires them in the checksums, so a mismatch fails the build instead of shipping. The refusal branches on both the publish and feed paths now have negative tests; each was verified by disabling the guard and confirming its test fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a schema discovery catalog listing available schemas, versions, identities, and validation metadata.
  - Added tooling to generate, inspect, and validate the discovery feed.
  - Release packages now include generated `release-notes.md` with schema identities, versions, and validation guidance.
  - Release publishing verifies and publishes the generated release notes.

- **Documentation**
  - Added quickstart guidance for schema discovery, catalogs, offline validation, and supported adapters.
  - Updated release documentation and schema-related links.

- **Bug Fixes**
  - Added safeguards against missing, stale, empty, symlinked, or unverified discovery feeds and release notes.
  - Added discovery-feed validation to preflight checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->