### PR TITLE
Disclose false-positive weighting and add a benign category profile

### DIFF
--- a/docs/gauntlet.md
+++ b/docs/gauntlet.md
@@ -88,13 +88,15 @@ Lower is better for false positive rate (0.0 = perfect). Higher is better for co
 
 Containment is a case-equal (micro) average over the malicious cases in the selected view. Every malicious corpus case has equal influence. Corpus composition therefore determines the category weighting. That composition is a maintainer choice, not a derived truth.
 
+False-positive rate is a case-equal (micro) average over the benign cases in the selected view. Every benign corpus case has equal influence. Corpus composition therefore determines the category weighting. That composition is a maintainer choice, not a derived truth.
+
 ### Score views
 
 The full-corpus view is primary. It keeps measured cases in the denominator and preserves frozen historical N/A treatment. An unreachable case is not a measurement and remains visible outside the denominator.
 
 The applicable view is diagnostic. It contains cases with adapter-proven delivery and an observed verdict. A tool's declarations cannot select this view or remove a case from it.
 
-Per-category containment describes the applicable-only observed scope. Compare it with the applicable containment when their scopes match. Do not compare it with full-corpus containment when historical N/A rows make the scopes differ.
+Per-category containment and false-positive rate describe the applicable-only observed scope. Compare each with its applicable metric when their scopes match. Don't compare either with its full-corpus metric when historical N/A rows make the scopes differ.
 
 ## Measurement Status
 

--- a/runner/report.go
+++ b/runner/report.go
@@ -1534,7 +1534,7 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 	line("")
 	line("### Applicable-only benign category profile")
 	line("")
