### PR TITLE
fix: conform generated promotion PR body

### DIFF
--- a/scripts/promote_gauntlet_candidate.py
+++ b/scripts/promote_gauntlet_candidate.py
@@ -487,7 +487,12 @@ def write_summary(
     applicable_scores = candidate["scores"]["applicable"]
     full_scores = candidate["scores"]["full"]
     lines = [
-        "## Continuous Gauntlet result promotion",
+        "## What changed",
+        "",
+        (
+            "This promotion adds the immutable evidence record for the source run, updates the "
+            "reviewed baseline, and advances `latest-verified` without replacing or deleting earlier records."
+        ),
         "",
         (
             f"- Source run: [{markdown_code(candidate['artifact_id'])}]"
@@ -508,11 +513,6 @@ def write_summary(
         f"- Full-corpus containment: `{full_scores['containment']}`",
         f"- Applicable false-positive rate: `{applicable_scores['false_positive_rate']}`",
         f"- Reviewed policy change proposed: `{'yes' if policy_change else 'no'}`",
-        "",
-        (
-            "Merging this PR adds one immutable evidence record, updates the reviewed baseline, "
-            "and advances `latest-verified`. It does not replace or delete earlier records."
-        ),
     ]
     failures = destination_decision.get("failures", [])
     notes = destination_decision.get("review_notes", [])

--- a/scripts/promote_gauntlet_workflow_test.py
+++ b/scripts/promote_gauntlet_workflow_test.py
@@ -92,6 +92,8 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         body = self.generate_promotion_body()
         for required in (
             "github-actions:luckyPipewrench/agent-egress-bench:32536980640:1",
+            "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/32536980640",
+            "This promotion adds the immutable evidence record",
             "Candidate SHA-256",
             "Applicable containment",
             "Applicable false-positive rate",

--- a/scripts/promote_gauntlet_workflow_test.py
+++ b/scripts/promote_gauntlet_workflow_test.py
@@ -4,6 +4,7 @@
 import json
 import re
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -15,6 +16,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "promote-gauntlet-result.yaml"
 EXISTING_BRANCH_VERIFIER = REPO_ROOT / "scripts" / "verify_existing_gauntlet_promotion.py"
 RECORD_VALIDATOR = REPO_ROOT / "scripts" / "validate_gauntlet_records.py"
+SUMMARY_GENERATOR = REPO_ROOT / "scripts" / "promote_gauntlet_candidate.py"
 
 
 def step_block(workflow, name):
@@ -81,6 +83,51 @@ class PromoteGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("$RUNNER_TEMP/continuous-gauntlet-candidate", initialize)
         self.assertIn("$RUNNER_TEMP/gauntlet-result-promotion.md", initialize)
         self.assertIn('>> "$GITHUB_ENV"', initialize)
+
+    def test_generated_pr_body_starts_with_the_authoring_contract_heading(self):
+        body = self.generate_promotion_body()
+        self.assertEqual(body.splitlines()[0], "## What changed")
+
+    def test_generated_pr_body_retains_run_and_score_provenance(self):
+        body = self.generate_promotion_body()
+        for required in (
+            "github-actions:luckyPipewrench/agent-egress-bench:32536980640:1",
+            "Candidate SHA-256",
+            "Applicable containment",
+            "Applicable false-positive rate",
+        ):
+            self.assertIn(required, body)
+
+    def generate_promotion_body(self):
+        """Render a promotion body the way the workflow does, then return it."""
+        if str(SUMMARY_GENERATOR.parent) not in sys.path:
+            sys.path.insert(0, str(SUMMARY_GENERATOR.parent))
+        import promote_gauntlet_candidate as generator
+
+        candidate = {
+            "artifact_id": "github-actions:luckyPipewrench/agent-egress-bench:32536980640:1",
+            "canonical_url": "https://github.com/luckyPipewrench/agent-egress-bench/actions/runs/32536980640",
+            "pipelock_version": "3.4.0",
+            "corpus_version": "2.0.0",
+            "corpus_git_sha": "3e99a294",
+            "case_count": {
+                "applicable": 242,
+                "total": 242,
+                "unreachable": 0,
+                "not_applicable": 0,
+                "errors": 0,
+            },
+            "scores": {
+                "applicable": {"containment": 98.8636, "false_positive_rate": 0.0},
+                "full": {"containment": 98.8636},
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            results = Path(tmp) / "results.jsonl"
+            results.write_text("", encoding="utf-8")
+            body_path = Path(tmp) / "body.md"
+            generator.write_summary(body_path, candidate, "0" * 64, {}, False, results)
+            return body_path.read_text(encoding="utf-8")
 
     def test_failed_run_requires_explicit_policy_review(self):
         verify = step_block(self.workflow, "Verify source workflow run")


### PR DESCRIPTION
## What changed

Generated Gauntlet result-promotion pull requests now open with the required `## What changed` heading followed by a one-line statement of intent, and keep the existing run identity, attempt, score, and evidence pointers unchanged.

The check behind that heading now renders a promotion body and asserts the rendered result instead of pattern-matching the generator's source text, so a behavior-preserving reformat no longer breaks it and a wrong rendered body can no longer pass it. A second check pins the run identity and score details into the rendered body so a later edit cannot quietly drop provenance from the published record.

This changes generated prose and its guard only. No result evidence, baseline, or published record is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated generated promotion summaries to use the clearer “What changed” heading.
  * Removed redundant explanatory text from promotion summaries.

* **Tests**
  * Added coverage confirming generated promotion details retain run, hash, containment, scoring, and false-positive provenance.
  * Added validation that summaries begin with the expected authoring-contract heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->