### PR TITLE
fix: verify the recorded tool version against the binary that ran

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -68,7 +68,7 @@ jobs:
           profile_file="$artifact_dir/tool-profile.json"
           test -f "$version_file" || { echo "no recorded binary version at $version_file"; exit 1; }
           test -f "$profile_file" || { echo "no tool profile at $profile_file"; exit 1; }
-          binary_version="$(head -1 "$version_file" | awk '{print $NF}' | sed 's/^v//')"
+          binary_version="$(awk '$1 == "pipelock" && $2 == "version" { print $3 }' "$version_file" | sed 's/^v//')"
           profile_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["tool_version"])' "$profile_file")"
           test -n "$binary_version" || { echo "could not read a version from $version_file"; exit 1; }
           test -n "$profile_version" || { echo "tool profile carries no tool_version"; exit 1; }

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -55,6 +55,32 @@ jobs:
             --reserve-seconds $((6 * 60)) \
             --benchmark-timeout-seconds $((24 * 60))
 
+      - name: Verify the recorded tool version matches the binary that ran
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Both artifacts are already captured as evidence and nothing compared
+          # them. The profile's tool_version reaches every result row and the
+          # signed receipt, so a stale profile publishes a score under a build
+          # that never executed the corpus.
+          artifact_dir="$GAUNTLET_ARTIFACT_DIR"
+          version_file="$artifact_dir/pipelock-version.txt"
+          profile_file="$artifact_dir/tool-profile.json"
+          test -f "$version_file" || { echo "no recorded binary version at $version_file"; exit 1; }
+          test -f "$profile_file" || { echo "no tool profile at $profile_file"; exit 1; }
+          binary_version="$(head -1 "$version_file" | awk '{print $NF}' | sed 's/^v//')"
+          profile_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["tool_version"])' "$profile_file")"
+          test -n "$binary_version" || { echo "could not read a version from $version_file"; exit 1; }
+          test -n "$profile_version" || { echo "tool profile carries no tool_version"; exit 1; }
+          if [ "$binary_version" != "$profile_version" ]; then
+            echo "tool_version mismatch"
+            echo "  profile claims: $profile_version"
+            echo "  binary reports: $binary_version"
+            echo "update examples/pipelock/tool-profile.json to $binary_version before publishing this run"
+            exit 1
+          fi
+          echo "tool version agrees: $binary_version"
+
       - name: Finalize GitHub provenance artifact
         shell: bash
         run: |

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -68,10 +68,23 @@ jobs:
           profile_file="$artifact_dir/tool-profile.json"
           test -f "$version_file" || { echo "no recorded binary version at $version_file"; exit 1; }
           test -f "$profile_file" || { echo "no tool profile at $profile_file"; exit 1; }
-          binary_version="$(awk '$1 == "pipelock" && $2 == "version" { print $3 }' "$version_file" | sed 's/^v//')"
+          # Exactly one canonical record. Several would mean the file was
+          # appended to, and comparing a multi-line value is not a comparison.
+          records="$(awk '$1 == "pipelock" && $2 == "version" { print $3 }' "$version_file")"
+          record_count="$(printf '%s\n' "$records" | grep -c . || true)"
+          if [ "$record_count" -ne 1 ]; then
+            echo "expected exactly one 'pipelock version <version>' record in $version_file, found $record_count"
+            exit 1
+          fi
+          binary_version="$(printf '%s' "$records" | sed 's/^v//')"
           profile_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["tool_version"])' "$profile_file")"
           test -n "$binary_version" || { echo "could not read a version from $version_file"; exit 1; }
           test -n "$profile_version" || { echo "tool profile carries no tool_version"; exit 1; }
