### PR TITLE
List scoreboard results neutrally and stop coercing absent scores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,7 @@ check-gauntlet-site:
 	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/validate_pipelock_result_inventory.py
 	@node gauntlet-site/scope-render_test.js
 	@node gauntlet-site/latest-result_test.js
+	@node gauntlet-site/index_test.js
 	@# An artifact and the manifest it was measured against are one pair, so both are
 	@# overridden together or neither is. Overriding one side validates an artifact
 	@# against a manifest it was never measured against, and the resulting digest or

--- a/gauntlet-site/index.html
+++ b/gauntlet-site/index.html
@@ -32,6 +32,7 @@ a:hover { text-decoration: underline; }
 .tool-meta { display: flex; gap: 0.25rem; align-items: center; flex-wrap: wrap; }
 .tool-version { font-family: var(--mono); font-size: 0.85rem; color: var(--muted); margin-right: 0.5rem; }
 .denominator { font-size: 0.8rem; color: var(--muted); margin-bottom: 1rem; }
+.ordering-disclosure { font-size: 0.8rem; color: var(--muted); margin: 0 0 1rem; }
 .scores-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 1rem; }
 .score-box { background: var(--bg); border: 1px solid var(--border); border-radius: 0.375rem; padding: 1rem; text-align: center; }
 .score-label { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.25rem; }
@@ -71,6 +72,7 @@ pre { background: var(--bg); border: 1px solid var(--border); border-radius: 0.3
 
 <h1>Pipelock Gauntlet</h1>
 <p class="subtitle">Agent egress security benchmark. Tests the security tool, not the agent.</p>
+<p class="ordering-disclosure">Results are listed alphabetically by tool name; entries without a usable name are listed as unknown. This order is not a ranking.</p>
 <div id="results"></div>
 
 <h2>How to Run</h2>
@@ -107,13 +109,17 @@ go build -o aeb-gauntlet .
     return e;
   }
 
+  function isScoreNumber(v) {
+    return typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= 1;
+  }
+
   function pctCls(v) {
-    if (v === null || v === undefined) return 'score-na';
+    if (!isScoreNumber(v)) return 'score-na';
     return '';
   }
 
   function fmtPct(v) {
-    if (v === null || v === undefined) return 'N/A';
+    if (!isScoreNumber(v)) return 'N/A';
     return (v * 100).toFixed(1) + '%';
   }
 
@@ -197,7 +203,7 @@ go build -o aeb-gauntlet .
   function renderTool(r, verified) {
     var card = el('div', 'tool-card');
     var hdr = el('div', 'tool-header');
-    hdr.appendChild(txt('span', r.tool || 'Unknown', 'tool-name'));
+    hdr.appendChild(txt('span', toolName(r), 'tool-name'));
 
     var meta = el('div', 'tool-meta');
     meta.appendChild(txt('span', r.tool_version || '', 'tool-version'));
@@ -273,21 +279,45 @@ go build -o aeb-gauntlet .
     return card;
   }
 
