### PR TITLE
docs: clarify gateway tool-result evidence

### DIFF
--- a/docs/GATEWAY-ADAPTER.md
+++ b/docs/GATEWAY-ADAPTER.md
@@ -64,10 +64,12 @@ is a `block` only with the same delivery proof. A successful local
 
 For a tool-result path, both allow and block require the fixture to record that
 case's matching observation while the case owns the identity-scoped response
-lease. A deny before the call reaches the fixture is `skip`, because it does not
-prove that the gateway inspected the declared result. The lease is released and
-cleared after each case, and an ordinary concurrent `tools/call` has no matching
-identity so it receives the fixture's default response.
+lease. A matching observation plus a returned deny proves only that the exact
+`tools/call` reached the fixture and the gateway then returned a denial. It does
+not establish that the gateway read or classified the declared result. A deny
+before the call reaches the fixture is `skip`. The lease is released and cleared
+after each case, and an ordinary concurrent `tools/call` has no matching identity
+so it receives the fixture's default response.
 
 Every JSON-RPC response is structurally validated and correlated by the exact
 request ID before deny classification. This is identical for ordinary JSON and

--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -929,7 +929,7 @@ const (
 	// block requires proof that the exact request did not reach the fixture.
 	deliveryAbsent deliveryExpectation = false
 	// deliveryRequired applies where the gateway must first see runner-owned
-	// upstream content: tool-result inspection and tools/list filtering.
+	// upstream content: tool-result response-path measurement and tools/list filtering.
 	deliveryRequired deliveryExpectation = true
 )
 


### PR DESCRIPTION
## What changed

Clarify that a matching fixture observation plus a returned denial proves the tool call reached the fixture and the gateway denied it, without claiming the gateway inspected or classified the returned content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how tool-result delivery outcomes are interpreted.
  * Matching fixture observations now distinguish successful delivery from evidence that the gateway inspected or classified the result.
  * Denials occurring before delivery continue to be reported as skipped.
  * Clarified that lease cleanup and default responses for unrelated concurrent calls remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->