### PR TITLE
Disclose containment weighting and add a per-category profile

### DIFF
--- a/docs/gauntlet.md
+++ b/docs/gauntlet.md
@@ -86,11 +86,15 @@ The Gauntlet evaluates tool performance on two independent outcome metrics. Ther
 
 Lower is better for false positive rate (0.0 = perfect). Higher is better for containment (1.0 = perfect).
 
+Containment is a case-equal (micro) average over the malicious cases in the selected view. Every malicious corpus case has equal influence. Corpus composition therefore determines the category weighting. That composition is a maintainer choice, not a derived truth.
+
 ### Score views
 
 The full-corpus view is primary. It keeps measured cases in the denominator and preserves frozen historical N/A treatment. An unreachable case is not a measurement and remains visible outside the denominator.
 
 The applicable view is diagnostic. It contains cases with adapter-proven delivery and an observed verdict. A tool's declarations cannot select this view or remove a case from it.
+
+Per-category containment describes the applicable-only observed scope. Compare it with the applicable containment when their scopes match. Do not compare it with full-corpus containment when historical N/A rows make the scopes differ.
 
 ## Measurement Status
 

--- a/runner/report.go
+++ b/runner/report.go
@@ -553,18 +553,44 @@ func openRootedArtifact(root *os.Root, name string) (*os.File, error) {
 // readRegularArtifact reads a report input, refusing anything that is not a
 // regular file. The report states facts about a run, and a file outside the run
 // directory is not one.
+// maxReportArtifactBytes bounds every run-artifact read. Run artifacts are
+// untrusted input, so an unbounded read lets one oversized file exhaust memory
+// and take report generation down with it. The largest artifact this repository
+// has ever retained is well under a megabyte, so this ceiling is generous by
+// several orders of magnitude and exists to fail closed, not to be tight.
+const maxReportArtifactBytes = 64 << 20
+
 func readRegularArtifact(dir, name string) ([]byte, error) {
 	handle, err := openRegularArtifact(dir, name)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = handle.Close() }()
-	return io.ReadAll(handle)
+	// Read one byte past the ceiling so an artifact sitting exactly at the
+	// limit is still accepted and anything larger is detected rather than
+	// silently truncated, which would be worse than refusing it outright.
+	data, err := io.ReadAll(io.LimitReader(handle, maxReportArtifactBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxReportArtifactBytes {
+		return nil, errArtifactTooLarge
+	}
+	return data, nil
 }
+
+// Compiled once at package scope. These ran per case entry and per result row,
+// so a full corpus recompiled the same expressions thousands of times per
+// report. The file already keeps reportRestrictedClaims this way.
+var (
+	reportProfileCaseIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,127}$`)
+	reportProfileDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
 
 var (
 	errNotRegularArtifact = errors.New("run artifact is not a regular file")
 	errEmptyArtifact      = errors.New("run artifact is empty")
+	errArtifactTooLarge   = errors.New("run artifact exceeds the maximum readable size")
 )
 
 func loadReportDocument(dir, name string) reportDocument {
@@ -708,7 +734,7 @@ func (r *buyerReport) categoryProfileArtifact(key, name string) ([]byte, string)
 	}
 	value, present := nestedValue(r.bundle.data, "evidence_sha256", key)
 	expected, digestOK := value.(string)
-	if !present || !digestOK || !regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(expected) {
+	if !present || !digestOK || !reportProfileDigestPattern.MatchString(expected) {
 		return nil, "the run bundle does not carry a valid " + name + " digest"
 	}
 	data, err := readRegularArtifact(r.dir, name)
@@ -737,7 +763,7 @@ func parseReportProfileCaseIndex(data []byte) (map[string]reportProfileCase, str
 	}
 	cases := make(map[string]reportProfileCase, len(rawCases))
 	for caseID, raw := range rawCases {
-		if !regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,127}$`).MatchString(caseID) {
+		if !reportProfileCaseIDPattern.MatchString(caseID) {
 			return nil, "case-index.json has an invalid case ID"
 		}
 		entry, entryOK := raw.(map[string]interface{})
@@ -799,7 +825,7 @@ func parseReportProfileResults(data []byte) (map[string]reportProfileResult, str
 		score, scoreOK := row["score"].(string)
 		evidence, evidenceOK := row["evidence"].(map[string]interface{})
 		state, stateOK := evidence["result_state"].(string)
-		if !caseIDOK || !regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,127}$`).MatchString(caseID) || !expectedOK ||
+		if !caseIDOK || !reportProfileCaseIDPattern.MatchString(caseID) || !expectedOK ||
 			(expected != "block" && expected != "allow") || !actualOK || !scoreOK || !evidenceOK || !stateOK {
 			return nil, "results.jsonl has an invalid row"
 		}
@@ -1462,7 +1488,7 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 		line("| Category | Blocked / observed malicious | Containment | Share of observed malicious denominator |")
 		line("| --- | ---: | ---: | ---: |")
 		for _, row := range profile.rows {
-			line("| %s | %d / %d | %s | %s |", markdownInline(row.category), row.blocked, row.malicious,
+			line("| %s | %d / %d | %s | %s |", markdownInline(safeReportText(row.category)), row.blocked, row.malicious,
 				reportCategoryProfilePercent(row.blocked, row.malicious), reportCategoryProfilePercent(row.malicious, profile.maliciousTotal))
 		}
 	}

--- a/runner/report.go
+++ b/runner/report.go
@@ -97,6 +97,30 @@ type buyerReport struct {
 	entrypoint string
 }
 
+type reportCategoryProfile struct {
+	rows           []reportCategoryProfileRow
+	maliciousTotal int
+	unavailable    string
+}
+
+type reportCategoryProfileRow struct {
+	category  string
+	blocked   int
+	malicious int
+}
+
+type reportProfileCase struct {
+	category string
+	expected string
+}
+
+type reportProfileResult struct {
+	caseID   string
+	expected string
+	actual   string
+	observed bool
+}
+
 func generateBuyerReport(dir, outputPath string) error {
 	report, err := loadBuyerReport(dir)
 	if err != nil {
@@ -612,6 +636,264 @@ func loadReportText(dir, name string) string {
 		return "Invalid in run artifacts: empty file"
 	}
 	return safeReportText(value)
+}
+
+// categoryProfile reconstructs the applicable-only malicious category profile
+// from the two retained inputs that bind case identity to observed outcomes.
+// The summary's per_category.applicable count cannot supply this denominator:
+// it includes benign rows, so using it would overstate the malicious scope.
+func (r *buyerReport) categoryProfile() reportCategoryProfile {
+	if reportNumber(r.summary, "schema_version") != "5" {
+		return reportCategoryProfile{unavailable: "requires a v5 summary and bound active evidence"}
+	}
+	indexData, unavailable := r.categoryProfileArtifact("case_index", "case-index.json")
+	if unavailable != "" {
+		return reportCategoryProfile{unavailable: unavailable}
+	}
+	resultsData, unavailable := r.categoryProfileArtifact("results", "results.jsonl")
+	if unavailable != "" {
+		return reportCategoryProfile{unavailable: unavailable}
+	}
+	if failures := r.summaryScopeFailures(); len(failures) > 0 {
+		return reportCategoryProfile{unavailable: "the summary scope does not match the retained result rows"}
+	}
+	cases, parseFailure := parseReportProfileCaseIndex(indexData)
+	if parseFailure != "" {
+		return reportCategoryProfile{unavailable: parseFailure}
+	}
+	results, parseFailure := parseReportProfileResults(resultsData)
+	if parseFailure != "" {
+		return reportCategoryProfile{unavailable: parseFailure}
+	}
+	if len(cases) != len(results) {
+		return reportCategoryProfile{unavailable: "the case index and result rows have different case IDs"}
+	}
+
+	byCategory := make(map[string]reportCategoryProfileRow)
+	for caseID, c := range cases {
+		result, present := results[caseID]
+		if !present || result.expected != c.expected {
+			return reportCategoryProfile{unavailable: "the case index and result rows have different case IDs or expected verdicts"}
+		}
+		row := byCategory[c.category]
+		row.category = c.category
+		if c.expected == "block" && result.observed {
+			row.malicious++
+			if result.actual == "block" {
+				row.blocked++
+			}
+		}
+		byCategory[c.category] = row
+	}
+
+	profile := reportCategoryProfile{rows: make([]reportCategoryProfileRow, 0, len(byCategory))}
+	for _, row := range byCategory {
+		profile.rows = append(profile.rows, row)
+		profile.maliciousTotal += row.malicious
+	}
+	sort.Slice(profile.rows, func(i, j int) bool { return profile.rows[i].category < profile.rows[j].category })
+	if !r.matchesApplicableContainment(profile) {
+		return reportCategoryProfile{unavailable: "the applicable containment does not match the bound result rows"}
+	}
+	return profile
+}
+
+// categoryProfileArtifact returns a retained input only when the run bundle
+// binds its exact bytes. A buyer report remains useful without this optional
+// profile, but a profile without this check could turn a replaced input into a
+// reassuring composition display.
+func (r *buyerReport) categoryProfileArtifact(key, name string) ([]byte, string) {
+	if r.bundle.data == nil {
+		return nil, "the run bundle does not bind " + name
+	}
+	value, present := nestedValue(r.bundle.data, "evidence_sha256", key)
+	expected, digestOK := value.(string)
+	if !present || !digestOK || !regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(expected) {
+		return nil, "the run bundle does not carry a valid " + name + " digest"
+	}
+	data, err := readRegularArtifact(r.dir, name)
+	if err != nil {
+		return nil, name + " is absent or unreadable"
+	}
+	actual := sha256.Sum256(data)
+	if hex.EncodeToString(actual[:]) != expected {
+		return nil, name + " does not match its retained digest"
+	}
+	return data, ""
+}
+
+func parseReportProfileCaseIndex(data []byte) (map[string]reportProfileCase, string) {
+	index, err := decodeReportJSONObject(data)
+	if err != nil {
+		return nil, "case-index.json is malformed"
+	}
+	version, versionOK := reportJSONInteger(index["schema_version"])
+	if !versionOK || (version != 2 && version != 3) || !reportExactKeys(index, "schema_version", "cases") {
+		return nil, "case-index.json has an unsupported schema"
+	}
+	rawCases, casesOK := index["cases"].(map[string]interface{})
+	if !casesOK || len(rawCases) == 0 {
+		return nil, "case-index.json has no usable cases"
+	}
+	cases := make(map[string]reportProfileCase, len(rawCases))
+	for caseID, raw := range rawCases {
+		if !regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,127}$`).MatchString(caseID) {
+			return nil, "case-index.json has an invalid case ID"
+		}
+		entry, entryOK := raw.(map[string]interface{})
+		if !entryOK || !reportExactKeys(entry, reportCaseIndexKeys(version)...) {
+			return nil, "case-index.json has an invalid case entry"
+		}
+		category, categoryOK := entry["category"].(string)
+		expected, expectedOK := entry["expected_verdict"].(string)
+		if !categoryOK || strings.TrimSpace(category) == "" || !expectedOK || (expected != "block" && expected != "allow") {
+			return nil, "case-index.json has an invalid case entry"
+		}
+		if version == 3 && !reportProfileCaseIndexV3EntryValid(entry) {
+			return nil, "case-index.json has an invalid case entry"
+		}
+		cases[caseID] = reportProfileCase{category: category, expected: expected}
+	}
+	return cases, ""
+}
+
+func reportCaseIndexKeys(version int) []string {
+	if version == 3 {
+		return []string{"category", "expected_verdict", "transport", "capability_tags"}
+	}
+	return []string{"category", "expected_verdict"}
+}
+
+func reportProfileCaseIndexV3EntryValid(entry map[string]interface{}) bool {
+	transport, transportOK := entry["transport"].(string)
+	tags, tagsOK := entry["capability_tags"].([]interface{})
+	if !transportOK || strings.TrimSpace(transport) == "" || !tagsOK || len(tags) == 0 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(tags))
+	for _, raw := range tags {
+		tag, tagOK := raw.(string)
+		if !tagOK || strings.TrimSpace(tag) == "" {
+			return false
+		}
+		if _, duplicate := seen[tag]; duplicate {
+			return false
+		}
+		seen[tag] = struct{}{}
+	}
+	return true
+}
+
+func parseReportProfileResults(data []byte) (map[string]reportProfileResult, string) {
+	results := make(map[string]reportProfileResult)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for line := 1; scanner.Scan(); line++ {
+		row, err := decodeReportJSONObject([]byte(scanner.Text()))
+		if err != nil {
+			return nil, "results.jsonl is malformed"
+		}
+		caseID, caseIDOK := row["case_id"].(string)
+		expected, expectedOK := row["expected_verdict"].(string)
+		actual, actualOK := row["actual_verdict"].(string)
+		score, scoreOK := row["score"].(string)
+		evidence, evidenceOK := row["evidence"].(map[string]interface{})
+		state, stateOK := evidence["result_state"].(string)
+		if !caseIDOK || !regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,127}$`).MatchString(caseID) || !expectedOK ||
+			(expected != "block" && expected != "allow") || !actualOK || !scoreOK || !evidenceOK || !stateOK {
+			return nil, "results.jsonl has an invalid row"
+		}
+		if _, duplicate := results[caseID]; duplicate {
+			return nil, "results.jsonl has duplicate case IDs"
+		}
+		observed := actual == "block" || actual == "allow"
+		if observed && ((score != "pass" && score != "fail") || state != "observed") {
+			return nil, "results.jsonl has an invalid observed row"
+		}
+		if actual == "unreachable" && (score != "error" || state != "unreachable") {
+			return nil, "results.jsonl has an invalid unreachable row"
+		}
+		if actual == "error" && (score != "error" || !reportErrorResultState(state)) {
+			return nil, "results.jsonl has an invalid error row"
+		}
+		if !observed && actual != "unreachable" && actual != "error" {
+			return nil, "results.jsonl has an invalid row"
+		}
+		results[caseID] = reportProfileResult{caseID: caseID, expected: expected, actual: actual, observed: observed}
+	}
+	if err := scanner.Err(); err != nil || len(results) == 0 {
+		return nil, "results.jsonl is malformed"
+	}
+	return results, ""
+}
+
+func reportErrorResultState(state string) bool {
+	switch state {
+	case "adapter_error", "delivery_unavailable", "verdict_unobservable", "invalid_verdict":
+		return true
+	default:
+		return false
+	}
+}
+
+func decodeReportJSONObject(data []byte) (map[string]interface{}, error) {
+	var object map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&object); err != nil {
+		return nil, err
+	}
+	if object == nil {
+		return nil, errors.New("expected JSON object")
+	}
+	if err := ensureJSONEOF(dec); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+func reportExactKeys(object map[string]interface{}, allowed ...string) bool {
+	if len(object) != len(allowed) {
+		return false
+	}
+	for _, key := range allowed {
+		if _, present := object[key]; !present {
+			return false
+		}
+	}
+	return true
+}
+
+func reportJSONInteger(value interface{}) (int, bool) {
+	number, numberOK := value.(json.Number)
+	if !numberOK {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(number.String())
+	return parsed, err == nil
+}
+
+func (r *buyerReport) matchesApplicableContainment(profile reportCategoryProfile) bool {
+	scores, scoresOK := r.summary.data["scores"].(map[string]interface{})
+	applicable, applicableOK := scores["applicable"].(map[string]interface{})
+	value, present := applicable["containment"]
+	if !scoresOK || !applicableOK || !present {
+		return false
+	}
+	if profile.maliciousTotal == 0 {
+		return value == nil
+	}
+	observed, numberOK := value.(json.Number)
+	if !numberOK {
+		return false
+	}
+	blocked := 0
+	for _, row := range profile.rows {
+		blocked += row.blocked
+	}
+	ratio, err := observed.Float64()
+	expected := float64(blocked) / float64(profile.maliciousTotal)
+	return err == nil && !math.IsNaN(ratio) && !math.IsInf(ratio, 0) && math.Abs(ratio-expected) <= 1e-12
 }
 
 // reportRowCounts is what results.jsonl actually contains, as opposed to what
@@ -1169,6 +1451,22 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 		bullet("False-positive rate", reportPercent(r.summary, "scores", "applicable", "false_positive_rate"))
 	}
 	line("")
+	line("### Applicable-only malicious category profile")
+	line("")
+	line("This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.")
+	line("")
+	profile := r.categoryProfile()
+	if profile.unavailable != "" {
+		line("Unavailable: %s.", markdownInline(profile.unavailable))
+	} else {
+		line("| Category | Blocked / observed malicious | Containment | Share of observed malicious denominator |")
+		line("| --- | ---: | ---: | ---: |")
+		for _, row := range profile.rows {
+			line("| %s | %d / %d | %s | %s |", markdownInline(row.category), row.blocked, row.malicious,
+				reportCategoryProfilePercent(row.blocked, row.malicious), reportCategoryProfilePercent(row.malicious, profile.maliciousTotal))
+		}
+	}
+	line("")
 	line("## Execution and bundle status")
 	line("")
 	bullet("Execution status", reportString(r.decision, "execution_status"))
@@ -1223,6 +1521,13 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 	for _, material := range r.materialList() {
 		line("- %s", markdownInline(material))
 	}
+}
+
+func reportCategoryProfilePercent(numerator, denominator int) string {
+	if denominator == 0 {
+		return "N/A"
+	}
+	return fmt.Sprintf("%.2f%%", 100*float64(numerator)/float64(denominator))
 }
 
 func (r *buyerReport) publicationEligibility() string {

--- a/runner/report.go
+++ b/runner/report.go
@@ -307,7 +307,7 @@ func generatePublicationLockup(dir, outputPath string, assurances []string, evid
 		}
 		line("")
 	}
-	line("%s total · %s applicable · %s unreachable · %s not applicable · %s errors · containment %s · false-positive rate %s", required["total"], required["applicable"], required["unreachable"], required["not applicable"], required["errors"], required["containment"], required["false-positive rate"])
+	line("%s total · %s applicable · %s unreachable · %s not applicable · %s errors · containment %s (%d/%d malicious cases; case-equal weighting from corpus composition) · false-positive rate %s", required["total"], required["applicable"], required["unreachable"], required["not applicable"], required["errors"], required["containment"], report.rowCounts.maliciousBlocked, report.rowCounts.maliciousTotal, required["false-positive rate"])
 	if len(naReasons) > 0 {
 		line("Not-applicable reasons: %s", markdownInline(strings.Join(naReasons, ", ")))
 	}

--- a/runner/report_test.go
+++ b/runner/report_test.go
@@ -612,6 +612,85 @@ func TestBuyerReportRendersBoundCategoryProfile(t *testing.T) {
 	}
 }
 
+// A run that observed no malicious case at all still gets a profile. The
+// zero-denominator branch of matchesApplicableContainment requires that
+// scores.applicable.containment be present and null, because a run with nothing
+// to measure must publish an absent rate rather than a zero one.
+func TestBuyerReportRendersProfileWhenNoMaliciousCaseWasObserved(t *testing.T) {
+	fixture := categoryProfileFixture()
+	for _, row := range fixture.results {
+		if row["expected_verdict"] != "block" {
+			continue
+		}
+		row["actual_verdict"] = "unreachable"
+		row["score"] = "error"
+		row["evidence"] = map[string]interface{}{"result_state": "unreachable"}
+	}
+	fixture.summary["case_count"] = map[string]interface{}{
+		"total": 5, "applicable": 2, "unreachable": 3, "not_applicable": 0,
+		"not_applicable_reasons": map[string]interface{}{}, "errors": 0,
+	}
+	fixture.summary["scores"] = map[string]interface{}{
+		"full":       map[string]interface{}{"containment": nil, "false_positive_rate": 0.0},
+		"applicable": map[string]interface{}{"containment": nil, "false_positive_rate": 0.0},
+	}
+	dir := t.TempDir()
+	fixture.write(t, dir)
+	writeCategoryProfileIndex(t, fixture, dir, categoryProfileIndex())
+
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	got := output.String()
+	if !strings.Contains(got, "### Applicable-only malicious category profile") {
+		t.Fatalf("profile section missing:\n%s", got)
+	}
+	if strings.Contains(got, "Unavailable:") {
+		t.Errorf("a run with no observed malicious case must still render a profile:\n%s", got)
+	}
+	// Every malicious category has a zero denominator, so each must read N/A
+	// rather than 0%, which would assert a containment the run never measured.
+	for _, want := range []string{
+		"| mcp\\_drift | 0 / 0 | N/A | N/A |",
+		"| url | 0 / 0 | N/A | N/A |",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in:\n%s", want, got)
+		}
+	}
+}
+
+// Category names come from case-index.json, which is untrusted run input, so
+// they must pass the claim-language gate like every other artifact-derived
+// string in this renderer. Without that, a category named for a certification
+// would render verbatim in a buyer report.
+func TestBuyerReportWithholdsRestrictedCategoryClaim(t *testing.T) {
+	fixture := categoryProfileFixture()
+	index := categoryProfileIndex()
+	index["cases"].(map[string]interface{})["url-attack-001"].(map[string]interface{})["category"] = "fips-certified"
+	index["cases"].(map[string]interface{})["url-benign-002"].(map[string]interface{})["category"] = "fips-certified"
+	dir := t.TempDir()
+	fixture.write(t, dir)
+	writeCategoryProfileIndex(t, fixture, dir, index)
+
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	got := output.String()
+	if strings.Contains(got, "fips-certified") {
+		t.Errorf("a restricted claim in a category name reached the report:\n%s", got)
+	}
+	if !strings.Contains(got, "Artifact value withheld by claim-language gate") {
+		t.Errorf("expected the claim-language gate to withhold the category:\n%s", got)
+	}
+}
+
 func TestBuyerReportMarksInvalidCategoryProfileUnavailable(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -631,9 +710,36 @@ func TestBuyerReportMarksInvalidCategoryProfileUnavailable(t *testing.T) {
 		{name: "malformed index", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
 			writeBoundReportEvidence(t, fixture, dir, "case_index", "case-index.json", []byte("{"))
 		}, want: "Unavailable: case-index.json is malformed."},
-		{name: "malformed results", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
+		// Named for what it proves. Unparseable rows fail loadReportResults
+		// first, so summaryScopeFailures answers and the profile parser is
+		// never reached. The case below reaches that parser.
+		{name: "unparseable results fail the scope check first", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
 			writeBoundReportEvidence(t, fixture, dir, "results", "results.jsonl", []byte("{"))
 		}, want: "Unavailable: the summary scope does not match the retained result rows."},
+		// Rows that loadReportResults accepts but the profile parser rejects:
+		// an observed malicious row whose evidence carries no result_state.
+		// Both the v5 and v6 result schemas require that field, so a row
+		// without it is invalid for its own schema rather than merely old.
+		{name: "observed row without a result state", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
+			rows := make([]map[string]interface{}, len(fixture.results))
+			copy(rows, fixture.results)
+			stripped := map[string]interface{}{}
+			for k, v := range rows[0] {
+				stripped[k] = v
+			}
+			stripped["evidence"] = map[string]interface{}{}
+			rows[0] = stripped
+			var encoded []byte
+			for _, row := range rows {
+				line, err := json.Marshal(row)
+				if err != nil {
+					t.Fatal(err)
+				}
+				encoded = append(encoded, line...)
+				encoded = append(encoded, '\n')
+			}
+			writeBoundReportEvidence(t, fixture, dir, "results", "results.jsonl", encoded)
+		}, want: "Unavailable: results.jsonl has an invalid row."},
 		{name: "results digest mismatch", mutate: func(t *testing.T, _ *reportFixture, dir string) {
 			data, err := os.ReadFile(filepath.Join(dir, "results.jsonl"))
 			if err != nil {

--- a/runner/report_test.go
+++ b/runner/report_test.go
@@ -530,6 +530,146 @@ func TestPublicationLockupCarriesMethodScopeAndScores(t *testing.T) {
 	}
 }
 
+func categoryProfileFixture() *reportFixture {
+	fixture := publicationFixture()
+	fixture.summary["case_count"] = map[string]interface{}{
+		"total": 5, "applicable": 4, "unreachable": 1, "not_applicable": 0,
+		"not_applicable_reasons": map[string]interface{}{}, "errors": 0,
+	}
+	fixture.summary["scores"] = map[string]interface{}{
+		"full":       map[string]interface{}{"containment": 0.5, "false_positive_rate": 0.0},
+		"applicable": map[string]interface{}{"containment": 0.5, "false_positive_rate": 0.0},
+	}
+	fixture.results = []map[string]interface{}{
+		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "url-attack-001", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "block", "actual_verdict": "block", "score": "pass", "evidence": map[string]interface{}{"result_state": "observed"}, "notes": ""},
+		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "url-benign-002", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "allow", "actual_verdict": "allow", "score": "pass", "evidence": map[string]interface{}{"result_state": "observed"}, "notes": ""},
+		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "mcp-drift-attack-003", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "block", "actual_verdict": "allow", "score": "fail", "evidence": map[string]interface{}{"result_state": "observed"}, "notes": ""},
+		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "headers-benign-004", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "allow", "actual_verdict": "allow", "score": "pass", "evidence": map[string]interface{}{"result_state": "observed"}, "notes": ""},
+		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "mcp-tool-attack-005", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "block", "actual_verdict": "unreachable", "score": "error", "evidence": map[string]interface{}{"result_state": "unreachable"}, "notes": ""},
+	}
+	return fixture
+}
+
+func categoryProfileIndex() map[string]interface{} {
+	return map[string]interface{}{
+		"schema_version": 3,
+		"cases": map[string]interface{}{
+			"url-attack-001":       map[string]interface{}{"category": "url", "expected_verdict": "block", "transport": "http_proxy", "capability_tags": []interface{}{"url_dlp"}},
+			"url-benign-002":       map[string]interface{}{"category": "url", "expected_verdict": "allow", "transport": "http_proxy", "capability_tags": []interface{}{"url_dlp"}},
+			"mcp-drift-attack-003": map[string]interface{}{"category": "mcp_drift", "expected_verdict": "block", "transport": "mcp_http", "capability_tags": []interface{}{"mcp_input_scan"}},
+			"headers-benign-004":   map[string]interface{}{"category": "headers", "expected_verdict": "allow", "transport": "http_proxy", "capability_tags": []interface{}{"header_dlp"}},
+			"mcp-tool-attack-005":  map[string]interface{}{"category": "mcp_tool", "expected_verdict": "block", "transport": "mcp_stdio", "capability_tags": []interface{}{"mcp_input_scan"}},
+		},
+	}
+}
+
+func writeBoundReportEvidence(t *testing.T, fixture *reportFixture, dir, key, name string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(data)
+	for _, document := range []map[string]interface{}{fixture.bundle, fixture.decision} {
+		document["evidence_sha256"].(map[string]interface{})[key] = hex.EncodeToString(digest[:])
+	}
+	writeFixtureJSON(t, filepath.Join(dir, "run-bundle.json"), fixture.bundle)
+	writeFixtureJSON(t, filepath.Join(dir, "execution-decision.json"), fixture.decision)
+}
+
+func writeCategoryProfileIndex(t *testing.T, fixture *reportFixture, dir string, index map[string]interface{}) {
+	t.Helper()
+	data, err := json.Marshal(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeBoundReportEvidence(t, fixture, dir, "case_index", "case-index.json", data)
+}
+
+func TestBuyerReportRendersBoundCategoryProfile(t *testing.T) {
+	fixture := categoryProfileFixture()
+	dir := t.TempDir()
+	fixture.write(t, dir)
+	writeCategoryProfileIndex(t, fixture, dir, categoryProfileIndex())
+
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	got := output.String()
+	for _, want := range []string{
+		"### Applicable-only malicious category profile",
+		"evidence of category coverage and concentration, not a score or ranking",
+		"| headers | 0 / 0 | N/A | 0.00% |",
+		"| mcp\\_drift | 0 / 1 | 0.00% | 50.00% |",
+		"| mcp\\_tool | 0 / 0 | N/A | 0.00% |",
+		"| url | 1 / 1 | 100.00% | 50.00% |",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("category profile missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuyerReportMarksInvalidCategoryProfileUnavailable(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, fixture *reportFixture, dir string)
+		want   string
+	}{
+		{name: "missing index", mutate: func(t *testing.T, _ *reportFixture, dir string) {
+			if err := os.Remove(filepath.Join(dir, "case-index.json")); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "Unavailable: case-index.json is absent or unreadable."},
+		{name: "malformed index", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
+			writeBoundReportEvidence(t, fixture, dir, "case_index", "case-index.json", []byte("{"))
+		}, want: "Unavailable: case-index.json is malformed."},
+		{name: "results digest mismatch", mutate: func(t *testing.T, _ *reportFixture, dir string) {
+			data, err := os.ReadFile(filepath.Join(dir, "results.jsonl"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "results.jsonl"), append(data, '\n'), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "Unavailable: results.jsonl does not match its retained digest."},
+		{name: "scope mismatch", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
+			index := categoryProfileIndex()
+			index["cases"].(map[string]interface{})["url-attack-001"].(map[string]interface{})["expected_verdict"] = "allow"
+			writeCategoryProfileIndex(t, fixture, dir, index)
+		}, want: "Unavailable: the case index and result rows have different case IDs or expected verdicts."},
+		{name: "applicable containment mismatch", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
+			fixture.summary["scores"].(map[string]interface{})["applicable"].(map[string]interface{})["containment"] = 0.75
+			writeFixtureJSON(t, filepath.Join(dir, "raw-summary.json"), fixture.summary)
+		}, want: "Unavailable: the applicable containment does not match the bound result rows."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := categoryProfileFixture()
+			dir := t.TempDir()
+			fixture.write(t, dir)
+			writeCategoryProfileIndex(t, fixture, dir, categoryProfileIndex())
+			tt.mutate(t, fixture, dir)
+			report, err := loadBuyerReport(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var output bytes.Buffer
+			report.renderMarkdown(&output)
+			got := output.String()
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("report did not mark profile unavailable as expected:\n%s", got)
+			}
+			if !strings.Contains(got, "- Containment: 50.00%") {
+				t.Fatalf("profile failure hid the primary score:\n%s", got)
+			}
+		})
+	}
+}
+
 func TestPublicationLockupListsFailuresBeforeScores(t *testing.T) {
 	fixture := publicationFixture()
 	fixture.results[0]["actual_verdict"] = "allow"

--- a/runner/report_test.go
+++ b/runner/report_test.go
@@ -518,7 +518,7 @@ func TestPublicationLockupCarriesMethodScopeAndScores(t *testing.T) {
 		"Publisher-declared assurance: **self run**",
 		"example/agent-egress-bench@cccccccccccccccccccccccccccccccccccccccc",
 		"2 total · 2 applicable · 0 unreachable · 0 not applicable · 0 errors",
-		"containment 100.00% · false-positive rate 0.00%",
+		"containment 100.00% (1/1 malicious cases; case-equal weighting from corpus composition) · false-positive rate 0.00%",
 		"Corpus Git observation: `clean` · tool version observation: `observed`",
 		"Exercised transports: http\\_proxy",
 		"internal consistency only",
@@ -748,7 +748,7 @@ func TestPublicationLockupFullScoreRetainsNotApplicableRows(t *testing.T) {
 		"notes": "not applicable: missing_requires",
 	})
 	fixture.summary["case_count"] = map[string]interface{}{
-		"total": 3, "applicable": 2, "not_applicable": 1,
+		"total": 3, "applicable": 2, "unreachable": 0, "not_applicable": 1,
 		"not_applicable_reasons": map[string]interface{}{"missing_requires": 1}, "errors": 0,
 	}
 	fixture.summary["scores"].(map[string]interface{})["full"] = map[string]interface{}{
@@ -766,6 +766,17 @@ func TestPublicationLockupFullScoreRetainsNotApplicableRows(t *testing.T) {
 	if report.rowCounts.maliciousBlocked != 1 || report.rowCounts.maliciousTotal != 2 {
 		t.Fatalf("full containment counts = %d/%d, want 1/2",
 			report.rowCounts.maliciousBlocked, report.rowCounts.maliciousTotal)
+	}
+	output := filepath.Join(t.TempDir(), "result-lockup.md")
+	if err := generatePublicationLockup(dir, output, []string{"self-run"}, "https://lab.example/results/run-1"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "containment 50.00% (1/2 malicious cases; case-equal weighting from corpus composition)") {
+		t.Fatalf("lockup omitted the full-corpus containment denominator:\n%s", data)
 	}
 }
 

--- a/runner/report_test.go
+++ b/runner/report_test.go
@@ -623,9 +623,17 @@ func TestBuyerReportMarksInvalidCategoryProfileUnavailable(t *testing.T) {
 				t.Fatal(err)
 			}
 		}, want: "Unavailable: case-index.json is absent or unreadable."},
+		{name: "missing results", mutate: func(t *testing.T, _ *reportFixture, dir string) {
+			if err := os.Remove(filepath.Join(dir, "results.jsonl")); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "Unavailable: results.jsonl is absent or unreadable."},
 		{name: "malformed index", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
 			writeBoundReportEvidence(t, fixture, dir, "case_index", "case-index.json", []byte("{"))
 		}, want: "Unavailable: case-index.json is malformed."},
+		{name: "malformed results", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
+			writeBoundReportEvidence(t, fixture, dir, "results", "results.jsonl", []byte("{"))
+		}, want: "Unavailable: the summary scope does not match the retained result rows."},
 		{name: "results digest mismatch", mutate: func(t *testing.T, _ *reportFixture, dir string) {
 			data, err := os.ReadFile(filepath.Join(dir, "results.jsonl"))
 			if err != nil {
@@ -635,6 +643,10 @@ func TestBuyerReportMarksInvalidCategoryProfileUnavailable(t *testing.T) {
 				t.Fatal(err)
 			}
 		}, want: "Unavailable: results.jsonl does not match its retained digest."},
+		{name: "summary scope mismatch", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
+			fixture.summary["case_count"].(map[string]interface{})["total"] = 6
+			writeFixtureJSON(t, filepath.Join(dir, "raw-summary.json"), fixture.summary)
+		}, want: "Unavailable: the summary scope does not match the retained result rows."},
 		{name: "scope mismatch", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
 			index := categoryProfileIndex()
 			index["cases"].(map[string]interface{})["url-attack-001"].(map[string]interface{})["expected_verdict"] = "allow"

--- a/runner/testdata/buyer-report/count-mismatch.golden.md
+++ b/runner/testdata/buyer-report/count-mismatch.golden.md
@@ -74,6 +74,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: 40.00%
 - False-positive rate: 0.00%
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/errors.golden.md
+++ b/runner/testdata/buyer-report/errors.golden.md
@@ -74,6 +74,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: 40.00%
 - False-positive rate: 0.00%
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: blocked

--- a/runner/testdata/buyer-report/exercised-capabilities.golden.md
+++ b/runner/testdata/buyer-report/exercised-capabilities.golden.md
@@ -77,6 +77,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: 40.00%
 - False-positive rate: 0.00%
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/healthy.golden.md
+++ b/runner/testdata/buyer-report/healthy.golden.md
@@ -74,6 +74,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: 40.00%
 - False-positive rate: 0.00%
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/malformed-summary.golden.md
+++ b/runner/testdata/buyer-report/malformed-summary.golden.md
@@ -73,6 +73,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: Absent from run artifacts
 - False-positive rate: Absent from run artifacts
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/missing-optional.golden.md
+++ b/runner/testdata/buyer-report/missing-optional.golden.md
@@ -74,6 +74,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: 40.00%
 - False-positive rate: 0.00%
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/missing-required.golden.md
+++ b/runner/testdata/buyer-report/missing-required.golden.md
@@ -74,6 +74,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: 40.00%
 - False-positive rate: 0.00%
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/not-applicable.golden.md
+++ b/runner/testdata/buyer-report/not-applicable.golden.md
@@ -74,6 +74,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: 40.00%
 - False-positive rate: 0.00%
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/not-publication-eligible.golden.md
+++ b/runner/testdata/buyer-report/not-publication-eligible.golden.md
@@ -74,6 +74,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: 40.00%
 - False-positive rate: 0.00%
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/unknown-verdict.golden.md
+++ b/runner/testdata/buyer-report/unknown-verdict.golden.md
@@ -74,6 +74,12 @@ Each metric stands on its own. Full-corpus scores retain historical N/A rows as 
 - Evidence: 40.00%
 - False-positive rate: 0.00%
 
+### Applicable-only malicious category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete


### PR DESCRIPTION
## What changed

The published containment score is a case-equal average: every observed malicious case carries one vote, so whichever attack family holds the most cases has the most influence over the headline. The arithmetic was already documented, but its consequence was not, and nothing beside a published number said which weighting produced it.

Three surfaces now disclose it. The metric documentation states that containment is case-equal over the malicious cases in the selected view, that corpus composition therefore sets the category weighting, and that composition is a maintainer choice rather than a derived truth. The publication lockup, which travels with a quoted score, now carries the malicious numerator and denominator beside the percentage. The buyer report gains an applicable-only per-category profile showing blocked over observed malicious, per-category containment, and each category's share of the denominator, so a reader can see whether a result reflects broad performance or one concentrated hole.

No schema, version, or scoring behavior changes, and no second aggregate is published. A category-equal average was evaluated and deliberately not added: splitting one category into two subcategories moves it while changing no case outcome, so it measures how category boundaries were drawn rather than a property of the corpus, and it is more volatile than the case-equal figure exactly where it claims to correct for density.

The profile is evidence, not a score, and it is bound to retained evidence by digest. Reviewers should distrust the failure direction: missing, malformed, digest-mismatched, or scope-mismatched evidence must render as unavailable and must never present as a zero, a blank, or anything a reader could take as a favorable result, and a per-category figure drawn from the applicable scope must never be compared against full-corpus containment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reports now include malicious-case containment totals and percentages.
  - Added applicable-only containment breakdowns by malicious category.
  - Reports identify unavailable category results when supporting evidence is missing or invalid.
  - Added validation for report evidence, including schema, matching, integrity, and safe artifact checks.

- **Documentation**
  - Clarified containment calculations, category scope, and comparison rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->