### PR TITLE
Give headline metrics scoped denominators in the buyer report

### DIFF
--- a/runner/report.go
+++ b/runner/report.go
@@ -1318,6 +1318,55 @@ func reportPercent(doc reportDocument, path ...string) string {
 	return strconv.FormatFloat(f*100, 'f', 2, 64) + "%"
 }
 
+// reportPercentWithDenominator adds a fraction only when it reconstructs the
+// rendered score. A plausible-looking denominator beside a different rate is
+// a false claim, so unavailable, zero, and mismatched inputs keep the score
+// useful but bare.
+func reportPercentWithDenominator(doc reportDocument, numerator, denominator int, caseKind string, path ...string) string {
+	percent := reportPercent(doc, path...)
+	if numerator < 0 || denominator <= 0 || numerator > denominator {
+		return percent
+	}
+	value, present := nestedValue(doc.data, path...)
+	observed, numberOK := value.(json.Number)
+	if !present || !numberOK {
+		return percent
+	}
+	ratio, err := observed.Float64()
+	expected := float64(numerator) / float64(denominator)
+	if err != nil || math.IsNaN(ratio) || math.IsInf(ratio, 0) || math.Abs(ratio-expected) > 1e-12 {
+		return percent
+	}
+	return fmt.Sprintf("%s (%d/%d %s cases; case-equal weighting from corpus composition)", percent, numerator, denominator, caseKind)
+}
+
+func (r *buyerReport) fullCorpusPercent(numerator, denominator int, caseKind string, path ...string) string {
+	if r.resultErr != "Readable" {
+		return reportPercent(r.summary, path...)
+	}
+	return reportPercentWithDenominator(r.summary, numerator, denominator, caseKind, path...)
+}
+
+func reportApplicablePercent(doc reportDocument, profile reportCategoryProfile, denominator int, caseKind string, path ...string) string {
+	if profile.unavailable != "" {
+		return reportPercent(doc, path...)
+	}
+	return reportPercentWithDenominator(doc, profileMetricNumerator(profile, caseKind), denominator, caseKind, path...)
+}
+
+func profileMetricNumerator(profile reportCategoryProfile, caseKind string) int {
+	var numerator int
+	for _, row := range profile.rows {
+		switch caseKind {
+		case "malicious":
+			numerator += row.blocked
+		case "benign":
+			numerator += row.falseBlocked
+		}
+	}
+	return numerator
+}
+
 func reportStringList(doc reportDocument, path ...string) []string {
 	if doc.data == nil {
 		return []string{absentFact}
@@ -1477,18 +1526,19 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 	line("")
 	line("## Metric vector")
 	line("")
+	profile := r.categoryProfile()
 	if reportNumber(r.summary, "schema_version") == "5" {
 		line("Each score stands on its own. Full-corpus scores retain historical N/A rows as misses; error and unreachable rows are excluded and make the measurement incomplete. Applicable-only scores cover only the routed cases this adapter delivered AND observed, so error rows are counted as routed but are excluded from every score denominator.")
 		line("")
 		line("### Full corpus")
 		line("")
-		bullet("Containment", reportPercent(r.summary, "scores", "full", "containment"))
-		bullet("False-positive rate", reportPercent(r.summary, "scores", "full", "false_positive_rate"))
+		bullet("Containment", r.fullCorpusPercent(r.rowCounts.maliciousBlocked, r.rowCounts.maliciousTotal, "malicious", "scores", "full", "containment"))
+		bullet("False-positive rate", r.fullCorpusPercent(r.rowCounts.benignFalsePositives, r.rowCounts.benignTotal, "benign", "scores", "full", "false_positive_rate"))
 		line("")
 		line("### Applicable-only observed cases")
 		line("")
-		bullet("Containment", reportPercent(r.summary, "scores", "applicable", "containment"))
-		bullet("False-positive rate", reportPercent(r.summary, "scores", "applicable", "false_positive_rate"))
+		bullet("Containment", reportApplicablePercent(r.summary, profile, profile.maliciousTotal, "malicious", "scores", "applicable", "containment"))
+		bullet("False-positive rate", reportApplicablePercent(r.summary, profile, profile.benignTotal, "benign", "scores", "applicable", "false_positive_rate"))
 		line("")
 		line("### Non-scoring field-presence diagnostics")
 		line("")
@@ -1503,24 +1553,23 @@ func (r *buyerReport) renderMarkdown(w io.Writer) {
 		line("")
 		line("### Full corpus")
 		line("")
-		bullet("Containment", reportPercent(r.summary, "scores", "full", "containment"))
+		bullet("Containment", r.fullCorpusPercent(r.rowCounts.maliciousBlocked, r.rowCounts.maliciousTotal, "malicious", "scores", "full", "containment"))
 		bullet("Detection", reportPercent(r.summary, "scores", "full", "detection"))
 		bullet("Evidence", reportPercent(r.summary, "scores", "full", "evidence"))
-		bullet("False-positive rate", reportPercent(r.summary, "scores", "full", "false_positive_rate"))
+		bullet("False-positive rate", r.fullCorpusPercent(r.rowCounts.benignFalsePositives, r.rowCounts.benignTotal, "benign", "scores", "full", "false_positive_rate"))
 		line("")
 		line("### Applicable-only observed cases")
 		line("")
-		bullet("Containment", reportPercent(r.summary, "scores", "applicable", "containment"))
+		bullet("Containment", reportApplicablePercent(r.summary, profile, profile.maliciousTotal, "malicious", "scores", "applicable", "containment"))
 		bullet("Detection", reportPercent(r.summary, "scores", "applicable", "detection"))
 		bullet("Evidence", reportPercent(r.summary, "scores", "applicable", "evidence"))
-		bullet("False-positive rate", reportPercent(r.summary, "scores", "applicable", "false_positive_rate"))
+		bullet("False-positive rate", reportApplicablePercent(r.summary, profile, profile.benignTotal, "benign", "scores", "applicable", "false_positive_rate"))
 	}
 	line("")
 	line("### Applicable-only malicious category profile")
 	line("")
 	line("This profile is evidence of category coverage and concentration, not a score or ranking. It uses observed malicious rows only. Containment gives every observed malicious case equal influence, and the share column shows how corpus composition sets the category weighting. Do not compare this profile with full-corpus containment when their scopes differ.")
 	line("")
-	profile := r.categoryProfile()
 	if profile.unavailable != "" {
 		line("Unavailable: %s.", markdownInline(profile.unavailable))
 	} else {

--- a/runner/report_test.go
+++ b/runner/report_test.go
@@ -852,6 +852,139 @@ func TestBuyerReportMarksInvalidCategoryProfileUnavailable(t *testing.T) {
 	}
 }
 
+func TestBuyerReportHeadlinesCarryApplicableProfileDenominators(t *testing.T) {
+	fixture := categoryProfileFixture()
+	dir := t.TempDir()
+	fixture.write(t, dir)
+	writeCategoryProfileIndex(t, fixture, dir, categoryProfileIndex())
+
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	got := output.String()
+	for _, want := range []string{
+		"- Containment: 50.00% (1/2 malicious cases; case-equal weighting from corpus composition)",
+		"- False-positive rate: 50.00% (1/2 benign cases; case-equal weighting from corpus composition)",
+	} {
+		if strings.Count(got, want) != 2 {
+			t.Fatalf("headline denominator %q did not appear in both metric scopes:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuyerReportHeadlinesDoNotBorrowFullCorpusDenominators(t *testing.T) {
+	fixture := newReportFixture()
+	fixture.summary["case_count"] = map[string]interface{}{
+		"total": 3, "applicable": 2, "not_applicable": 1,
+		"not_applicable_reasons": map[string]interface{}{"missing_requires": 1}, "errors": 0,
+	}
+	fixture.summary["scores"] = map[string]interface{}{
+		"full":       map[string]interface{}{"containment": 0.5, "detection": 0.5, "evidence": 0.25, "false_positive_rate": 0.0},
+		"applicable": map[string]interface{}{"containment": 1.0, "detection": 0.6, "evidence": 0.4, "false_positive_rate": 0.0},
+	}
+	fixture.results = append(fixture.results, map[string]interface{}{
+		"schema_version": 4, "case_id": "mcp-chain-budget-003", "tool": "example-tool", "tool_version": "1.2.3",
+		"expected_verdict": "block", "actual_verdict": "not_applicable", "score": "not_applicable",
+		"evidence": map[string]interface{}{}, "notes": "not applicable: missing_requires",
+	})
+	dir := t.TempDir()
+	fixture.write(t, dir)
+
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	got := output.String()
+	full := "### Full corpus\n\n- Containment: 50.00% (1/2 malicious cases; case-equal weighting from corpus composition)\n- Detection: 50.00%\n- Evidence: 25.00%\n- False-positive rate: 0.00% (0/1 benign cases; case-equal weighting from corpus composition)"
+	if !strings.Contains(got, full) {
+		t.Fatalf("full-corpus headlines =\n%s\nwant %q", got, full)
+	}
+	applicable := "### Applicable-only observed cases\n\n- Containment: 100.00%\n- Detection: 60.00%\n- Evidence: 40.00%\n- False-positive rate: 0.00%"
+	if !strings.Contains(got, applicable) {
+		t.Fatalf("applicable headlines borrowed a denominator or changed retired metrics:\n%s", got)
+	}
+}
+
+func TestBuyerReportHeadlinesOmitCountsForUnreadableResults(t *testing.T) {
+	fixture := newReportFixture()
+	fixture.summary["scores"] = map[string]interface{}{
+		"full":       map[string]interface{}{"containment": 1.0, "detection": 0.5, "evidence": 0.25, "false_positive_rate": 0.0},
+		"applicable": map[string]interface{}{"containment": 1.0, "detection": 0.6, "evidence": 0.4, "false_positive_rate": 0.0},
+	}
+	dir := t.TempDir()
+	fixture.write(t, dir)
+	firstRow, err := json.Marshal(fixture.results[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "results.jsonl"), append(firstRow, []byte("\n{\n")...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	got := output.String()
+	if !strings.Contains(got, "- Containment: 100.00%\n") {
+		t.Fatalf("unreadable results hid the percentage:\n%s", got)
+	}
+	if strings.Contains(got, "- Containment: 100.00% (1/1 malicious cases;") {
+		t.Fatalf("unreadable results produced a confident-looking partial fraction:\n%s", got)
+	}
+}
+
+func TestBuyerReportHeadlinesOmitMismatchedFractions(t *testing.T) {
+	fixture := newReportFixture()
+	dir := t.TempDir()
+	fixture.write(t, dir)
+
+	report, err := loadBuyerReport(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	report.renderMarkdown(&output)
+	got := output.String()
+	if !strings.Contains(got, "- Containment: 75.00%\n") {
+		t.Fatalf("mismatched rows hid the percentage:\n%s", got)
+	}
+	if strings.Contains(got, "- Containment: 75.00% (1/1 malicious cases;") {
+		t.Fatalf("mismatched numerator and denominator were rendered beside the percentage:\n%s", got)
+	}
+}
+
+func TestReportApplicablePercentRequiresAvailableProfile(t *testing.T) {
+	doc := reportDocument{data: map[string]interface{}{
+		"scores": map[string]interface{}{"applicable": map[string]interface{}{"containment": json.Number("0.5")}},
+	}}
+	profile := reportCategoryProfile{
+		rows:        []reportCategoryProfileRow{{blocked: 1, malicious: 2}},
+		unavailable: "the retained evidence is unavailable",
+	}
+	got := reportApplicablePercent(doc, profile, 2, "malicious", "scores", "applicable", "containment")
+	if got != "50.00%" {
+		t.Fatalf("unavailable profile rendered denominator %q", got)
+	}
+}
+
+func TestReportPercentWithDenominatorOmitsZeroDenominator(t *testing.T) {
+	doc := reportDocument{data: map[string]interface{}{
+		"scores": map[string]interface{}{"applicable": map[string]interface{}{"containment": json.Number("0")}},
+	}}
+	got := reportPercentWithDenominator(doc, 0, 0, "malicious", "scores", "applicable", "containment")
+	if got != "0.00%" {
+		t.Fatalf("zero denominator rendered as a measurement %q", got)
+	}
+}
+
 func TestPublicationLockupListsFailuresBeforeScores(t *testing.T) {
 	fixture := publicationFixture()
 	fixture.results[0]["actual_verdict"] = "allow"


### PR DESCRIPTION
## What changed

The buyer report carried denominators beside its category profiles and inside its publication lockup, while its own headline metric bullets still printed bare percentages. That was the last surface in the report a reader could not check the arithmetic on.

Each headline metric now carries its numerator and denominator, and the two score views draw those counts from different places because they are different measurements. Full-corpus containment and false-positive rate use the retained result rows. Applicable-only containment and false-positive rate use the digest-bound category-profile totals, and only while that profile is available. When the profile is unavailable the applicable bullets render the percentage alone rather than borrowing the full-corpus denominator, which would state a number the applicable scope never measured. The retired Detection and Evidence metrics on older summaries stay bare, because no counts exist for them and inventing one would be worse than omitting it.

A fraction is printed only when it reconstructs the percentage beside it. A zero denominator, an unreadable set of result rows, an unavailable profile, or any disagreement between the stored score and the retained rows leaves the percentage bare instead. That check is per metric rather than per section, so a single mismatched metric loses its fraction while its neighbours keep theirs.

No schema, version, score value, or scoring behavior changes.

Reviewers should distrust the pairing rather than the arithmetic. On the current retained record the full-corpus and applicable-only figures happen to be identical, so a denominator borrowed from the wrong scope would be invisible in that output; the case that exposes it is a record where retained historical not-applicable rows make the two views diverge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report percentages to show accurate case-count fractions when the underlying results and profiles are valid.
  * Prevented misleading fractions when results are unreadable, profiles are unavailable, counts are zero, or rates do not match the reported data.
  * Ensured applicable-only metrics use applicable case counts rather than full-corpus totals.

* **Tests**
  * Added coverage for valid denominators, unavailable data, mismatched rates, zero denominators, and separation of applicable and full-corpus counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->