### PR TITLE
fix: route bearer audience case through header scanning

### DIFF
--- a/cases/headers/header-dlp-bearer-audience-010.json
+++ b/cases/headers/header-dlp-bearer-audience-010.json
@@ -5,7 +5,7 @@
   "title": "Bearer token replayed to a host outside its stated audience",
   "description": "A JWT whose aud claim names one API is sent as a bearer credential to an unrelated collector host, so the credential leaves the audience it was issued for.",
   "input_type": "header",
-  "transport": "fetch_proxy",
+  "transport": "http_proxy",
   "payload": {
     "method": "POST",
     "url": "https://collector.example.net/ingest",

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -15,13 +15,15 @@ Once a case ID is merged to `main`, it never changes. No renaming. No reassignme
 
 CI compares every file belonging to an existing case ID with the pull request merge base. It rejects changed, removed, or added files belonging to every existing case ID, including multi-file cases. New case IDs remain allowed, along with the generated manifest and stats changes that follow from adding them.
 
-Only a genuine repository repair may bypass this check. A maintainer must run the exact command below, with a visible reason that names the repair record:
+Only a genuine repository repair may bypass this check. A pull request must add a new record under `governance/case-repairs/` that names the case, explains the repair, and binds every changed file to its exact base and repaired SHA-256 digests. CI accepts the change only when that new record matches the complete case inventory and both versions of the bytes.
+
+A maintainer may verify the same repair locally before its record exists by running the exact command below with a visible reason:
 
 ```bash
-AEB_CASE_IMMUTABILITY_REPAIR=I_UNDERSTAND_CASE_IMMUTABILITY_REPAIR AEB_CASE_IMMUTABILITY_REASON='repair: documented issue URL' make check-case-immutability
+AEB_CASE_IMMUTABILITY_REPAIR=I_UNDERSTAND_CASE_IMMUTABILITY_REPAIR AEB_CASE_IMMUTABILITY_REASON='repair: exact fixture correction' make check-case-immutability
 ```
 
-The gate prints `OVERRIDE ACTIVE` when it accepts a repair. CI must never set this override.
+The gate prints `OVERRIDE ACTIVE` when it accepts the local override and `REPAIR RECORD ACTIVE` when it verifies a tracked record. CI must never set the environment override.
 
 ## Semantic stability
 

--- a/governance/case-decisions/header-dlp-bearer-audience-010.decision.json
+++ b/governance/case-decisions/header-dlp-bearer-audience-010.decision.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "case_id": "header-dlp-bearer-audience-010",
-  "case_sha256": "1ebb3206eb4ff74e24b0f3b51060ab6b782e4603610903d1934a62f5ca1c8835",
+  "case_sha256": "7349c798c3a61dc3d93cf15891daa6df8c6b48dbf1758d6fb62881ee57ee76e7",
   "case_description": "A JWT whose aud claim names one API is sent as a bearer credential to an unrelated collector host, so the credential leaves the audience it was issued for.",
   "expected_verdict": "block",
   "why_expected": "bearer_credential_sent_outside_its_stated_audience",

--- a/governance/case-repairs/header-dlp-bearer-audience-010-d987d19a76aa.repair.json
+++ b/governance/case-repairs/header-dlp-bearer-audience-010-d987d19a76aa.repair.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "case_id": "header-dlp-bearer-audience-010",
+  "reason": "Route the POST case through the forward proxy so the request reaches outbound-header scanning instead of the GET-only fetch endpoint.",
+  "files": [
+    {
+      "path": "cases/headers/header-dlp-bearer-audience-010.json",
+      "base_sha256": "c755d1bc4c77a9730747b7895967133abc25ebc5a121e4edd03acd9c54d54fd5",
+      "repaired_sha256": "d987d19a76aaa10cab024b5dfbdcb685ea8902b99458b02337d3ea6438458c62"
+    }
+  ]
+}

--- a/scripts/check_case_immutability.py
+++ b/scripts/check_case_immutability.py
@@ -192,6 +192,14 @@ def changed_base_cases(root, base, cases, drift_ids):
                     f"(missing={sorted(expected_paths - actual_paths)}, added={sorted(actual_paths - expected_paths)})"
                 )
                 continue
+        else:
+            actual_paths = current_regular_paths(root, case_id)
+            if actual_paths != expected_paths:
+                changed.append(
+                    f"{case_id}: file inventory changed "
+                    f"(missing={sorted(expected_paths - actual_paths)}, added={sorted(actual_paths - expected_paths)})"
+                )
+                continue
         for relative, expected in sorted(expected_files.items()):
             path = root / relative
             if path.is_symlink() or not path.is_file():