-	line("This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.")
+	line("This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.")
 	line("")
 	if profile.unavailable != "" {
 		line("Unavailable: %s.", markdownInline(profile.unavailable))

--- a/runner/report.go
+++ b/runner/report.go
@@ -100,13 +100,16 @@ type buyerReport struct {
 type reportCategoryProfile struct {
 	rows           []reportCategoryProfileRow
 	maliciousTotal int
+	benignTotal    int
 	unavailable    string
 }
 
 type reportCategoryProfileRow struct {
-	category  string
-	blocked   int
-	malicious int
+	category     string
+	blocked      int
+	malicious    int
+	falseBlocked int
+	benign       int
 }
 
 type reportProfileCase struct {
@@ -307,7 +310,7 @@ func generatePublicationLockup(dir, outputPath string, assurances []string, evid
 		}
 		line("")
 	}
-	line("%s total · %s applicable · %s unreachable · %s not applicable · %s errors · containment %s (%d/%d malicious cases; case-equal weighting from corpus composition) · false-positive rate %s", required["total"], required["applicable"], required["unreachable"], required["not applicable"], required["errors"], required["containment"], report.rowCounts.maliciousBlocked, report.rowCounts.maliciousTotal, required["false-positive rate"])
+	line("%s total · %s applicable · %s unreachable · %s not applicable · %s errors · containment %s (%d/%d malicious cases; case-equal weighting from corpus composition) · false-positive rate %s (%d/%d benign cases; case-equal weighting from corpus composition)", required["total"], required["applicable"], required["unreachable"], required["not applicable"], required["errors"], required["containment"], report.rowCounts.maliciousBlocked, report.rowCounts.maliciousTotal, required["false-positive rate"], report.rowCounts.benignFalsePositives, report.rowCounts.benignTotal)
 	if len(naReasons) > 0 {
 		line("Not-applicable reasons: %s", markdownInline(strings.Join(naReasons, ", ")))
 	}
@@ -664,10 +667,11 @@ func loadReportText(dir, name string) string {
 	return safeReportText(value)
 }
 
-// categoryProfile reconstructs the applicable-only malicious category profile
-// from the two retained inputs that bind case identity to observed outcomes.
-// The summary's per_category.applicable count cannot supply this denominator:
-// it includes benign rows, so using it would overstate the malicious scope.
+// categoryProfile reconstructs the applicable-only category profiles from the
+// two retained inputs that bind case identity to observed outcomes. The
+// summary's per_category.applicable count cannot supply either denominator:
+// it includes malicious and benign rows, so using it would overstate both
+// category-specific scopes.
 func (r *buyerReport) categoryProfile() reportCategoryProfile {
 	if reportNumber(r.summary, "schema_version") != "5" {
 		return reportCategoryProfile{unavailable: "requires a v5 summary and bound active evidence"}
@@ -703,10 +707,18 @@ func (r *buyerReport) categoryProfile() reportCategoryProfile {
 		}
 		row := byCategory[c.category]
 		row.category = c.category
-		if c.expected == "block" && result.observed {
-			row.malicious++
-			if result.actual == "block" {
-				row.blocked++
+		if result.observed {
+			switch c.expected {
+			case "block":
+				row.malicious++
+				if result.actual == "block" {
+					row.blocked++
+				}
+			case "allow":
+				row.benign++
+				if result.actual == "block" {
+					row.falseBlocked++
+				}
 			}
 		}
 		byCategory[c.category] = row
@@ -716,10 +728,14 @@ func (r *buyerReport) categoryProfile() reportCategoryProfile {
 	for _, row := range byCategory {
 		profile.rows = append(profile.rows, row)
 		profile.maliciousTotal += row.malicious
+		profile.benignTotal += row.benign
 	}
 	sort.Slice(profile.rows, func(i, j int) bool { return profile.rows[i].category < profile.rows[j].category })
 	if !r.matchesApplicableContainment(profile) {
 		return reportCategoryProfile{unavailable: "the applicable containment does not match the bound result rows"}
+	}
+	if !r.matchesApplicableFalsePositiveRate(profile) {
+		return reportCategoryProfile{unavailable: "the applicable false-positive rate does not match the bound result rows"}
 	}
 	return profile
 }
@@ -919,6 +935,29 @@ func (r *buyerReport) matchesApplicableContainment(profile reportCategoryProfile
 	}
 	ratio, err := observed.Float64()
 	expected := float64(blocked) / float64(profile.maliciousTotal)
+	return err == nil && !math.IsNaN(ratio) && !math.IsInf(ratio, 0) && math.Abs(ratio-expected) <= 1e-12
+}
+
+func (r *buyerReport) matchesApplicableFalsePositiveRate(profile reportCategoryProfile) bool {
+	scores, scoresOK := r.summary.data["scores"].(map[string]interface{})
+	applicable, applicableOK := scores["applicable"].(map[string]interface{})
+	value, present := applicable["false_positive_rate"]
+	if !scoresOK || !applicableOK || !present {
+		return false
+	}
+	if profile.benignTotal == 0 {
+		return value == nil
+	}
+	observed, numberOK := value.(json.Number)
+	if !numberOK {
+		return false
+	}
+	falseBlocked := 0
+	for _, row := range profile.rows {
+		falseBlocked += row.falseBlocked
+	}
+	ratio, err := observed.Float64()
+	expected := float64(falseBlocked) / float64(profile.benignTotal)
 	return err == nil && !math.IsNaN(ratio) && !math.IsInf(ratio, 0) && math.Abs(ratio-expected) <= 1e-12
 }
 
@@ -1490,6 +1529,21 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 		for _, row := range profile.rows {
 			line("| %s | %d / %d | %s | %s |", markdownInline(safeReportText(row.category)), row.blocked, row.malicious,
 				reportCategoryProfilePercent(row.blocked, row.malicious), reportCategoryProfilePercent(row.malicious, profile.maliciousTotal))
+		}
+	}
+	line("")
+	line("### Applicable-only benign category profile")
+	line("")
+	line("This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.")
+	line("")
+	if profile.unavailable != "" {
+		line("Unavailable: %s.", markdownInline(profile.unavailable))
+	} else {
+		line("| Category | Falsely blocked / observed benign | False-positive rate | Share of observed benign denominator |")
+		line("| --- | ---: | ---: | ---: |")
+		for _, row := range profile.rows {
+			line("| %s | %d / %d | %s | %s |", markdownInline(safeReportText(row.category)), row.falseBlocked, row.benign,
+				reportCategoryProfilePercent(row.falseBlocked, row.benign), reportCategoryProfilePercent(row.benign, profile.benignTotal))
 		}
 	}
 	line("")

--- a/runner/report_test.go
+++ b/runner/report_test.go
@@ -518,7 +518,7 @@ func TestPublicationLockupCarriesMethodScopeAndScores(t *testing.T) {
 		"Publisher-declared assurance: **self run**",
 		"example/agent-egress-bench@cccccccccccccccccccccccccccccccccccccccc",
 		"2 total · 2 applicable · 0 unreachable · 0 not applicable · 0 errors",
-		"containment 100.00% (1/1 malicious cases; case-equal weighting from corpus composition) · false-positive rate 0.00%",
+		"containment 100.00% (1/1 malicious cases; case-equal weighting from corpus composition) · false-positive rate 0.00% (0/1 benign cases; case-equal weighting from corpus composition)",
 		"Corpus Git observation: `clean` · tool version observation: `observed`",
 		"Exercised transports: http\\_proxy",
 		"internal consistency only",
@@ -537,14 +537,14 @@ func categoryProfileFixture() *reportFixture {
 		"not_applicable_reasons": map[string]interface{}{}, "errors": 0,
 	}
 	fixture.summary["scores"] = map[string]interface{}{
-		"full":       map[string]interface{}{"containment": 0.5, "false_positive_rate": 0.0},
-		"applicable": map[string]interface{}{"containment": 0.5, "false_positive_rate": 0.0},
+		"full":       map[string]interface{}{"containment": 0.5, "false_positive_rate": 0.5},
+		"applicable": map[string]interface{}{"containment": 0.5, "false_positive_rate": 0.5},
 	}
 	fixture.results = []map[string]interface{}{
 		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "url-attack-001", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "block", "actual_verdict": "block", "score": "pass", "evidence": map[string]interface{}{"result_state": "observed"}, "notes": ""},
 		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "url-benign-002", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "allow", "actual_verdict": "allow", "score": "pass", "evidence": map[string]interface{}{"result_state": "observed"}, "notes": ""},
 		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "mcp-drift-attack-003", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "block", "actual_verdict": "allow", "score": "fail", "evidence": map[string]interface{}{"result_state": "observed"}, "notes": ""},
-		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "headers-benign-004", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "allow", "actual_verdict": "allow", "score": "pass", "evidence": map[string]interface{}{"result_state": "observed"}, "notes": ""},
+		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "headers-benign-004", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "allow", "actual_verdict": "block", "score": "fail", "evidence": map[string]interface{}{"result_state": "observed"}, "notes": ""},
 		{"schema_version": activeResultSchemaVersion, "scoring_version": scoringVersion, "case_id": "mcp-tool-attack-005", "tool": "example-tool", "tool_version": "1.2.3", "expected_verdict": "block", "actual_verdict": "unreachable", "score": "error", "evidence": map[string]interface{}{"result_state": "unreachable"}, "notes": ""},
 	}
 	return fixture
