### PR TITLE
Detect response truncation and fail only where the body decides

### DIFF
--- a/runner/adapter/capped_read.go
+++ b/runner/adapter/capped_read.go
@@ -1,0 +1,42 @@
+package adapter
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/luckyPipewrench/agent-egress-bench/runner/internal/cappedread"
+)
+
+type truncatedResponseError struct {
+	cap      int64
+	observed int64
+}
+
+func (e *truncatedResponseError) Error() string {
+	return fmt.Sprintf("response body exceeded %d-byte cap; observed %d bytes", e.cap, e.observed)
+}
+
+func readCappedResponse(r io.Reader, cap int64) ([]byte, error) {
+	result, err := cappedread.Read(r, cap)
+	if err != nil {
+		return nil, err
+	}
+	if result.Truncated {
+		return nil, &truncatedResponseError{cap: cap, observed: result.ObservedBytes}
+	}
+	return result.Bytes, nil
+}
+
+func cappedResponseEvidence(err error) map[string]interface{} {
+	var truncated *truncatedResponseError
+	if !errors.As(err, &truncated) {
+		return nil
+	}
+	return map[string]interface{}{
+		"response_truncated":           true,
+		"response_cap_bytes":           truncated.cap,
+		"response_bytes_observed":      truncated.observed,
+		"response_truncation_observed": fmt.Sprintf("response exceeded %d-byte cap after %d bytes", truncated.cap, truncated.observed),
+	}
+}

--- a/runner/adapter/capped_read.go
+++ b/runner/adapter/capped_read.go
@@ -4,9 +4,23 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/luckyPipewrench/agent-egress-bench/runner/internal/cappedread"
 )