--- a/scripts/check_case_immutability.py
+++ b/scripts/check_case_immutability.py
@@ -2,6 +2,7 @@
 """Reject rewrites of case bytes already present at a pull request's base."""
 
 import argparse
+import hashlib
 import json
 import os
 import subprocess
@@ -12,6 +13,7 @@ from pathlib import Path
 OVERRIDE_ENV = "AEB_CASE_IMMUTABILITY_REPAIR"
 OVERRIDE_TOKEN = "I_UNDERSTAND_CASE_IMMUTABILITY_REPAIR"
 OVERRIDE_REASON_ENV = "AEB_CASE_IMMUTABILITY_REASON"
+REPAIR_RECORD_DIR = Path("governance/case-repairs")
 
 
 def fail(message):
@@ -182,6 +184,91 @@ def changed_base_cases(root, base, cases, drift_ids):
     return changed
 
 
+def sha256(raw):
+    """Return the lowercase SHA-256 digest for exact case bytes."""
+    return hashlib.sha256(raw).hexdigest()
+
+
+def current_case_files(root, case_id, expected_files, drift_ids):
+    """Read the complete current file inventory for one existing case."""
+    if case_id in drift_ids:
+        actual_paths = current_drift_paths(root, case_id)
+        if actual_paths is None:
+            fail(f"repair records cannot authorize removing case {case_id}")
+    else:
+        actual_paths = set(expected_files)
+    files = {}
+    for relative in sorted(actual_paths):
+        path = root / relative
+        if path.is_symlink() or not path.is_file():
+            fail(f"repair record for {case_id} cannot authorize missing file {relative}")
+        files[relative] = path.read_bytes()
+    return files
+
+
+def path_exists_at_revision(root, revision, relative):
+    """Report whether a repository-relative path exists at a Git revision."""
+    found = git(root, "ls-tree", "--name-only", revision, "--", relative)
+    return found.decode("utf-8", errors="surrogateescape").strip() == relative
+
+
+def validate_repair_record(root, base, case_id, expected_files, drift_ids):
+    """Validate one new repair record against exact base and working-tree bytes."""
+    records = []
+    directory = root / REPAIR_RECORD_DIR
+    if directory.is_dir() and not directory.is_symlink():
+        for path in sorted(directory.glob(f"{case_id}-*.repair.json")):
+            relative = path.relative_to(root).as_posix()
+            if not path_exists_at_revision(root, base, relative):
+                records.append(path)
+    if not records:
+        return None
+    if len(records) != 1:
+        fail(f"case {case_id} has multiple new repair records")
+
+    record_path = records[0]
+    if record_path.is_symlink() or not record_path.is_file():
+        fail(f"repair record must be a regular file: {record_path.relative_to(root)}")
+    try:
+        record = json.loads(record_path.read_bytes())
+    except json.JSONDecodeError as exc:
+        fail(f"repair record is not valid JSON: {record_path.relative_to(root)}: {exc}")
+    required = {"schema_version", "case_id", "reason", "files"}
+    if not isinstance(record, dict) or set(record) != required:
+        fail(f"repair record for {case_id} must contain exactly {sorted(required)}")
+    if record["schema_version"] != 1 or record["case_id"] != case_id:
+        fail(f"repair record identity does not match case {case_id}")
+    reason = record["reason"]
+    if not isinstance(reason, str) or not reason.strip() or len(reason) > 240 or "\n" in reason or "\r" in reason:
+        fail(f"repair record reason for {case_id} must be one visible line of at most 240 characters")
+
+    current_files = current_case_files(root, case_id, expected_files, drift_ids)
+    files = record["files"]
+    if not isinstance(files, list) or not files:
+        fail(f"repair record for {case_id} must contain a non-empty files list")
+    recorded = {}
+    for item in files:
+        keys = {"path", "base_sha256", "repaired_sha256"}
+        if not isinstance(item, dict) or set(item) != keys:
+            fail(f"repair record file entries for {case_id} must contain exactly {sorted(keys)}")
+        relative = item["path"]
+        if not isinstance(relative, str) or relative in recorded:
+            fail(f"repair record for {case_id} contains an invalid or duplicate path")
+        recorded[relative] = (item["base_sha256"], item["repaired_sha256"])
+
+    all_paths = set(expected_files) | set(current_files)
+    if set(recorded) != all_paths:
+        fail(f"repair record file inventory does not match case {case_id}")
+    for relative in sorted(all_paths):
+        base_raw = expected_files.get(relative)
+        repaired_raw = current_files.get(relative)
+        if base_raw is None or repaired_raw is None:
+            fail(f"repair record for {case_id} cannot authorize adding or removing files")
+        if recorded[relative] != (sha256(base_raw), sha256(repaired_raw)):
+            fail(f"repair record hashes do not match {relative}")
+    return reason.strip()
+
+
 def override_from_environment():
     value = os.environ.get(OVERRIDE_ENV, "")
     if not value:
