### PR TITLE
fix: restore Pipelock Gauntlet adapter compatibility

### DIFF
--- a/.github/workflows/pipelock.yaml
+++ b/.github/workflows/pipelock.yaml
@@ -20,22 +20,14 @@ jobs:
           fetch-depth: 0
 
       # The action runs the whole-tree audit and resolves the shared config, but
-      # its built-in diff scan is disabled here. Pin its release so the generated
-      # config cannot gain fields that the source-pinned scanner below cannot
-      # parse. Advance both producers together through a reviewed change.
-      #
-      # Why: a scanner fix on Pipelock's default branch does not reach a release
-      # for weeks, and this repository inherits every bug that shipped meanwhile.
-      # Whole-file-deletion hunk parsing was fixed in pipelock#1145, which is on
-      # Pipelock's default branch and absent from v3.3.0, so the released binary
-      # rejects any pull request that deletes a file with "unverifiable input:
-      # content outside unified diff hunks" and surfaces it as "Secrets detected
-      # in PR diff" when there is no secret.
+      # its built-in diff scan is disabled here. Pin the action release and the
+      # scanner source together so generated config cannot drift beyond what the
+      # scanner parses. Advance both producers through a reviewed change.
       - name: Pipelock Scan
         id: pipelock
-        uses: luckyPipewrench/pipelock@9d2e37d296359c38e599525a0424cdc189a812e1 # v3.0.0
+        uses: luckyPipewrench/pipelock@4c748ab986d611138ce202ab800b16eca6fb589f # v3.4.0
         with:
-          version: '3.3.0'
+          version: '3.4.0'
           scan-diff: 'false'
           fail-on-findings: 'true'
           test-vectors: 'false'
@@ -62,11 +54,11 @@ jobs:
       # would let any later commit on Pipelock change or disable this
       # repository's secret gate with no reviewed change here. Advance this pin
       # through a normal reviewed pull request when a scanner fix is needed.
-      # This commit contains pipelock#1145, the whole-file-deletion hunk fix.
+      # This commit is the reviewed v3.4.0 release.
       - name: Build scanner from pinned Pipelock commit
         shell: bash
         env:
-          PIPELOCK_REV: 96a57e78c0f577a6074c6b48917d618c1f88f1ab
+          PIPELOCK_REV: 4c748ab986d611138ce202ab800b16eca6fb589f
         run: |
           set -euo pipefail
           GOBIN="${RUNNER_TEMP}/bin" go install "github.com/luckyPipewrench/pipelock/cmd/pipelock@${PIPELOCK_REV}"

--- a/examples/pipelock/pipelock-benchmark.yaml
+++ b/examples/pipelock/pipelock-benchmark.yaml
@@ -223,9 +223,10 @@ address_protection:
   action: block
 
 reverse_proxy:
-  enabled: true
-  listen: "127.0.0.1:9992"
-  upstream: "http://127.0.0.1:9993"
+  # The proxy adapter does not exercise Pipelock's reverse-proxy listener.
+  # Leaving its fixed example ports enabled makes two independent benchmark
+  # runs collide before any declared case starts.
+  enabled: false
 
 logging:
   format: json

--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"mime"
 	"net/http"
 	"net/url"
@@ -46,7 +47,12 @@ func nextGatewayRequestIdentity() (string, error) {
 	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
 		return "", fmt.Errorf("generate request identity: %w", err)
 	}
-	return fmt.Sprintf("aeb-request-%x", nonce), nil
+	// Fixed-width decimal preserves all 256 random bits while keeping these
+	// correlation values below 4-bit query-entropy thresholds. Hex plus the
+	// fixed prefix can block the benchmark's own delivery proof before it
+	// reaches the trusted fixture.
+	decimal := new(big.Int).SetBytes(nonce[:]).String()
+	return "aeb-request-" + strings.Repeat("0", 78-len(decimal)) + decimal, nil
 }
 
 func prepareGatewayRequest(message map[string]interface{}) (map[string]interface{}, gatewayRequest, error) {

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -3,10 +3,11 @@ package adapter
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -496,24 +497,51 @@ func TestMCPGatewayAdapterUsesUniqueInitializeIDs(t *testing.T) {
 	}
 }
 
