### PR TITLE
docs: stop implying this repo is the live Pipelock exam

### DIFF
--- a/.github/workflows/continuous-gauntlet.yaml
+++ b/.github/workflows/continuous-gauntlet.yaml
@@ -9,8 +9,6 @@ on:
         description: "Corpus ref to benchmark. Must resolve to origin/main or a tag."
         required: false
         default: main
-  schedule:
-    - cron: '17 6 * * *'
 
 concurrency:
   group: continuous-gauntlet-${{ github.event.inputs.corpus_ref || 'main' }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -89,6 +89,45 @@ jobs:
       - name: Run runner tests
         run: cd runner && go test -race -count=1 ./...
 
+  # Coverage is telemetry for the README badge. It must not become a required
+  # status check: an uploader hiccup cannot block a green validate/runner job.
+  # Promotion dispatches this workflow with GITHUB_TOKEN; skip coverage there.
+  coverage:
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.25"
+
+      - name: Collect Go coverage
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.cache/pipelock-tmp" "$HOME/.cache/go-build"
+          export TMPDIR="$HOME/.cache/pipelock-tmp"
+          export GOCACHE="$HOME/.cache/go-build"
+          for module in runner validate capability-registry; do
+            ( cd "$module" && go test -race -count=1 -coverprofile=coverage.out ./... )
+          done
+
+      - name: Upload coverage
+        # Best-effort telemetry. The Codecov uploader's integrity check can
+        # fail independently of the tests, and coverage is not a merge gate.
+        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          files: runner/coverage.out,validate/coverage.out,capability-registry/coverage.out
+          disable_search: true
+          fail_ci_if_error: false
+
   # The shared gate above is the normal push contract. Keep this narrower job
   # solely for the validate module's declared minimum Go compatibility, which
   # the Go 1.25 preflight cannot prove.

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Full governance policy: [docs/GOVERNANCE.md](docs/GOVERNANCE.md).
 - [What is an Agent Firewall?](https://pipelab.org/agent-firewall/) — the security architecture this corpus tests
 - [AI Agent Security: Three Layers](https://pipelab.org/learn/ai-agent-security/) — hooks, guardrails, and egress inspection explained
 - [MCP Vulnerabilities](https://pipelab.org/learn/mcp-vulnerabilities/) — the MCP attack surface mapped
-- [Pipelock Gauntlet history](https://pipelab.org/gauntlet/) — the maintainer's disclosed first-party run history
+- [Pipelock Gauntlet history](https://pipelab.org/gauntlet/results/): the maintainer's disclosed first-party run history
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml"><img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml/badge.svg" alt="Pipelock Scan"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/luckyPipewrench/agent-egress-bench"><img src="https://api.scorecard.dev/projects/github.com/luckyPipewrench/agent-egress-bench/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://goreportcard.com/report/github.com/luckyPipewrench/agent-egress-bench"><img src="https://goreportcard.com/badge/github.com/luckyPipewrench/agent-egress-bench" alt="Go Report Card"></a>
+  <a href="https://codecov.io/gh/luckyPipewrench/agent-egress-bench"><img src="https://codecov.io/gh/luckyPipewrench/agent-egress-bench/graph/badge.svg" alt="codecov"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
   <a href="https://discord.gg/badNfhGKTc"><img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
   <a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/validate.yaml"><img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/validate.yaml/badge.svg" alt="Validate Cases"></a>
   <a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/security.yaml"><img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/security.yaml/badge.svg" alt="Security"></a>
   <a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml"><img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml/badge.svg" alt="Pipelock Scan"></a>
-  <a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/continuous-gauntlet.yaml"><img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/continuous-gauntlet.yaml/badge.svg" alt="Continuous Gauntlet"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/luckyPipewrench/agent-egress-bench"><img src="https://api.scorecard.dev/projects/github.com/luckyPipewrench/agent-egress-bench/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://goreportcard.com/report/github.com/luckyPipewrench/agent-egress-bench"><img src="https://goreportcard.com/badge/github.com/luckyPipewrench/agent-egress-bench" alt="Go Report Card"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
@@ -114,7 +113,7 @@ It requires Linux, Go 1.25 or newer, Python 3, Git, curl, jq, tar, GNU timeout, 
 
 The raw directory intentionally has no made-up public URL. GitHub Actions or another retaining platform adds its real artifact ID and HTTPS location later, without modifying the evidence bytes. Creating a schedule and publishing a result are separate operator decisions.
 
-The repository's scheduled Pipelock lane is read-only and produces review candidates, not automatic public claims. Approved candidates are retained as digest-addressed, hash-linked evidence directories, and a reviewed pull request advances the `latest-verified` pointer. The included reference renderer verifies and displays score, scope, N/A reasons, false-positive rate, and the canonical run URL together. It renders this repository's first-party Pipelock history and ranks nothing. See [Continuous Gauntlet Results](docs/CONTINUOUS-RESULTS.md) for the repository review and publication contract.
+The corpus, runner, and portable command live in this repository. The product's scheduled candidate currently runs in [`luckyPipewrench/pipelock`](https://github.com/luckyPipewrench/pipelock). Public scores are selected and published. They are not automatic. First-party published history is at [pipelab.org/gauntlet/results](https://pipelab.org/gauntlet/results/). Approved records retained here are digest-addressed, hash-linked evidence directories, and a reviewed pull request advances the `latest-verified` pointer. The included reference renderer verifies and displays score, scope, N/A reasons, false-positive rate, and the canonical run URL together. It ranks nothing. See [Continuous Gauntlet Results](docs/CONTINUOUS-RESULTS.md) for the review and publication contract.
 
 For other tools, the runner writes per-case JSONL results to stdout (one object per case, see [docs/RUNNER.md](docs/RUNNER.md)) and a Gauntlet summary JSON to the path passed via `--output` (containment, false-positive rate, non-scoring output-field diagnostics, and per-category results, see [docs/gauntlet.md](docs/gauntlet.md)). `--emit-receipt-profile` additionally writes a reproducible receipt-scoring profile with retained corpus and tool-version observations (see [docs/RECEIPT-SCORING.md](docs/RECEIPT-SCORING.md)).
 
@@ -124,7 +123,7 @@ For other tools, the runner writes per-case JSONL results to stdout (one object 
 
 The Gauntlet reports containment and false-positive rate separately, plus non-scoring field-presence diagnostics. [docs/gauntlet.md](docs/gauntlet.md) owns metric definitions, result states, denominators, and measurement status. [Results Use and Attribution](docs/RESULTS-USE.md) owns the claims and disclosures that travel with a public result.
 
-The maintainer's disclosed first-party Pipelock history is published at [pipelab.org/gauntlet](https://pipelab.org/gauntlet/). Every other publisher owns its results.
+The maintainer's disclosed first-party Pipelock history is published at [pipelab.org/gauntlet/results](https://pipelab.org/gauntlet/results/). Every other publisher owns its results.
 
 ## What this does NOT test
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  notify:
+    # One coverage job uploads the three Go modules as a single report.
+    after_n_builds: 1
+    wait_for_ci: false
+
+parsers:
+  go:
+    # Go profiles are statement-based. Counting Codecov partials as hits keeps
+    # the badge aligned with Go's own coverage model.
+    partials_as_hits: true
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/docs/CONTINUOUS-RESULTS.md
+++ b/docs/CONTINUOUS-RESULTS.md
@@ -2,16 +2,16 @@
 
 This repository owns the corpus, the runner, and the portable command. Public scores are selected and published. A completed run is not a public claim by itself. First-party published Pipelock history is at [pipelab.org/gauntlet/results](https://pipelab.org/gauntlet/results/). The product's scheduled candidate currently runs in [luckyPipewrench/pipelock](https://github.com/luckyPipewrench/pipelock).
 
-This repository still has a read-only `Continuous Gauntlet` workflow and a promotion path that accepts only a completed run of that workflow from this repository. That remaining path is not the live public exam.
+This repository's `Continuous Gauntlet` workflow is not scheduled. A maintainer can dispatch it by hand. That path is not the live public exam.
 
 1. A completed run of this repository's read-only `Continuous Gauntlet` workflow retains a candidate evidence bundle. That workflow is not the product's public schedule.
 2. A maintainer chooses a completed run in the `Prepare Gauntlet result promotion` workflow.
 3. The promotion workflow downloads that exact bundle, recomputes its decision, and opens a pull request.
 4. Merging the pull request is the repository publication approval. It adds an immutable record and advances `latest-verified`.
 
-The remaining scheduled workflow cannot write repository contents or open a pull request. A raw run never moves the committed pointer by itself. Candidate Actions artifacts are retained for 14 days, so a maintainer must prepare the promotion before that download window closes.
+That workflow cannot write repository contents or open a pull request. A raw run never moves the committed pointer by itself. Candidate Actions artifacts are retained for 14 days, so a maintainer must prepare the promotion before that download window closes.
 
-Scheduled runs of that remaining workflow do not create pull requests. The workflow summary says **PASS — NO ACTION REQUIRED** when the candidate matches the approved scope. Owner action is needed only when it says **REVIEW REQUIRED** for a scope or policy change, or **BLOCKED** for an incomplete or failed run.
+Manual runs of that workflow do not create pull requests. The workflow summary says **PASS — NO ACTION REQUIRED** when the candidate matches the approved scope. Owner action is needed only when it says **REVIEW REQUIRED** for a scope or policy change, or **BLOCKED** for an incomplete or failed run.
 
 Clean runs finish green. Review-required and blocked runs finish red so GitHub's workflow run and ordinary failed-workflow notifications surface the action; the first line of the run summary distinguishes a review from a broken run. Email delivery still depends on the owner's GitHub notification settings.
 

--- a/docs/CONTINUOUS-RESULTS.md
+++ b/docs/CONTINUOUS-RESULTS.md
@@ -1,17 +1,19 @@
 # Continuous Gauntlet Results
 
-The Pipelock reference lane separates execution, review, and publication.
+This repository owns the corpus, the runner, and the portable command. Public scores are selected and published. A completed run is not a public claim by itself. First-party published Pipelock history is at [pipelab.org/gauntlet/results](https://pipelab.org/gauntlet/results/). The product's scheduled candidate currently runs in [luckyPipewrench/pipelock](https://github.com/luckyPipewrench/pipelock).
 
-1. The read-only `Continuous Gauntlet` workflow runs the portable benchmark and retains a candidate evidence bundle.
+This repository still has a read-only `Continuous Gauntlet` workflow and a promotion path that accepts only a completed run of that workflow from this repository. That remaining path is not the live public exam.
+
+1. A completed run of this repository's read-only `Continuous Gauntlet` workflow retains a candidate evidence bundle. That workflow is not the product's public schedule.
 2. A maintainer chooses a completed run in the `Prepare Gauntlet result promotion` workflow.
 3. The promotion workflow downloads that exact bundle, recomputes its decision, and opens a pull request.
 4. Merging the pull request is the repository publication approval. It adds an immutable record and advances `latest-verified`.
 
-The scheduled workflow cannot write repository contents or open a pull request. A raw run never moves the committed pointer by itself. Candidate Actions artifacts are retained for 14 days, so a maintainer must prepare the promotion before that download window closes.
+The remaining scheduled workflow cannot write repository contents or open a pull request. A raw run never moves the committed pointer by itself. Candidate Actions artifacts are retained for 14 days, so a maintainer must prepare the promotion before that download window closes.
 
-Daily runs do not create pull requests. The workflow summary says **PASS — NO ACTION REQUIRED** when the candidate matches the approved scope. Owner action is needed only when it says **REVIEW REQUIRED** for a scope or policy change, or **BLOCKED** for an incomplete or failed run.
+Scheduled runs of that remaining workflow do not create pull requests. The workflow summary says **PASS — NO ACTION REQUIRED** when the candidate matches the approved scope. Owner action is needed only when it says **REVIEW REQUIRED** for a scope or policy change, or **BLOCKED** for an incomplete or failed run.
 
-Clean runs finish green. Review-required and blocked runs finish red so the Actions badge and normal failed-workflow notifications surface the action; the first line of the run summary distinguishes a review from a broken run. Email delivery still depends on the owner's GitHub notification settings.
+Clean runs finish green. Review-required and blocked runs finish red so GitHub's workflow run and ordinary failed-workflow notifications surface the action; the first line of the run summary distinguishes a review from a broken run. Email delivery still depends on the owner's GitHub notification settings.
 
 ## Append-only layout
 
@@ -63,6 +65,6 @@ The portable command is not tied to GitHub Actions:
 ./scripts/run-pipelock-gauntlet.sh
 ```
 
-An independent lab can repeat that command with its own scheduler and retain the same portable bundle. Its platform supplies its own real artifact ID and HTTPS URL during finalization. Its publication policy remains independent from this repository's self-operated Pipelock lane. Matching the Pipelock release, corpus commit and digest, runner version, fixtures, and applicable/N/A denominator makes the two results directly reconcilable without pretending they share an operator.
+An independent lab can repeat that command with its own scheduler and retain the same portable bundle. Its platform supplies its own real artifact ID and HTTPS URL during finalization. Its publication policy remains independent from the product's scheduled candidate. Matching the Pipelock release, corpus commit and digest, runner version, fixtures, and applicable/N/A denominator makes the two results directly reconcilable without pretending they share an operator.
 
 An operator calling its program continuous declares the publication selection rule before execution, keeps each completed scored result in scope, and shows the run date beside every displayed score. Superseding records link to retained predecessors. An error, incomplete measurement, or unknown state stays visibly non-successful instead of leaving the last successful result looking current. The neutral publication lockup described in [RESULTS-USE.md](RESULTS-USE.md) makes the reproducibility facts portable across the operator's report, badge data, website, and social presentation without transferring ownership of the method or the operator's brand.

--- a/docs/RESULTS-USE.md
+++ b/docs/RESULTS-USE.md
@@ -150,9 +150,9 @@ These constraints bind this repository and its maintainer, not just outside publ
 - no private preview of an adverse result to the affected vendor before publication;
 - no retroactive scoring change to move a published number. Scoring changes get a version.
 
-The maintainer builds Pipelock, and the Pipelock reference lane in this repository publishes
-first-party regression evidence under `gauntlet-site/results/pipelock/`. That lane is disclosed
-self-run and artifact-validated evidence. It carries no independence claim.
+The maintainer builds Pipelock. Retained Pipelock records under
+`gauntlet-site/results/pipelock/` are archived first-party regression evidence. They are not the
+live product schedule or public score, and they carry no independence claim.
 
 See [GOVERNANCE.md](GOVERNANCE.md) for neutrality and contribution rules, and
 [gauntlet.md](gauntlet.md) for how results are produced and published.

--- a/scripts/check_claim_language.py
+++ b/scripts/check_claim_language.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Fail the build when documentation makes a claim the method cannot support.
 
-Three checks run together:
+Four checks run together:
 
 1. Banned claim terms. Certification, ranking, and absolute-security language
    must not appear in contributor-facing documentation. A line that needs the
@@ -12,6 +12,9 @@ Three checks run together:
    results. Deleting either is the failure mode this check exists to catch.
 3. Target review stays public and limited to setup. Documentation must not
    promise private notice or a prepublication result preview to a target.
+4. Exam home. README must not badge this repository's Continuous Gauntlet
+   workflow, and ``docs/CONTINUOUS-RESULTS.md`` must not read as if that
+   workflow is still the live public Pipelock execution.
 """
 
 import re
@@ -23,6 +26,17 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # The definitions document names the terms it forbids, so the banned-term scan
 # skips it. Its own required content is asserted separately below.
 DEFINITIONS_DOC = Path("docs/RESULTS-USE.md")
+README_FILE = Path("README.md")
+CONTINUOUS_RESULTS_DOC = Path("docs/CONTINUOUS-RESULTS.md")
+
+# A README badge whose href is this repository's Continuous Gauntlet workflow
+# implies this repo is still the live product exam. The Pipelock Scan badge
+# (pipelock.yaml) is this repo being scanned, which is a different thing.
+GAUNTLET_WORKFLOW_BADGE = re.compile(
+    r"actions/workflows/continuous-gauntlet\.yaml",
+    re.IGNORECASE,
+)
+PIPELOCK_SCAN_BADGE = "actions/workflows/pipelock.yaml"
 
 SCAN_ROOTS = (
     Path("README.md"),
@@ -91,6 +105,14 @@ BANNED = (
         r"\b(?:received|obtained|accessed)\b",
         "targets get no private or prepublication result review",
     ),
+    (
+        r"(?:this |the )?repository's scheduled Pipelock lane",
+        "this repository is not the live Pipelock schedule; the corpus and runner live here",
+    ),
+    (
+        r"this repository's self-operated Pipelock lane",
+        "do not describe this repository as operating the live Pipelock lane",
+    ),
 )
 
 COMPILED = tuple((re.compile(pattern, re.IGNORECASE), reason) for pattern, reason in BANNED)
@@ -153,12 +175,57 @@ def section_text(text: str, heading: str):
     return "\n".join(body) if inside or body else None
 
 
+def check_readme_exam_home(text: str):
+    """Report a README that still treats this repo as the live product exam."""
+    findings = []
+    if GAUNTLET_WORKFLOW_BADGE.search(text):
+        findings.append(
+            f"{README_FILE}: Continuous Gauntlet badge still points at this "
+            "repository's continuous-gauntlet.yaml; this repository is not "
+            "the live product schedule"
+        )
+    if PIPELOCK_SCAN_BADGE not in text:
+        findings.append(
+            f"{README_FILE}: missing the Pipelock Scan badge for pipelock.yaml"
+        )
+    return findings
+
+
+def check_continuous_results(text: str):
+    """Report a continuous-results doc that still reads as the live public exam."""
+    findings = []
+    if "luckyPipewrench/pipelock" not in text:
+        findings.append(
+            f"{CONTINUOUS_RESULTS_DOC}: must name luckyPipewrench/pipelock as "
+            "the product's scheduled candidate"
+        )
+    if "https://pipelab.org/gauntlet/results/" not in text:
+        findings.append(
+            f"{CONTINUOUS_RESULTS_DOC}: must point at "
+            "https://pipelab.org/gauntlet/results/ for first-party published history"
+        )
+    if "./scripts/run-pipelock-gauntlet.sh" not in text:
+        findings.append(f"{CONTINUOUS_RESULTS_DOC}: missing the portable command")
+    collapsed = " ".join(text.split()).lower()
+    if "independent" not in collapsed or "operator" not in collapsed:
+        findings.append(
+            f"{CONTINUOUS_RESULTS_DOC}: missing independent-operator language"
+        )
+    return findings
+
+
 def check_definitions(text: str):
     """Report missing required content in the definitions document."""
     findings = []
     for label in REQUIRED_DEFINITIONS:
         if label not in text:
             findings.append(f"{DEFINITIONS_DOC}: missing the {label} assurance label")
+
+    if re.search(r"\bPipelock reference lane in this repository\b", text, re.IGNORECASE):
+        findings.append(
+            f"{DEFINITIONS_DOC}: must not present this repository as Pipelock's "
+            "live reference lane or publication home"
+        )
 
     # The permission has to live in its own section. Matching the phrase anywhere
     # in the document would pass while the adverse-results section itself said
@@ -207,6 +274,18 @@ def main():
         findings.append(f"{DEFINITIONS_DOC}: missing")
     else:
         findings.extend(check_definitions(definitions_path.read_text(encoding="utf-8")))
+
+    readme_path = REPO_ROOT / README_FILE
+    if not readme_path.is_file():
+        findings.append(f"{README_FILE}: missing")
+    else:
+        findings.extend(check_readme_exam_home(readme_path.read_text(encoding="utf-8")))
+
+    continuous_path = REPO_ROOT / CONTINUOUS_RESULTS_DOC
+    if not continuous_path.is_file():
+        findings.append(f"{CONTINUOUS_RESULTS_DOC}: missing")
+    else:
+        findings.extend(check_continuous_results(continuous_path.read_text(encoding="utf-8")))
 
     if findings:
         print("check-claim-language: FAIL")

--- a/scripts/check_claim_language.py
+++ b/scripts/check_claim_language.py
@@ -42,6 +42,9 @@ GAUNTLET_WORKFLOW_BADGE = re.compile(
     re.IGNORECASE,
 )
 PIPELOCK_SCAN_BADGE = "actions/workflows/pipelock.yaml"
+CODECOV_BADGE_IMG = (
+    "https://codecov.io/gh/luckyPipewrench/agent-egress-bench/graph/badge.svg"
+)
 LIVE_PUBLIC_EXAM_CLAIM = re.compile(
     r"this repository'?s?.{0,160}continuous gauntlet.{0,80}is the live public",
     re.IGNORECASE | re.DOTALL,
@@ -203,6 +206,10 @@ def check_readme_exam_home(text: str):
     if PIPELOCK_SCAN_BADGE not in text:
         findings.append(
             f"{README_FILE}: missing the Pipelock Scan badge for pipelock.yaml"
+        )
+    if CODECOV_BADGE_IMG not in text:
+        findings.append(
+            f"{README_FILE}: missing the codecov coverage badge"
         )
     return findings
 

--- a/scripts/check_claim_language.py
+++ b/scripts/check_claim_language.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Fail the build when documentation makes a claim the method cannot support.
 
-Four checks run together:
+Five checks run together:
 
 1. Banned claim terms. Certification, ranking, and absolute-security language
    must not appear in contributor-facing documentation. A line that needs the
@@ -15,6 +15,9 @@ Four checks run together:
 4. Exam home. README must not badge this repository's Continuous Gauntlet
    workflow, and ``docs/CONTINUOUS-RESULTS.md`` must not read as if that
    workflow is still the live public Pipelock execution.
+5. No leftover daily exam. ``.github/workflows/continuous-gauntlet.yaml``
+   must not schedule a Pipelock run. The product schedule lives in
+   luckyPipewrench/pipelock.
 """
 
 import re
@@ -28,15 +31,28 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFINITIONS_DOC = Path("docs/RESULTS-USE.md")
 README_FILE = Path("README.md")
 CONTINUOUS_RESULTS_DOC = Path("docs/CONTINUOUS-RESULTS.md")
+CONTINUOUS_WORKFLOW = Path(".github/workflows/continuous-gauntlet.yaml")
 
-# A README badge whose href is this repository's Continuous Gauntlet workflow
-# implies this repo is still the live product exam. The Pipelock Scan badge
-# (pipelock.yaml) is this repo being scanned, which is a different thing.
+# A README badge image for this repository's Continuous Gauntlet workflow
+# implies this repo is still the live product exam. A prose link to the
+# workflow file is not that claim. The Pipelock Scan badge (pipelock.yaml)
+# is this repo being scanned, which is a different thing.
 GAUNTLET_WORKFLOW_BADGE = re.compile(
-    r"actions/workflows/continuous-gauntlet\.yaml",
+    r"actions/workflows/continuous-gauntlet\.yaml/badge\.svg",
     re.IGNORECASE,
 )
 PIPELOCK_SCAN_BADGE = "actions/workflows/pipelock.yaml"
+LIVE_PUBLIC_EXAM_CLAIM = re.compile(
+    r"this repository'?s?.{0,160}continuous gauntlet.{0,80}is the live public",
+    re.IGNORECASE | re.DOTALL,
+)
+REFERENCE_LANE_CLAIM = re.compile(
+    r"(?:"
+    r"pipelock reference lane in this repository"
+    r"|this repository is pipelock'?s?(?: live)? reference lane"
+    r")",
+    re.IGNORECASE,
+)
 
 SCAN_ROOTS = (
     Path("README.md"),
@@ -211,6 +227,22 @@ def check_continuous_results(text: str):
         findings.append(
             f"{CONTINUOUS_RESULTS_DOC}: missing independent-operator language"
         )
+    if LIVE_PUBLIC_EXAM_CLAIM.search(text):
+        findings.append(
+            f"{CONTINUOUS_RESULTS_DOC}: must not call this repository's "
+            "Continuous Gauntlet workflow the live public Pipelock exam"
+        )
+    return findings
+
+
+def check_workflow_not_scheduled(text: str):
+    """Report a Continuous Gauntlet workflow that still runs on a schedule."""
+    findings = []
+    if re.search(r"(?m)^\s+schedule:", text) or re.search(r"(?m)^\s+-\s*cron:", text):
+        findings.append(
+            f"{CONTINUOUS_WORKFLOW}: this repository must not schedule a daily "
+            "Pipelock exam; the product schedule lives in luckyPipewrench/pipelock"
+        )
     return findings
 
 
@@ -221,7 +253,7 @@ def check_definitions(text: str):
         if label not in text:
             findings.append(f"{DEFINITIONS_DOC}: missing the {label} assurance label")
 
-    if re.search(r"\bPipelock reference lane in this repository\b", text, re.IGNORECASE):
+    if REFERENCE_LANE_CLAIM.search(text):
         findings.append(
             f"{DEFINITIONS_DOC}: must not present this repository as Pipelock's "
             "live reference lane or publication home"
@@ -286,6 +318,12 @@ def main():
         findings.append(f"{CONTINUOUS_RESULTS_DOC}: missing")
     else:
         findings.extend(check_continuous_results(continuous_path.read_text(encoding="utf-8")))
+
+    workflow_path = REPO_ROOT / CONTINUOUS_WORKFLOW
+    if not workflow_path.is_file():
+        findings.append(f"{CONTINUOUS_WORKFLOW}: missing")
+    else:
+        findings.extend(check_workflow_not_scheduled(workflow_path.read_text(encoding="utf-8")))
 
     if findings:
         print("check-claim-language: FAIL")

--- a/scripts/check_claim_language_test.py
+++ b/scripts/check_claim_language_test.py
@@ -135,21 +135,35 @@ class DefinitionsDocumentTest(unittest.TestCase):
 
 
 class GauntletExamHomeTest(unittest.TestCase):
+    SCAN_AND_COVERAGE = (
+        '<a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml">'
+        '<img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml/badge.svg" '
+        'alt="Pipelock Scan"></a>\n'
+        '<a href="https://codecov.io/gh/luckyPipewrench/agent-egress-bench">'
+        '<img src="https://codecov.io/gh/luckyPipewrench/agent-egress-bench/graph/badge.svg" '
+        'alt="codecov"></a>\n'
+    )
+
     def test_prose_workflow_link_is_not_a_badge_finding(self):
         text = (
-            '<a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml">'
-            '<img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml/badge.svg" '
-            'alt="Pipelock Scan"></a>\n'
-            "See .github/workflows/continuous-gauntlet.yaml for the optional manual workflow.\n"
+            self.SCAN_AND_COVERAGE
+            + "See .github/workflows/continuous-gauntlet.yaml for the optional manual workflow.\n"
         )
         self.assertEqual(check.check_readme_exam_home(text), [])
 
-    def test_continuous_gauntlet_readme_badge_is_reported(self):
+    def test_codecov_badge_is_required(self):
         text = (
             '<a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml">'
             '<img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml/badge.svg" '
             'alt="Pipelock Scan"></a>\n'
-            '<a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/continuous-gauntlet.yaml">'
+        )
+        findings = check.check_readme_exam_home(text)
+        self.assertTrue(any("codecov" in finding for finding in findings))
+
+    def test_continuous_gauntlet_readme_badge_is_reported(self):
+        text = (
+            self.SCAN_AND_COVERAGE
+            + '<a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/continuous-gauntlet.yaml">'
             '<img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/continuous-gauntlet.yaml/badge.svg" '
             'alt="Continuous Gauntlet"></a>\n'
         )

--- a/scripts/check_claim_language_test.py
+++ b/scripts/check_claim_language_test.py
@@ -82,6 +82,13 @@ class DefinitionsDocumentTest(unittest.TestCase):
         findings = check.check_definitions(damaged)
         self.assertTrue(any("live reference lane" in finding for finding in findings))
 
+    def test_reversed_reference_lane_claim_is_reported(self):
+        damaged = self.text + (
+            "\nThis repository is Pipelock's reference lane and publication home.\n"
+        )
+        findings = check.check_definitions(damaged)
+        self.assertTrue(any("live reference lane" in finding for finding in findings))
+
     def reverse_the_permission(self):
         """Return the document with the adverse-results permission taken away."""
         body = check.section_text(self.text, check.ADVERSE_SECTION)
@@ -128,6 +135,15 @@ class DefinitionsDocumentTest(unittest.TestCase):
 
 
 class GauntletExamHomeTest(unittest.TestCase):
+    def test_prose_workflow_link_is_not_a_badge_finding(self):
+        text = (
+            '<a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml">'
+            '<img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml/badge.svg" '
+            'alt="Pipelock Scan"></a>\n'
+            "See .github/workflows/continuous-gauntlet.yaml for the optional manual workflow.\n"
+        )
+        self.assertEqual(check.check_readme_exam_home(text), [])
+
     def test_continuous_gauntlet_readme_badge_is_reported(self):
         text = (
             '<a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml">'
@@ -186,9 +202,32 @@ class GauntletExamHomeTest(unittest.TestCase):
         self.assertTrue(any("luckyPipewrench/pipelock" in finding for finding in findings))
         self.assertTrue(any("pipelab.org/gauntlet/results" in finding for finding in findings))
 
+    def test_live_public_exam_claim_is_reported_with_required_strings(self):
+        text = (
+            "The product's scheduled candidate currently runs in luckyPipewrench/pipelock.\n"
+            "https://pipelab.org/gauntlet/results/\n"
+            "./scripts/run-pipelock-gauntlet.sh\n"
+            "An independent lab can repeat that command with its own scheduler. "
+            "An operator calling its program continuous declares the publication selection rule.\n"
+            "This repository's Continuous Gauntlet workflow is the live public Pipelock execution.\n"
+        )
+        findings = check.check_continuous_results(text)
+        self.assertTrue(any("live public Pipelock exam" in finding for finding in findings))
+
     def test_live_continuous_results_passes(self):
         text = (REPO_ROOT / check.CONTINUOUS_RESULTS_DOC).read_text(encoding="utf-8")
         self.assertEqual(check.check_continuous_results(text), [])
+
+    def test_scheduled_workflow_is_reported(self):
+        findings = check.check_workflow_not_scheduled(
+            "on:\n  workflow_dispatch:\n  schedule:\n    - cron: '17 6 * * *'\n"
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertIn("must not schedule a daily", findings[0])
+
+    def test_live_workflow_is_not_scheduled(self):
+        text = (REPO_ROOT / check.CONTINUOUS_WORKFLOW).read_text(encoding="utf-8")
+        self.assertEqual(check.check_workflow_not_scheduled(text), [])
 
 
 class RepositoryTest(unittest.TestCase):

--- a/scripts/check_claim_language_test.py
+++ b/scripts/check_claim_language_test.py
@@ -74,6 +74,14 @@ class DefinitionsDocumentTest(unittest.TestCase):
         findings = check.check_definitions(damaged)
         self.assertTrue(any("Challenge-verified" in finding for finding in findings))
 
+    def test_bench_reference_lane_claim_is_reported(self):
+        damaged = self.text + (
+            "\nThe Pipelock reference lane in this repository publishes first-party "
+            "regression evidence.\n"
+        )
+        findings = check.check_definitions(damaged)
+        self.assertTrue(any("live reference lane" in finding for finding in findings))
+
     def reverse_the_permission(self):
         """Return the document with the adverse-results permission taken away."""
         body = check.section_text(self.text, check.ADVERSE_SECTION)
@@ -117,6 +125,70 @@ class DefinitionsDocumentTest(unittest.TestCase):
         )
         findings = check.check_definitions(damaged)
         self.assertTrue(any("setup review public" in f for f in findings))
+
+
+class GauntletExamHomeTest(unittest.TestCase):
+    def test_continuous_gauntlet_readme_badge_is_reported(self):
+        text = (
+            '<a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml">'
+            '<img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/pipelock.yaml/badge.svg" '
+            'alt="Pipelock Scan"></a>\n'
+            '<a href="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/continuous-gauntlet.yaml">'
+            '<img src="https://github.com/luckyPipewrench/agent-egress-bench/actions/workflows/continuous-gauntlet.yaml/badge.svg" '
+            'alt="Continuous Gauntlet"></a>\n'
+        )
+        findings = check.check_readme_exam_home(text)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("continuous-gauntlet.yaml", findings[0])
+        self.assertIn("not the live product schedule", findings[0])
+
+    def test_pipelock_scan_badge_is_required(self):
+        findings = check.check_readme_exam_home("<p align=\"center\">no badges</p>\n")
+        self.assertTrue(any("pipelock.yaml" in finding for finding in findings))
+
+    def test_live_readme_keeps_scan_badge_and_drops_gauntlet_badge(self):
+        text = (REPO_ROOT / check.README_FILE).read_text(encoding="utf-8")
+        self.assertEqual(check.check_readme_exam_home(text), [])
+
+    def test_scheduled_pipelock_lane_claim_is_reported(self):
+        text = (
+            "The repository's scheduled Pipelock lane is read-only and "
+            "produces review candidates, not automatic public claims.\n"
+        )
+        findings = check.scan_text(Path("README.md"), text)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("scheduled Pipelock lane", findings[0])
+
+    def test_this_repository_scheduled_lane_claim_is_reported(self):
+        text = "this repository's scheduled Pipelock lane still runs the exam.\n"
+        findings = check.scan_text(Path("docs/CONTINUOUS-RESULTS.md"), text)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("scheduled Pipelock lane", findings[0])
+
+    def test_self_operated_lane_claim_is_reported(self):
+        text = (
+            "Its publication policy remains independent from this "
+            "repository's self-operated Pipelock lane.\n"
+        )
+        findings = check.scan_text(Path("docs/CONTINUOUS-RESULTS.md"), text)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("self-operated Pipelock lane", findings[0])
+
+    def test_old_continuous_results_opening_is_reported(self):
+        old = (
+            "The Pipelock reference lane separates execution, review, and publication.\n"
+            "1. The read-only `Continuous Gauntlet` workflow runs the portable "
+            "benchmark and retains a candidate evidence bundle.\n"
+            "./scripts/run-pipelock-gauntlet.sh\n"
+            "An independent lab can repeat that command with its own scheduler.\n"
+        )
+        findings = check.check_continuous_results(old)
+        self.assertTrue(any("luckyPipewrench/pipelock" in finding for finding in findings))
+        self.assertTrue(any("pipelab.org/gauntlet/results" in finding for finding in findings))
+
+    def test_live_continuous_results_passes(self):
+        text = (REPO_ROOT / check.CONTINUOUS_RESULTS_DOC).read_text(encoding="utf-8")
+        self.assertEqual(check.check_continuous_results(text), [])
 
 
 class RepositoryTest(unittest.TestCase):

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -561,6 +561,29 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertLess(self.entrypoint.index('curl -fsSL "$asset_url"'), self.entrypoint.index(digest_check))
         self.assertLess(self.entrypoint.index(digest_check), self.entrypoint.index('tar -xzf "$work_dir/$asset"'))
 
+    def test_validate_workflow_uploads_go_coverage(self):
+        validate_workflow = (
+            Path(__file__).resolve().parent.parent / ".github" / "workflows" / "validate.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("coverage:", validate_workflow)
+        self.assertIn("-coverprofile=coverage.out", validate_workflow)
+        self.assertIn(
+            "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f",
+            validate_workflow,
+        )
+        self.assertIn("fail_ci_if_error: false", validate_workflow)
+        self.assertIn("continue-on-error: true", validate_workflow)
+        self.assertIn("runner/coverage.out", validate_workflow)
+        self.assertIn("validate/coverage.out", validate_workflow)
+        self.assertIn("capability-registry/coverage.out", validate_workflow)
+        self.assertIn("github.event_name != 'workflow_dispatch'", validate_workflow)
+        scanned = re.findall(r'go-version: "(\d+\.\d+\.\d+)"', validate_workflow)
+        self.assertEqual(
+            len(scanned),
+            1,
+            f"coverage job must not add a second exact-patch Go pin, found {scanned}",
+        )
+
     def test_workflow_is_not_scheduled(self):
         trigger = self.workflow[self.workflow.index("on:") : self.workflow.index("concurrency:")]
         self.assertIn("workflow_dispatch:", trigger)

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -561,6 +561,12 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertLess(self.entrypoint.index('curl -fsSL "$asset_url"'), self.entrypoint.index(digest_check))
         self.assertLess(self.entrypoint.index(digest_check), self.entrypoint.index('tar -xzf "$work_dir/$asset"'))
 
+    def test_workflow_is_not_scheduled(self):
+        trigger = self.workflow[self.workflow.index("on:") : self.workflow.index("concurrency:")]
+        self.assertIn("workflow_dispatch:", trigger)
+        self.assertNotIn("schedule:", trigger)
+        self.assertNotIn("cron:", trigger)
+
     def test_scheduled_lane_has_no_public_write_permission(self):
         self.assertRegex(self.workflow, r"(?m)^permissions:\n  contents: read$")
         self.assertNotIn("contents: write", self.workflow)


### PR DESCRIPTION
## What changed

Remove the Continuous Gauntlet badge and stop this README from treating the leftover scheduled workflow as the live Pipelock exam.

The scheduled candidate currently runs in luckyPipewrench/pipelock. First-party published history is at https://pipelab.org/gauntlet/results/.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and guides to clarify the distinction between archived evidence, candidate runs, and publicly published scores.
  * Added links to the published Gauntlet results history and identified the product’s scheduled candidate location.
  * Clarified the remaining workflow’s role in the promotion process.

* **Quality Improvements**
  * Expanded documentation checks to detect outdated scheduling, badge, and publication claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->