### PR TITLE
Reject undeclared case fields in the runner as the validator does

### DIFF
--- a/runner/case.go
+++ b/runner/case.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -63,6 +62,10 @@ type Case struct {
 	SafeExample     *bool                  `json:"safe_example,omitempty"`
 	Notes           string                 `json:"notes"`
 	Source          string                 `json:"source"`
+	// Supersedes is not read by the scorer. It is declared so the runner and
+	// the validator accept exactly the same field set: without it, strict
+	// decoding here would reject a case the validator considers valid.
+	Supersedes string `json:"supersedes,omitempty"`
 }
 
 // Profile contains tool identity, reporting claims, and the exact immutable
@@ -123,7 +126,11 @@ func loadCases(dir string) ([]Case, error) {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 		var c Case
-		if err := json.Unmarshal(data, &c); err != nil {
+		// Strict, matching the validator. A permissive decode here would let a
+		// case with an undeclared field execute with that field silently
+		// dropped, so the same file would behave differently depending on
+		// whether the validator gate ran first.
+		if err := decodeStrictJSON(data, &c); err != nil {
 			return fmt.Errorf("parsing %s: %w", path, err)
 		}
 		if c.SchemaVersion != activeCaseSchemaVersion {
@@ -153,7 +160,7 @@ func readHistoricalCase(path string) (Case, error) {
 		return Case{}, fmt.Errorf("reading historical case: %w", err)
 	}
 	var c Case
-	if err := json.Unmarshal(data, &c); err != nil {
+	if err := decodeStrictJSON(data, &c); err != nil {
 		return Case{}, fmt.Errorf("parsing historical case: %w", err)
 	}
 	if c.SchemaVersion != 2 {

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -306,3 +306,42 @@ func containsString(values []string, wanted string) bool {
 	}
 	return false
 }
+
+// The runner and the validator must accept exactly the same field set. A
+// permissive runner would execute a case with an undeclared field silently
+// dropped, so the same file would behave differently depending on whether the
+// validator gate ran first.
+func TestLoadCasesRejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	caseJSON := `{"schema_version":4,"id":"unknown-field-case","expected_verdict":"block","expected_verdet":"allow"}`
+	if err := os.WriteFile(filepath.Join(dir, "unknown-field-case.json"), []byte(caseJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadCases(dir)
+	if err == nil {
+		t.Fatal("loadCases accepted an undeclared field; the validator rejects it")
+	}
+	if !strings.Contains(err.Error(), "expected_verdet") {
+		t.Errorf("error should name the undeclared field, got %v", err)
+	}
+}
+
+// supersedes is declared by the validator and carries no scoring meaning, so
+// strict decoding must still accept it. Without the matching runner field a
+// case the validator calls valid would fail to execute.
+func TestLoadCasesAcceptsSupersedes(t *testing.T) {
+	dir := t.TempDir()
+	caseJSON := `{"schema_version":4,"id":"superseding-case","expected_verdict":"block","supersedes":"old-case-001"}`
+	if err := os.WriteFile(filepath.Join(dir, "superseding-case.json"), []byte(caseJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases, err := loadCases(dir)
+	if err != nil {
+		t.Fatalf("loadCases rejected a validator-accepted field: %v", err)
+	}
+	if len(cases) != 1 || cases[0].Supersedes != "old-case-001" {
+		t.Fatalf("supersedes not parsed: %+v", cases)
+	}
+}

--- a/runner/case_test.go
+++ b/runner/case_test.go
@@ -313,7 +313,7 @@ func containsString(values []string, wanted string) bool {
 // validator gate ran first.
 func TestLoadCasesRejectsUnknownField(t *testing.T) {
 	dir := t.TempDir()
-	caseJSON := `{"schema_version":4,"id":"unknown-field-case","expected_verdict":"block","expected_verdet":"allow"}`
+	caseJSON := fmt.Sprintf(`{"schema_version":%d,"id":"unknown-field-case","expected_verdict":"block","expected_verdet":"allow"}`, activeCaseSchemaVersion)
 	if err := os.WriteFile(filepath.Join(dir, "unknown-field-case.json"), []byte(caseJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +332,7 @@ func TestLoadCasesRejectsUnknownField(t *testing.T) {
 // case the validator calls valid would fail to execute.
 func TestLoadCasesAcceptsSupersedes(t *testing.T) {
 	dir := t.TempDir()
-	caseJSON := `{"schema_version":4,"id":"superseding-case","expected_verdict":"block","supersedes":"old-case-001"}`
+	caseJSON := fmt.Sprintf(`{"schema_version":%d,"id":"superseding-case","expected_verdict":"block","supersedes":"old-case-001"}`, activeCaseSchemaVersion)
 	if err := os.WriteFile(filepath.Join(dir, "superseding-case.json"), []byte(caseJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What changed

The runner now rejects a case file carrying an undeclared field, matching what the validator has always done. Previously `validate/main.go:508` decoded strictly while `runner/case.go` decoded permissively, so a case with a misspelled or invented field was refused by the validation gate but silently executed by the runner with that field dropped. The same file could therefore measure different things depending on which entry point loaded it, and a typo in a security-relevant field such as `expected_verdict` would degrade into a silently wrong result rather than an error.

Making the runner strict on its own would have rejected valid cases: the runner's `Case` lacked the `supersedes` field the validator declares, so any case using it would have failed to execute. That field is now declared on the runner side as well, carrying no scoring meaning, so both loaders accept exactly the same field set.

The historical schema-v2 reader is tightened the same way for consistency of the class, though it has no non-test consumer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Case data now supports an optional “supersedes” value.

- **Bug Fixes**
  - Invalid or undeclared case fields are now rejected during loading instead of being silently ignored.
  - Supported “supersedes” information is preserved when cases are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->