### PR TITLE
fix: reject ambiguous duplicate responses across MCP transports

### DIFF
--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -1110,7 +1110,10 @@ func (a *MCPGatewayAdapter) gatewayDecodeFailure(err error, request *gatewayRequ
 	reason := "malformed_jsonrpc_response"
 	var mismatch *responseCorrelationError
 	var malformedSSE *malformedSSEResponseError
-	if errors.As(err, &mismatch) {
+	var duplicateSSE *duplicateSSEJSONRPCResponseError
+	if errors.As(err, &duplicateSSE) {
+		reason = "duplicate_sse_response"
+	} else if errors.As(err, &mismatch) {
 		reason = "response_id_mismatch"
 	} else if errors.As(err, &malformedSSE) {
 		reason = "malformed_sse_response"
@@ -1196,10 +1199,43 @@ func (e *responseCorrelationError) Error() string { return e.err.Error() }
 
 func (e *responseCorrelationError) Unwrap() error { return e.err }
 
+// duplicateSSEJSONRPCResponseError marks a stream that contains more than one
+// JSON-RPC response for a single request. JSON-RPC permits one response per
+// request; accepting one would leave the other unscored.
+type duplicateSSEJSONRPCResponseError struct{ wantedID []byte }
+
+func (e *duplicateSSEJSONRPCResponseError) Error() string {
+	return fmt.Sprintf("SSE response contains multiple JSON-RPC messages for request id %s", e.wantedID)
+}
+
 func jsonRPCMessageFromSSE(body, wantedID []byte) ([]byte, error) {
 	var dataLines [][]byte
 	var mismatch error
-	var malformed error
+	var matched []byte
+	processEvent := func() error {
+		message, matchesRequest, err := matchingSSEJSONRPCMessage(dataLines, wantedID)
+		if matchesRequest {
+			if err != nil {
+				return err
+			}
+			if matched != nil {
+				return &duplicateSSEJSONRPCResponseError{wantedID: wantedID}
+			}
+			matched = message
+			return nil
+		}
+		if err != nil {
+			var correlation *responseCorrelationError
+			if errors.As(err, &correlation) {
+				mismatch = err
+				return nil
+			}
+			// A malformed event without a usable, different request id might be
+			// part of this response, so it is ambiguous evidence and cannot score.
+			return err
+		}
+		return nil
+	}
 	for _, rawLine := range bytes.Split(body, []byte("\n")) {
 		line := bytes.TrimSuffix(rawLine, []byte("\r"))
 		if len(line) != 0 {
@@ -1212,46 +1248,77 @@ func jsonRPCMessageFromSSE(body, wantedID []byte) ([]byte, error) {
 			}
 			continue
 		}
-		if message, err := matchingSSEJSONRPCMessage(dataLines, wantedID); err == nil && message != nil {
-			return message, nil
-		} else if err != nil {
-			var correlation *responseCorrelationError
-			if errors.As(err, &correlation) {
-				mismatch = err
-			} else {
-				malformed = err
-			}
+		if err := processEvent(); err != nil {
+			return nil, err
 		}
 		dataLines = nil
 	}
-	if message, err := matchingSSEJSONRPCMessage(dataLines, wantedID); err == nil && message != nil {
-		return message, nil
-	} else if err != nil {
-		var correlation *responseCorrelationError
-		if errors.As(err, &correlation) {
-			mismatch = err
-		} else {
-			malformed = err
-		}
+	if err := processEvent(); err != nil {
+		return nil, err
+	}
+	if matched != nil {
+		return matched, nil
 	}
 	if mismatch != nil {
 		return nil, mismatch
 	}
-	if malformed != nil {
-		return nil, &malformedSSEResponseError{err: malformed}
-	}
 	return nil, &malformedSSEResponseError{err: fmt.Errorf("SSE response has no JSON-RPC message for request id %s", wantedID)}
 }
 
-func matchingSSEJSONRPCMessage(dataLines [][]byte, wantedID []byte) ([]byte, error) {
+func matchingSSEJSONRPCMessage(dataLines [][]byte, wantedID []byte) ([]byte, bool, error) {
 	if len(dataLines) == 0 {
-		return nil, nil
+		return nil, false, nil
 	}
 	message := bytes.Join(dataLines, []byte("\n"))
-	if _, err := jsonRPCMessageForRequest(message, wantedID); err != nil {
-		return nil, err
+	var response map[string]json.RawMessage
+	if err := json.Unmarshal(bytes.TrimSpace(message), &response); err != nil {
+		return nil, false, fmt.Errorf("invalid JSON-RPC response: %w", err)
 	}
-	return message, nil
+	id, hasID := response["id"]
+	if !hasID || len(id) == 0 {
+		if err := validateSSEJSONRPCNotification(response); err != nil {
+			return nil, false, err
+		}
+		// ID-less JSON-RPC notifications, including progress updates, are not
+		// responses and may share this stream without affecting the verdict.
+		return nil, false, nil
+	}
+	var got, wanted interface{}
+	if err := json.Unmarshal(id, &got); err != nil {
+		return nil, false, fmt.Errorf("decode response id: %w", err)
+	}
+	if err := json.Unmarshal(wantedID, &wanted); err != nil {
+		return nil, false, fmt.Errorf("decode request id: %w", err)
+	}
+	if !jsonRPCIDsEqual(got, wanted) {
+		return nil, false, &responseCorrelationError{err: fmt.Errorf("JSON-RPC response id %s does not match request id %s", id, wantedID)}
+	}
+	if _, err := jsonRPCMessageForRequest(message, wantedID); err != nil {
+		return nil, true, err
+	}
+	return message, true, nil
+}
+
+func validateSSEJSONRPCNotification(message map[string]json.RawMessage) error {
+	version, ok := message["jsonrpc"]
+	if !ok || !bytes.Equal(bytes.TrimSpace(version), []byte(`"2.0"`)) {
+		return errors.New("JSON-RPC notification must contain jsonrpc 2.0")
+	}
+	method, ok := message["method"]
+	if !ok {
+		return errors.New("JSON-RPC notification must contain method")
+	}
+	var methodName string
+	if err := json.Unmarshal(method, &methodName); err != nil || methodName == "" {
+		return errors.New("JSON-RPC notification method must be a non-empty string")
+	}
+	if _, hasResult := message["result"]; hasResult {
+		return errors.New("JSON-RPC notification must not contain result")
+	}
+	if _, hasError := message["error"]; hasError {
+		return errors.New("JSON-RPC notification must not contain error")
+	}
+	return nil
 }
 
 func jsonRPCMessageForRequest(message, wantedID []byte) ([]byte, error) {

--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -1118,7 +1118,17 @@ func (a *MCPGatewayAdapter) gatewayDecodeFailure(err error, request *gatewayRequ
 	} else if errors.As(err, &malformedSSE) {
 		reason = "malformed_sse_response"
 	}
-	return a.gatewaySkipWithObservation(reason, request, status, "")
+	result := a.gatewaySkipWithObservation(reason, request, status, "")
+	if duplicateSSE != nil && result != nil {
+		// Name the request that was answered twice, matching what the stdio
+		// path records. Without it a triage reader sees only that some request
+		// was duplicated.
+		if result.Evidence == nil {
+			result.Evidence = map[string]interface{}{}
+		}
+		result.Evidence["duplicate_response_id"] = string(duplicateSSE.wantedID)
+	}
+	return result
 }
 
 func (a *MCPGatewayAdapter) attachObservation(result *Result, request *gatewayRequest) {

--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -1321,9 +1321,76 @@ func validateSSEJSONRPCNotification(message map[string]json.RawMessage) error {
 	return nil
 }
 
+// duplicateJSONMemberName reports the first object member name that appears
+// more than once in the same object, anywhere in the document. Decoding into a
+// map silently keeps one of them, so a target could carry two results for one
+// request and leave the runner reporting a verdict on content that a client
+// parsing the same bytes need not agree with. RFC 8259 says object names SHOULD
+// be unique, so rejecting the ambiguity costs no correct server anything.
+func duplicateJSONMemberName(data []byte) (string, bool) {
+	type frame struct {
+		object    bool
+		expectKey bool
+		names     map[string]struct{}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var stack []*frame
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			// Malformed input is reported by the caller's own decode, which runs
+			// next and produces the precise error.
+			return "", false
+		}
+		if delim, ok := token.(json.Delim); ok {
+			switch delim {
+			case '{':
+				stack = append(stack, &frame{object: true, expectKey: true, names: map[string]struct{}{}})
+				continue
+			case '[':
+				stack = append(stack, &frame{})
+				continue
+			case '}', ']':
+				if len(stack) > 0 {
+					stack = stack[:len(stack)-1]
+				}
+				if len(stack) > 0 && stack[len(stack)-1].object {
+					stack[len(stack)-1].expectKey = true
+				}
+				continue
+			}
+		}
+		if len(stack) == 0 {
+			continue
+		}
+		top := stack[len(stack)-1]
+		if !top.object {
+			continue
+		}
+		if !top.expectKey {
+			top.expectKey = true
+			continue
+		}
+		name, ok := token.(string)
+		if !ok {
+			return "", false
+		}
+		if _, seen := top.names[name]; seen {
+			return name, true
+		}
+		top.names[name] = struct{}{}
+		top.expectKey = false
+	}
+}
+
 func jsonRPCMessageForRequest(message, wantedID []byte) ([]byte, error) {
+	trimmed := bytes.TrimSpace(message)
+	if name, duplicate := duplicateJSONMemberName(trimmed); duplicate {
+		return nil, fmt.Errorf("JSON-RPC response repeats object member %q, so its content is ambiguous", name)
+	}
 	var response map[string]json.RawMessage
-	if err := json.Unmarshal(bytes.TrimSpace(message), &response); err != nil {
+	if err := json.Unmarshal(trimmed, &response); err != nil {
 		return nil, fmt.Errorf("invalid JSON-RPC response: %w", err)
 	}
 	version, ok := response["jsonrpc"]

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -2754,3 +2754,24 @@ func TestMCPGatewayAdapterRejectsMultiCallLabeledAsSingleToolCall(t *testing.T) 
 		t.Fatalf("a refused case must prove neither delivery nor observation: %+v", result)
 	}
 }
+
+func TestJSONRPCMessageForRequestRejectsDuplicateResultMember(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"content":"clean"},"result":{"content":"poisoned"}}`)
+	if _, err := jsonRPCMessageForRequest(body, []byte("1")); err == nil {
+		t.Fatal("error = nil, want rejection of a response carrying two results for one request")
+	}
+}
+
+func TestJSONRPCMessageForRequestRejectsNestedDuplicateMember(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"content":"clean","content":"poisoned"}}`)
+	if _, err := jsonRPCMessageForRequest(body, []byte("1")); err == nil {
+		t.Fatal("error = nil, want rejection of a duplicate member nested inside the result")
+	}
+}
+
+func TestJSONRPCMessageForRequestAcceptsRepeatedNamesInSiblingObjects(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a","description":"x"},{"name":"b","description":"y"}]}}`)
+	if _, err := jsonRPCMessageForRequest(body, []byte("1")); err != nil {
+		t.Fatalf("error = %v, want an ordinary inventory response to remain scoreable", err)
+	}
+}

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -931,19 +931,35 @@ func TestMCPGatewayAdapterSkipsDuplicateSSEResponseForRequest(t *testing.T) {
 	defer fm.Close()
 	client := &http.Client{Timeout: time.Second}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// t.Fatal exits only the goroutine that calls it, so a handler-side
+		// failure here would leave the test goroutine running and surface later
+		// as a confusing decode or timeout error instead of as its own cause.
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			t.Fatal(err)
+			t.Errorf("read request body: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
-		if requestMethodFromBody(t, body) != "tools/call" {
-			writeJSONRPC(t, w, requestIDFromBody(t, body), nil)
+		var request struct {
+			Method string          `json:"method"`
+			ID     json.RawMessage `json:"id"`
+		}
+		if err := json.Unmarshal(body, &request); err != nil {
+			t.Errorf("decode gateway request: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if request.Method != "tools/call" {
+			writeJSONRPC(t, w, request.ID, nil)
 			return
 		}
 		if _, err := forwardMCPGatewayRequest(client, r.Context(), fm.MCPHTTP().URL(), body); err != nil {
-			t.Fatal(err)
+			t.Errorf("forward MCP gateway request: %v", err)
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
-		id := requestIDFromBody(t, body)
+		id := request.ID
 		_, _ = fmt.Fprintf(w, "data: {\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{\"content\":\"first\"}}\n\ndata: {\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{\"content\":\"second\"}}\n\n", id, id)
 	}))
 	defer server.Close()
@@ -955,6 +971,9 @@ func TestMCPGatewayAdapterSkipsDuplicateSSEResponseForRequest(t *testing.T) {
 	result := a.Run(gatewayToolsCallCase("gateway-duplicate-sse-response"), time.Second)
 	if result.Err != nil || result.Verdict != "skip" || result.Evidence["reason"] != "duplicate_sse_response" || result.Evidence["upstream_reached"] != true {
 		t.Fatalf("result = %+v, want delivered duplicate SSE response skip", result)
+	}
+	if result.Evidence["duplicate_response_id"] == nil {
+		t.Fatalf("evidence = %+v, want the duplicated request id recorded for triage", result.Evidence)
 	}
 }
 
@@ -2773,5 +2792,49 @@ func TestJSONRPCMessageForRequestAcceptsRepeatedNamesInSiblingObjects(t *testing
 	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a","description":"x"},{"name":"b","description":"y"}]}}`)
 	if _, err := jsonRPCMessageForRequest(body, []byte("1")); err != nil {
 		t.Fatalf("error = %v, want an ordinary inventory response to remain scoreable", err)
+	}
+}
+
+func TestMCPStdioDuplicateIgnoresMalformedMatchingLines(t *testing.T) {
+	requestIDs := map[string]struct{}{"number:1": {}}
+	for name, lines := range map[string][]string{
+		"null error object": {
+			`{"jsonrpc":"2.0","id":1,"error":null}`,
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"real"}}`,
+		},
+		"missing jsonrpc version": {
+			`{"id":1,"result":{"content":"not a JSON-RPC response"}}`,
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"real"}}`,
+		},
+		"error object without code or message": {
+			`{"jsonrpc":"2.0","id":1,"error":{"detail":"no code or message"}}`,
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"real"}}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := mcpStdioDuplicateRequestResponse(lines, requestIDs); got != nil {
+				t.Fatalf("result = %+v, want a malformed line to leave the later genuine response scoreable", got)
+			}
+		})
+	}
+}
+
+func TestMCPStdioDuplicateStillRejectsGenuineDuplicates(t *testing.T) {
+	requestIDs := map[string]struct{}{"number:1": {}}
+	for name, lines := range map[string][]string{
+		"two results": {
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"clean"}}`,
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"poisoned"}}`,
+		},
+		"deny then deliver": {
+			`{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"policy denied"}}`,
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"delivered anyway"}}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := mcpStdioDuplicateRequestResponse(lines, requestIDs); got == nil {
+				t.Fatal("result = nil, want a genuine duplicate response to stay unscoreable")
+			}
+		})
 	}
 }

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -2850,6 +2850,10 @@ func TestMCPStdioRejectsAmbiguousDuplicateMembers(t *testing.T) {
 	for name, line := range map[string]string{
 		"duplicate root member":   `{"jsonrpc":"2.0","id":1,"result":{"content":"clean"},"result":{"content":"poisoned"}}`,
 		"duplicate nested member": `{"jsonrpc":"2.0","id":1,"result":{"content":"clean","content":"poisoned"}}`,
+		// Repeating the id itself makes correlation ambiguous, so a single
+		// decoded value must not decide whether the line is ours.
+		"requested id repeated first":  `{"jsonrpc":"2.0","id":1,"id":99,"result":{"content":"clean"},"result":{"content":"poisoned"}}`,
+		"requested id repeated second": `{"jsonrpc":"2.0","id":99,"id":1,"result":{"content":"clean"},"result":{"content":"poisoned"}}`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			got := mcpStdioDuplicateRequestResponse([]string{line}, requestIDs)
@@ -2876,6 +2880,10 @@ func TestMCPStdioKeepsOrdinaryMultiplexedOutputScoreable(t *testing.T) {
 		},
 		"repeated names in sibling objects": {
 			`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a"},{"name":"b"}]}}`,
+		},
+		"ambiguous id where no candidate was requested": {
+			`{"jsonrpc":"2.0","id":98,"id":99,"result":{"content":"a"},"result":{"content":"b"}}`,
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"real"}}`,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -2830,6 +2830,12 @@ func TestMCPStdioDuplicateStillRejectsGenuineDuplicates(t *testing.T) {
 			`{"jsonrpc":"2.0","id":1,"error":{"code":-32001,"message":"policy denied"}}`,
 			`{"jsonrpc":"2.0","id":1,"result":{"content":"delivered anyway"}}`,
 		},
+		// JSON-RPC permits any result value, so a null result is a real answer
+		// rather than an absent member.
+		"null result then a second answer": {
+			`{"jsonrpc":"2.0","id":1,"result":null}`,
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"poisoned"}}`,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if got := mcpStdioDuplicateRequestResponse(lines, requestIDs); got == nil {

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -894,7 +895,7 @@ func TestMCPGatewayAdapterSkipsMalformedToolsListInventory(t *testing.T) {
 	}
 }
 
-func TestMCPGatewayAdapterAllowsSSEToolsListResponse(t *testing.T) {
+func TestMCPGatewayAdapterAllowsSSEProgressAndUnrelatedEvents(t *testing.T) {
 	fm, err := fixture.StartAll()
 	if err != nil {
 		t.Fatal(err)
@@ -912,7 +913,48 @@ func TestMCPGatewayAdapterAllowsSSEToolsListResponse(t *testing.T) {
 
 	result := a.Run(gatewayToolDefinitionCase("gateway-sse-tools-list", "poisoned_tool"), time.Second)
 	if result.Err != nil || result.Verdict != "allow" {
-		t.Fatalf("result = %+v, want SSE tools/list allow", result)
+		t.Fatalf("result = %+v, want SSE tools/list allow after progress and unrelated events", result)
+	}
+}
+
+func TestJSONRPCMessageFromSSERejectsDuplicateResponseForRequest(t *testing.T) {
+	body := []byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":\"CLEAN\"}}\n\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":\"POISONED\"}}\n\n")
+	_, err := jsonRPCMessageFromSSE(body, []byte("1"))
+	var duplicate *duplicateSSEJSONRPCResponseError
+	if !errors.As(err, &duplicate) {
+		t.Fatalf("error = %v, want duplicate SSE response error", err)
+	}
+}
+
+func TestMCPGatewayAdapterSkipsDuplicateSSEResponseForRequest(t *testing.T) {
+	fm := fixtureManagerForGatewayTest(t)
+	defer fm.Close()
+	client := &http.Client{Timeout: time.Second}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if requestMethodFromBody(t, body) != "tools/call" {
+			writeJSONRPC(t, w, requestIDFromBody(t, body), nil)
+			return
+		}
+		if _, err := forwardMCPGatewayRequest(client, r.Context(), fm.MCPHTTP().URL(), body); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		id := requestIDFromBody(t, body)
+		_, _ = fmt.Fprintf(w, "data: {\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{\"content\":\"first\"}}\n\ndata: {\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":{\"content\":\"second\"}}\n\n", id, id)
+	}))
+	defer server.Close()
+
+	a, err := NewMCPGatewayAdapter(GatewayPlugin{Name: "duplicate SSE gateway", Transport: "streamable_http", Client: GatewayClient{Endpoint: server.URL}}, fm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := a.Run(gatewayToolsCallCase("gateway-duplicate-sse-response"), time.Second)
+	if result.Err != nil || result.Verdict != "skip" || result.Evidence["reason"] != "duplicate_sse_response" || result.Evidence["upstream_reached"] != true {
+		t.Fatalf("result = %+v, want delivered duplicate SSE response skip", result)
 	}
 }
 
@@ -2521,7 +2563,7 @@ func sseToolsListGateway(t *testing.T, upstreamURL string) *httptest.Server {
 		}
 		if request.Method == "tools/list" {
 			w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
-			_, _ = fmt.Fprintf(w, "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"other-request\",\"result\":{\"tools\":[]}}\n\nevent: message\ndata: %s\n\n", responseBody)
+			_, _ = fmt.Fprintf(w, "event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{}}\n\nevent: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"other-request\",\"result\":{\"tools\":[]}}\n\nevent: message\ndata: %s\n\n", responseBody)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -2844,3 +2844,44 @@ func TestMCPStdioDuplicateStillRejectsGenuineDuplicates(t *testing.T) {
 		})
 	}
 }
