### PR TITLE
ci: pin the reviewer to the release carrying credential redaction

### DIFF
--- a/.github/workflows/pr-review.yaml
+++ b/.github/workflows/pr-review.yaml
@@ -47,7 +47,7 @@ jobs:
        github.event_name == 'workflow_dispatch')
     # Pinned to an immutable Pipelock commit in both positions. A branch or tag
     # here would run reviewer code that can change under the pin.
-    uses: luckyPipewrench/pipelock/.github/workflows/pr-review-reusable.yaml@74b3b3f1099d8d6d8ffeb67407ba7e99d1bd3119
+    uses: luckyPipewrench/pipelock/.github/workflows/pr-review-reusable.yaml@aa5c8dc6661c72632533ef6cee9453614ee4d885
     with:
       pr_number: >-
         ${{ github.event_name == 'issue_comment' &&
@@ -57,7 +57,7 @@ jobs:
         (github.event.comment.body == '/review deep' && 'deep' ||
          'default') ||
         inputs.review_mode }}
-      reviewer_sha: 74b3b3f1099d8d6d8ffeb67407ba7e99d1bd3119
+      reviewer_sha: aa5c8dc6661c72632533ef6cee9453614ee4d885
     # Personal-account repositories cannot use secrets: inherit with a reusable
     # workflow, so every secret the reviewer needs is mapped by name.
     secrets:


### PR DESCRIPTION
## What changed

This moves the pinned reviewer commit to the release that redacts credential material before publishing model text. The reviewer posts its findings into pull-request comments, and a finding can quote the line it's describing, so until this pin moves that text reaches a public comment without being checked for credentials first.

Both pinned positions move together in a single commit, the workflow reference and the reviewer input. Leaving them out of step would run one commit's workflow against a different commit's reviewer, which is the failure this pinning exists to prevent, so a reviewer checking this change should confirm both moved and that no third commit is referenced anywhere in the file.

Nothing else in the caller changes. The trigger conditions, the authorization gate and the mapped secrets are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated pull request review workflow to use a newer pinned review component version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->