### PR TITLE
fix: stabilize snapshot and security-scan versioning

### DIFF
--- a/.github/workflows/pipelock.yaml
+++ b/.github/workflows/pipelock.yaml
@@ -19,10 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      # The action installs the latest Pipelock RELEASE. It still runs the
-      # whole-tree audit and resolves the shared config, but its built-in diff
-      # scan is disabled here and both diff scans below use a scanner built from
-      # Pipelock's default branch instead.
+      # The action runs the whole-tree audit and resolves the shared config, but
+      # its built-in diff scan is disabled here. Pin its release so the generated
+      # config cannot gain fields that the source-pinned scanner below cannot
+      # parse. Advance both producers together through a reviewed change.
       #
       # Why: a scanner fix on Pipelock's default branch does not reach a release
       # for weeks, and this repository inherits every bug that shipped meanwhile.
@@ -35,6 +35,7 @@ jobs:
         id: pipelock
         uses: luckyPipewrench/pipelock@9d2e37d296359c38e599525a0424cdc189a812e1 # v3.0.0
         with:
+          version: '3.3.0'
           scan-diff: 'false'
           fail-on-findings: 'true'
           test-vectors: 'false'

--- a/scripts/pipelock_scan_workflow_test.py
+++ b/scripts/pipelock_scan_workflow_test.py
@@ -148,8 +148,11 @@ class PipelockScanWorkflowTest(unittest.TestCase):
         ]
         self.assertEqual(1, len(action_steps), "expected one Pipelock action step")
         version = str((action_steps[0].get("with") or {}).get("version") or "")
-        self.assertRegex(version, r"^\d+\.\d+\.\d+$", "pin the audit config producer to a stable release")
-        self.assertNotEqual("latest", version, "a moving release can produce config the pinned scanner cannot parse")
+        self.assertEqual(
+            "3.3.0",
+            version,
+            "advance the audit config producer and source-pinned scanner together after proving compatibility",
+        )
 
     def test_scanned_diff_is_generated_with_text(self):
         """The diff feeding the scanner must be generated with --text.

--- a/scripts/pipelock_scan_workflow_test.py
+++ b/scripts/pipelock_scan_workflow_test.py
@@ -139,6 +139,18 @@ class PipelockScanWorkflowTest(unittest.TestCase):
                     "upstream commit cannot silently change or disable this gate",
                 )
 
+    def test_audit_config_producer_is_version_pinned(self):
+        """The audit config must not drift ahead of the pinned scanner."""
+        action_steps = [
+            step
+            for step in (self.job.get("steps") or [])
+            if str(step.get("uses") or "").startswith("luckyPipewrench/pipelock@")
+        ]
+        self.assertEqual(1, len(action_steps), "expected one Pipelock action step")
+        version = str((action_steps[0].get("with") or {}).get("version") or "")
+        self.assertRegex(version, r"^\d+\.\d+\.\d+$", "pin the audit config producer to a stable release")
+        self.assertNotEqual("latest", version, "a moving release can produce config the pinned scanner cannot parse")
+
     def test_scanned_diff_is_generated_with_text(self):
         """The diff feeding the scanner must be generated with --text.
 

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -23,7 +23,7 @@ from typing import Any
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
-SNAPSHOT_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?-SNAPSHOT-[0-9a-f]{7}$")
+SNAPSHOT_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?-SNAPSHOT-[0-9a-f]{4,40}$")
 IDENTITY_NAME = "release-identity.json"
 CHECKSUM_NAME = "checksums.txt"
 SCHEMA_CATALOG_PATH = "schemas/index.json"
@@ -148,7 +148,12 @@ def snapshot_source_tag(repo: Path, commit: str) -> str:
 def snapshot_version(repo: Path, commit: str) -> str:
     tag = snapshot_source_tag(repo, commit)
     template = configured_snapshot_template(repo)
-    values = {"{{ .Version }}": tag[1:], "{{ .ShortCommit }}": commit[:7]}
+    # Match GoReleaser's git show --format=%h producer instead of guessing the
+    # abbreviation length. Git chooses that length from the repository's
+    # object population and core.abbrev setting, so fresh and long-lived clones
+    # can legitimately render different lengths for the same commit.
+    short_commit = git(repo, "show", "--format=%h", "--quiet", commit)
+    values = {"{{ .Version }}": tag[1:], "{{ .ShortCommit }}": short_commit}
     if any(token not in values for token in re.findall(r"{{[^}]+}}", template)):
         fail("GoReleaser snapshot.version_template uses an unsupported value")
     rendered = template