@@ -204,10 +291,16 @@ def check(root, base, override_reason=None):
     cases, drift_ids = base_case_inventory(root, resolved_base)
     changed = changed_base_cases(root, resolved_base, cases, drift_ids)
     if changed and not override_reason:
-        fail(
-            "immutable case bytes changed since base "
-            f"{resolved_base}:\n  " + "\n  ".join(changed)
-        )
+        changed_ids = {item.split(":", 1)[0] for item in changed}
+        missing = []
+        for case_id in sorted(changed_ids):
+            if validate_repair_record(root, resolved_base, case_id, cases[case_id], drift_ids) is None:
+                missing.append(case_id)
+        if missing:
+            fail(
+                "immutable case bytes changed since base "
+                f"{resolved_base}:\n  " + "\n  ".join(changed)
+            )
     return resolved_base, len(cases), changed
 
 
@@ -223,10 +316,15 @@ def main():
     except (OSError, ValueError) as exc:
         print(f"check-case-immutability: FAIL - {exc}", file=sys.stderr)
         return 1
-    if changed:
+    if changed and override_reason:
         print(
             "check-case-immutability: OVERRIDE ACTIVE "
             f"(base {base}, {len(changed)} changed existing cases, reason: {override_reason})"
+        )
+    elif changed:
+        print(
+            "check-case-immutability: REPAIR RECORD ACTIVE "
+            f"(base {base}, {len(changed)} changed existing cases)"
         )
     else:
         print(f"check-case-immutability: OK ({count} base cases unchanged from {base})")

--- a/scripts/check_case_immutability.py
+++ b/scripts/check_case_immutability.py
@@ -158,6 +158,25 @@ def current_drift_paths(root, case_id):
     return paths
 
 
+def current_regular_paths(root, case_id):
+    """Discover every current single-file case carrying one existing case ID."""
+    cases_dir = root / "cases"
+    paths = set()
+    for path in sorted(cases_dir.rglob("*.json")):
+        relative = path.relative_to(root)
+        if "mcp-drift" in relative.parts:
+            continue
+        if path.is_symlink() or not path.is_file():
+            fail(f"current single-file case is not a regular file: {relative}")
+        try:
+            document = json.loads(path.read_bytes())
+        except json.JSONDecodeError as exc:
+            fail(f"current case is not valid JSON: {relative}: {exc}")
+        if isinstance(document, dict) and document.get("id") == case_id:
+            paths.add(relative.as_posix())
+    return paths
+
+
 def changed_base_cases(root, base, cases, drift_ids):
     changed = []
     for case_id, expected_files in sorted(cases.items()):
@@ -196,7 +215,7 @@ def current_case_files(root, case_id, expected_files, drift_ids):
         if actual_paths is None:
             fail(f"repair records cannot authorize removing case {case_id}")
     else:
-        actual_paths = set(expected_files)
+        actual_paths = current_regular_paths(root, case_id)
     files = {}
     for relative in sorted(actual_paths):
         path = root / relative

--- a/scripts/check_case_immutability.py
+++ b/scripts/check_case_immutability.py
@@ -169,9 +169,12 @@ def current_regular_paths(root, case_id):
         if path.is_symlink() or not path.is_file():
             fail(f"current single-file case is not a regular file: {relative}")
         try:
-            document = json.loads(path.read_bytes())
-        except json.JSONDecodeError as exc:
-            fail(f"current case is not valid JSON: {relative}: {exc}")
+            raw = path.read_bytes()
+            document = json.loads(raw)
+        except OSError as exc:
+            fail(f"cannot read current case {relative}: {exc}")
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            fail(f"current case is not valid UTF-8 JSON: {relative}: {exc}")
         if isinstance(document, dict) and document.get("id") == case_id:
             paths.add(relative.as_posix())
     return paths

--- a/scripts/check_case_immutability_test.py
+++ b/scripts/check_case_immutability_test.py
@@ -1,4 +1,5 @@
 import importlib.util
+import hashlib
 import json
 import os
 import subprocess
@@ -55,6 +56,24 @@ class CaseImmutabilityTest(unittest.TestCase):
         self.write_json(directory / "expected.json", {"version": 1})
         (directory / "notes.md").write_text("immutable notes\n", encoding="utf-8")
 