+
+func TestMCPStdioRejectsAmbiguousDuplicateMembers(t *testing.T) {
+	requestIDs := map[string]struct{}{"number:1": {}}
+	for name, line := range map[string]string{
+		"duplicate root member":   `{"jsonrpc":"2.0","id":1,"result":{"content":"clean"},"result":{"content":"poisoned"}}`,
+		"duplicate nested member": `{"jsonrpc":"2.0","id":1,"result":{"content":"clean","content":"poisoned"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := mcpStdioDuplicateRequestResponse([]string{line}, requestIDs)
+			if got == nil {
+				t.Fatal("result = nil, want an ambiguous response to stay unscoreable")
+			}
+			if got.Verdict != "skip" || got.Evidence["reason"] != "mcp_stdio_ambiguous_response" {
+				t.Fatalf("result = %+v, want a skip naming the ambiguous response", got)
+			}
+		})
+	}
+}
+
+func TestMCPStdioKeepsOrdinaryMultiplexedOutputScoreable(t *testing.T) {
+	requestIDs := map[string]struct{}{"number:1": {}}
+	for name, lines := range map[string][]string{
+		"duplicate member belongs to another request": {
+			`{"jsonrpc":"2.0","id":99,"result":{"content":"a","content":"b"}}`,
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"real"}}`,
+		},
+		"non-JSON log line before the response": {
+			`starting server on port 1234`,
+			`{"jsonrpc":"2.0","id":1,"result":{"content":"real"}}`,
+		},
+		"repeated names in sibling objects": {
+			`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"a"},{"name":"b"}]}}`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := mcpStdioDuplicateRequestResponse(lines, requestIDs); got != nil {
+				t.Fatalf("result = %+v, want ordinary stdout to remain scoreable", got)
+			}
+		})
+	}
+}

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -2392,6 +2392,20 @@ func (p *ProxyAdapter) runMCPStdio(c Case, timeout time.Duration) Result {
 		return mcpStdioObservationMissingResult(observer, evidence)
 	}
 