+          # Validate both operands. Comparing without validating lets two
+          # identical nonsense values agree and pass, which reads as a match.
+          semver='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          printf '%s' "$binary_version" | grep -Eq "$semver" || { echo "binary version is not a version: $binary_version"; exit 1; }
+          printf '%s' "$profile_version" | grep -Eq "$semver" || { echo "profile tool_version is not a version: $profile_version"; exit 1; }
           if [ "$binary_version" != "$profile_version" ]; then
             echo "tool_version mismatch"
             echo "  profile claims: $profile_version"

--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -70,7 +70,7 @@ jobs:
           test -f "$profile_file" || { echo "no tool profile at $profile_file"; exit 1; }
           # Exactly one canonical record. Several would mean the file was
           # appended to, and comparing a multi-line value is not a comparison.
-          records="$(awk '$1 == "pipelock" && $2 == "version" { print $3 }' "$version_file")"
+          records="$(awk '$1 == "pipelock" && $2 == "version" && NF == 3 { print $3 }' "$version_file")"
           record_count="$(printf '%s\n' "$records" | grep -c . || true)"
           if [ "$record_count" -ne 1 ]; then
             echo "expected exactly one 'pipelock version <version>' record in $version_file, found $record_count"

--- a/examples/pipelock/harness.sh
+++ b/examples/pipelock/harness.sh
@@ -59,9 +59,21 @@ TOOL_VERSION=$(jq -r '.tool_version' "$PROFILE")
 # so a stale value attributes a run to a build that never executed it. Ask the
 # binary what it is and refuse to run when the two disagree, rather than recording
 # the profile's claim as fact.
-BINARY_VERSION=$("$PIPELOCK" --version 2>/dev/null | awk '$1 == "pipelock" && $2 == "version" { print $3 }' | sed 's/^v//') || BINARY_VERSION=""
-if [ -z "$BINARY_VERSION" ]; then
-    echo "error: could not read a version from $PIPELOCK --version" >&2
+VERSION_RECORDS=$("$PIPELOCK" --version 2>/dev/null | awk '$1 == "pipelock" && $2 == "version" { print $3 }') || VERSION_RECORDS=""
+RECORD_COUNT=$(printf '%s\n' "$VERSION_RECORDS" | grep -c . || true)
+if [ "$RECORD_COUNT" -ne 1 ]; then
+    echo "error: expected exactly one 'pipelock version <version>' record from $PIPELOCK --version, found $RECORD_COUNT" >&2
+    exit 1
+fi
+BINARY_VERSION=$(printf '%s' "$VERSION_RECORDS" | sed 's/^v//')
+# Validate both operands. Two identical nonsense values would otherwise agree.
+SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+if ! printf '%s' "$BINARY_VERSION" | grep -Eq "$SEMVER"; then
+    echo "error: $PIPELOCK reported something that is not a version: $BINARY_VERSION" >&2
+    exit 1
+fi
+if ! printf '%s' "$TOOL_VERSION" | grep -Eq "$SEMVER"; then
+    echo "error: the profile's tool_version is not a version: $TOOL_VERSION" >&2
     exit 1
 fi
 if [ "$BINARY_VERSION" != "$TOOL_VERSION" ]; then

--- a/examples/pipelock/harness.sh
+++ b/examples/pipelock/harness.sh
@@ -59,7 +59,7 @@ TOOL_VERSION=$(jq -r '.tool_version' "$PROFILE")
 # so a stale value attributes a run to a build that never executed it. Ask the
 # binary what it is and refuse to run when the two disagree, rather than recording
 # the profile's claim as fact.
-BINARY_VERSION=$("$PIPELOCK" --version 2>/dev/null | awk '{print $NF}' | sed 's/^v//') || BINARY_VERSION=""
+BINARY_VERSION=$("$PIPELOCK" --version 2>/dev/null | awk '$1 == "pipelock" && $2 == "version" { print $3 }' | sed 's/^v//') || BINARY_VERSION=""
 if [ -z "$BINARY_VERSION" ]; then
     echo "error: could not read a version from $PIPELOCK --version" >&2
     exit 1

