### PR TITLE
fix: accept pinned commits from canonical history

### DIFF
--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -78,6 +78,59 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertIn('${original_args[$original_arg_index]}', self.entrypoint)
         self.assertNotRegex(self.entrypoint, r"\$\{original_args\[[@*]\]")
 
+    def test_canonical_pinned_commit_may_be_in_origin_main_history(self):
+        ancestry_guard = (
+            'git merge-base --is-ancestor "$corpus_git_sha" refs/remotes/origin/main'
+        )
+        self.assertIn(ancestry_guard, self.entrypoint)
+        self.assertNotIn('[[ "$corpus_git_sha" == "$origin_main_sha" ]]', self.entrypoint)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+
+            def git(*arguments):
+                return subprocess.run(
+                    ["git", *arguments],
+                    cwd=repo,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+
+            self.assertEqual(git("init").returncode, 0)
+            self.assertEqual(git("config", "user.name", "Test Operator").returncode, 0)
+            self.assertEqual(git("config", "user.email", "operator@example.test").returncode, 0)
+            (repo / "fixture").write_text("one\n", encoding="utf-8")
+            self.assertEqual(git("add", "fixture").returncode, 0)
+            self.assertEqual(git("commit", "-m", "first").returncode, 0)
+            first = git("rev-parse", "HEAD").stdout.strip()
+            (repo / "fixture").write_text("two\n", encoding="utf-8")
+            self.assertEqual(git("commit", "-am", "second").returncode, 0)
+            main_tip = git("rev-parse", "HEAD").stdout.strip()
+            self.assertEqual(
+                git("update-ref", "refs/remotes/origin/main", main_tip).returncode,
+                0,
+            )
+
+            self.assertEqual(
+                git("merge-base", "--is-ancestor", first, "refs/remotes/origin/main").returncode,
+                0,
+            )
+            self.assertEqual(git("checkout", "--detach", first).returncode, 0)
+            (repo / "other").write_text("side\n", encoding="utf-8")
+            self.assertEqual(git("add", "other").returncode, 0)
+            self.assertEqual(git("commit", "-m", "divergent").returncode, 0)
+            divergent = git("rev-parse", "HEAD").stdout.strip()
+            self.assertEqual(
+                git(
+                    "merge-base",
+                    "--is-ancestor",
+                    divergent,
+                    "refs/remotes/origin/main",
+                ).returncode,
+                1,
+            )
+
     def test_doctor_reports_every_check_as_json_without_starting_a_run(self):
         before = set((REPO_ROOT / "continuous-gauntlet-runs").glob("*"))
         result = subprocess.run(

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -354,14 +354,13 @@ else
 fi
 
 corpus_git_sha="$(git rev-parse HEAD)"
-origin_main_sha="$(git rev-parse --verify origin/main 2>/dev/null || true)"
 if [[ "$development_mode" == true ]]; then
   pointed_tags="$(git tag --points-at HEAD)"
 else
   pointed_tags="$(git ls-remote --tags https://github.com/luckyPipewrench/agent-egress-bench.git | \
     awk -v sha="$corpus_git_sha" '$1 == sha { print $2 }')"
 fi
-if [[ "$corpus_git_sha" == "$origin_main_sha" ]]; then
+if git merge-base --is-ancestor "$corpus_git_sha" refs/remotes/origin/main; then
   corpus_ref_kind="origin/main"
 elif [[ -n "$pointed_tags" ]]; then
   corpus_ref_kind="tag"


### PR DESCRIPTION
## What changed

- Accept an immutable corpus commit when Git proves it belongs to the fetched `origin/main` history, so reproducible hosted runs don’t break whenever benchmark main advances.
- Keep divergent commits fail-closed and bind the behavior with success, rejection, and non-vacuity coverage. Reviewers should distrust any path that classifies a commit without checking its ancestry against the freshly fetched canonical ref.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved corpus validation to accept pinned commits that are part of the fetched main branch history.
  * Continued to reject commits that diverge from the main branch history.

* **Tests**
  * Added coverage verifying acceptance of historical ancestor commits and rejection of divergent commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->