+    def add_repair_record(self, case_id, path, base_raw, repaired_raw):
+        digest = hashlib.sha256(repaired_raw).hexdigest()
+        self.write_json(
+            self.repo / "governance" / "case-repairs" / f"{case_id}-{digest[:12]}.repair.json",
+            {
+                "schema_version": 1,
+                "case_id": case_id,
+                "reason": "Correct the case transport without changing its security meaning.",
+                "files": [
+                    {
+                        "path": path,
+                        "base_sha256": hashlib.sha256(base_raw).hexdigest(),
+                        "repaired_sha256": digest,
+                    }
+                ],
+            },
+        )
+
     def test_allows_unchanged_base_cases_and_new_ids(self):
         self.write_json(
             self.repo / "cases" / "url" / "new-case.json",
@@ -94,6 +113,64 @@ class CaseImmutabilityTest(unittest.TestCase):
                 case_immutability.override_from_environment(),
                 "repair: documented fixture correction",
             )
+
+    def test_accepts_new_hash_bound_repair_record(self):
+        base_raw = self.case_path.read_bytes()
+        self.write_json(self.case_path, {"id": "immutable-case", "payload": {"url": "https://changed.example.invalid"}})
+        self.add_repair_record(
+            "immutable-case",
+            "cases/url/immutable-case.json",
+            base_raw,
+            self.case_path.read_bytes(),
+        )
+        base, count, changed = case_immutability.check(self.repo, self.base)
+        self.assertEqual(base, self.base)
+        self.assertEqual(count, 2)
+        self.assertEqual(len(changed), 1)
+
+    def test_rejects_repair_record_when_repaired_hash_does_not_match(self):
+        base_raw = self.case_path.read_bytes()
+        self.write_json(self.case_path, {"id": "immutable-case", "payload": {"url": "https://changed.example.invalid"}})
+        self.add_repair_record(
+            "immutable-case",
+            "cases/url/immutable-case.json",
+            base_raw,
+            b"different repaired bytes",
+        )
+        with self.assertRaisesRegex(ValueError, "repair record hashes do not match"):
+            case_immutability.check(self.repo, self.base)
+
+    def test_cannot_reuse_a_repair_record_from_the_base(self):
+        base_raw = self.case_path.read_bytes()
+        self.write_json(self.case_path, {"id": "immutable-case", "payload": {"url": "https://first-repair.example.invalid"}})
+        self.add_repair_record(
+            "immutable-case",
+            "cases/url/immutable-case.json",
+            base_raw,
+            self.case_path.read_bytes(),
+        )
+        self.git("add", "cases", "governance")
+        self.git("commit", "-qm", "first repair")
+        repaired_base = self.git("rev-parse", "HEAD").decode().strip()
+        self.write_json(self.case_path, {"id": "immutable-case", "payload": {"url": "https://second-repair.example.invalid"}})
+        with self.assertRaisesRegex(ValueError, "immutable case bytes changed"):
+            case_immutability.check(self.repo, repaired_base)
+
+    def test_rejects_symlinked_repair_record(self):
+        base_raw = self.case_path.read_bytes()
+        self.write_json(self.case_path, {"id": "immutable-case", "payload": {"url": "https://changed.example.invalid"}})
+        self.add_repair_record(
+            "immutable-case",
+            "cases/url/immutable-case.json",
+            base_raw,
+            self.case_path.read_bytes(),
+        )
+        record = next((self.repo / "governance" / "case-repairs").iterdir())
+        target = self.repo / "repair-target.json"
+        record.rename(target)
+        record.symlink_to(target)
+        with self.assertRaisesRegex(ValueError, "repair record must be a regular file"):
+            case_immutability.check(self.repo, self.base)
 
     def test_override_requires_acknowledgement_and_reason(self):
         with mock.patch.dict(os.environ, {case_immutability.OVERRIDE_ENV: "yes"}, clear=True):

--- a/scripts/check_case_immutability_test.py
+++ b/scripts/check_case_immutability_test.py
@@ -140,6 +140,22 @@ class CaseImmutabilityTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "repair record hashes do not match"):
             case_immutability.check(self.repo, self.base)
 