+	// JSON-RPC permits notifications alongside responses, but a request has at
+	// most one response. A second result or error for a request we issued means
+	// the proxy delivered content whose semantics we cannot represent with one
+	// case response. Do not let a first policy error or matching result hide it.
+	if duplicate := mcpStdioDuplicateRequestResponse(lines, expectedResponseIDs); duplicate != nil {
+		for key, value := range observationEvidence {
+			duplicate.Evidence[key] = value
+		}
+		if observer != nil {
+			duplicate.Evidence["upstream_reached"] = upstreamObserved
+		}
+		return *duplicate
+	}
+
 	// Check response lines for policy-block JSON-RPC errors.
 	// Tool-specific policy errors use the JSON-RPC server-error range.
 	// Standard JSON-RPC errors (-32700 to -32600) are protocol issues, not blocks.
@@ -4085,6 +4099,38 @@ func verifyMCPStdioResponses(caseID string, lines []string, expected []interface
 			"synthesized_response": true,
 		},
 	}
+}
+
+// mcpStdioDuplicateRequestResponse rejects only duplicate JSON-RPC responses
+// for a request from this run. Notifications, non-JSON log lines, and
+// responses for other request IDs may legitimately share stdout and remain
+// outside the case response contract.
+func mcpStdioDuplicateRequestResponse(lines []string, requestIDs map[string]struct{}) *Result {
+	seen := make(map[string]struct{}, len(requestIDs))
+	for _, line := range lines {
+		var response struct {
+			Result json.RawMessage `json:"result"`
+			Error  json.RawMessage `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(line), &response); err != nil {
+			continue
+		}
+		if (response.Result == nil) == (response.Error == nil) {
+			continue
+		}
+		id := jsonRPCResponseIDCorrelationKey(line)
+		if _, requested := requestIDs[id]; !requested {
+			continue
+		}
+		if _, duplicate := seen[id]; duplicate {
+			return &Result{Verdict: "skip", Evidence: map[string]interface{}{
+				"reason":                "mcp_stdio_duplicate_response",
+				"duplicate_response_id": id,
+			}}
+		}
+		seen[id] = struct{}{}
+	}
+	return nil
 }
 
 func mcpResponseMatches(expected, actual map[string]interface{}) bool {

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -4151,6 +4151,21 @@ func isJSONRPCResponseLine(line string) bool {
 func mcpStdioDuplicateRequestResponse(lines []string, requestIDs map[string]struct{}) *Result {
 	seen := make(map[string]struct{}, len(requestIDs))
 	for _, line := range lines {
+		// A single line can be ambiguous on its own. Decoding keeps the last of
+		// two members sharing a name, so the runner and the agent's own parser
+		// need not agree on which one is the answer. Check this before the
+		// response-shape test, because that test decodes and would inherit the
+		// same silent choice.
+		if name, duplicate := duplicateJSONMemberName([]byte(line)); duplicate {
+			if _, requested := requestIDs[jsonRPCResponseIDCorrelationKey(line)]; requested {
+				return &Result{Verdict: "skip", Evidence: map[string]interface{}{
+					"reason":                "mcp_stdio_ambiguous_response",
+					"duplicate_member":      name,
+					"duplicate_response_id": jsonRPCResponseIDCorrelationKey(line),
+				}}
+			}
+			continue
+		}
 		if !isJSONRPCResponseLine(line) {
 			continue
 		}

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -4123,8 +4123,13 @@ func isJSONRPCResponseLine(line string) bool {
 	if response.Version != "2.0" {
 		return false
 	}
-	hasResult := len(response.Result) > 0 && !bytes.Equal(bytes.TrimSpace(response.Result), []byte("null"))
-	hasError := len(response.Error) > 0 && !bytes.Equal(bytes.TrimSpace(response.Error), []byte("null"))
+	// Membership, not value. JSON-RPC permits any result value including null,
+	// so treating a null result as an absent member would let a valid response
+	// go uncounted and hide the duplicate that follows it. An error member is
+	// different: the specification requires an Error Object there, so a null or
+	// shapeless error is not a response at all.
+	hasResult := response.Result != nil
+	hasError := response.Error != nil
 	if hasResult == hasError {
 		return false
 	}

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -4105,17 +4105,48 @@ func verifyMCPStdioResponses(caseID string, lines []string, expected []interface
 // for a request from this run. Notifications, non-JSON log lines, and
 // responses for other request IDs may legitimately share stdout and remain
 // outside the case response contract.
+// isJSONRPCResponseLine reports whether a stdout line is a well-formed JSON-RPC
+// 2.0 response. Only a real response may consume a request's single answer, so
+// anything malformed is ignored here rather than counted. Counting it would let
+// one stray line make the following genuine response look like a duplicate and
+// turn a legitimate server's output unscoreable, which is the same damage as
+// missing the duplicate it was meant to catch.
+func isJSONRPCResponseLine(line string) bool {
+	var response struct {
+		Version string          `json:"jsonrpc"`
+		Result  json.RawMessage `json:"result"`
+		Error   json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(line), &response); err != nil {
+		return false
+	}
+	if response.Version != "2.0" {
+		return false
+	}
+	hasResult := len(response.Result) > 0 && !bytes.Equal(bytes.TrimSpace(response.Result), []byte("null"))
+	hasError := len(response.Error) > 0 && !bytes.Equal(bytes.TrimSpace(response.Error), []byte("null"))
+	if hasResult == hasError {
+		return false
+	}
+	if hasError {
+		var rpcError struct {
+			Code    *int    `json:"code"`
+			Message *string `json:"message"`
+		}
+		if err := json.Unmarshal(response.Error, &rpcError); err != nil {
+			return false
+		}
+		if rpcError.Code == nil || rpcError.Message == nil {
+			return false
+		}
+	}
+	return true
+}
+
 func mcpStdioDuplicateRequestResponse(lines []string, requestIDs map[string]struct{}) *Result {
 	seen := make(map[string]struct{}, len(requestIDs))
 	for _, line := range lines {
-		var response struct {
-			Result json.RawMessage `json:"result"`
-			Error  json.RawMessage `json:"error"`
-		}
-		if err := json.Unmarshal([]byte(line), &response); err != nil {
-			continue
-		}
-		if (response.Result == nil) == (response.Error == nil) {
+		if !isJSONRPCResponseLine(line) {
 			continue
 		}
 		id := jsonRPCResponseIDCorrelationKey(line)

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -4101,6 +4101,43 @@ func verifyMCPStdioResponses(caseID string, lines []string, expected []interface
 	}
 }
 
+// rootJSONRPCIDCandidateKeys returns a correlation key for every root-level id
+// member in the line. A well-formed response has exactly one. When a line
+// repeats the member, single-value decoding silently picks one of them, so the
+// runner can correlate a response to a request nobody asked about while another
+// parser correlates the same bytes to one we did. Enumerating the candidates is
+// what lets the caller refuse that ambiguity instead of resolving it by luck.
+func rootJSONRPCIDCandidateKeys(line string) []string {
+	decoder := json.NewDecoder(strings.NewReader(line))
+	decoder.UseNumber()
+	token, err := decoder.Token()
+	if err != nil {
+		return nil
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return nil
+	}
+	var keys []string
+	for decoder.More() {
+		nameToken, err := decoder.Token()
+		if err != nil {
+			return keys
+		}
+		name, ok := nameToken.(string)
+		if !ok {
+			return keys
+		}
+		var value interface{}
+		if err := decoder.Decode(&value); err != nil {
+			return keys
+		}
+		if name == "id" {
+			keys = append(keys, jsonRPCIDCorrelationKey(value))
+		}
+	}
+	return keys
+}
+
 // mcpStdioDuplicateRequestResponse rejects only duplicate JSON-RPC responses
 // for a request from this run. Notifications, non-JSON log lines, and
 // responses for other request IDs may legitimately share stdout and remain
@@ -4157,12 +4194,21 @@ func mcpStdioDuplicateRequestResponse(lines []string, requestIDs map[string]stru
 		// response-shape test, because that test decodes and would inherit the
 		// same silent choice.
 		if name, duplicate := duplicateJSONMemberName([]byte(line)); duplicate {
-			if _, requested := requestIDs[jsonRPCResponseIDCorrelationKey(line)]; requested {
-				return &Result{Verdict: "skip", Evidence: map[string]interface{}{
-					"reason":                "mcp_stdio_ambiguous_response",
-					"duplicate_member":      name,
-					"duplicate_response_id": jsonRPCResponseIDCorrelationKey(line),
-				}}
+			// Correlate against every candidate id, not the one decoding happened
+			// to keep. A line repeating both a requested and an unrequested id
+			// would otherwise be dismissed as somebody else's traffic.
+			candidates := rootJSONRPCIDCandidateKeys(line)
+			if len(candidates) == 0 {
+				candidates = []string{jsonRPCResponseIDCorrelationKey(line)}
+			}
+			for _, candidate := range candidates {
+				if _, requested := requestIDs[candidate]; requested {
+					return &Result{Verdict: "skip", Evidence: map[string]interface{}{
+						"reason":                "mcp_stdio_ambiguous_response",
+						"duplicate_member":      name,
+						"duplicate_response_id": candidate,
+					}}
+				}
 			}
 			continue
 		}

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -351,6 +351,61 @@ func TestRunMCPStdio_UnobservedPolicyDenyBlocks(t *testing.T) {
 	}
 }
 
+func TestRunMCPStdio_PolicyDenyThenPayloadForSameRequestSkips(t *testing.T) {
+	// The first line looks like a policy block, but the second line carries a
+	// tool definition for the same fresh request identity. Before the duplicate
+	// response guard, runMCPStdio returned block without examining that payload.
+	result := (&ProxyAdapter{mcpCmd: mcpStdioTestProxyCommand(t, "policy-deny-then-payload")}).runMCPStdio(
+		mcpStdioExpectedBlockResponseCase("mcp-stdio-policy-deny-then-payload"), 5*time.Second)
+	t.Logf("observed result: verdict=%q evidence=%+v", result.Verdict, result.Evidence)
+	if result.Err != nil || result.Verdict != "skip" {
+		t.Fatalf("result = %+v, want skip when a same-ID payload follows a policy deny", result)
+	}
+	if got := result.Evidence["reason"]; got != "mcp_stdio_duplicate_response" {
+		t.Fatalf("reason = %v, want mcp_stdio_duplicate_response; evidence=%+v", got, result.Evidence)
+	}
+}
+
+func TestRunMCPStdio_MatchedResponseThenPayloadForSameRequestSkips(t *testing.T) {
+	// The first response exactly matches the runner-owned fixture, while the
+	// second same-ID response carries extra tool content. Before the guard,
+	// verifyMCPStdioResponses returned allow after matching the first line.
+	result := (&ProxyAdapter{mcpCmd: mcpStdioTestProxyCommand(t, "matched-response-then-payload")}).runMCPStdio(Case{
+		ID:        "mcp-stdio-matched-response-then-payload",
+		Transport: "mcp_stdio",
+		InputType: "mcp_tool_definition",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{
+			map[string]interface{}{"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+			map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": map[string]interface{}{"tools": []interface{}{}}},
+		}},
+	}, 5*time.Second)
+	t.Logf("observed result: verdict=%q evidence=%+v", result.Verdict, result.Evidence)
+	if result.Err != nil || result.Verdict != "skip" {
+		t.Fatalf("result = %+v, want skip when a same-ID payload follows a matched response", result)
+	}
+	if got := result.Evidence["reason"]; got != "mcp_stdio_duplicate_response" {
+		t.Fatalf("reason = %v, want mcp_stdio_duplicate_response; evidence=%+v", got, result.Evidence)
+	}
+}
+
+func TestRunMCPStdio_MixedStdoutStillAllows(t *testing.T) {
+	// Stdout may contain a log line, a notification, and a response for another
+	// request before the one response this case owns. None answers this request.
+	result := (&ProxyAdapter{mcpCmd: mcpStdioTestProxyCommand(t, "mixed-stdout-then-match")}).runMCPStdio(Case{
+		ID:        "mcp-stdio-mixed-stdout",
+		Transport: "mcp_stdio",
+		InputType: "mcp_tool_definition",
+		Payload: map[string]interface{}{"jsonrpc_messages": []interface{}{
+			map[string]interface{}{"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+			map[string]interface{}{"jsonrpc": "2.0", "id": 1, "result": map[string]interface{}{"tools": []interface{}{}}},
+		}},
+	}, 5*time.Second)
+	t.Logf("observed result: verdict=%q evidence=%+v", result.Verdict, result.Evidence)
+	if result.Err != nil || result.Verdict != "allow" {
+		t.Fatalf("result = %+v, want allow for unrelated mixed stdout", result)
+	}
+}
+
 func TestProxyAdapterRunMCPStdioStalePolicyDenySkips(t *testing.T) {
 	// A policy-looking error for a different request can be left over from a
 	// prior session or emitted by a process that never reads this case. It does
@@ -687,6 +742,38 @@ func TestMCPStdioProxyHelper(t *testing.T) {
 	upstream := bufio.NewScanner(conn)
 	client := bufio.NewScanner(os.Stdin)
 	for call := 0; client.Scan(); call++ {
+		if mode == "policy-deny-then-payload" || mode == "matched-response-then-payload" || mode == "mixed-stdout-then-match" {
+			var request struct {
+				ID json.RawMessage `json:"id"`
+			}
+			if err := json.Unmarshal(client.Bytes(), &request); err != nil || len(request.ID) == 0 {
+				fmt.Fprintln(os.Stderr, "decode duplicate-response request")
+				os.Exit(2)
+			}
+			if _, err := fmt.Fprintln(conn, client.Text()); err != nil {
+				fmt.Fprintf(os.Stderr, "forward duplicate-response request: %v\n", err)
+				os.Exit(2)
+			}
+			if !upstream.Scan() {
+				fmt.Fprintln(os.Stderr, "runner-owned MCP stdio upstream did not respond")
+				os.Exit(2)
+			}
+			switch mode {
+			case "policy-deny-then-payload":
+				_, _ = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"error":{"code":-32001,"message":"policy denied"}}`+"\n", request.ID)
+			case "matched-response-then-payload":
+				_, _ = fmt.Fprintln(os.Stdout, upstream.Text())
+			case "mixed-stdout-then-match":
+				_, _ = fmt.Fprintln(os.Stdout, "info: normal proxy output")
+				_, _ = fmt.Fprintln(os.Stdout, `{"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":50}}`)
+				_, _ = fmt.Fprintln(os.Stdout, `{"jsonrpc":"2.0","id":"unrelated","result":{"ok":true}}`)
+				_, _ = fmt.Fprintln(os.Stdout, upstream.Text())
+			}
+			if mode != "mixed-stdout-then-match" {
+				_, _ = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"delivered_payload","inputSchema":{}}]}}`+"\n", request.ID)
+			}
+			return
+		}
 		budgetBlockAt := -1
 		budgetErrorCode := -32001
 		forwardBeforeBudgetBlock := false


### PR DESCRIPTION
## What changed

The gateway SSE decoder returned the first event whose JSON-RPC id matched the request and never examined later events, so a target could answer with a clean or denied first event and then deliver the real payload in a second event carrying the same id. The stdio path had the same shape in two places: a policy-error line credited a block without establishing that no later line delivered content, and response verification returned an allow after one matching response while a later duplicate for the same id went unread.

Both transports now treat more than one response for a request issued by the current run as ambiguous evidence and fail closed to an unscoreable skip, never to an allow and never to a credited block. Progress notifications, non-JSON output, and responses for other request ids stay acceptable, which is the direction that matters for availability: a decoder that cannot read an ordinary streaming or multiplexed server is worth as little as one that can be fooled by a second event.

The judgement a reviewer should distrust is the boundary between a genuinely ambiguous duplicate and normal multi-message traffic. Both guards key on request ids the run issued, so an error there either rejects legitimate servers or lets a duplicate response pass unobserved while a verdict is still reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed and command-line protocol responses to detect duplicate or ambiguous replies reliably.
  * Valid progress notifications and unrelated events are now handled without disrupting legitimate operations.
  * Malformed responses and invalid duplicate fields are rejected consistently.
  * Duplicate replies now produce a safe, clearly identified skip outcome while preserving upstream evidence.
* **Tests**
  * Expanded coverage for duplicate responses, notifications, unrelated output, and nested response validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->