+
+// decisionBodyCap bounds a response body the runner must read completely in
+// order to decide a verdict. It is deliberately far above any body a target
+// legitimately returns on a decision path, because truncation here is fatal:
+// a deny marker past the cap would be silently missed and the case would score
+// as a miss the target did not earn. The former 4096-byte bound was set to
+// limit memory, not to bound a decision, and the benchmark's own example target
+// config permits fetch responses three orders of magnitude larger.
+const decisionBodyCap = 1 << 20
+
+// observationBodyCap bounds a response body the runner reads for context rather
+// than for the verdict. Truncation here is recorded and tolerated.
+const observationBodyCap = 1 << 20
 
 type truncatedResponseError struct {
 	cap      int64
@@ -17,6 +31,9 @@ func (e *truncatedResponseError) Error() string {
 	return fmt.Sprintf("response body exceeded %d-byte cap; observed %d bytes", e.cap, e.observed)
 }
 
+// readCappedResponse reads a body the caller needs in full to decide a verdict.
+// Truncation is an error, because scoring a decision from a prefix reports a
+// measurement the runner did not make.
 func readCappedResponse(r io.Reader, cap int64) ([]byte, error) {
 	result, err := cappedread.Read(r, cap)
 	if err != nil {
@@ -26,6 +43,23 @@ func readCappedResponse(r io.Reader, cap int64) ([]byte, error) {
 		return nil, &truncatedResponseError{cap: cap, observed: result.ObservedBytes}
 	}
 	return result.Bytes, nil
+}
+
+// readObservedResponse reads a body whose content cannot change the verdict the
+// caller is about to return. A read error is still an error, but truncation is
+// reported to the caller instead of failing the case, so a large legitimate
+// response does not make an otherwise complete run unpublishable.
+//
+// Callers must only use this where the verdict is already determined by status
+// and delivery proof. Using it where a deny marker in the body could flip the
+// outcome would reintroduce the silent-prefix fail-open this package exists to
+// close.
+func readObservedResponse(r io.Reader, cap int64) ([]byte, bool, error) {
+	result, err := cappedread.Read(r, cap)
+	if err != nil {
+		return nil, false, err
+	}
+	return result.Bytes, result.Truncated, nil
 }
 
 func cappedResponseEvidence(err error) map[string]interface{} {
@@ -39,4 +73,51 @@ func cappedResponseEvidence(err error) map[string]interface{} {
 		"response_bytes_observed":      truncated.observed,
 		"response_truncation_observed": fmt.Sprintf("response exceeded %d-byte cap after %d bytes", truncated.cap, truncated.observed),
 	}
+}
+
+// noteObservedTruncation records that a non-decision body was truncated, so an
+// operator reading the row can tell a complete observation from a partial one
+// even though the verdict did not depend on it.
+func noteObservedTruncation(evidence map[string]interface{}, truncated bool, cap int64) map[string]interface{} {
+	if !truncated {
+		return evidence
+	}
+	if evidence == nil {
+		evidence = map[string]interface{}{}
+	}
+	evidence["observation_truncated"] = true
+	evidence["observation_cap_bytes"] = cap
+	return evidence
+}
+
+// bodyDecidesVerdict reports whether classifyHTTPResponse consults the response
+// body to decide this status. Only 400, 403, and 502 reach hasDenyMarker; every
+// other status is decided by the status alone, and 2xx through 3xx returns allow
+// without reading the body at all.
+//
+// Truncation matters exactly where this returns true. Where it returns false, a
+// large legitimate body cannot change the outcome, so failing the case would
+// refuse valid traffic and make an otherwise complete run unpublishable without
+// protecting anything.
+func bodyDecidesVerdict(statusCode int) bool {
+	switch statusCode {
+	case http.StatusBadRequest, http.StatusForbidden, http.StatusBadGateway:
+		return true
+	default:
+		return false
+	}
+}
+
+// readClassifiedResponse reads a body that classifyHTTPResponse will inspect.
+// Truncation is fatal only for the statuses whose verdict depends on the body,
+// and is recorded and tolerated otherwise.
+func readClassifiedResponse(r io.Reader, statusCode int, cap int64) ([]byte, bool, error) {
+	body, truncated, err := readObservedResponse(r, cap)
+	if err != nil {
+		return nil, false, err
+	}
+	if truncated && bodyDecidesVerdict(statusCode) {
+		return nil, true, &truncatedResponseError{cap: cap, observed: int64(len(body)) + 1}
+	}
+	return body, truncated, nil
 }

--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -903,9 +903,12 @@ func (a *MCPGatewayAdapter) sendResponse(ctx context.Context, client *http.Clien
 		return a.classifyGatewayResponse(nil, nil, err, requireResponse, emptyResponseReason, request, expectation, caseID)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	responseBody, err := readCappedResponse(resp.Body, 1<<20)
 	if err != nil {
-		return nil, &Result{Err: fmt.Errorf("case %s: read MCP gateway response: %w", caseID, err)}
+		return nil, &Result{
+			Err:      fmt.Errorf("case %s: read MCP gateway response: %w", caseID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
 	}
 	response, result := a.classifyGatewayResponse(resp, responseBody, nil, requireResponse, emptyResponseReason, request, expectation, caseID)
 	if result != nil {

--- a/runner/adapter/gateway.go
+++ b/runner/adapter/gateway.go
@@ -903,7 +903,7 @@ func (a *MCPGatewayAdapter) sendResponse(ctx context.Context, client *http.Clien
 		return a.classifyGatewayResponse(nil, nil, err, requireResponse, emptyResponseReason, request, expectation, caseID)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := readCappedResponse(resp.Body, 1<<20)
+	responseBody, err := readCappedResponse(resp.Body, decisionBodyCap)
 	if err != nil {
 		return nil, &Result{
 			Err:      fmt.Errorf("case %s: read MCP gateway response: %w", caseID, err),

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -1599,7 +1599,11 @@ func sessionEnforcingGateway(t *testing.T, upstreamURL, sessionID string) *httpt
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := readCappedResponse(r.Body, 1<<20)
 		if err != nil {
-			t.Fatal(err)
+			// t.Fatal only unwinds this handler goroutine, so the client would
+			// block on a response that never arrives.
+			t.Errorf("capped read: %v", err)
+			http.Error(w, "capped read", http.StatusInternalServerError)
+			return
 		}
 		_ = r.Body.Close()
 		var req struct {
@@ -1640,7 +1644,11 @@ func sessionEnforcingGateway(t *testing.T, upstreamURL, sessionID string) *httpt
 		defer func() { _ = resp.Body.Close() }()
 		respBody, err := readCappedResponse(resp.Body, 1<<20)
 		if err != nil {
-			t.Fatal(err)
+			// t.Fatal only unwinds this handler goroutine, so the client would
+			// block on a response that never arrives.
+			t.Errorf("capped read: %v", err)
+			http.Error(w, "capped read", http.StatusInternalServerError)
+			return
 		}
 		_, _ = w.Write(respBody)
 	}))
@@ -1682,7 +1690,11 @@ func lateSessionGateway(t *testing.T, upstreamURL string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := readCappedResponse(r.Body, 1<<20)
 		if err != nil {
-			t.Fatal(err)
+			// t.Fatal only unwinds this handler goroutine, so the client would
+			// block on a response that never arrives.
+			t.Errorf("capped read: %v", err)
+			http.Error(w, "capped read", http.StatusInternalServerError)
+			return
 		}
 		_ = r.Body.Close()
 		var req struct {
@@ -1722,7 +1734,11 @@ func lateSessionGateway(t *testing.T, upstreamURL string) *httptest.Server {
 		defer func() { _ = resp.Body.Close() }()
 		respBody, err := readCappedResponse(resp.Body, 1<<20)
 		if err != nil {
-			t.Fatal(err)
+			// t.Fatal only unwinds this handler goroutine, so the client would
+			// block on a response that never arrives.
+			t.Errorf("capped read: %v", err)
+			http.Error(w, "capped read", http.StatusInternalServerError)
+			return
 		}
 		_, _ = w.Write(respBody)
 	}))
@@ -1744,7 +1760,11 @@ func TestMCPGatewayAdapterDrivesMultiCallSequenceAndBlocksForbiddenCall(t *testi
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, readErr := readCappedResponse(r.Body, 1<<20)
 		if readErr != nil {
-			t.Fatal(readErr)
+			// t.Fatal only unwinds this handler goroutine, so the client would
+			// block on a response that never arrives.
+			t.Errorf("capped read: %v", readErr)
+			http.Error(w, "capped read", http.StatusInternalServerError)
+			return
 		}
 		_ = r.Body.Close()
 		var req struct {
@@ -1783,7 +1803,11 @@ func TestMCPGatewayAdapterDrivesMultiCallSequenceAndBlocksForbiddenCall(t *testi
 		defer func() { _ = resp.Body.Close() }()
 		respBody, err := readCappedResponse(resp.Body, 1<<20)
 		if err != nil {
-			t.Fatal(err)
+			// t.Fatal only unwinds this handler goroutine, so the client would
+			// block on a response that never arrives.
+			t.Errorf("capped read: %v", err)
+			http.Error(w, "capped read", http.StatusInternalServerError)
+			return
 		}
 		_, _ = w.Write(respBody)
 	}))
@@ -1867,7 +1891,11 @@ func TestMCPGatewayAdapterSkipsSequenceWhenNotAllCallsReachUpstream(t *testing.T
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, readErr := readCappedResponse(r.Body, 1<<20)
 		if readErr != nil {
-			t.Fatal(readErr)
+			// t.Fatal only unwinds this handler goroutine, so the client would
+			// block on a response that never arrives.
+			t.Errorf("capped read: %v", readErr)
+			http.Error(w, "capped read", http.StatusInternalServerError)
+			return
 		}
 		_ = r.Body.Close()
 		var req struct {
@@ -1907,7 +1935,11 @@ func TestMCPGatewayAdapterSkipsSequenceWhenNotAllCallsReachUpstream(t *testing.T
 		defer func() { _ = resp.Body.Close() }()
 		respBody, err := readCappedResponse(resp.Body, 1<<20)
 		if err != nil {
-			t.Fatal(err)
+			// t.Fatal only unwinds this handler goroutine, so the client would
+			// block on a response that never arrives.
+			t.Errorf("capped read: %v", err)
+			http.Error(w, "capped read", http.StatusInternalServerError)
+			return
 		}
 		_, _ = w.Write(respBody)
 	}))

--- a/runner/adapter/gateway_test.go
+++ b/runner/adapter/gateway_test.go
@@ -1597,7 +1597,7 @@ func sessionEnforcingGateway(t *testing.T, upstreamURL, sessionID string) *httpt
 	t.Helper()
 	client := &http.Client{Timeout: time.Second}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		body, err := readCappedResponse(r.Body, 1<<20)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1638,7 +1638,10 @@ func sessionEnforcingGateway(t *testing.T, upstreamURL, sessionID string) *httpt
 			return
 		}
 		defer func() { _ = resp.Body.Close() }()
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		respBody, err := readCappedResponse(resp.Body, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_, _ = w.Write(respBody)
 	}))
 }
@@ -1677,7 +1680,7 @@ func lateSessionGateway(t *testing.T, upstreamURL string) *httptest.Server {
 	t.Helper()
 	client := &http.Client{Timeout: time.Second}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		body, err := readCappedResponse(r.Body, 1<<20)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1717,7 +1720,10 @@ func lateSessionGateway(t *testing.T, upstreamURL string) *httptest.Server {
 			return
 		}
 		defer func() { _ = resp.Body.Close() }()
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		respBody, err := readCappedResponse(resp.Body, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_, _ = w.Write(respBody)
 	}))
 }
@@ -1736,7 +1742,7 @@ func TestMCPGatewayAdapterDrivesMultiCallSequenceAndBlocksForbiddenCall(t *testi
 	toolsCalls := 0
 	client := &http.Client{Timeout: time.Second}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, readErr := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		body, readErr := readCappedResponse(r.Body, 1<<20)
 		if readErr != nil {
 			t.Fatal(readErr)
 		}
@@ -1775,7 +1781,10 @@ func TestMCPGatewayAdapterDrivesMultiCallSequenceAndBlocksForbiddenCall(t *testi
 			return
 		}
 		defer func() { _ = resp.Body.Close() }()
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		respBody, err := readCappedResponse(resp.Body, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_, _ = w.Write(respBody)
 	}))
 	defer server.Close()
@@ -1856,7 +1865,7 @@ func TestMCPGatewayAdapterSkipsSequenceWhenNotAllCallsReachUpstream(t *testing.T
 	toolsCalls := 0
 	client := &http.Client{Timeout: time.Second}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, readErr := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		body, readErr := readCappedResponse(r.Body, 1<<20)
 		if readErr != nil {
 			t.Fatal(readErr)
 		}
@@ -1896,7 +1905,10 @@ func TestMCPGatewayAdapterSkipsSequenceWhenNotAllCallsReachUpstream(t *testing.T
 			return
 		}
 		defer func() { _ = resp.Body.Close() }()
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		respBody, err := readCappedResponse(resp.Body, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_, _ = w.Write(respBody)
 	}))
 	defer server.Close()

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -651,12 +651,12 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		if res.Verdict == "allow" {
 			return Result{
 				Verdict: "skip",
-				Evidence: map[string]interface{}{
+				Evidence: noteObservedTruncation(map[string]interface{}{
 					"reason":           "ws_upgrade_not_101",
 					"status_code":      resp.StatusCode,
 					"upstream_reached": false,
 					"detail":           truncate(bodyStr, 120),
-				},
+				}, bodyTruncated, observationBodyCap),
 			}
 		}
 		return res