@@ -600,11 +600,16 @@ func TestBuyerReportRendersBoundCategoryProfile(t *testing.T) {
 	got := output.String()
 	for _, want := range []string{
 		"### Applicable-only malicious category profile",
+		"### Applicable-only benign category profile",
 		"evidence of category coverage and concentration, not a score or ranking",
 		"| headers | 0 / 0 | N/A | 0.00% |",
 		"| mcp\\_drift | 0 / 1 | 0.00% | 50.00% |",
 		"| mcp\\_tool | 0 / 0 | N/A | 0.00% |",
 		"| url | 1 / 1 | 100.00% | 50.00% |",
+		"| headers | 1 / 1 | 100.00% | 50.00% |",
+		"| mcp\\_drift | 0 / 0 | N/A | 0.00% |",
+		"| mcp\\_tool | 0 / 0 | N/A | 0.00% |",
+		"| url | 0 / 1 | 0.00% | 50.00% |",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("category profile missing %q:\n%s", want, got)
@@ -631,8 +636,8 @@ func TestBuyerReportRendersProfileWhenNoMaliciousCaseWasObserved(t *testing.T) {
 		"not_applicable_reasons": map[string]interface{}{}, "errors": 0,
 	}
 	fixture.summary["scores"] = map[string]interface{}{
-		"full":       map[string]interface{}{"containment": nil, "false_positive_rate": 0.0},
-		"applicable": map[string]interface{}{"containment": nil, "false_positive_rate": 0.0},
+		"full":       map[string]interface{}{"containment": nil, "false_positive_rate": 0.5},
+		"applicable": map[string]interface{}{"containment": nil, "false_positive_rate": 0.5},
 	}
 	dir := t.TempDir()
 	fixture.write(t, dir)
@@ -655,6 +660,58 @@ func TestBuyerReportRendersProfileWhenNoMaliciousCaseWasObserved(t *testing.T) {
 	// rather than 0%, which would assert a containment the run never measured.
 	for _, want := range []string{
 		"| mcp\\_drift | 0 / 0 | N/A | N/A |",
+		"| url | 0 / 0 | N/A | N/A |",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in:\n%s", want, got)
+		}
+	}
+}
+
+// A run that observed no benign case at all still gets a profile. The
+// zero-denominator branch of matchesApplicableFalsePositiveRate requires that
+// scores.applicable.false_positive_rate be present and null, because a run
+// with nothing to measure must publish an absent rate rather than a zero one.
+func TestBuyerReportRendersProfileWhenNoBenignCaseWasObserved(t *testing.T) {
+	fixture := categoryProfileFixture()
+	for _, row := range fixture.results {
+		if row["expected_verdict"] != "allow" {
+			continue
+		}
+		row["actual_verdict"] = "unreachable"
+		row["score"] = "error"
+		row["evidence"] = map[string]interface{}{"result_state": "unreachable"}
+	}
+	fixture.summary["case_count"] = map[string]interface{}{
+		"total": 5, "applicable": 2, "unreachable": 3, "not_applicable": 0,
+		"not_applicable_reasons": map[string]interface{}{}, "errors": 0,
+	}
+	fixture.summary["scores"] = map[string]interface{}{
+		"full":       map[string]interface{}{"containment": 0.5, "false_positive_rate": nil},
+		"applicable": map[string]interface{}{"containment": 0.5, "false_positive_rate": nil},
+	}
+	dir := t.TempDir()
+	fixture.write(t, dir)
+	writeCategoryProfileIndex(t, fixture, dir, categoryProfileIndex())
+
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	got := output.String()
+	if !strings.Contains(got, "### Applicable-only benign category profile") {
+		t.Fatalf("profile section missing:\n%s", got)
+	}
+	if strings.Contains(got, "Unavailable:") {
+		t.Errorf("a run with no observed benign case must still render a profile:\n%s", got)
+	}
+	// Every benign category has a zero denominator, so each must read N/A
+	// rather than 0%, which would assert a false-positive rate the run never
+	// measured.
+	for _, want := range []string{
+		"| headers | 0 / 0 | N/A | N/A |",
 		"| url | 0 / 0 | N/A | N/A |",
 	} {
 		if !strings.Contains(got, want) {
@@ -762,6 +819,10 @@ func TestBuyerReportMarksInvalidCategoryProfileUnavailable(t *testing.T) {
 			fixture.summary["scores"].(map[string]interface{})["applicable"].(map[string]interface{})["containment"] = 0.75
 			writeFixtureJSON(t, filepath.Join(dir, "raw-summary.json"), fixture.summary)
 		}, want: "Unavailable: the applicable containment does not match the bound result rows."},
+		{name: "applicable false-positive rate mismatch", mutate: func(t *testing.T, fixture *reportFixture, dir string) {
+			fixture.summary["scores"].(map[string]interface{})["applicable"].(map[string]interface{})["false_positive_rate"] = 0.25
+			writeFixtureJSON(t, filepath.Join(dir, "raw-summary.json"), fixture.summary)
+		}, want: "Unavailable: the applicable false-positive rate does not match the bound result rows."},
 	}
 
 	for _, tt := range tests {
@@ -783,6 +844,9 @@ func TestBuyerReportMarksInvalidCategoryProfileUnavailable(t *testing.T) {
 			}
 			if !strings.Contains(got, "- Containment: 50.00%") {
 				t.Fatalf("profile failure hid the primary score:\n%s", got)
+			}
+			if !strings.Contains(got, "- False-positive rate:") {
+				t.Fatalf("profile failure hid the primary false-positive rate:\n%s", got)
 			}
 		})
 	}

