### PR TITLE
fix: enforce canonical corpus provenance

### DIFF
--- a/control-evidence/g2/authentication/assessor.go
+++ b/control-evidence/g2/authentication/assessor.go
@@ -595,7 +595,7 @@ func externalToPackage(root, path string) bool {
 		return false
 	}
 	rel, err := filepath.Rel(a, b)
-	return err == nil && rel != "." && rel != ".." && strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+	return err == nil && rel != "." && (rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }
 
 func readRegularBounded(path string, maxBytes int64) ([]byte, error) {

--- a/control-evidence/g2/authentication/assessor_test.go
+++ b/control-evidence/g2/authentication/assessor_test.go
@@ -307,6 +307,18 @@ func TestAssessRejectsPhysicalContainmentThroughSymlinkedParent(t *testing.T) {
 	}
 }
 
+func TestExternalToPackageAcceptsParentDirectory(t *testing.T) {
+	root := t.TempDir()
+	pkg := filepath.Join(root, "nested", "pkg")
+	if err := os.MkdirAll(pkg, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	if !externalToPackage(pkg, filepath.Dir(pkg)) {
+		t.Fatal("parent directory outside the package was rejected as internal")
+	}
+}
+
 func TestConcurrentSameEpochPoliciesCannotBothPass(t *testing.T) {
 	fixture := newFixture(t)
 	firstPolicy := signed(t, fixture.root, policyType, fixture.policy)

--- a/runner/receipt_evidence_containment_test.go
+++ b/runner/receipt_evidence_containment_test.go
@@ -102,3 +102,27 @@ func TestEvidenceFiles_SkipsNonRegularEntries(t *testing.T) {
 		t.Fatalf("got %v, want only %q", got, real)
 	}
 }
+
+func TestEvidenceFiles_RetainsInternalSymlinkFromRelativeDirectory(t *testing.T) {
+	root := t.TempDir()
+	evidence := filepath.Join(root, "evidence")
+	if err := os.Mkdir(evidence, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	real := filepath.Join(evidence, "real.jsonl")
+	if err := os.WriteFile(real, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, filepath.Join(evidence, "inside-link.jsonl")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+	t.Chdir(root)
+
+	got, err := evidenceFiles("", ReceiptEvidenceDeclaration{EvidenceDir: "evidence", FileGlob: "*.jsonl"})
+	if err != nil {
+		t.Fatalf("evidenceFiles: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d files %v, want the file and its internal symlink", len(got), got)
+	}
+}

--- a/runner/receipt_observer.go
+++ b/runner/receipt_observer.go
@@ -169,7 +169,11 @@ func evidenceFiles(profileDir string, decl ReceiptEvidenceDeclaration) ([]string
 	for _, entry := range entries {
 		entryTypes[filepath.Join(dir, entry.Name())] = entry
 	}
-	resolvedDir, err := filepath.EvalSymlinks(dir)
+	absoluteDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving evidence_dir %q: %w", dir, err)
+	}
+	resolvedDir, err := filepath.EvalSymlinks(absoluteDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolving evidence_dir %q: %w", dir, err)
 	}
@@ -184,7 +188,11 @@ func evidenceFiles(profileDir string, decl ReceiptEvidenceDeclaration) ([]string
 			continue
 		}
 		if entry.Type()&os.ModeSymlink != 0 {
-			resolved, err := filepath.EvalSymlinks(match)
+			absoluteMatch, err := filepath.Abs(match)
+			if err != nil {
+				continue
+			}
+			resolved, err := filepath.EvalSymlinks(absoluteMatch)
 			if err != nil {
 				continue
 			}

--- a/runner/receipt_profile_provenance.go
+++ b/runner/receipt_profile_provenance.go
@@ -75,7 +75,7 @@ func observeCorpusGitProvenance(sourceRoots []string) CorpusGitProvenance {
 		checkout := observeGitCheckout(sourceRoot)
 		key := checkout.root
 		if key == "" {
-			key = checkout.status + ":" + filepath.Clean(sourceRoot)
+			key = checkout.status
 		}
 		if previous, exists := checkouts[key]; exists {
 			checkouts[key] = mergeObservedGitCheckouts(previous, checkout)
@@ -131,7 +131,11 @@ func gitSHAValue(value *string) string {
 }
 
 func observeGitCheckout(sourceRoot string) observedGitCheckout {
-	resolvedSource, err := filepath.EvalSymlinks(sourceRoot)
+	absoluteSource, err := filepath.Abs(sourceRoot)
+	if err != nil {
+		return observedGitCheckout{status: corpusGitStatusUnavailable}
+	}
+	resolvedSource, err := filepath.EvalSymlinks(absoluteSource)
 	if err != nil {
 		return observedGitCheckout{status: corpusGitStatusUnavailable}
 	}

--- a/runner/receipt_profile_provenance.go
+++ b/runner/receipt_profile_provenance.go
@@ -70,12 +70,13 @@ func observeCorpusGitProvenance(sourceRoots []string) CorpusGitProvenance {
 		return CorpusGitProvenance{Status: corpusGitStatusUnavailable}
 	}
 
+	sourceRoots = independentSourceRoots(sourceRoots)
 	checkouts := make(map[string]observedGitCheckout, len(sourceRoots))
 	for _, sourceRoot := range sourceRoots {
 		checkout := observeGitCheckout(sourceRoot)
 		key := checkout.root
 		if key == "" {
-			key = checkout.status
+			key = sourceRoot
 		}
 		if previous, exists := checkouts[key]; exists {
 			checkouts[key] = mergeObservedGitCheckouts(previous, checkout)
@@ -101,6 +102,39 @@ func observeCorpusGitProvenance(sourceRoots []string) CorpusGitProvenance {
 		}
 	}
 	return CorpusGitProvenance{Status: corpusGitStatusUnavailable}
+}
+
+func independentSourceRoots(sourceRoots []string) []string {
+	normalized := make([]string, 0, len(sourceRoots))
+	for _, sourceRoot := range sourceRoots {
+		absolute, err := filepath.Abs(sourceRoot)
+		if err != nil {
+			absolute = filepath.Clean(sourceRoot)
+		}
+		if resolved, resolveErr := filepath.EvalSymlinks(absolute); resolveErr == nil {
+			absolute = resolved
+		}
+		normalized = append(normalized, absolute)
+	}
+
+	independent := make([]string, 0, len(normalized))
+	for index, candidate := range normalized {
+		contained := false
+		for otherIndex, other := range normalized {
+			if index == otherIndex || candidate == other {
+				continue
+			}
+			relative, err := filepath.Rel(other, candidate)
+			if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+				contained = true
+				break
+			}
+		}
+		if !contained {
+			independent = append(independent, candidate)
+		}
+	}
+	return independent
 }
 
 func mergeObservedGitCheckouts(left, right observedGitCheckout) observedGitCheckout {

--- a/runner/receipt_profile_provenance_test.go
+++ b/runner/receipt_profile_provenance_test.go
@@ -27,6 +27,63 @@ func TestLoadRunCorpusRecordsCleanGitRevision(t *testing.T) {
 	}
 }
 
+func TestLoadRunCorpusRecordsCleanGitRevisionFromRelativePath(t *testing.T) {
+	root := writeGitCorpus(t)
+	wantSHA := runGitForTest(t, root, "rev-parse", "HEAD")
+	t.Chdir(filepath.Dir(root))
+
+	run, err := loadRunCorpus(filepath.Base(root), "")
+	if err != nil {
+		t.Fatalf("loadRunCorpus: %v", err)
+	}
+	if run.gitProvenance.Status != corpusGitStatusClean {
+		t.Fatalf("corpus_git_status = %q, want clean", run.gitProvenance.Status)
+	}
+	if run.gitProvenance.SHA == nil || *run.gitProvenance.SHA != wantSHA {
+		t.Fatalf("corpus_git_sha = %v, want %q", run.gitProvenance.SHA, wantSHA)
+	}
+}
+
+func TestObserveCorpusGitProvenanceMergesRelativeRootsFromOneCheckout(t *testing.T) {
+	root := writeGitCorpus(t)
+	nested := filepath.Join(root, "nested")
+	if err := os.Mkdir(nested, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "fixture.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, root, "add", "nested/fixture.json")
+	runGitForTest(t, root, "commit", "-qm", "nested fixture")
+	wantSHA := runGitForTest(t, root, "rev-parse", "HEAD")
+	t.Chdir(filepath.Dir(root))
+
+	provenance := observeCorpusGitProvenance([]string{
+		filepath.Base(root),
+		filepath.Join(filepath.Base(root), "nested"),
+	})
+	if provenance.Status != corpusGitStatusClean {
+		t.Fatalf("corpus_git_status = %q, want clean", provenance.Status)
+	}
+	if provenance.SHA == nil || *provenance.SHA != wantSHA {
+		t.Fatalf("corpus_git_sha = %v, want %q", provenance.SHA, wantSHA)
+	}
+}
+
+func TestObserveCorpusGitProvenanceCollapsesRootlessSourcesByStatus(t *testing.T) {
+	root := t.TempDir()
+	first := filepath.Join(root, "cases")
+	second := filepath.Join(first, "mcp-drift")
+	if err := os.MkdirAll(second, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	provenance := observeCorpusGitProvenance([]string{first, second})
+	if provenance.Status != corpusGitStatusNotGitCheckout {
+		t.Fatalf("corpus_git_status = %q, want not_git_checkout", provenance.Status)
+	}
+}
+
 func TestLoadRunCorpusRecordsDirtyGitCheckout(t *testing.T) {
 	root := writeGitCorpus(t)
 	if err := os.WriteFile(filepath.Join(root, "dirty.txt"), []byte("changed"), 0o600); err != nil {

--- a/runner/receipt_profile_provenance_test.go
+++ b/runner/receipt_profile_provenance_test.go
@@ -70,7 +70,7 @@ func TestObserveCorpusGitProvenanceMergesRelativeRootsFromOneCheckout(t *testing
 	}
 }
 
-func TestObserveCorpusGitProvenanceCollapsesRootlessSourcesByStatus(t *testing.T) {
+func TestObserveCorpusGitProvenanceCollapsesNestedRootlessSources(t *testing.T) {
 	root := t.TempDir()
 	first := filepath.Join(root, "cases")
 	second := filepath.Join(first, "mcp-drift")
@@ -81,6 +81,21 @@ func TestObserveCorpusGitProvenanceCollapsesRootlessSourcesByStatus(t *testing.T
 	provenance := observeCorpusGitProvenance([]string{first, second})
 	if provenance.Status != corpusGitStatusNotGitCheckout {
 		t.Fatalf("corpus_git_status = %q, want not_git_checkout", provenance.Status)
+	}
+}
+
+func TestObserveCorpusGitProvenanceKeepsIndependentRootlessSourcesSeparate(t *testing.T) {
+	first := filepath.Join(t.TempDir(), "cases")
+	second := filepath.Join(t.TempDir(), "cases")
+	for _, root := range []string{first, second} {
+		if err := os.MkdirAll(root, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	provenance := observeCorpusGitProvenance([]string{first, second})
+	if provenance.Status != corpusGitStatusMultipleSources {
+		t.Fatalf("corpus_git_status = %q, want multiple_sources", provenance.Status)
 	}
 }
 

--- a/runner/report.go
+++ b/runner/report.go
@@ -1238,8 +1238,13 @@ func (r *buyerReport) receiptProfileBindingError(reference capabilityregistry.Re
 	if receipt.SchemaVersion == activeReceiptProfileSchemaVersion && receipt.BenchmarkManifestSHA256 != reportString(r.summary, "benchmark_manifest_sha256") {
 		return "receipt profile benchmark manifest digest does not match the result"
 	}
-	if receipt.SchemaVersion == activeReceiptProfileSchemaVersion && receipt.CorpusGitStatus == corpusGitStatusClean && receipt.CorpusGitSHA != reportString(r.summary, "method_commit") {
-		return "receipt profile corpus Git commit does not match the result method commit"
+	if receipt.SchemaVersion == activeReceiptProfileSchemaVersion {
+		if receipt.CorpusGitStatus != corpusGitStatusClean {
+			return "v5 receipt profile requires clean corpus Git provenance for publication"
+		}
+		if receipt.CorpusGitSHA != reportString(r.summary, "method_commit") {
+			return "receipt profile corpus Git commit does not match the result method commit"
+		}
 	}
 	if receipt.ToolProfileSHA256 != reportString(r.summary, "tool_profile_sha256") {
 		return "receipt profile tool profile digest does not match the result"

--- a/runner/report_test.go
+++ b/runner/report_test.go
@@ -314,6 +314,31 @@ func TestBuyerReportRefusesCleanCorpusCommitContradiction(t *testing.T) {
 	}
 }
 
+func TestBuyerReportRefusesNonCleanCorpusForPublication(t *testing.T) {
+	fixture := publicationFixture()
+	dir := t.TempDir()
+	fixture.write(t, dir)
+	receiptPath := filepath.Join(dir, "receipt-profile.json")
+	data, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt ReceiptProfile
+	if err := decodeStrictJSON(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	receipt.CorpusGitStatus = corpusGitStatusUnavailable
+	receipt.CorpusGitSHA = ""
+	writeFixtureJSON(t, receiptPath, receipt)
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if problem := report.receiptProfileBindingError(receipt.CapabilityRegistry); problem != "v5 receipt profile requires clean corpus Git provenance for publication" {
+		t.Fatalf("corpus Git binding = %q", problem)
+	}
+}
+
 func TestV4ReceiptProfileBindingStaysReadableAfterActiveSchemaAdvances(t *testing.T) {
 	fixture := newReportFixture()
 	dir := t.TempDir()

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -312,10 +312,10 @@ def validate_active_registry_binding(run_dir, summary, results):
         git_sha = receipt.get("corpus_git_sha")
         if git_status not in {"clean", "dirty", "not_git_checkout", "multiple_sources", "unavailable", "changed_during_capture"}:
             raise ValueError("receipt profile corpus_git_status is invalid")
-        if git_status == "clean" and (not isinstance(git_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", git_sha)):
+        if git_status != "clean":
+            raise ValueError("v5 receipt profile requires clean corpus Git provenance for publication")
+        if not isinstance(git_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", git_sha):
             raise ValueError("clean receipt profile requires a full corpus_git_sha")
-        if git_status != "clean" and git_sha != "":
-            raise ValueError("non-clean receipt profile requires an empty corpus_git_sha")
         observed = receipt.get("observed_tool_version")
         if not isinstance(observed, dict) or set(observed) != {"status", "value"}:
             raise ValueError("receipt profile observed_tool_version is invalid")
@@ -327,8 +327,8 @@ def validate_active_registry_binding(run_dir, summary, results):
             raise ValueError("observed tool version requires a non-empty value")
         if observed_status != "observed" and observed_value is not None:
             raise ValueError("unavailable tool version requires a null value")
-        if git_status == "clean" and git_sha != summary.get("method_commit"):
-            raise ValueError("receipt profile corpus Git commit does not match summary method commit")
+        if git_sha != summary.get("method_commit"):
+            raise ValueError("receipt profile corpus Git commit does not match summary method_commit")
     if snapshot.get("id") != reference["id"] or snapshot.get("format") != reference["format"] or snapshot.get("revision") != reference["revision"]:
         raise ValueError("capability registry snapshot identity does not match summary")
     entries = snapshot.get("entries")

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -369,8 +369,8 @@ class ProvenanceBuilderTest(unittest.TestCase):
                         "corpus_version": summary["corpus_version"],
                         "corpus_sha256": summary["corpus_sha256"],
                         "benchmark_manifest_sha256": summary["benchmark_manifest_sha256"],
-                        "corpus_git_sha": summary.get("method_commit", ""),
-                        "corpus_git_status": "unavailable",
+                        "corpus_git_sha": "c" * 40,
+                        "corpus_git_status": "clean",
                         "tool_profile_sha256": summary["tool_profile_sha256"],
                         "capability_registry": reference,
                         "verifier": {
@@ -552,10 +552,10 @@ class ProvenanceBuilderTest(unittest.TestCase):
             "missing v5 provenance field observed_tool_version",
         )
 
-    def test_v5_rejects_dirty_corpus_with_a_git_sha(self):
+    def test_v5_rejects_non_clean_corpus_for_publication(self):
         self.assert_v5_receipt_mutation_rejected(
-            lambda receipt: receipt.update(corpus_git_status="dirty", corpus_git_sha="d" * 40),
-            "non-clean receipt profile requires an empty corpus_git_sha",
+            lambda receipt: receipt.update(corpus_git_status="dirty", corpus_git_sha=""),
+            "requires clean corpus Git provenance for publication",
         )
 
     def test_v5_rejects_observed_tool_version_without_value(self):

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -257,6 +257,12 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertEqual(json.loads(result.stdout)["tool_version"], "9.9.9")
         self.assertNotEqual(source_profile["tool_version"], "9.9.9")
 
+    def test_canonical_runner_binds_absolute_corpus_and_receipt_commit(self):
+        self.assertIn('--cases "$repo_root/cases"', self.entrypoint)
+        self.assertNotIn("--cases ./cases", self.entrypoint)
+        self.assertIn('.corpus_git_status == "clean" and .corpus_git_sha == $sha', self.entrypoint)
+        self.assertIn("canonical receipt does not bind the clean corpus commit", self.entrypoint)
+
     def test_target_runs_under_a_filesystem_restricted_environment(self):
         self.assertIn("go build -o \"$target_sandbox\" ./cmd/target-sandbox", self.entrypoint)
         self.assertIn('pipelock_bin="$target_wrapper"', self.entrypoint)

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -577,7 +577,7 @@ cmd=(
   --mcp-cmd "$mcp_cmd"
   --managed-proxy-cmd "$managed_proxy_cmd"
   --managed-mcp-http-cmd "$managed_mcp_http_cmd"
-  --cases ./cases
+  --cases "$repo_root/cases"
   --profile "$runtime_profile_path"
   --method-repository "$corpus_repository"
   --method-commit "$corpus_git_sha"
@@ -623,7 +623,7 @@ grep -Fq -- '--seeded-blocklist-domain exfil-collector.example.net' "$command_pa
 
 failure_reason="corpus statistics or case index generation failed"
 make stats > "$stats_path"
-"$gauntlet_bin" --cases ./cases --case-index > "$case_index_path"
+"$gauntlet_bin" --cases "$repo_root/cases" --case-index > "$case_index_path"
 
 failure_reason="Gauntlet runner failed"
 set +e
@@ -637,6 +637,10 @@ if [[ "$run_status" -ne 0 ]]; then
 fi
 grep -Eq '^Fixtures: HTTP=.* TLS=.* WS=.* DNS=.* MCP_HTTP=' "$stderr_path" || \
   die "runner did not report fixture startup"
+if [[ "$canonical_execution" == true ]] && ! jq -e --arg sha "$corpus_git_sha" \
+  '.corpus_git_status == "clean" and .corpus_git_sha == $sha' "$receipt_profile_path" >/dev/null; then
+  die "canonical receipt does not bind the clean corpus commit"
+fi
 
 failure_reason="target sandbox integrity check failed"
 post_run_dirty="$(git status --porcelain=v1 --untracked-files=all)"


### PR DESCRIPTION
## What changed

- Normalize corpus and receipt-evidence paths before provenance checks, preserve rootless source states, and accept a parent directory as external G2 evidence.
- Require canonical publication bundles to carry a clean receipt commit matching the recorded benchmark commit.

The failure direction is closed: missing or contradictory corpus provenance now stops canonical finalization. Reviewers should distrust any path where a non-clean v5 receipt can still become publication-eligible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of relative evidence directories and symlinked evidence files.
  - Correctly recognizes a package’s parent directory as external.
  - Improved provenance tracking for relative corpus paths and shared checkouts.

- **Validation**
  - Active receipt publication now requires clean corpus provenance and a complete commit identifier matching the recorded method commit.
  - Canonical Gauntlet runs now use stable repository-based paths and verify corpus provenance before completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->