+  function toolName(result) {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return 'Unknown result';
+    if (typeof result.tool !== 'string' || !result.tool.trim()) return 'Unknown tool';
+    return result.tool.trim();
+  }
+
+  function malformedResultCard(result) {
+    var card = el('div', 'tool-card');
+    var hdr = el('div', 'tool-header');
+    var isObject = result && typeof result === 'object' && !Array.isArray(result);
+    var name = isObject ? toolName(result) : '';
+    hdr.appendChild(txt('span', name && name !== 'Unknown tool' ? 'Malformed result record: ' + name : 'Malformed result record', 'tool-name'));
+    card.appendChild(hdr);
+    var message = isObject ? 'This result object has malformed fields. Its measurements are unavailable.' :
+      'This entry is ' + (result === null ? 'null' : Array.isArray(result) ? 'array' : typeof result) + ', not a result object. Its measurements are unavailable.';
+    card.appendChild(txt('div', message, 'denominator'));
+    return card;
+  }
+
+  function renderResult(result, verified) {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return malformedResultCard(result);
+    try {
+      return renderTool(result, verified);
+    } catch (err) {
+      return malformedResultCard(result);
+    }
+  }
+
   function render(results, verified) {
     while (container.firstChild) container.removeChild(container.firstChild);
-    if (!results || results.length === 0) {
+    var entries = Array.isArray(results) ? results.slice() : results ? [results] : [];
+    if (entries.length === 0) {
       container.appendChild(txt('div', 'No results yet. Be the first to run the Gauntlet.', 'empty-state'));
       return;
     }
-    results.sort(function(a, b) {
-      var s = function(r) {
-        var sc = r.scores || {};
-        var f = sc.full || sc;
-        return (f && f.containment) || 0;
-      };
-      return s(b) - s(a);
+    entries.sort(function(a, b) {
+      return toolName(a).localeCompare(toolName(b));
     });
-    results.forEach(function(r) { container.appendChild(renderTool(r, verified)); });
+    entries.forEach(function(r) { container.appendChild(renderResult(r, verified)); });
   }
 
   function loadLegacyResult() {

--- a/gauntlet-site/index.html
+++ b/gauntlet-site/index.html
@@ -113,6 +113,13 @@ go build -o aeb-gauntlet .
     return typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= 1;
   }
 
+  // Absent counts must read as absent. Coercing a missing count to 0 publishes
+  // a number the artifact never carried, which is the same defect as scoring a
+  // null containment as zero.
+  function fmtCount(v) {
+    return (typeof v === 'number' && Number.isFinite(v) && v >= 0) ? String(v) : 'unknown';
+  }
+
   function pctCls(v) {
     if (!isScoreNumber(v)) return 'score-na';
     return '';
@@ -224,8 +231,8 @@ go build -o aeb-gauntlet .
       card.appendChild(window.renderGauntletScope(r));
       card.appendChild(window.renderGauntletControlCoverage(r));
     } else {
-      var unreachable = Object.prototype.hasOwnProperty.call(cc, 'unreachable') ? (cc.unreachable || 0) + ' unreachable, ' : '';
-      card.appendChild(txt('div', 'Routed ' + (cc.applicable || 0) + ' / ' + (cc.total || 0) + ' cases (' + unreachable + (cc.not_applicable || 0) + ' N/A, ' + (cc.errors || 0) + ' errors)', 'denominator'));
+      var unreachable = Object.prototype.hasOwnProperty.call(cc, 'unreachable') ? fmtCount(cc.unreachable) + ' unreachable, ' : '';
+      card.appendChild(txt('div', 'Routed ' + fmtCount(cc.applicable) + ' / ' + fmtCount(cc.total) + ' cases (' + unreachable + fmtCount(cc.not_applicable) + ' N/A, ' + fmtCount(cc.errors) + ' errors)', 'denominator'));
     }
 
     var scores = r.scores || {};
@@ -239,7 +246,7 @@ go build -o aeb-gauntlet .
       // Full corpus is the primary view. Applicable-only is a diagnostic of the
       // cases this adapter routed, rather than the whole corpus. Routed is not
       // the same as observed: the count includes rows that ended in error.
-      card.appendChild(txt('div', 'Full Corpus Scores (' + (cc.total || 0) + ' cases)', 'section-label'));
+      card.appendChild(txt('div', 'Full Corpus Scores (' + fmtCount(cc.total) + ' cases)', 'section-label'));
       card.appendChild(makeScoresGrid(full, fullDiagnostics, r.schema_version));
 
       // A real button, not a click-handled div: the control is keyboard
@@ -249,7 +256,7 @@ go build -o aeb-gauntlet .
       aToggle.type = 'button';
       var aWrap = el('div', 'hidden');
       aToggle.setAttribute('aria-expanded', 'false');
-      aWrap.appendChild(txt('div', 'Diagnostic only. Covers the ' + (cc.applicable || 0) + ' cases this adapter routed, which includes any that ended in error, not the complete corpus.', 'denominator'));
+      aWrap.appendChild(txt('div', 'Diagnostic only. Covers the ' + fmtCount(cc.applicable) + ' cases this adapter routed, which includes any that ended in error, not the complete corpus.', 'denominator'));
       aWrap.appendChild(makeScoresGrid(applicable, applicableDiagnostics, r.schema_version));
       aToggle.addEventListener('click', function() {
         aWrap.classList.toggle('hidden');
@@ -285,25 +292,37 @@ go build -o aeb-gauntlet .
     return result.tool.trim();
   }
 
-  function malformedResultCard(result) {
+  // Two distinct cards, because the page must not assert more than it knows.
+  // notAResultCard states a determination we actually made: the entry is not a
+  // result object. undisplayableResultCard covers a render that threw, where
+  // the cause is unknown: bad data and a bug in this page produce the identical
+  // exception, so naming a tool's record malformed would publish a claim about
+  // that vendor which we cannot support.
+  function notAResultCard(result) {
     var card = el('div', 'tool-card');
     var hdr = el('div', 'tool-header');
-    var isObject = result && typeof result === 'object' && !Array.isArray(result);
-    var name = isObject ? toolName(result) : '';
-    hdr.appendChild(txt('span', name && name !== 'Unknown tool' ? 'Malformed result record: ' + name : 'Malformed result record', 'tool-name'));
+    hdr.appendChild(txt('span', 'Not a result record', 'tool-name'));
     card.appendChild(hdr);
-    var message = isObject ? 'This result object has malformed fields. Its measurements are unavailable.' :
-      'This entry is ' + (result === null ? 'null' : Array.isArray(result) ? 'array' : typeof result) + ', not a result object. Its measurements are unavailable.';
-    card.appendChild(txt('div', message, 'denominator'));
+    card.appendChild(txt('div', 'This entry is ' + (result === null ? 'null' : Array.isArray(result) ? 'array' : typeof result) + ', not a result object. Its measurements are unavailable.', 'denominator'));
+    return card;
+  }
+
+  function undisplayableResultCard(result) {
+    var card = el('div', 'tool-card');
+    var hdr = el('div', 'tool-header');
+    var name = toolName(result);
+    hdr.appendChild(txt('span', name && name !== 'Unknown tool' ? 'Result unavailable: ' + name : 'Result unavailable', 'tool-name'));
+    card.appendChild(hdr);
+    card.appendChild(txt('div', 'This result could not be displayed. The cause is not established here, so no claim is made about the record itself. Its measurements are unavailable.', 'denominator'));
     return card;
   }
 
   function renderResult(result, verified) {
-    if (!result || typeof result !== 'object' || Array.isArray(result)) return malformedResultCard(result);
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return notAResultCard(result);
     try {
       return renderTool(result, verified);
     } catch (err) {
-      return malformedResultCard(result);
+      return undisplayableResultCard(result);
     }
   }
 

--- a/gauntlet-site/index.html
+++ b/gauntlet-site/index.html
@@ -117,7 +117,10 @@ go build -o aeb-gauntlet .
   // a number the artifact never carried, which is the same defect as scoring a
   // null containment as zero.
   function fmtCount(v) {
-    return (typeof v === 'number' && Number.isFinite(v) && v >= 0) ? String(v) : 'unknown';
+    // Integer, because a case count is a count of cases. A fractional value is
+    // not a smaller count, it is evidence the artifact is wrong, and printing
+    // it would present that as a real total.
+    return (typeof v === 'number' && Number.isInteger(v) && v >= 0) ? String(v) : 'unknown';
   }
 
   function pctCls(v) {
@@ -328,14 +331,27 @@ go build -o aeb-gauntlet .
 
   function render(results, verified) {
     while (container.firstChild) container.removeChild(container.firstChild);
-    var entries = Array.isArray(results) ? results.slice() : results ? [results] : [];
+    // Only null and undefined mean "nothing was published". A payload of
+    // false, 0, or "" is a value that is not a result object, and rendering it
+    // as an empty page would report absence when the truth is malformed input.
+    var entries = Array.isArray(results) ? results.slice() : results == null ? [] : [results];
     if (entries.length === 0) {
       container.appendChild(txt('div', 'No results yet. Be the first to run the Gauntlet.', 'empty-state'));
       return;
     }
+    // Code-point order, not localeCompare, which varies by browser locale and
+    // would make the order this page discloses non-reproducible for a reader
+    // checking it. The original index breaks ties so equal names keep their
+    // source order rather than being reordered by the sort.
+    entries = entries.map(function(entry, index) { return {entry: entry, index: index}; });
     entries.sort(function(a, b) {
-      return toolName(a).localeCompare(toolName(b));
+      var an = toolName(a.entry);
+      var bn = toolName(b.entry);
+      if (an < bn) return -1;
+      if (an > bn) return 1;
+      return a.index - b.index;
     });
+    entries = entries.map(function(item) { return item.entry; });
     entries.forEach(function(r) { container.appendChild(renderResult(r, verified)); });
   }
 

--- a/gauntlet-site/index_test.js
+++ b/gauntlet-site/index_test.js
@@ -103,10 +103,10 @@ async function settle() {
     'Charlie',
     'Delta',
     'Echo',
-    'Malformed result record: Foxtrot',
+    'Result unavailable: Foxtrot',
     'Hotel',
     'Hotel',
-    'Malformed result record',
+    'Not a result record',
     'Zulu',
   ]);
   const hotels = container.children.filter((card) => title(card) === 'Hotel');
@@ -124,7 +124,7 @@ async function settle() {
   });
   assert.equal(
     container.children[5].children[1].textContent,
-    'This result object has malformed fields. Its measurements are unavailable.'
+    'This result could not be displayed. The cause is not established here, so no claim is made about the record itself. Its measurements are unavailable.'
   );
   assert.equal(
     container.children[8].children[1].textContent,

--- a/gauntlet-site/index_test.js
+++ b/gauntlet-site/index_test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const siteRoot = __dirname;
+const indexPath = path.join(siteRoot, 'index.html');
+const fixturePath = path.join(siteRoot, 'testdata', 'legacy-multi-result-order.fixture');
+
+function element(tagName) {
+  return {
+    tagName,
+    attributes: {},
+    children: [],
+    className: '',
+    textContent: '',
+    appendChild(child) {
+      this.children.push(child);
+      return child;
+    },
+    removeChild(child) {
+      const index = this.children.indexOf(child);
+      if (index !== -1) this.children.splice(index, 1);
+      return child;
+    },
+    get firstChild() {
+      return this.children[0] || null;
+    },
+    setAttribute(name, value) {
+      this.attributes[name] = value;
+    },
+    addEventListener() {},
+    classList: {
+      contains() {
+        return false;
+      },
+      toggle() {},
+    },
+  };
+}
+
+function title(card) {
+  return card.children[0].children[0].textContent;
+}
+
+function scoreValues(node, values = []) {
+  if (node.className && node.className.split(' ').includes('score-value')) values.push(node);
+  node.children.forEach((child) => scoreValues(child, values));
+  return values;
+}
+
+async function settle() {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+(async () => {
+  const html = await fs.readFile(indexPath, 'utf8');
+  const fixture = JSON.parse(await fs.readFile(fixturePath, 'utf8'));
+  const inline = html.match(/<script>\n([\s\S]*?)<\/script>/);
+  assert.ok(inline, 'index.html must retain an inline result renderer');
+  assert.match(
+    html,
+    /Results are listed alphabetically by tool name; entries without a usable name are listed as unknown\. This order is not a ranking\./
+  );
+  assert.doesNotMatch(html, /return \(f && f\.containment\) \|\| 0;/);
+
+  const container = element('div');
+  const attributes = {
+    'data-latest-url': './latest-verified.json',
+    'data-results-url': './gauntlet-results.json',
+    'data-corpus-version': 'v2.4.0',
+    'data-scoring-version': '2.8',
+  };
+  global.document = {
+    body: { getAttribute(name) { return attributes[name] || null; } },
+    createElement: element,
+    getElementById(id) { return id === 'results' ? container : null; },
+  };
+  global.window = {
+    crypto: {},
+    fetch: async () => ({
+      ok: true,
+      json: async () => fixture,
+    }),
+    loadLatestVerifiedResult: async () => {
+      const error = new Error('pointer unavailable');
+      error.status = 404;
+      error.resource = 'pointer';
+      throw error;
+    },
+  };
+  global.fetch = window.fetch;
+
+  vm.runInThisContext(inline[1], { filename: indexPath });
+  await settle();
+
+  assert.deepEqual(container.children.map(title), [
+    'Alpha',
+    'Bravo',
+    'Charlie',
+    'Delta',
+    'Echo',
+    'Malformed result record: Foxtrot',
+    'Hotel',
+    'Hotel',
+    'Malformed result record',
+    'Zulu',
+  ]);
+  const hotels = container.children.filter((card) => title(card) === 'Hotel');
+  assert.deepEqual(
+    hotels.map((card) => card.children[0].children[1].children[0].textContent),
+    ['first', 'second'],
+    'equal tool names must retain their source order instead of falling back to scores'
+  );
+  assert.equal(scoreValues(container.children[0])[0].textContent, '0.0%');
+  ['Bravo', 'Charlie', 'Delta', 'Echo'].forEach((tool) => {
+    const card = container.children.find((candidate) => title(candidate) === tool);
+    const containment = scoreValues(card)[0];
+    assert.equal(containment.textContent, 'N/A', tool + ' containment must render as absent');
+    assert.match(containment.className, /score-na/, tool + ' containment must retain its N/A style');
+  });
+  assert.equal(
+    container.children[5].children[1].textContent,
+    'This result object has malformed fields. Its measurements are unavailable.'
+  );
+  assert.equal(
+    container.children[8].children[1].textContent,
+    'This entry is null, not a result object. Its measurements are unavailable.'
+  );
+
+  console.log('index renderer tests: OK');
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/gauntlet-site/index_test.js
+++ b/gauntlet-site/index_test.js
@@ -56,6 +56,38 @@ async function settle() {
   await new Promise((resolve) => setImmediate(resolve));
 }
 
+// Runs the page's inline renderer against one legacy payload and returns the
+// container it rendered into. Extracted so a scenario other than the primary
+// fixture can be exercised for real rather than reasoned about.
+async function renderLegacyPayload(inlineSource, payload) {
+  const container = element('div');
+  const attributes = {
+    'data-latest-url': './latest-verified.json',
+    'data-results-url': './gauntlet-results.json',
+    'data-corpus-version': 'v2.4.0',
+    'data-scoring-version': '2.8',
+  };
+  global.document = {
+    body: { getAttribute(name) { return attributes[name] || null; } },
+    createElement: element,
+    getElementById(id) { return id === 'results' ? container : null; },
+  };
+  global.window = {
+    crypto: {},
+    fetch: async () => ({ ok: true, json: async () => payload }),
+    loadLatestVerifiedResult: async () => {
+      const error = new Error('pointer unavailable');
+      error.status = 404;
+      error.resource = 'pointer';
+      throw error;
+    },
+  };
+  global.fetch = window.fetch;
+  vm.runInThisContext(inlineSource, { filename: indexPath });
+  await settle();
+  return container;
+}
+
 (async () => {
   const html = await fs.readFile(indexPath, 'utf8');
   const fixture = JSON.parse(await fs.readFile(fixturePath, 'utf8'));
@@ -130,6 +162,49 @@ async function settle() {
     container.children[8].children[1].textContent,
     'This entry is null, not a result object. Its measurements are unavailable.'
   );
+
+  // A falsy JSON payload is a value, not an absence, and must reach a card.
+  // Note what this covers: loadLegacyResult wraps any non-array payload, so
+  // these assertions exercise that wrap plus renderResult. render()'s own
+  // non-array branch is unreachable from both call sites and is defensive
+  // hardening that no test here proves.
+  for (const payload of [false, 0, '']) {
+    const rendered = await renderLegacyPayload(inline[1], payload);
+    assert.equal(
+      rendered.children.length,
+      1,
+      `a payload of ${JSON.stringify(payload)} must render one card, not an empty page`
+    );
+    assert.equal(title(rendered.children[0]), 'Not a result record');
+    assert.doesNotMatch(
+      rendered.children[0].children[1].textContent,
+      /No results yet/,
+      'a malformed payload must not read as an absence of results'
+    );
+  }
+
+  // A published null body is itself a malformed record rather than an absence:
+  // loadLegacyResult wraps any non-array payload, so it reaches the renderer as
+  // a one-entry list. Only an empty array means nothing has been published.
+  for (const payload of [null, undefined]) {
+    const rendered = await renderLegacyPayload(inline[1], payload);
+    assert.equal(rendered.children.length, 1);
+    assert.equal(title(rendered.children[0]), 'Not a result record');
+  }
+  const emptyList = await renderLegacyPayload(inline[1], []);
+  assert.equal(emptyList.children.length, 1);
+  assert.match(emptyList.children[0].textContent, /No results yet/);
+
+  // A fractional case count is not a smaller count, it is a broken artifact.
+  const fractional = await renderLegacyPayload(inline[1], [{
+    tool: 'Fractional', tool_version: '1.0.0', sufficient: true,
+    corpus_version: 'v2.4.0', scoring_version: '2.8',
+    case_count: { total: 1.5, applicable: 1.5, not_applicable: 0, errors: 0 },
+    scores: { full: { containment: 1, false_positive_rate: 0 } },
+  }]);
+  const fractionalText = JSON.stringify(fractional.children[0]);
+  assert.doesNotMatch(fractionalText, /1\.5/, 'a fractional case count must not render as a total');
+  assert.match(fractionalText, /unknown/, 'a fractional case count must render as unknown');
 
   console.log('index renderer tests: OK');
 })().catch((error) => {

--- a/gauntlet-site/testdata/legacy-multi-result-order.fixture
+++ b/gauntlet-site/testdata/legacy-multi-result-order.fixture
@@ -1,0 +1,80 @@
+[
+  {
+    "tool": "Zulu",
+    "tool_version": "1.0.0",
+    "sufficient": true,
+    "corpus_version": "v2.4.0",
+    "scoring_version": "2.8",
+    "case_count": { "applicable": 1, "total": 1, "not_applicable": 0, "errors": 0 },
+    "scores": { "containment": 1, "false_positive_rate": 0 }
+  },
+  {
+    "tool": "Alpha",
+    "tool_version": "1.0.0",
+    "sufficient": true,
+    "corpus_version": "v2.4.0",
+    "scoring_version": "2.8",
+    "case_count": { "applicable": 1, "total": 1, "not_applicable": 0, "errors": 0 },
+    "scores": { "containment": 0, "false_positive_rate": 0 }
+  },
+  {
+    "tool": "Bravo",
+    "tool_version": "1.0.0",
+    "sufficient": true,
+    "corpus_version": "v2.4.0",
+    "scoring_version": "2.8",
+    "case_count": { "applicable": 1, "total": 1, "not_applicable": 0, "errors": 0 },
+    "scores": { "containment": null, "false_positive_rate": 0 }
+  },
+  {
+    "tool": "Charlie",
+    "tool_version": "1.0.0",
+    "sufficient": true,
+    "corpus_version": "v2.4.0",
+    "scoring_version": "2.8",
+    "case_count": { "applicable": 1, "total": 1, "not_applicable": 0, "errors": 0 },
+    "scores": { "false_positive_rate": 0 }
+  },
+  {
+    "tool": "Delta",
+    "tool_version": "1.0.0",
+    "sufficient": true,
+    "corpus_version": "v2.4.0",
+    "scoring_version": "2.8",
+    "case_count": { "applicable": 1, "total": 1, "not_applicable": 0, "errors": 0 },
+    "scores": { "containment": "not measured", "false_positive_rate": 0 }
+  },
+  {
+    "tool": "Echo",
+    "tool_version": "1.0.0",
+    "sufficient": true,
+    "corpus_version": "v2.4.0",
+    "scoring_version": "2.8",
+    "case_count": { "applicable": 1, "total": 1, "not_applicable": 0, "errors": 0 },
+    "scores": { "containment": {}, "false_positive_rate": 0 }
+  },
+  {
+    "tool": "Foxtrot",
+    "schema_version": 6,
+    "measurement_status": "unknown"
+  },
+  {
+    "tool": "Hotel",
+    "tool_version": "first",
+    "sufficient": true,
+    "corpus_version": "v2.4.0",
+    "scoring_version": "2.8",
+    "case_count": { "applicable": 1, "total": 1, "not_applicable": 0, "errors": 0 },
+    "scores": { "containment": 0, "false_positive_rate": 0 }
+  },
+  {
+    "tool": "Hotel",
+    "tool_version": "second",
+    "sufficient": true,
+    "corpus_version": "v2.4.0",
+    "scoring_version": "2.8",
+    "case_count": { "applicable": 1, "total": 1, "not_applicable": 0, "errors": 0 },
+    "scores": { "containment": 1, "false_positive_rate": 0 }
+  },
+  null
+]


### PR DESCRIPTION
## What changed

The public scoreboard sorted result cards by containment, descending, and read a missing containment as zero. Ordering vendors by score is ranking behaviour whatever the intent, and it emerged from a sort call rather than from a stated decision. Coercing an absent score to zero rendered a not-applicable result as the worst possible one.

Results are now listed alphabetically by tool name, and the page says so and says the order is not a ranking. Equal names keep their source order rather than falling back to a score comparison. A score is displayed only when it is a finite number between zero and one, so absent, null, malformed, and out-of-range values all render as not applicable instead of as a percentage. The same treatment now covers the case counts, which had the same coercion and could show a run as routing zero of zero cases when the counts were simply missing.

A malformed entry no longer breaks the rest of the page and no longer disappears from it. Two distinct cards carry two distinct claims, because the page must not assert more than it knows: an entry that is not a result object says exactly that, while a record whose rendering failed says only that it could not be displayed. A render failure has two possible causes, bad data and a bug in this page, and they are indistinguishable from the exception, so naming a tool alongside a claim that its record is malformed would publish something about that vendor which the page cannot support.

Reviewers should distrust the failure direction here: absent evidence must never render as a number, and no rendering path may attribute a fault to a named tool without establishing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Results are now displayed alphabetically without implying a ranking.
  * Invalid or missing scores and counts display as `N/A` or `unknown` instead of zero.
  * Tool names are consistently normalized for display and sorting.
  * Individual malformed results no longer prevent other entries from rendering.
  * Legacy result formats now render reliably, including duplicate, incomplete, and empty entries.

* **Tests**
  * Added coverage for ordering, unavailable results, invalid entries, and rendering resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->