-func TestGatewayRequestIdentitiesAreOpaqueRandomNonces(t *testing.T) {
-	first, err := nextGatewayRequestIdentity()
-	if err != nil {
-		t.Fatal(err)
-	}
-	second, err := nextGatewayRequestIdentity()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if first == second {
-		t.Fatalf("request identity reused: %s", first)
-	}
-	for _, identity := range []string{first, second} {
-		suffix := strings.TrimPrefix(identity, "aeb-request-")
-		decoded, err := hex.DecodeString(suffix)
-		if err != nil || len(decoded) != 32 {
-			t.Fatalf("identity %q is not a 256-bit opaque nonce: bytes=%d err=%v", identity, len(decoded), err)
-		}
+func TestGatewayRequestIdentitiesAreOpaqueLowEntropyRandomNonces(t *testing.T) {
+	for name, mint := range map[string]func() (string, error){
+		"gateway":   nextGatewayRequestIdentity,
+		"mcp_stdio": freshMCPStdioRequestIdentity,
+	} {
+		t.Run(name, func(t *testing.T) {
+			first, err := mint()
+			if err != nil {
+				t.Fatal(err)
+			}
+			second, err := mint()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if first == second {
+				t.Fatalf("request identity reused: %s", first)
+			}
+			for _, identity := range []string{first, second} {
+				suffix := strings.TrimPrefix(identity, "aeb-request-")
+				if len(suffix) != 78 {
+					t.Fatalf("identity %q has decimal width %d, want 78", identity, len(suffix))
+				}
+				decoded, ok := new(big.Int).SetString(suffix, 10)
+				if !ok || decoded.Sign() < 0 || decoded.BitLen() > 256 {
+					t.Fatalf("identity %q is not a decimal encoding of a 256-bit nonce", identity)
+				}
+				for _, character := range suffix {
+					if character < '0' || character > '9' {
+						t.Fatalf("identity %q has a non-decimal suffix", identity)
+					}
+				}
+				counts := make(map[rune]int)
+				for _, character := range identity {
+					counts[character]++
+				}
+				entropy := 0.0
+				for _, count := range counts {
+					probability := float64(count) / float64(len(identity))
+					entropy -= probability * math.Log2(probability)
+				}
+				if entropy >= 4.0 {
+					t.Fatalf("identity %q has %.2f bits of character entropy, want below 4.0", identity, entropy)
+				}
+			}
+		})
 	}
 }
 

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -201,12 +201,11 @@ func (p *ProxyAdapter) beginHTTPFixtureDelivery(path string) (deliveryProof, err
 	return proof, nil
 }
 
-// nextHTTPDeliveryToken keeps the 256-bit opaque identity while using only
-// hexadecimal characters. The token is appended to the URL under test; a
-// human-readable prefix raises its Shannon entropy above a strict scanner's
-// threshold and makes the benchmark's own delivery proof block before the
-// declared case reaches the fixture. Hex is load-bearing here: its 16-symbol
-// alphabet caps Shannon entropy at 4.0; base64url would reintroduce the bug.
+// nextHTTPDeliveryToken keeps the fixed-width decimal encoding of the 256-bit
+// opaque identity but removes its human-readable prefix. The token is appended
+// to the URL under test; a human-readable prefix raises its Shannon entropy
+// above a strict scanner's threshold and makes the benchmark's own delivery
+// proof block before the declared case reaches the fixture.
 func nextHTTPDeliveryToken() (string, error) {
 	identity, err := nextGatewayRequestIdentity()
 	if err != nil {
@@ -2153,11 +2152,7 @@ func correlateMCPStdioSessionMessages(clientMsgs, serverResponses []interface{})
 }
 
 func freshMCPStdioRequestIdentity() (string, error) {
-	bytes := make([]byte, 16)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", fmt.Errorf("generate random request identity: %w", err)
-	}
-	return "aeb-stdio-" + base64.RawURLEncoding.EncodeToString(bytes), nil
+	return nextGatewayRequestIdentity()
 }
 
 func mcpStdioObservationEvidence(observer *mcpStdioUpstreamObserver) (map[string]interface{}, bool) {

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -190,7 +190,7 @@ type deliveryProof struct {
 // its counter. The token is what makes attribution exact when cases share a
 // declared path or a target fetches asynchronously.
 func (p *ProxyAdapter) beginHTTPFixtureDelivery(path string) (deliveryProof, error) {
-	token, err := nextGatewayRequestIdentity()
+	token, err := nextHTTPDeliveryToken()
 	if err != nil {
 		return deliveryProof{}, err
 	}
@@ -199,6 +199,20 @@ func (p *ProxyAdapter) beginHTTPFixtureDelivery(path string) (deliveryProof, err
 		proof.baseline = p.httpFixtureRequests(path, token)
 	}
 	return proof, nil
+}
+
+// nextHTTPDeliveryToken keeps the 256-bit opaque identity while using only
+// hexadecimal characters. The token is appended to the URL under test; a
+// human-readable prefix raises its Shannon entropy above a strict scanner's
+// threshold and makes the benchmark's own delivery proof block before the
+// declared case reaches the fixture. Hex is load-bearing here: its 16-symbol
+// alphabet caps Shannon entropy at 4.0; base64url would reintroduce the bug.
+func nextHTTPDeliveryToken() (string, error) {
+	identity, err := nextGatewayRequestIdentity()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(identity, "aeb-request-"), nil
 }
 
 // annotate appends the delivery token to a fixture URL, leaving the query the

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -25,6 +26,51 @@ import (
 
 	"github.com/luckyPipewrench/agent-egress-bench/runner/fixture"
 )
+
+func TestHTTPDeliveryTokenIsOpaqueWithoutEntropyRaisingPrefix(t *testing.T) {
+	token, err := nextHTTPDeliveryToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := hex.DecodeString(token)
+	if err != nil || len(decoded) != 32 {
+		t.Fatalf("token %q is not a 256-bit hexadecimal nonce: bytes=%d err=%v", token, len(decoded), err)
+	}
+	if strings.Contains(token, "aeb-request-") {
+		t.Fatalf("HTTP delivery token retained entropy-raising prefix: %q", token)
+	}
+	second, err := nextHTTPDeliveryToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token == second {
+		t.Fatalf("HTTP delivery token reused: %q", token)
+	}
+
+	var capturedPath, capturedToken string
+	a := ProxyAdapter{httpFixtureRequests: func(path, token string) int64 {
+		capturedPath, capturedToken = path, token
+		return 7
+	}}
+	proof, err := a.beginHTTPFixtureDelivery("/case")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capturedPath != proof.path || capturedToken != proof.token || proof.baseline != 7 {
+		t.Fatalf("delivery proof was not propagated to the counter: captured=(%q,%q) proof=%+v", capturedPath, capturedToken, proof)
+	}
+	annotated, err := proof.annotate("https://fixture.example/case?declared=value")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := url.Parse(annotated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := parsed.Query().Get(fixture.DeliveryTokenParam); got != proof.token {
+		t.Fatalf("annotated delivery token %q does not match proof token %q", got, proof.token)
+	}
+}
 
 func TestRunWebSocketFrameViaProxy_Non101UpgradeSkipsNotAllows(t *testing.T) {
 	// A proxy-local 200 to a WebSocket upgrade request proves nothing about

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -5,11 +5,11 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -32,9 +32,9 @@ func TestHTTPDeliveryTokenIsOpaqueWithoutEntropyRaisingPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	decoded, err := hex.DecodeString(token)
-	if err != nil || len(decoded) != 32 {
-		t.Fatalf("token %q is not a 256-bit hexadecimal nonce: bytes=%d err=%v", token, len(decoded), err)
+	decoded, ok := new(big.Int).SetString(token, 10)
+	if !ok || len(token) != 78 || decoded.Sign() < 0 || decoded.BitLen() > 256 {
+		t.Fatalf("token %q is not a fixed-width decimal encoding of a 256-bit nonce", token)
 	}
 	if strings.Contains(token, "aeb-request-") {
 		t.Fatalf("HTTP delivery token retained entropy-raising prefix: %q", token)

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -180,6 +180,25 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("--release-pin", self.entrypoint)
         self.assertIn("reviewed release pin is invalid", self.entrypoint)
 
+    def test_runtime_profile_uses_the_verified_release_version(self):
+        self.assertIn('runtime_profile_path="$output_dir/tool-profile.json"', self.entrypoint)
+        self.assertIn('--arg version "$PIPELOCK_VERSION"', self.entrypoint)
+        self.assertIn("'.tool_version = $version'", self.entrypoint)
+        self.assertIn('--profile "$runtime_profile_path"', self.entrypoint)
+        self.assertNotIn("--profile examples/pipelock/tool-profile.json", self.entrypoint)
+        self.assertIn('failure_reason="runtime tool profile generation failed"', self.entrypoint)
+
+        source_profile = json.loads(PIPELOCK_PROFILE.read_text(encoding="utf-8"))
+        result = subprocess.run(
+            ["jq", "--arg", "version", "9.9.9", ".tool_version = $version", str(PIPELOCK_PROFILE)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["tool_version"], "9.9.9")
+        self.assertNotEqual(source_profile["tool_version"], "9.9.9")
+
     def test_target_runs_under_a_filesystem_restricted_environment(self):
         self.assertIn("go build -o \"$target_sandbox\" ./cmd/target-sandbox", self.entrypoint)
         self.assertIn('pipelock_bin="$target_wrapper"', self.entrypoint)

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -183,6 +183,11 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
     def test_target_runs_under_a_filesystem_restricted_environment(self):
         self.assertIn("go build -o \"$target_sandbox\" ./cmd/target-sandbox", self.entrypoint)
         self.assertIn('pipelock_bin="$target_wrapper"', self.entrypoint)
+        self.assertIn(
+            'PIPELOCK_POSTURE_PROOF=$work_dir/absent-posture-proof.json',
+            self.entrypoint,
+        )
+        self.assertIn("/usr/bin/env", self.entrypoint)
         self.assertIn('sha256sum "$target_binary"', self.entrypoint)
         self.assertIn("target sandbox integrity check failed", self.entrypoint)
         self.assertIn("benchmark target modified the corpus checkout", self.entrypoint)
@@ -312,6 +317,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("not a trusted identity boundary", readme)
         config = PIPELOCK_CONFIG.read_text(encoding="utf-8")
         self.assertRegex(config, r"(?m)^\s+max_tool_calls_per_session: 0$")
+        self.assertRegex(config, r"(?ms)^reverse_proxy:\n(?:\s+#.*\n)*\s+enabled: false$")
 
     def test_collection_upload_and_enforcement_order_is_fail_safe(self):
         ensure = self.workflow.index("      - name: Ensure fail-closed decision exists")

--- a/scripts/pipelock_scan_workflow_test.py
+++ b/scripts/pipelock_scan_workflow_test.py
@@ -149,7 +149,7 @@ class PipelockScanWorkflowTest(unittest.TestCase):
         self.assertEqual(1, len(action_steps), "expected one Pipelock action step")
         version = str((action_steps[0].get("with") or {}).get("version") or "")
         self.assertEqual(
-            "3.3.0",
+            "3.4.0",
             version,
             "advance the audit config producer and source-pinned scanner together after proving compatibility",
         )

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -402,10 +402,16 @@ done
 PYTHONDONTWRITEBYTECODE=1 python3 "$provenance_script" "${start_args[@]}"
 cp "$repo_root/cases/MANIFEST.txt" "$output_dir/corpus-manifest.txt"
 profile_path="$repo_root/examples/pipelock/tool-profile.json"
-cp "$profile_path" "$output_dir/tool-profile.json"
-registry_id="$(jq -r '.capability_registry.id // empty' "$profile_path")"
-registry_format="$(jq -r '.capability_registry.format // empty' "$profile_path")"
-registry_revision="$(jq -r '.capability_registry.revision // empty' "$profile_path")"
+runtime_profile_path="$output_dir/tool-profile.json"
+# The reviewed profile describes capabilities, while the release pin names the
+# binary actually under test. Bind the recorded profile to that verified binary
+# even when an operator supplies an external release pin.
+failure_reason="runtime tool profile generation failed"
+jq --arg version "$PIPELOCK_VERSION" '.tool_version = $version' \
+  "$profile_path" > "$runtime_profile_path"
+registry_id="$(jq -r '.capability_registry.id // empty' "$runtime_profile_path")"
+registry_format="$(jq -r '.capability_registry.format // empty' "$runtime_profile_path")"
+registry_revision="$(jq -r '.capability_registry.revision // empty' "$runtime_profile_path")"
 [[ -n "$registry_id" && "$registry_format" =~ ^[1-9][0-9]*$ && "$registry_revision" =~ ^[1-9][0-9]*$ ]] || \
   die "tool profile has no valid capability registry reference"
 registry_snapshot="$repo_root/capability-registry/$registry_id/format-$registry_format/revision-$registry_revision.json"
@@ -572,7 +578,7 @@ cmd=(
   --managed-proxy-cmd "$managed_proxy_cmd"
   --managed-mcp-http-cmd "$managed_mcp_http_cmd"
   --cases ./cases
-  --profile examples/pipelock/tool-profile.json
+  --profile "$runtime_profile_path"
   --method-repository "$corpus_repository"
   --method-commit "$corpus_git_sha"
   --adapter-owner "agent-egress-bench maintainers"

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -507,7 +507,15 @@ target_wrapper="$work_dir/pipelock-sandboxed"
     /etc/nsswitch.conf /etc/gai.conf /etc/passwd /etc/group /etc/localtime; do
     [[ -e "$readable_path" ]] && printf ' %q' "$readable_path"
   done
-  printf ' -- %q "$@"\n' "$target_binary"
+  # This target is benchmark-managed rather than launched by `pipelock
+  # contain`, so it has no signed runtime posture capsule. `target-sandbox`
+  # deliberately rebuilds the environment; pass this target-specific override
+  # through argv using env(1), pointing at an absent file inside the read-only
+  # extracted-artifact directory. Missing means "no attested containment" while
+  # malformed or unreadable evidence still fails closed, and the measured target
+  # cannot manufacture its own self-consistent capsule at that path.
+  [[ -x /usr/bin/env ]] || die "target sandbox requires /usr/bin/env"
+  printf ' -- %q %q %q "$@"\n' /usr/bin/env "PIPELOCK_POSTURE_PROOF=$work_dir/absent-posture-proof.json" "$target_binary"
 } > "$target_wrapper"
 chmod 0755 "$target_wrapper"
 pipelock_bin="$target_wrapper"


### PR DESCRIPTION
## What changed

- Keeps benchmark-managed Pipelock processes independent of ambient containment state and prevents runner-owned delivery tokens or unused fixed ports from blocking declared cases.
- Pins the repository security scanner to v3.4.0 while preserving the reviewed v3.3 Gauntlet baseline.
- The unresolved POST-on-fetch case remains an instrument error, so this change can't promote a v3.4 baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated Pipelock scanning to version 3.4.0.
  * Improved HTTP fixture tokens with opaque, hexadecimal values that do not expose readable prefixes.
  * Strengthened restricted workflow execution by requiring an absent proof file and validating the environment tool.

* **Configuration**
  * Disabled the reverse proxy in the benchmark configuration.

* **Tests**
  * Expanded coverage for token uniqueness, workflow restrictions, proxy settings, and the updated scanner version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->