@@ -299,6 +304,8 @@ def build_identity(repo: Path, tag: str, version: str, commit: str, snapshot: bo
         fail(f"release tag {tag} does not resolve to requested commit")
     if git(repo, "status", "--porcelain", "--untracked-files=all"):
         fail("release tree has tracked or untracked changes")
+    if snapshot and version != snapshot_version(repo, commit):
+        fail("snapshot identity must use tag snapshot and the GoReleaser snapshot version")
     ignored_inputs = ignored_runner_build_inputs(repo)
     if ignored_inputs:
         fail(f"release tree has ignored runner build inputs: {ignored_inputs}")

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -45,7 +45,7 @@ class ReleaseBuildTest(unittest.TestCase):
         self.commit = subprocess.run(["git", "-C", str(self.root), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout.strip()
         subprocess.run(["git", "-C", str(self.root), "tag", "-a", "v1.0.0", "-m", "baseline", self.commit], check=True)
         self.identity = self.root / ".release/release-identity.json"
-        self.snapshot_version = f"1.0.0-SNAPSHOT-{self.commit[:7]}"
+        self.snapshot_version = f"1.0.0-SNAPSHOT-{self.git_short(self.commit)}"
 
     def tearDown(self) -> None:
         try:
@@ -57,6 +57,12 @@ class ReleaseBuildTest(unittest.TestCase):
         result = subprocess.run([sys.executable, str(SCRIPT), *args], text=True, capture_output=True)
         self.assertEqual(result.returncode, expect, msg=result.stderr)
         return result
+
+    def git_short(self, commit: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(self.root), "show", "--format=%h", "--quiet", commit],
+            check=True, text=True, capture_output=True,
+        ).stdout.strip()
 
     def prepare(self) -> None:
         self.invoke(
@@ -202,7 +208,7 @@ class ReleaseBuildTest(unittest.TestCase):
         subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "broken contract"], check=True)
         broken_commit = subprocess.run(["git", "-C", str(self.root), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout.strip()
         result = subprocess.run(
-            [sys.executable, str(SCRIPT), "prepare", "--repo-root", str(self.root), "--tag", "snapshot", "--version", f"1.0.0-SNAPSHOT-{broken_commit[:7]}", "--commit", broken_commit, "--snapshot", "--output", str(self.identity)],
+            [sys.executable, str(SCRIPT), "prepare", "--repo-root", str(self.root), "--tag", "snapshot", "--version", f"1.0.0-SNAPSHOT-{self.git_short(broken_commit)}", "--commit", broken_commit, "--snapshot", "--output", str(self.identity)],
             text=True, capture_output=True,
         )
         self.assertNotEqual(result.returncode, 0)
@@ -234,14 +240,46 @@ class ReleaseBuildTest(unittest.TestCase):
         subprocess.run(["git", "-C", str(self.root), "commit", "-qm", "commented version"], check=True)
         commit = subprocess.run(["git", "-C", str(self.root), "rev-parse", "HEAD"], check=True, text=True, capture_output=True).stdout.strip()
         identity = self.root / ".release/comment-identity.json"
-        version = f"1.0.0-SNAPSHOT-{commit[:7]}"
+        version = f"1.0.0-SNAPSHOT-{self.git_short(commit)}"
         self.invoke("prepare", "--repo-root", str(self.root), "--tag", "snapshot", "--version", version, "--commit", commit, "--snapshot", "--output", str(identity))
         self.assertEqual("v2.4.0", json.loads(identity.read_text(encoding="utf-8"))["corpus"]["version"])
 
     def test_snapshot_version_uses_the_configured_goreleaser_template(self) -> None:
         subprocess.run(["git", "-C", str(self.root), "tag", "-a", "v1.1.0-snaptest", "-m", "snapshot base", self.commit], check=True)
         result = self.invoke("snapshot-version", "--repo-root", str(self.root), "--commit", self.commit)
-        self.assertEqual(f"1.1.0-snaptest-SNAPSHOT-{self.commit[:7]}", result.stdout.strip())
+        self.assertEqual(f"1.1.0-snaptest-SNAPSHOT-{self.git_short(self.commit)}", result.stdout.strip())
+
+    def test_snapshot_version_matches_gits_configured_abbreviation(self) -> None:
+        subprocess.run(["git", "-C", str(self.root), "config", "core.abbrev", "12"], check=True)
+        result = self.invoke("snapshot-version", "--repo-root", str(self.root), "--commit", self.commit)
+        self.assertEqual(f"1.0.0-SNAPSHOT-{self.commit[:12]}", result.stdout.strip())
+
+    def test_snapshot_identity_rejects_a_nonproducer_abbreviation(self) -> None:
+        produced = self.git_short(self.commit)
+        wrong_length = 8 if len(produced) == 7 else 7
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "prepare",
+                "--repo-root",
+                str(self.root),
+                "--tag",
+                "snapshot",
+                "--version",
+                f"1.0.0-SNAPSHOT-{self.commit[:wrong_length]}",
+                "--commit",
+                self.commit,
+                "--snapshot",
+                "--output",
+                str(self.identity),
+            ],
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("snapshot identity must use tag snapshot", result.stderr)
+        self.assertFalse(self.identity.exists())
 
     def test_snapshot_version_rejects_an_unsupported_goreleaser_template(self) -> None:
         config = self.root / ".goreleaser.yaml"
@@ -256,7 +294,7 @@ class ReleaseBuildTest(unittest.TestCase):
 
     def test_release_shell_uses_goreleaser_snapshot_version(self) -> None:
         subprocess.run(["git", "-C", str(self.root), "tag", "-a", "v1.1.0-snaptest", "-m", "snapshot base", self.commit], check=True)
-        expected = f"1.1.0-snaptest-SNAPSHOT-{self.commit[:7]}"
+        expected = f"1.1.0-snaptest-SNAPSHOT-{self.git_short(self.commit)}"
         fake_bin = Path(self.temp.name) / "bin"
         fake_bin.mkdir()
         fake = fake_bin / "goreleaser"
@@ -736,7 +774,7 @@ class ReleaseBuildTest(unittest.TestCase):
             text=True,
             capture_output=True,
         ).stdout.strip()
-        self.snapshot_version = f"1.0.0-SNAPSHOT-{self.commit[:7]}"
+        self.snapshot_version = f"1.0.0-SNAPSHOT-{self.git_short(self.commit)}"
 
         self.prepare()
         dist = self.root / "dist"
@@ -895,7 +933,7 @@ class ReleaseBuildTest(unittest.TestCase):
         result = subprocess.run(
             [
                 sys.executable, str(SCRIPT), "prepare", "--repo-root", str(self.root),
-                "--tag", "snapshot", "--version", f"1.0.0-SNAPSHOT-{broken_commit[:7]}",
+                "--tag", "snapshot", "--version", f"1.0.0-SNAPSHOT-{self.git_short(broken_commit)}",
                 "--commit", broken_commit, "--snapshot", "--output", str(self.identity),
             ],
             text=True,
@@ -923,7 +961,7 @@ class ReleaseBuildTest(unittest.TestCase):
         result = subprocess.run(
             [
                 sys.executable, str(SCRIPT), "prepare", "--repo-root", str(self.root),
-                "--tag", "snapshot", "--version", f"1.0.0-SNAPSHOT-{broken_commit[:7]}",
+                "--tag", "snapshot", "--version", f"1.0.0-SNAPSHOT-{self.git_short(broken_commit)}",
                 "--commit", broken_commit, "--snapshot", "--output", str(self.identity),
             ],
             text=True,


### PR DESCRIPTION
## What changed

- Snapshot creation derives `.ShortCommit` with the same Git command as GoReleaser, keeping archive and companion-artifact versions aligned across clone histories.
- The security workflow pins its audit-config producer to Pipelock v3.3.0, preventing a newer config schema from breaking the source-pinned scanner before it scans the diff.

Both paths fail closed when producer output cannot be consumed. Reviewers should distrust a green result unless the pinned producer/consumer pair actually ran.