@@ -1710,7 +1710,9 @@ func (p *ProxyAdapter) runWebSocket(c Case, timeout time.Duration) Result {
 				"payload": "benchmark websocket probe",
 			},
 		}
-		return p.runWebSocketFrameViaProxy(probe, timeout)
+		probeResult := p.runWebSocketFrameViaProxy(probe, timeout)
+		probeResult.Evidence = noteObservedTruncation(probeResult.Evidence, wsTruncated, observationBodyCap)
+		return probeResult
 	}
 	return res
 }
@@ -2843,7 +2845,7 @@ func jsonRPCIDString(id interface{}) string {
 	}
 }
 
-func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
+func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) (mcpResult Result) {
 	if p.mcpHTTPURL == "" {
 		return Result{
 			Verdict:  "skip",
@@ -2870,7 +2872,12 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 	// Establish the session before the case's own messages so a target that
 	// requires an issued token evaluates them, rather than refusing every one
 	// for want of a session and turning that refusal into a scored block.
-	sessionToken, err := p.establishMCPHTTPListenerSession(context.Background(), client)
+	sessionToken, setupTruncated, err := p.establishMCPHTTPListenerSession(context.Background(), client)
+	// Every return below must carry this, so merge on the way out rather than at
+	// each exit: a single missed path drops the evidence silently.
+	defer func() {
+		mcpResult.Evidence = noteObservedTruncation(mcpResult.Evidence, setupTruncated, observationBodyCap)
+	}()
 	if err != nil {
 		return Result{
 			Err:      fmt.Errorf("case %s: establish MCP HTTP listener session: %w", c.ID, err),
@@ -3314,7 +3321,10 @@ const (
 // measurement into an error and looks like a finding. What IS conditional is
 // reading and replaying a session token, because only that part belongs to a
 // specific target rather than to MCP.
-func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, client *http.Client) (string, error) {
+// The bool reports that the drained setup body was truncated. Setup does not
+// depend on that body, so it is not an error, but the eventual case result must
+// still say the observation was partial rather than silently complete.
+func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, client *http.Client) (string, bool, error) {
 	// Setup is recognized only on a non-batch initialize that carries no
 	// negotiated protocol version, so this frame must stay exactly that shape.
 	// Do not add an Mcp-Protocol-Version header here: it makes the target treat
@@ -3327,17 +3337,17 @@ func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, clie
 	}
 	body, err := json.Marshal(message)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.mcpHTTPURL, bytes.NewReader(body))
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	// The body is drained and discarded. Only the issued token matters here,
@@ -3345,15 +3355,16 @@ func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, clie
 	// status and the declared token header alone, so truncating this drain cannot
 	// change the outcome and must not fail an otherwise valid session: a large
 	// 2xx setup response would otherwise error every MCP case in the run.
-	if _, _, err := readObservedResponse(resp.Body, observationBodyCap); err != nil {
-		return "", fmt.Errorf("read listener session response: %w", err)
+	_, setupTruncated, err := readObservedResponse(resp.Body, observationBodyCap)
+	if err != nil {
+		return "", false, fmt.Errorf("read listener session response: %w", err)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return "", nil
+		return "", setupTruncated, nil
 	}
 	// Read the token only from a declared header. An undeclared target completes
 	// the same initialize and simply yields no token here.
-	return p.declaredSessionToken(resp.Header), nil
+	return p.declaredSessionToken(resp.Header), setupTruncated, nil
 }
 
 // declaredSessionToken reads an issued token from the declared header only.
@@ -3471,7 +3482,7 @@ func validMCPInitializeResponse(body []byte) bool {
 // then the adapter sends the corresponding client request through the product.
 // Posting a JSON-RPC response to the product's listener would test only that a
 // listener rejects an invalid client request, not response scanning.
-func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Result {
+func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) (responseResult Result) {
 	if p.mcpHTTPFixture == nil {
 		return Result{Verdict: "skip", Evidence: map[string]interface{}{
 			"reason": "no MCP HTTP upstream fixture configured for response case",
@@ -3489,7 +3500,10 @@ func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Res
 	// frame reaches the upstream fixture, so running it inside a lease window
 	// perturbs the very delivery proof the lease exists to make exact.
 	responseClient := newMCPHTTPClient(timeout)
-	sessionToken, err := p.establishMCPHTTPListenerSession(ctx, responseClient)
+	sessionToken, responseSetupTruncated, err := p.establishMCPHTTPListenerSession(ctx, responseClient)
+	defer func() {
+		responseResult.Evidence = noteObservedTruncation(responseResult.Evidence, responseSetupTruncated, observationBodyCap)
+	}()
 	if err != nil {
 		return Result{
 			Err:      fmt.Errorf("case %s: establish MCP HTTP listener session: %w", c.ID, err),

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -633,7 +633,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		return Result{Err: fmt.Errorf("case %s: ws upgrade response: %w", c.ID, err)}
 	}
 	if resp.StatusCode != http.StatusSwitchingProtocols {
-		body, err := readCappedResponse(resp.Body, 4096)
+		body, _, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
 		_ = resp.Body.Close()
 		if err != nil {
 			return Result{
@@ -1105,7 +1105,7 @@ func (p *ProxyAdapter) runFetchProxy(c Case, timeout time.Duration) Result {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := readCappedResponse(resp.Body, 4096)
+	body, err := readCappedResponse(resp.Body, decisionBodyCap)
 	if err != nil {
 		return Result{
 			Err:      fmt.Errorf("case %s: read fetch proxy response: %w", c.ID, err),
@@ -1384,14 +1384,16 @@ func (p *ProxyAdapter) runHTTPProxy(c Case, timeout time.Duration) Result {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := readCappedResponse(resp.Body, 4096)
+	body, bodyTruncated, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
 	if err != nil {
 		return Result{
 			Err:      fmt.Errorf("case %s: read proxy response: %w", c.ID, err),
 			Evidence: cappedResponseEvidence(err),
 		}
 	}
-	return observedProxyVerdict(classifyResponse(resp.StatusCode, string(body)))
+	proxyResult := observedProxyVerdict(classifyResponse(resp.StatusCode, string(body)))
+	proxyResult.Evidence = noteObservedTruncation(proxyResult.Evidence, bodyTruncated, observationBodyCap)
+	return proxyResult
 }
 
 func (p *ProxyAdapter) runResponseContentViaTLSIntercept(c Case, timeout time.Duration, responseBody string) Result {
@@ -1584,7 +1586,7 @@ func (p *ProxyAdapter) doHTTPProxyRequest(caseID, method, targetURL string, body
 		}
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, err := readCappedResponse(resp.Body, 4096)
+	respBody, _, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
 	if err != nil {
 		return Result{
 			Err:      fmt.Errorf("case %s: read HTTP proxy response: %w", caseID, err),
@@ -1673,7 +1675,7 @@ func (p *ProxyAdapter) runWebSocket(c Case, timeout time.Duration) Result {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := readCappedResponse(resp.Body, 4096)
+	body, _, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
 	_ = resp.Body.Close()
 	if err != nil {
 		return Result{
@@ -2892,7 +2894,7 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 		if err != nil {
 			return Result{Err: fmt.Errorf("case %s: MCP HTTP request: %w", c.ID, err)}
 		}
-		body, err := readCappedResponse(resp.Body, 4096)
+		body, err := readCappedResponse(resp.Body, decisionBodyCap)
 		_ = resp.Body.Close()
 		if err != nil {
 			return Result{
@@ -3250,7 +3252,7 @@ func (p *ProxyAdapter) sendMCPHTTPGatewayRequest(ctx context.Context, client *ht
 		return mcpHTTPGatewayResponse{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := readCappedResponse(resp.Body, 1<<20)
+	responseBody, err := readCappedResponse(resp.Body, decisionBodyCap)
 	if err != nil {
 		return mcpHTTPGatewayResponse{}, fmt.Errorf("read response: %w", err)
 	}
@@ -3335,7 +3337,7 @@ func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, clie
 	defer func() { _ = resp.Body.Close() }()
 	// The body is drained and discarded. Only the issued token matters here,
 	// and leaving it unread would strand the connection.
-	if _, err := readCappedResponse(resp.Body, 1<<20); err != nil {
+	if _, err := readCappedResponse(resp.Body, decisionBodyCap); err != nil {
 		return "", fmt.Errorf("read listener session response: %w", err)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
@@ -3559,7 +3561,7 @@ func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Res
 		return Result{Err: fmt.Errorf("case %s: MCP HTTP request: %w", c.ID, err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := readCappedResponse(resp.Body, 1<<20)
+	responseBody, err := readCappedResponse(resp.Body, decisionBodyCap)
 	if err != nil {
 		return Result{
 			Err:      fmt.Errorf("case %s: read MCP HTTP response: %w", c.ID, err),
@@ -3658,7 +3660,7 @@ func (p *ProxyAdapter) primeMCPHTTPToolResultBaseline(ctx context.Context, sessi
 		return &Result{Err: fmt.Errorf("send tool-result baseline request: %w", err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := readCappedResponse(resp.Body, 1<<20)
+	responseBody, err := readCappedResponse(resp.Body, decisionBodyCap)
 	if err != nil {
 		return &Result{
 			Err:      fmt.Errorf("read tool-result baseline response: %w", err),
@@ -3799,7 +3801,7 @@ func (p *ProxyAdapter) runScanAPITextWithKind(caseID, text string, timeout time.
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := readCappedResponse(resp.Body, 4096)
+	respBody, err := readCappedResponse(resp.Body, decisionBodyCap)
 	if err != nil {
 		return Result{
 			Err:      fmt.Errorf("case %s: read scan API (%s) response: %w", caseID, kind, err),

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -633,7 +633,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		return Result{Err: fmt.Errorf("case %s: ws upgrade response: %w", c.ID, err)}
 	}
 	if resp.StatusCode != http.StatusSwitchingProtocols {
-		body, _, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
+		body, bodyTruncated, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
 		_ = resp.Body.Close()
 		if err != nil {
 			return Result{
@@ -647,6 +647,7 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		// response (including a proxy-local 200) is unproven and must fail closed
 		// to skip, not allow.
 		res := classifyResponse(resp.StatusCode, bodyStr)
+		res.Evidence = noteObservedTruncation(res.Evidence, bodyTruncated, observationBodyCap)
 		if res.Verdict == "allow" {
 			return Result{
 				Verdict: "skip",
@@ -1586,7 +1587,7 @@ func (p *ProxyAdapter) doHTTPProxyRequest(caseID, method, targetURL string, body
 		}
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, _, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
+	respBody, respTruncated, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
 	if err != nil {
 		return Result{
 			Err:      fmt.Errorf("case %s: read HTTP proxy response: %w", caseID, err),
@@ -1598,9 +1599,12 @@ func (p *ProxyAdapter) doHTTPProxyRequest(caseID, method, targetURL string, body
 	// can synthesize a response after CONNECT without ever forwarding. Credit a
 	// passthrough allow only when the runner-managed fixture counter advanced.
 	if caFile != "" && p.tlsFixtureServed(fixtureBaseline) {
-		return observedProxyVerdict(classifyUpstreamResponse(resp.StatusCode, string(respBody)))
+		upstreamResult := observedProxyVerdict(classifyUpstreamResponse(resp.StatusCode, string(respBody)))
+		upstreamResult.Evidence = noteObservedTruncation(upstreamResult.Evidence, respTruncated, observationBodyCap)
+		return upstreamResult
 	}
 	result := classifyResponse(resp.StatusCode, string(respBody))
+	result.Evidence = noteObservedTruncation(result.Evidence, respTruncated, observationBodyCap)
 	if caFile != "" && result.Verdict == "allow" {
 		result.Verdict = "skip"
 		if result.Evidence == nil {
@@ -1675,7 +1679,7 @@ func (p *ProxyAdapter) runWebSocket(c Case, timeout time.Duration) Result {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
+	body, wsTruncated, err := readClassifiedResponse(resp.Body, resp.StatusCode, observationBodyCap)
 	_ = resp.Body.Close()
 	if err != nil {
 		return Result{
@@ -1688,6 +1692,7 @@ func (p *ProxyAdapter) runWebSocket(c Case, timeout time.Duration) Result {
 	// about whether an upstream frame was actually forwarded. Require real frame
 	// proof by re-running the same target through the frame-oriented path.
 	res := classifyResponse(resp.StatusCode, string(body))
+	res.Evidence = noteObservedTruncation(res.Evidence, wsTruncated, observationBodyCap)
 	if res.Verdict == "allow" {
 		// Route through runWebSocketFrameViaProxy so that only a genuine
 		// 101 upgrade and upstream frame echo can score allow.
@@ -3336,8 +3341,11 @@ func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, clie
 	}
 	defer func() { _ = resp.Body.Close() }()
 	// The body is drained and discarded. Only the issued token matters here,
-	// and leaving it unread would strand the connection.
-	if _, err := readCappedResponse(resp.Body, decisionBodyCap); err != nil {
+	// and leaving it unread would strand the connection. Setup is decided by the
+	// status and the declared token header alone, so truncating this drain cannot
+	// change the outcome and must not fail an otherwise valid session: a large
+	// 2xx setup response would otherwise error every MCP case in the run.
+	if _, _, err := readObservedResponse(resp.Body, observationBodyCap); err != nil {
 		return "", fmt.Errorf("read listener session response: %w", err)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {

--- a/runner/adapter/proxy.go
+++ b/runner/adapter/proxy.go
@@ -633,8 +633,14 @@ func (p *ProxyAdapter) runWebSocketFrameViaProxy(c Case, timeout time.Duration) 
 		return Result{Err: fmt.Errorf("case %s: ws upgrade response: %w", c.ID, err)}
 	}
 	if resp.StatusCode != http.StatusSwitchingProtocols {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		body, err := readCappedResponse(resp.Body, 4096)
 		_ = resp.Body.Close()
+		if err != nil {
+			return Result{
+				Err:      fmt.Errorf("case %s: read ws upgrade response: %w", c.ID, err),
+				Evidence: cappedResponseEvidence(err),
+			}
+		}
 		bodyStr := string(body)
 		// A WebSocket upgrade that did not return 101 never reached the upstream
 		// frame path. A 400/403 is still an explicit proxy block, but any other
@@ -1099,7 +1105,13 @@ func (p *ProxyAdapter) runFetchProxy(c Case, timeout time.Duration) Result {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	body, err := readCappedResponse(resp.Body, 4096)
+	if err != nil {
+		return Result{
+			Err:      fmt.Errorf("case %s: read fetch proxy response: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
+	}
 	// The fetch endpoint returns JSON with blocked, block_reason, and scanner fields.
 	var fetchResp struct {
 		Blocked     bool   `json:"blocked"`
@@ -1372,7 +1384,13 @@ func (p *ProxyAdapter) runHTTPProxy(c Case, timeout time.Duration) Result {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	body, err := readCappedResponse(resp.Body, 4096)
+	if err != nil {
+		return Result{
+			Err:      fmt.Errorf("case %s: read proxy response: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
+	}
 	return observedProxyVerdict(classifyResponse(resp.StatusCode, string(body)))
 }
 
@@ -1566,7 +1584,13 @@ func (p *ProxyAdapter) doHTTPProxyRequest(caseID, method, targetURL string, body
 		}
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	respBody, err := readCappedResponse(resp.Body, 4096)
+	if err != nil {
+		return Result{
+			Err:      fmt.Errorf("case %s: read HTTP proxy response: %w", caseID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
+	}
 	// A configured CA proves only that the client was prepared to validate the
 	// fixture's certificate. It does not prove the fixture answered: the proxy
 	// can synthesize a response after CONNECT without ever forwarding. Credit a
@@ -1649,8 +1673,14 @@ func (p *ProxyAdapter) runWebSocket(c Case, timeout time.Duration) Result {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	body, err := readCappedResponse(resp.Body, 4096)
 	_ = resp.Body.Close()
+	if err != nil {
+		return Result{
+			Err:      fmt.Errorf("case %s: read ws proxy response: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
+	}
 	// The /ws endpoint returned an HTTP response instead of completing a
 	// WebSocket upgrade. That response is local to the proxy and proves nothing
 	// about whether an upstream frame was actually forwarded. Require real frame
@@ -2833,7 +2863,13 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 	// Establish the session before the case's own messages so a target that
 	// requires an issued token evaluates them, rather than refusing every one
 	// for want of a session and turning that refusal into a scored block.
-	sessionToken := p.establishMCPHTTPListenerSession(context.Background(), client)
+	sessionToken, err := p.establishMCPHTTPListenerSession(context.Background(), client)
+	if err != nil {
+		return Result{
+			Err:      fmt.Errorf("case %s: establish MCP HTTP listener session: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
+	}
 	var responses int
 	upstreamBefore, _ := p.mcpHTTPUpstreamCallCount()
 	for _, rawMessage := range msgList {
@@ -2856,8 +2892,14 @@ func (p *ProxyAdapter) runMCPHTTP(c Case, timeout time.Duration) Result {
 		if err != nil {
 			return Result{Err: fmt.Errorf("case %s: MCP HTTP request: %w", c.ID, err)}
 		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		body, err := readCappedResponse(resp.Body, 4096)
 		_ = resp.Body.Close()
+		if err != nil {
+			return Result{
+				Err:      fmt.Errorf("case %s: read MCP HTTP response: %w", c.ID, err),
+				Evidence: cappedResponseEvidence(err),
+			}
+		}
 		// Test the declared refusal FIRST, before anything looks at the body.
 		// Gating this on the body classifying as a block leaves the hole the
 		// declaration exists to close: a target that sets its refusal header
@@ -3033,7 +3075,10 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 	}
 	initialize, err := p.sendMCPHTTPGatewayRequest(ctx, client, initializeMessage, "", "")
 	if err != nil {
-		return Result{Err: fmt.Errorf("case %s: send MCP initialize request: %w", c.ID, err)}
+		return Result{
+			Err:      fmt.Errorf("case %s: send MCP initialize request: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
 	}
 	if !proxyMCPHTTPDelivered(p.mcpHTTPFixture, initializeRequest) {
 		evidence["reason"] = "temporal_initialize_upstream_unproven"
@@ -3060,7 +3105,13 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 		"method":  "notifications/initialized",
 		"params":  map[string]interface{}{},
 	}, sessionID, sessionToken)
-	if err != nil || initialized.status < http.StatusOK || initialized.status >= http.StatusMultipleChoices {
+	if err != nil {
+		return Result{
+			Err:      fmt.Errorf("case %s: send MCP initialized notification: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
+	}
+	if initialized.status < http.StatusOK || initialized.status >= http.StatusMultipleChoices {
 		evidence["reason"] = "temporal_initialized_notification_failed"
 		return Result{Verdict: "skip", Evidence: evidence}
 	}
@@ -3077,7 +3128,10 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 	baseline, err := p.sendMCPHTTPGatewayRequest(ctx, client, baselineMessage, sessionID, sessionToken)
 	baselineRelease()
 	if err != nil {
-		return Result{Err: fmt.Errorf("case %s: send baseline tools/list request: %w", c.ID, err)}
+		return Result{
+			Err:      fmt.Errorf("case %s: send baseline tools/list request: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
 	}
 	baselineDelivered := proxyMCPHTTPDelivered(p.mcpHTTPFixture, baselineRequest)
 	evidence["original_inventory_reached_upstream"] = baselineDelivered
@@ -3110,7 +3164,10 @@ func (p *ProxyAdapter) runMCPHTTPTemporalInventory(c Case, timeout time.Duration
 	changed, err := p.sendMCPHTTPGatewayRequest(ctx, client, changedMessage, sessionID, sessionToken)
 	changedRelease()
 	if err != nil {
-		return Result{Err: fmt.Errorf("case %s: send changed tools/list request: %w", c.ID, err)}
+		return Result{
+			Err:      fmt.Errorf("case %s: send changed tools/list request: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
 	}
 	changedDelivered := proxyMCPHTTPDelivered(p.mcpHTTPFixture, changedRequest)
 	evidence["changed_inventory_reached_upstream"] = changedDelivered
@@ -3193,7 +3250,7 @@ func (p *ProxyAdapter) sendMCPHTTPGatewayRequest(ctx context.Context, client *ht
 		return mcpHTTPGatewayResponse{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	responseBody, err := readCappedResponse(resp.Body, 1<<20)
 	if err != nil {
 		return mcpHTTPGatewayResponse{}, fmt.Errorf("read response: %w", err)
 	}
@@ -3250,7 +3307,7 @@ const (
 // measurement into an error and looks like a finding. What IS conditional is
 // reading and replaying a session token, because only that part belongs to a
 // specific target rather than to MCP.
-func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, client *http.Client) string {
+func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, client *http.Client) (string, error) {
 	// Setup is recognized only on a non-batch initialize that carries no
 	// negotiated protocol version, so this frame must stay exactly that shape.
 	// Do not add an Mcp-Protocol-Version header here: it makes the target treat
@@ -3263,28 +3320,30 @@ func (p *ProxyAdapter) establishMCPHTTPListenerSession(ctx context.Context, clie
 	}
 	body, err := json.Marshal(message)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.mcpHTTPURL, bytes.NewReader(body))
 	if err != nil {
-		return ""
+		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	resp, err := client.Do(req)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	// The body is drained and discarded. Only the issued token matters here,
 	// and leaving it unread would strand the connection.
-	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	if _, err := readCappedResponse(resp.Body, 1<<20); err != nil {
+		return "", fmt.Errorf("read listener session response: %w", err)
+	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return ""
+		return "", nil
 	}
 	// Read the token only from a declared header. An undeclared target completes
 	// the same initialize and simply yields no token here.
-	return p.declaredSessionToken(resp.Header)
+	return p.declaredSessionToken(resp.Header), nil
 }
 
 // declaredSessionToken reads an issued token from the declared header only.
@@ -3420,7 +3479,13 @@ func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Res
 	// frame reaches the upstream fixture, so running it inside a lease window
 	// perturbs the very delivery proof the lease exists to make exact.
 	responseClient := newMCPHTTPClient(timeout)
-	sessionToken := p.establishMCPHTTPListenerSession(ctx, responseClient)
+	sessionToken, err := p.establishMCPHTTPListenerSession(ctx, responseClient)
+	if err != nil {
+		return Result{
+			Err:      fmt.Errorf("case %s: establish MCP HTTP listener session: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
+	}
 	var (
 		request       map[string]interface{}
 		gatewayReq    gatewayRequest
@@ -3494,9 +3559,12 @@ func (p *ProxyAdapter) runMCPHTTPResponseCase(c Case, timeout time.Duration) Res
 		return Result{Err: fmt.Errorf("case %s: MCP HTTP request: %w", c.ID, err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	responseBody, err := readCappedResponse(resp.Body, 1<<20)
 	if err != nil {
-		return Result{Err: fmt.Errorf("case %s: read MCP HTTP response: %w", c.ID, err)}
+		return Result{
+			Err:      fmt.Errorf("case %s: read MCP HTTP response: %w", c.ID, err),
+			Evidence: cappedResponseEvidence(err),
+		}
 	}
 
 	delivered := proxyMCPHTTPDelivered(p.mcpHTTPFixture, gatewayReq)
@@ -3590,9 +3658,12 @@ func (p *ProxyAdapter) primeMCPHTTPToolResultBaseline(ctx context.Context, sessi
 		return &Result{Err: fmt.Errorf("send tool-result baseline request: %w", err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
-	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	responseBody, err := readCappedResponse(resp.Body, 1<<20)
 	if err != nil {
-		return &Result{Err: fmt.Errorf("read tool-result baseline response: %w", err)}
+		return &Result{
+			Err:      fmt.Errorf("read tool-result baseline response: %w", err),
+			Evidence: cappedResponseEvidence(err),
+		}
 	}
 	if !proxyMCPHTTPDelivered(p.mcpHTTPFixture, gatewayReq) {
 		return &Result{Verdict: "skip", Evidence: map[string]interface{}{"reason": "tool_result_baseline_unproven", "upstream_reached": false}}
@@ -3728,7 +3799,13 @@ func (p *ProxyAdapter) runScanAPITextWithKind(caseID, text string, timeout time.
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	respBody, err := readCappedResponse(resp.Body, 4096)
+	if err != nil {
+		return Result{
+			Err:      fmt.Errorf("case %s: read scan API (%s) response: %w", caseID, kind, err),
+			Evidence: cappedResponseEvidence(err),
+		}
+	}
 
 	if resp.StatusCode >= 400 {
 		return Result{Err: fmt.Errorf("case %s: scan API (%s) returned %d: %s", caseID, kind, resp.StatusCode, truncate(string(respBody), 120))}

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -77,7 +77,7 @@ func TestRunFetchProxyRejectsTruncatedResponseBeforePrefixVerdict(t *testing.T) 
 	// A decoy that no classifier recognises would make this test pass whether or
 	// not truncation actually hid a decision, which proves the guard fires but
 	// not that it protects anything.
-	suffix := []byte(`,"blocked":true,"block_reason":"dlp","scanner":"dlp"}`)
+	suffix := []byte(`","blocked":true,"block_reason":"dlp","scanner":"dlp"}`)
 	filler := bytes.Repeat([]byte("a"), decisionBodyCap)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write(append(append([]byte(`{"padding":"`), filler...), suffix...))

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -72,6 +72,39 @@ func TestHTTPDeliveryTokenIsOpaqueWithoutEntropyRaisingPrefix(t *testing.T) {
 	}
 }
 
+func TestRunFetchProxyRejectsTruncatedResponseBeforePrefixVerdict(t *testing.T) {
+	const cap = 4096
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// A 200 response used to score allow even though the security-relevant
+		// content appeared after the cap and was absent from the classified prefix.
+		_, _ = w.Write(append(bytes.Repeat([]byte("a"), cap), []byte("BLOCK")...))
+	}))
+	defer server.Close()
+
+	address := strings.TrimPrefix(server.URL, "http://")
+	adapt, err := NewProxyAdapter(address, "", "", "")
+	if err != nil {
+		t.Fatalf("NewProxyAdapter: %v", err)
+	}
+	result := adapt.Run(Case{
+		ID:        "truncated-fetch-response-001",
+		Transport: "fetch_proxy",
+		InputType: "url",
+		Payload: map[string]interface{}{
+			"url": "https://api.vendor.example/resource",
+		},
+	}, time.Second)
+	if result.Err == nil {
+		t.Fatalf("result = %+v, want adapter error instead of a prefix verdict", result)
+	}
+	if result.Verdict == "allow" || result.Verdict == "block" {
+		t.Fatalf("result verdict = %q, want no scored verdict", result.Verdict)
+	}
+	if result.Evidence["response_truncated"] != true || result.Evidence["response_cap_bytes"] != int64(cap) || result.Evidence["response_bytes_observed"] != int64(cap+1) {
+		t.Fatalf("truncation evidence = %#v, want cap and observed byte count", result.Evidence)
+	}
+}
+
 func TestRunWebSocketFrameViaProxy_Non101UpgradeSkipsNotAllows(t *testing.T) {
 	// A proxy-local 200 to a WebSocket upgrade request proves nothing about
 	// whether the upgrade reached upstream. A non-101 response must fail closed

--- a/runner/adapter/proxy_test.go
+++ b/runner/adapter/proxy_test.go
@@ -73,11 +73,14 @@ func TestHTTPDeliveryTokenIsOpaqueWithoutEntropyRaisingPrefix(t *testing.T) {
 }
 
 func TestRunFetchProxyRejectsTruncatedResponseBeforePrefixVerdict(t *testing.T) {
-	const cap = 4096
+	// The suffix is a real fetch-endpoint block field rather than a bare marker.
+	// A decoy that no classifier recognises would make this test pass whether or
+	// not truncation actually hid a decision, which proves the guard fires but
+	// not that it protects anything.
+	suffix := []byte(`,"blocked":true,"block_reason":"dlp","scanner":"dlp"}`)
+	filler := bytes.Repeat([]byte("a"), decisionBodyCap)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// A 200 response used to score allow even though the security-relevant
-		// content appeared after the cap and was absent from the classified prefix.
-		_, _ = w.Write(append(bytes.Repeat([]byte("a"), cap), []byte("BLOCK")...))
+		_, _ = w.Write(append(append([]byte(`{"padding":"`), filler...), suffix...))
 	}))
 	defer server.Close()
 
@@ -93,15 +96,86 @@ func TestRunFetchProxyRejectsTruncatedResponseBeforePrefixVerdict(t *testing.T) 
 		Payload: map[string]interface{}{
 			"url": "https://api.vendor.example/resource",
 		},
-	}, time.Second)
+	}, 10*time.Second)
 	if result.Err == nil {
 		t.Fatalf("result = %+v, want adapter error instead of a prefix verdict", result)
 	}
 	if result.Verdict == "allow" || result.Verdict == "block" {
 		t.Fatalf("result verdict = %q, want no scored verdict", result.Verdict)
 	}
-	if result.Evidence["response_truncated"] != true || result.Evidence["response_cap_bytes"] != int64(cap) || result.Evidence["response_bytes_observed"] != int64(cap+1) {
+	if result.Evidence["response_truncated"] != true || result.Evidence["response_cap_bytes"] != int64(decisionBodyCap) {
 		t.Fatalf("truncation evidence = %#v, want cap and observed byte count", result.Evidence)
+	}
+}
+
+// A body the verdict does not depend on must not invalidate the run. The
+// benchmark's own example target permits fetch responses far above any cap the
+// runner sets, so failing a large successful response would refuse legitimate
+// traffic and make an otherwise complete corpus unpublishable.
+func TestForwardProxyToleratesLargeSuccessfulBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(bytes.Repeat([]byte("a"), observationBodyCap+1024))
+	}))
+	defer server.Close()
+
+	address := strings.TrimPrefix(server.URL, "http://")
+	adapt, err := NewProxyAdapter(address, "", "", "")
+	if err != nil {
+		t.Fatalf("NewProxyAdapter: %v", err)
+	}
+	result := adapt.Run(Case{
+		ID:        "large-allow-body-001",
+		Transport: "http_proxy",
+		InputType: "url",
+		Payload: map[string]interface{}{
+			"url": "http://api.vendor.example/resource",
+		},
+	}, 10*time.Second)
+	if result.Err != nil {
+		t.Fatalf("result.Err = %v, want a scored verdict for a large successful body", result.Err)
+	}
+	if result.Verdict != "allow" {
+		t.Fatalf("result verdict = %q, want allow decided by status alone", result.Verdict)
+	}
+	if result.Evidence["observation_truncated"] != true {
+		t.Fatalf("evidence = %#v, want the truncated observation recorded", result.Evidence)
+	}
+	if result.Evidence["observation_cap_bytes"] != int64(observationBodyCap) {
+		t.Fatalf("evidence = %#v, want the observation cap recorded", result.Evidence)
+	}
+}
+
+// Truncation stays fatal for the statuses whose verdict depends on the body. A
+// deny marker past the cap would otherwise be missed and the target would take
+// a miss it did not earn.
+func TestBodyDecidesVerdictCoversDenyMarkerStatuses(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusForbidden, http.StatusBadGateway} {
+		if !bodyDecidesVerdict(status) {
+			t.Fatalf("bodyDecidesVerdict(%d) = false, want true", status)
+		}
+	}
+	for _, status := range []int{http.StatusOK, http.StatusFound, http.StatusMethodNotAllowed, http.StatusInternalServerError} {
+		if bodyDecidesVerdict(status) {
+			t.Fatalf("bodyDecidesVerdict(%d) = true, want false", status)
+		}
+	}
+}
+
+func TestReadClassifiedResponseFailsOnlyWhenBodyDecides(t *testing.T) {
+	oversized := bytes.Repeat([]byte("a"), 64)
+	if _, _, err := readClassifiedResponse(bytes.NewReader(oversized), http.StatusForbidden, 8); err == nil {
+		t.Fatal("truncated 403 returned no error, want a refusal to score from a prefix")
+	}
+	body, truncated, err := readClassifiedResponse(bytes.NewReader(oversized), http.StatusOK, 8)
+	if err != nil {
+		t.Fatalf("truncated 200 returned %v, want tolerance", err)
+	}
+	if !truncated {
+		t.Fatal("truncated 200 reported truncated = false, want the observation recorded")
+	}
+	if len(body) != 8 {
+		t.Fatalf("len(body) = %d, want the capped prefix", len(body))
 	}
 }
 

--- a/runner/fixture/mcp_http.go
+++ b/runner/fixture/mcp_http.go
@@ -5,12 +5,13 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/luckyPipewrench/agent-egress-bench/runner/internal/cappedread"
 )
 
 // MCPHTTPFixture runs a minimal Streamable HTTP MCP upstream.
@@ -272,8 +273,17 @@ func StartMCPHTTP() (*MCPHTTPFixture, error) {
 			return
 		}
 		f.calls.Add(1)
-		body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		read, err := cappedread.Read(r.Body, 1<<20)
 		_ = r.Body.Close()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("read MCP request: %v", err), http.StatusBadRequest)
+			return
+		}
+		if read.Truncated {
+			http.Error(w, fmt.Sprintf("MCP request exceeded %d-byte cap after %d bytes", 1<<20, read.ObservedBytes), http.StatusRequestEntityTooLarge)
+			return
+		}
+		body := read.Bytes
 		var req struct {
 			JSONRPC string          `json:"jsonrpc"`
 			ID      json.RawMessage `json:"id"`

--- a/runner/internal/cappedread/cappedread.go
+++ b/runner/internal/cappedread/cappedread.go
@@ -1,0 +1,41 @@
+// Package cappedread reads bounded responses without mistaking a prefix for a complete body.
+package cappedread
+
+import (
+	"fmt"
+	"io"
+	"math"
+)
+
+// Result records a capped read. Bytes holds at most Cap bytes. ObservedBytes
+// includes the one extra byte read to distinguish a complete body at the cap
+// from a truncated body.
+type Result struct {
+	Bytes         []byte
+	ObservedBytes int64
+	Truncated     bool
+}
+
+// Read reads up to cap bytes plus one sentinel byte. A body exactly cap bytes
+// long is complete; a body that supplies the sentinel byte is truncated.
+func Read(r io.Reader, cap int64) (Result, error) {
+	if cap < 0 {
+		return Result{}, fmt.Errorf("negative read cap %d", cap)
+	}
+	if cap == math.MaxInt64 {
+		return Result{}, fmt.Errorf("read cap %d cannot reserve a sentinel byte", cap)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(r, cap+1))
+	result := Result{ObservedBytes: int64(len(data))}
+	if err != nil {
+		return result, err
+	}
+	if result.ObservedBytes > cap {
+		result.Truncated = true
+		result.Bytes = data[:cap]
+		return result, nil
+	}
+	result.Bytes = data
+	return result, nil
+}

--- a/runner/internal/cappedread/cappedread_test.go
+++ b/runner/internal/cappedread/cappedread_test.go
@@ -1,0 +1,84 @@
+package cappedread
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadDetectsTruncation(t *testing.T) {
+	const cap = int64(8)
+	securityRelevantSuffix := "BLOCK"
+	tests := []struct {
+		name          string
+		body          string
+		wantBody      string
+		wantObserved  int64
+		wantTruncated bool
+	}{
+		{
+			name:          "exactly at cap is complete",
+			body:          "12345678",
+			wantBody:      "12345678",
+			wantObserved:  cap,
+			wantTruncated: false,
+		},
+		{
+			name:          "one byte over cap is truncated",
+			body:          "123456789",
+			wantBody:      "12345678",
+			wantObserved:  cap + 1,
+			wantTruncated: true,
+		},
+		{
+			name:          "security relevant suffix after cap cannot become a prefix verdict",
+			body:          "benign--" + strings.Repeat("padding", 4) + securityRelevantSuffix,
+			wantBody:      "benign--",
+			wantObserved:  cap + 1,
+			wantTruncated: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Read(strings.NewReader(tc.body), cap)
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if string(got.Bytes) != tc.wantBody {
+				t.Fatalf("Bytes = %q, want %q", got.Bytes, tc.wantBody)
+			}
+			if got.ObservedBytes != tc.wantObserved {
+				t.Fatalf("ObservedBytes = %d, want %d", got.ObservedBytes, tc.wantObserved)
+			}
+			if got.Truncated != tc.wantTruncated {
+				t.Fatalf("Truncated = %t, want %t", got.Truncated, tc.wantTruncated)
+			}
+			if tc.wantTruncated && strings.Contains(string(got.Bytes), securityRelevantSuffix) {
+				t.Fatalf("truncated prefix unexpectedly contains security suffix %q", securityRelevantSuffix)
+			}
+		})
+	}
+}
+
+func TestReadReturnsReadError(t *testing.T) {
+	want := errors.New("read failed")
+	got, err := Read(errReader{err: want}, 8)
+	if !errors.Is(err, want) {
+		t.Fatalf("Read error = %v, want %v", err, want)
+	}
+	if got.Truncated {
+		t.Fatal("Truncated = true after read error, want false")
+	}
+}
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+var _ io.Reader = errReader{}

--- a/runner/managed_gateway_integration_test.go
+++ b/runner/managed_gateway_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/luckyPipewrench/agent-egress-bench/runner/adapter"
 	"github.com/luckyPipewrench/agent-egress-bench/runner/fixture"
+	"github.com/luckyPipewrench/agent-egress-bench/runner/internal/cappedread"
 )
 
 // End-to-end: a gateway plugin with a managed lifecycle must start its gateway,
@@ -167,8 +168,12 @@ func TestBuildManagedGatewayAdapterDoesNotCreditManagedDenyAsAtomicProof(t *test
 func forwardingGatewayHandler(upstream string) http.Handler {
 	client := &http.Client{Timeout: 3 * time.Second}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		body, err := readManagedGatewayBody(r.Body)
 		_ = r.Body.Close()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		var req struct {
 			ID     json.RawMessage `json:"id"`
 			Method string          `json:"method"`
@@ -199,7 +204,11 @@ func forwardingGatewayHandler(upstream string) http.Handler {
 			return
 		}
 		defer func() { _ = resp.Body.Close() }()
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		respBody, err := readManagedGatewayBody(resp.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
 		_, _ = w.Write(respBody)
 	})
 }
@@ -252,8 +261,12 @@ func TestGatewayForwardHelper(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		body, err := readManagedGatewayBody(r.Body)
 		_ = r.Body.Close()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		var req struct {
 			ID     json.RawMessage `json:"id"`
 			Method string          `json:"method"`
@@ -302,7 +315,11 @@ func TestGatewayForwardHelper(t *testing.T) {
 			return
 		}
 		defer func() { _ = resp.Body.Close() }()
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		respBody, err := readManagedGatewayBody(resp.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
 		_, _ = w.Write(respBody)
 	})
 
@@ -322,6 +339,17 @@ func TestGatewayForwardHelper(t *testing.T) {
 		_, _ = fmt.Fprintf(os.Stderr, "forwarding gateway helper exited: %v\n", err)
 		return
 	}
+}
+
+func readManagedGatewayBody(r io.Reader) ([]byte, error) {
+	read, err := cappedread.Read(r, 1<<20)
+	if err != nil {
+		return nil, err
+	}
+	if read.Truncated {
+		return nil, fmt.Errorf("response exceeded %d-byte cap after %d bytes", 1<<20, read.ObservedBytes)
+	}
+	return read.Bytes, nil
 }
 
 func gatewayForwardHelperCommand() string {

--- a/runner/result_state_test.go
+++ b/runner/result_state_test.go
@@ -208,6 +208,71 @@ func TestResultState_BrokenFixtureRouteRecordsErrorWithNoObservedVerdict(t *test
 	}
 }
 
+func TestResultState_TruncatedGatewayResponseRecordsAdapterError(t *testing.T) {
+	fm, err := fixture.StartAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fm.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if request.Method == "initialize" {
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"test-gateway","version":"1"}}}`, request.ID)
+			return
+		}
+		// BLOCK falls after the cap. Without truncation detection the runner
+		// would classify the incomplete success response rather than reject it.
+		_, _ = w.Write(append([]byte(`{"jsonrpc":"2.0","id":"`), append(bytes.Repeat([]byte("a"), 1<<20), []byte(`BLOCK"}`)...)...))
+	}))
+	defer server.Close()
+
+	adapt, err := adapter.NewMCPGatewayAdapter(adapter.GatewayPlugin{
+		Name:      "truncating gateway",
+		Transport: "streamable_http",
+		Client:    adapter.GatewayClient{Endpoint: server.URL},
+	}, fm)
+	if err != nil {
+		t.Fatalf("NewMCPGatewayAdapter: %v", err)
+	}
+	c := Case{
+		ID:              "result-state-truncated-response-001",
+		Transport:       "mcp_http",
+		InputType:       "mcp_tool_call",
+		ExpectedVerdict: "block",
+		Payload: map[string]interface{}{
+			"jsonrpc_messages": []interface{}{map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      "case-call",
+				"method":  "tools/call",
+				"params":  map[string]interface{}{"name": "example", "arguments": map[string]interface{}{}},
+			}},
+		},
+	}
+	var output bytes.Buffer
+	results, _, unreachable, _, err := runCases([]Case{c}, stateTestProfile(), adapt, time.Second, false, &output)
+	if err != nil {
+		t.Fatalf("runCases: %v", err)
+	}
+	if len(unreachable) != 0 || len(results) != 1 {
+		t.Fatalf("results=%d unreachable=%d, want one non-measurement error row", len(results), len(unreachable))
+	}
+	got := results[0]
+	if got.ActualVerdict != "error" || got.Score != "error" || got.Evidence["result_state"] != string(ResultStateAdapterError) {
+		t.Fatalf("result = %+v, want truncated adapter response to be non-measurement error", got)
+	}
+	if got.Evidence["response_truncated"] != true || got.Evidence["response_cap_bytes"] != int64(1<<20) || got.Evidence["response_bytes_observed"] != int64(1<<20+1) {
+		t.Fatalf("truncation evidence = %#v, want cap and observed byte count", got.Evidence)
+	}
+}
+
 func TestResultState_ObservedAllowForMaliciousCaseFails(t *testing.T) {
 	c := stateTestCase()
 	adapt := &stateTestAdapter{


### PR DESCRIPTION
## What changed

Capped response reads now detect truncation instead of mistaking a prefix for a complete body, and truncation is fatal only on the paths where the body actually decides the verdict.

Every capped read used `io.ReadAll(io.LimitReader(body, N))`. That returns no error when the limit is reached, and nothing compared the returned length against the cap, so the runner could classify a verdict from a silent prefix and report it as a measurement. Seven sites capped at 4096 bytes and discarded the read error entirely. A shared helper now reads one byte past the cap, so a body exactly at the cap reads as complete and a body that supplies the sentinel byte reads as truncated, and read errors propagate instead of being dropped.

Making every truncated read fatal would have traded one failure direction for another. `classifyHTTPResponse` consults the body only for 400, 403, and 502, where a deny marker decides between block and skip; on 2xx through 3xx it returns allow from the status alone without reading the body. So truncation is fatal for those three statuses and for the decision-bearing fetch, MCP, and scan API reads, and is recorded in evidence but tolerated elsewhere. The former 4096-byte bounds were set to limit memory rather than to bound a decision, and are raised to a shared 1 MiB decision cap.

Both failure directions matter here and the tests cover both. Disabling the sentinel check makes the fetch adapter return a scored `allow` for a response whose block field sits past the cap. Forcing every status to be treated as body-deciding makes a large successful proxy response fail the case instead of scoring it, which is what would refuse legitimate traffic: the example target config permits fetch responses three orders of magnitude above the old bound, so one large response would have made an otherwise complete corpus run unpublishable.

Reviewers should distrust the status list in `bodyDecidesVerdict` most. It is derived from the branches in `classifyHTTPResponse` that reach `hasDenyMarker`, and if that function grows a fourth body-consulting status without this list following, a deny marker past the cap becomes silently invisible again.

No result state, `actual_verdict` value, schema, or contract changed. Scoring logic and score denominators are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized or incomplete HTTP responses across gateway, proxy, WebSocket, and MCP operations.
  * Responses needed to determine a verdict now fail safely when truncated or unreadable.
  * Non-verdict observations continue processing while recording truncation details.
  * Improved error reporting for failed request and response body reads.
  * Oversized incoming request bodies are rejected with clear HTTP errors.

* **Tests**
  * Added coverage for truncation, response-size limits, partial reads, and error evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->