--- a/examples/pipelock/harness.sh
+++ b/examples/pipelock/harness.sh
@@ -55,6 +55,23 @@ command -v "$PIPELOCK" >/dev/null 2>&1 || { echo "error: pipelock binary not fou
 TOOL=$(jq -r '.tool' "$PROFILE")
 TOOL_VERSION=$(jq -r '.tool_version' "$PROFILE")
 
+# The profile's tool_version reaches both every result line and the signed receipt,
+# so a stale value attributes a run to a build that never executed it. Ask the
+# binary what it is and refuse to run when the two disagree, rather than recording
+# the profile's claim as fact.
+BINARY_VERSION=$("$PIPELOCK" --version 2>/dev/null | awk '{print $NF}' | sed 's/^v//') || BINARY_VERSION=""
+if [ -z "$BINARY_VERSION" ]; then
+    echo "error: could not read a version from $PIPELOCK --version" >&2
+    exit 1
+fi
+if [ "$BINARY_VERSION" != "$TOOL_VERSION" ]; then
+    echo "error: tool_version mismatch" >&2
+    echo "  profile ($PROFILE): $TOOL_VERSION" >&2
+    echo "  binary  ($PIPELOCK): $BINARY_VERSION" >&2
+    echo "  update the profile's tool_version to $BINARY_VERSION before running." >&2
+    exit 1
+fi
+
 # Start pipelock
 echo "starting pipelock on port $PORT..." >&2
 "$PIPELOCK" run --config "$CONFIG" --listen "127.0.0.1:$PORT" &

--- a/examples/pipelock/harness.sh
+++ b/examples/pipelock/harness.sh
@@ -59,7 +59,7 @@ TOOL_VERSION=$(jq -r '.tool_version' "$PROFILE")
 # so a stale value attributes a run to a build that never executed it. Ask the
 # binary what it is and refuse to run when the two disagree, rather than recording
 # the profile's claim as fact.
-VERSION_RECORDS=$("$PIPELOCK" --version 2>/dev/null | awk '$1 == "pipelock" && $2 == "version" { print $3 }') || VERSION_RECORDS=""
+VERSION_RECORDS=$("$PIPELOCK" --version 2>/dev/null | awk '$1 == "pipelock" && $2 == "version" && NF == 3 { print $3 }') || VERSION_RECORDS=""
 RECORD_COUNT=$(printf '%s\n' "$VERSION_RECORDS" | grep -c . || true)
 if [ "$RECORD_COUNT" -ne 1 ]; then
     echo "error: expected exactly one 'pipelock version <version>' record from $PIPELOCK --version, found $RECORD_COUNT" >&2


### PR DESCRIPTION
## What changed

The tool profile's `tool_version` reaches every result row and the signed receipt, and nothing compared it against the binary under test. A run published its score under whatever version the profile happened to carry.

The gap isn't theoretical. The profile currently records 3.3.0 while a local build reports 3.4.0-rc2.

The gauntlet workflow was already capturing both the profile and the binary's own version output as evidence. It now compares them and fails the job when they disagree, before anything is finalized or published. The legacy fetch-only harness gets the same check at startup.

## Failure direction

This can only stop a run, never let one through, so the risk is a workflow that refuses to publish a legitimate result. Both branches were exercised: a matching version proceeds, a mismatch and an unreadable version each stop with a message naming both values.

Reading a version under `set -euo pipefail` needs care, since a binary that exits nonzero fails the whole pipeline and kills the script before it can report why. The read tolerates that and handles the empty result explicitly.

Anyone benchmarking their own build will now have to set `tool_version` to match it. That friction is the point: the alternative is a score attributed to a version that never ran.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to detect missing or mismatched tool version information before execution.
  * Jobs now fail clearly when the installed Pipelock binary version does not match the recorded profile version.

* **Tests**
  * Added automated checks to verify version consistency across generated artifacts and installed tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->