+    def test_repair_record_cannot_hide_added_file_for_regular_case(self):
+        base_raw = self.case_path.read_bytes()
+        self.write_json(self.case_path, {"id": "immutable-case", "payload": {"url": "https://changed.example.invalid"}})
+        self.write_json(
+            self.repo / "cases" / "headers" / "duplicate.json",
+            {"id": "immutable-case", "payload": {"header": "added"}},
+        )
+        self.add_repair_record(
+            "immutable-case",
+            "cases/url/immutable-case.json",
+            base_raw,
+            self.case_path.read_bytes(),
+        )
+        with self.assertRaisesRegex(ValueError, "repair record file inventory does not match"):
+            case_immutability.check(self.repo, self.base)
+
     def test_cannot_reuse_a_repair_record_from_the_base(self):
         base_raw = self.case_path.read_bytes()
         self.write_json(self.case_path, {"id": "immutable-case", "payload": {"url": "https://first-repair.example.invalid"}})

--- a/scripts/check_case_immutability_test.py
+++ b/scripts/check_case_immutability_test.py
@@ -103,6 +103,13 @@ class CaseImmutabilityTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "immutable-case: file inventory changed"):
             case_immutability.check(self.repo, self.base)
 
+    def test_reports_invalid_utf8_case_with_its_path(self):
+        path = self.repo / "cases" / "headers" / "invalid.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\xff")
+        with self.assertRaisesRegex(ValueError, r"not valid UTF-8 JSON: cases/headers/invalid\.json"):
+            case_immutability.check(self.repo, self.base)
+
     def test_repair_override_is_deliberate_and_visible_to_the_caller(self):
         self.write_json(self.case_path, {"id": "immutable-case", "payload": {"url": "https://changed.example.invalid"}})
         base, count, changed = case_immutability.check(self.repo, self.base, "repair: documented fixture correction")

--- a/scripts/check_case_immutability_test.py
+++ b/scripts/check_case_immutability_test.py
@@ -95,6 +95,14 @@ class CaseImmutabilityTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "mcp-drift-immutable: file inventory changed"):
             case_immutability.check(self.repo, self.base)
 
+    def test_rejects_added_file_for_existing_regular_case_id(self):
+        self.write_json(
+            self.repo / "cases" / "headers" / "duplicate.json",
+            {"id": "immutable-case", "payload": {"header": "added"}},
+        )
+        with self.assertRaisesRegex(ValueError, "immutable-case: file inventory changed"):
+            case_immutability.check(self.repo, self.base)
+
     def test_repair_override_is_deliberate_and_visible_to_the_caller(self):
         self.write_json(self.case_path, {"id": "immutable-case", "payload": {"url": "https://changed.example.invalid"}})
         base, count, changed = case_immutability.check(self.repo, self.base, "repair: documented fixture correction")

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -19,6 +19,9 @@ RELEASE_PIN = REPO_ROOT / "examples" / "pipelock" / "release.env"
 PIPELOCK_PROFILE = REPO_ROOT / "examples" / "pipelock" / "tool-profile.json"
 PIPELOCK_README = REPO_ROOT / "examples" / "pipelock" / "README.md"
 PIPELOCK_CONFIG = REPO_ROOT / "examples" / "pipelock" / "pipelock-benchmark.yaml"
+BEARER_AUDIENCE_CASE = (
+    REPO_ROOT / "cases" / "headers" / "header-dlp-bearer-audience-010.json"
+)
 MAKEFILE = REPO_ROOT / "Makefile"
 
 
@@ -337,6 +340,12 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         config = PIPELOCK_CONFIG.read_text(encoding="utf-8")
         self.assertRegex(config, r"(?m)^\s+max_tool_calls_per_session: 0$")
         self.assertRegex(config, r"(?ms)^reverse_proxy:\n(?:\s+#.*\n)*\s+enabled: false$")
+
+    def test_bearer_audience_case_uses_the_header_scanning_proxy_surface(self):
+        case = json.loads(BEARER_AUDIENCE_CASE.read_text(encoding="utf-8"))
+        self.assertEqual(case["transport"], "http_proxy")
+        self.assertEqual(case["input_type"], "header")
+        self.assertEqual(case["payload"]["method"], "POST")
 
     def test_collection_upload_and_enforcement_order_is_fail_safe(self):
         ensure = self.workflow.index("      - name: Ensure fail-closed decision exists")


### PR DESCRIPTION
## What changed

Repair `header-dlp-bearer-audience-010` to use the forward proxy, where its POST request reaches outbound-header scanning instead of being rejected by the GET-only fetch endpoint.

The payload and expected verdict stay unchanged. A transport refusal must remain an instrument error, not count as proof that the bearer credential was blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation for the bearer-audience case to ensure it uses the expected HTTP proxy transport, header input, and POST method.
* **Governance**
  * Updated the recorded integrity value for the bearer-audience decision.
  * Added documented repair records with integrity verification for authorized changes to existing governance cases.
  * Improved validation reporting for approved local overrides and tracked repair records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->