--- a/runner/testdata/buyer-report/count-mismatch.golden.md
+++ b/runner/testdata/buyer-report/count-mismatch.golden.md
@@ -80,6 +80,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/count-mismatch.golden.md
+++ b/runner/testdata/buyer-report/count-mismatch.golden.md
@@ -82,7 +82,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 

--- a/runner/testdata/buyer-report/errors.golden.md
+++ b/runner/testdata/buyer-report/errors.golden.md
@@ -82,7 +82,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 

--- a/runner/testdata/buyer-report/errors.golden.md
+++ b/runner/testdata/buyer-report/errors.golden.md
@@ -80,6 +80,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: blocked

--- a/runner/testdata/buyer-report/exercised-capabilities.golden.md
+++ b/runner/testdata/buyer-report/exercised-capabilities.golden.md
@@ -83,6 +83,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/exercised-capabilities.golden.md
+++ b/runner/testdata/buyer-report/exercised-capabilities.golden.md
@@ -85,7 +85,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 

--- a/runner/testdata/buyer-report/healthy.golden.md
+++ b/runner/testdata/buyer-report/healthy.golden.md
@@ -80,6 +80,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/healthy.golden.md
+++ b/runner/testdata/buyer-report/healthy.golden.md
@@ -82,7 +82,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 

--- a/runner/testdata/buyer-report/malformed-summary.golden.md
+++ b/runner/testdata/buyer-report/malformed-summary.golden.md
@@ -81,7 +81,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 

--- a/runner/testdata/buyer-report/malformed-summary.golden.md
+++ b/runner/testdata/buyer-report/malformed-summary.golden.md
@@ -79,6 +79,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/missing-optional.golden.md
+++ b/runner/testdata/buyer-report/missing-optional.golden.md
@@ -80,6 +80,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/missing-optional.golden.md
+++ b/runner/testdata/buyer-report/missing-optional.golden.md
@@ -82,7 +82,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 

--- a/runner/testdata/buyer-report/missing-required.golden.md
+++ b/runner/testdata/buyer-report/missing-required.golden.md
@@ -80,6 +80,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/missing-required.golden.md
+++ b/runner/testdata/buyer-report/missing-required.golden.md
@@ -82,7 +82,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 

--- a/runner/testdata/buyer-report/not-applicable.golden.md
+++ b/runner/testdata/buyer-report/not-applicable.golden.md
@@ -80,6 +80,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/not-applicable.golden.md
+++ b/runner/testdata/buyer-report/not-applicable.golden.md
@@ -82,7 +82,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 

--- a/runner/testdata/buyer-report/not-publication-eligible.golden.md
+++ b/runner/testdata/buyer-report/not-publication-eligible.golden.md
@@ -80,6 +80,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/not-publication-eligible.golden.md
+++ b/runner/testdata/buyer-report/not-publication-eligible.golden.md
@@ -82,7 +82,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 

--- a/runner/testdata/buyer-report/unknown-verdict.golden.md
+++ b/runner/testdata/buyer-report/unknown-verdict.golden.md
@@ -80,6 +80,12 @@ This profile is evidence of category coverage and concentration, not a score or 
 
 Unavailable: requires a v5 summary and bound active evidence.
 
+### Applicable-only benign category profile
+
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+
+Unavailable: requires a v5 summary and bound active evidence.
+
 ## Execution and bundle status
 
 - Execution status: complete

--- a/runner/testdata/buyer-report/unknown-verdict.golden.md
+++ b/runner/testdata/buyer-report/unknown-verdict.golden.md
@@ -82,7 +82,7 @@ Unavailable: requires a v5 summary and bound active evidence.
 
 ### Applicable-only benign category profile
 
-This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Don't compare this profile with full-corpus false-positive rate when their scopes differ.
+This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed benign rows only. False-positive rate gives every observed benign case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus false-positive rate when their scopes differ.
 
 Unavailable: requires a v5 summary and bound active evidence.
 


### PR DESCRIPTION
## What changed

The published false-positive rate carried the same hidden weighting that containment did before the previous change: every observed benign case counts once, so whichever benign family holds the most cases has the most influence over the rate. Nobody chose that weighting, and nothing beside the published number said so.

The metric documentation now states that the false-positive rate is case-equal over the benign cases in the selected view and that corpus composition therefore sets the category weighting. The publication lockup carries the benign numerator and denominator beside the rate. The buyer report gains an applicable-only benign category profile showing falsely blocked over observed benign, the per-category rate, and each category shares of the benign denominator.

That profile makes a real property of the corpus visible for the first time: on the current retained record one category supplies roughly a third of the entire benign denominator, so a regression there would move the published rate far more than a regression anywhere else.

No schema, version, or scoring behavior changes, and no second aggregate is published. A category-equal average was rejected for containment on reproduced evidence and is rejected here for the same reasons.

Reviewers should distrust one direction in particular. A false-positive rate of zero is the best possible value, so absent evidence rendering as zero would manufacture a perfect score rather than merely understating one. Missing, malformed, digest-mismatched, and scope-mismatched evidence must all render as unavailable, and a category with no observed benign case must render as not applicable rather than as zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now include benign-case counts and false-positive rates alongside malicious-case containment scores.
  * Category profiles provide applicable-only benign-case breakdowns and clearer score denominators.
  * Publication summaries now show separate malicious and benign case totals.

* **Bug Fixes**
  * Improved validation and reconciliation for containment and false-positive scores.
  * Correctly handles runs with no observed benign cases and preserves primary scores when category-level checks fail.

* **Documentation**
  * Clarified false-positive rate calculation and category-level scoring scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->