### PR TITLE
fix: show reconstructing score denominators on the results page

### DIFF
--- a/gauntlet-site/index.html
+++ b/gauntlet-site/index.html
@@ -37,6 +37,7 @@ a:hover { text-decoration: underline; }
 .score-box { background: var(--bg); border: 1px solid var(--border); border-radius: 0.375rem; padding: 1rem; text-align: center; }
 .score-label { font-size: 0.75rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.25rem; }
 .score-value { font-size: 1.8rem; font-weight: 700; font-family: var(--mono); }
+.score-fraction { font-size: 0.75rem; color: var(--muted); margin-top: 0.25rem; }
 .score-na { color: var(--muted); font-size: 1.2rem; }
 .section-label { font-size: 0.85rem; color: var(--muted); margin: 1rem 0 0.5rem; font-weight: 600; }
 .failure-summary { border-left: 3px solid var(--red); margin: 0.75rem 0 1rem; padding: 0.25rem 0 0.25rem 0.75rem; color: var(--text); }
@@ -133,10 +134,24 @@ go build -o aeb-gauntlet .
     return (v * 100).toFixed(1) + '%';
   }
 
-  function makeScoreBox(label, val) {
+  // A fraction is published only when it reconstructs the score beside it.
+  // Missing, malformed, zero, and mismatched counts keep the percent bare.
+  function formatScoreFraction(score, counts, caseKind) {
+    if (!isScoreNumber(score) || !counts || typeof counts !== 'object') return '';
+    var numerator = counts.numerator;
+    var denominator = counts.denominator;
+    if (!Number.isInteger(numerator) || !Number.isInteger(denominator)) return '';
+    if (numerator < 0 || denominator <= 0 || numerator > denominator) return '';
+    if (Math.abs(score - (numerator / denominator)) > 1e-12) return '';
+    return numerator + '/' + denominator + ' ' + caseKind;
+  }
+
+  function makeScoreBox(label, val, counts, caseKind) {
     var box = el('div', 'score-box');
     box.appendChild(txt('div', label, 'score-label'));
     box.appendChild(txt('div', fmtPct(val), 'score-value ' + pctCls(val)));
+    var fraction = formatScoreFraction(val, counts, caseKind);
+    if (fraction) box.appendChild(txt('div', fraction, 'score-fraction'));
     return box;
   }
 
@@ -144,18 +159,19 @@ go build -o aeb-gauntlet .
     return txt('span', text, 'badge badge-' + cls);
   }
 
-  function makeScoresGrid(scores, diagnostics, schemaVersion) {
+  function makeScoresGrid(scores, diagnostics, schemaVersion, metricCounts) {
+    metricCounts = metricCounts || {};
     var grid = el('div', 'scores-grid');
-    grid.appendChild(makeScoreBox('Containment', scores.containment));
-    grid.appendChild(makeScoreBox('False Positive', scores.false_positive_rate));
+    grid.appendChild(makeScoreBox('Containment', scores.containment, metricCounts.containment, 'malicious cases'));
+    grid.appendChild(makeScoreBox('False Positive', scores.false_positive_rate, metricCounts.false_positive_rate, 'benign cases'));
     if (schemaVersion === 5 || schemaVersion === 6) {
       diagnostics = diagnostics || {};
       grid.appendChild(makeScoreBox('Label present (diagnostic)', diagnostics.classification_present_rate));
       grid.appendChild(makeScoreBox('Structured field present (diagnostic)', diagnostics.structured_evidence_present_rate));
     } else {
       // Frozen v2 records retain their original published field names.
-      grid.appendChild(makeScoreBox('Detection', scores.detection));
-      grid.appendChild(makeScoreBox('Evidence', scores.evidence));
+      grid.appendChild(makeScoreBox('Detection', scores.detection, metricCounts.detection, 'cases'));
+      grid.appendChild(makeScoreBox('Evidence', scores.evidence, metricCounts.evidence, 'cases'));
     }
     return grid;
   }
@@ -249,8 +265,8 @@ go build -o aeb-gauntlet .
       // Full corpus is the primary view. Applicable-only is a diagnostic of the
       // cases this adapter routed, rather than the whole corpus. Routed is not
       // the same as observed: the count includes rows that ended in error.
-      card.appendChild(txt('div', 'Full Corpus Scores (' + fmtCount(cc.total) + ' cases)', 'section-label'));
-      card.appendChild(makeScoresGrid(full, fullDiagnostics, r.schema_version));
+      card.appendChild(txt('div', 'Full Corpus Scores', 'section-label'));
+      card.appendChild(makeScoresGrid(full, fullDiagnostics, r.schema_version, (r.metric_counts || {}).full));
 
       // A real button, not a click-handled div: the control is keyboard
       // operable and announced as a control, and aria-expanded is derived from
@@ -260,7 +276,7 @@ go build -o aeb-gauntlet .
       var aWrap = el('div', 'hidden');
       aToggle.setAttribute('aria-expanded', 'false');
       aWrap.appendChild(txt('div', 'Diagnostic only. Covers the ' + fmtCount(cc.applicable) + ' cases this adapter routed, which includes any that ended in error, not the complete corpus.', 'denominator'));
-      aWrap.appendChild(makeScoresGrid(applicable, applicableDiagnostics, r.schema_version));
+      aWrap.appendChild(makeScoresGrid(applicable, applicableDiagnostics, r.schema_version, (r.metric_counts || {}).applicable));
       aToggle.addEventListener('click', function() {
         aWrap.classList.toggle('hidden');
         aToggle.setAttribute('aria-expanded', aWrap.classList.contains('hidden') ? 'false' : 'true');
@@ -269,7 +285,7 @@ go build -o aeb-gauntlet .
       card.appendChild(aWrap);
     } else {
       card.appendChild(txt('div', 'Scores', 'section-label'));
-      card.appendChild(makeScoresGrid(full, fullDiagnostics, r.schema_version));
+      card.appendChild(makeScoresGrid(full, fullDiagnostics, r.schema_version, (r.metric_counts || {}).full));
     }
 
     var cats = makeCategories(r.per_category, r.schema_version);

--- a/gauntlet-site/index_test.js
+++ b/gauntlet-site/index_test.js
@@ -206,6 +206,50 @@ async function renderLegacyPayload(inlineSource, payload) {
   assert.doesNotMatch(fractionalText, /1\.5/, 'a fractional case count must not render as a total');
   assert.match(fractionalText, /unknown/, 'a fractional case count must render as unknown');
 
+  const reconstructing = await renderLegacyPayload(inline[1], [{
+    tool: 'Counted', tool_version: '1.0.0', sufficient: true,
+    corpus_version: 'v2.4.0', scoring_version: '2.8',
+    case_count: { total: 242, applicable: 242, not_applicable: 0, errors: 0 },
+    scores: {
+      full: { containment: 0.9886363636363636, false_positive_rate: 0 },
+      applicable: { containment: 0.9886363636363636, false_positive_rate: 0 },
+    },
+    metric_counts: {
+      full: {
+        containment: { numerator: 174, denominator: 176 },
+        false_positive_rate: { numerator: 0, denominator: 66 },
+      },
+      applicable: {
+        containment: { numerator: 174, denominator: 176 },
+        false_positive_rate: { numerator: 0, denominator: 66 },
+      },
+    },
+  }]);
+  const counted = reconstructing.children[0];
+  assert.equal(scoreValues(counted)[0].textContent, '98.9%');
+  assert.match(JSON.stringify(counted), /174\/176 malicious cases/);
+  assert.match(JSON.stringify(counted), /0\/66 benign cases/);
+
+  const mismatched = await renderLegacyPayload(inline[1], [{
+    tool: 'Mismatched', tool_version: '1.0.0', sufficient: true,
+    corpus_version: 'v2.4.0', scoring_version: '2.8',
+    case_count: { total: 242, applicable: 242, not_applicable: 0, errors: 0 },
+    scores: {
+      full: { containment: 0.9886363636363636, false_positive_rate: 0 },
+      applicable: { containment: 0.9886363636363636, false_positive_rate: 0 },
+    },
+    metric_counts: {
+      full: {
+        containment: { numerator: 1, denominator: 2 },
+        false_positive_rate: { numerator: 0, denominator: 66 },
+      },
+    },
+  }]);
+  const mismatchedText = JSON.stringify(mismatched.children[0]);
+  assert.doesNotMatch(mismatchedText, /1\/2/, 'a fraction that does not reconstruct the percent must stay unpublished');
+  assert.match(mismatchedText, /0\/66 benign cases/, 'a reconstructing neighbour must keep its fraction');
+  assert.equal(scoreValues(mismatched.children[0])[0].textContent, '98.9%');
+
   console.log('index renderer tests: OK');
 })().catch((error) => {
   console.error(error);

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -244,6 +244,9 @@
     if (fullFalsePositiveCounts.denominator < falsePositiveCounts.denominator) {
       throw new Error('full false-positive denominator cannot be smaller than the applicable denominator');
     }
+    if (fullFalsePositiveCounts.numerator < falsePositiveCounts.numerator) {
+      throw new Error('full false-positive numerator cannot be smaller than the applicable numerator');
+    }
     if (fullContainmentCounts.denominator < containmentCounts.denominator) {
       throw new Error('full containment denominator cannot be smaller than the applicable denominator');
     }
@@ -260,6 +263,10 @@
     if (artifact.schema_version === 6 &&
         fullContainmentCounts.numerator !== containmentCounts.numerator) {
       throw new Error('full containment numerator must equal the applicable numerator');
+    }
+    if (artifact.schema_version === 6 &&
+        fullFalsePositiveCounts.numerator !== falsePositiveCounts.numerator) {
+      throw new Error('full false-positive numerator must equal the applicable numerator');
     }
     if (containmentCounts.denominator > applicable || falsePositiveCounts.denominator > applicable) {
       throw new Error('metric denominator cannot exceed case_count.applicable');

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -21,6 +21,19 @@
     return value === null ? 'N/A' : (value * 100).toFixed(1) + '%';
   }
 
+  // validateMetricFraction already required this equality. Publishing the
+  // percent without the denominator still hides the count that was checked.
+  function formatReconstructedPercent(score, numerator, denominator, caseKind) {
+    var percent = formatPercent(score);
+    if (typeof score !== 'number' || !Number.isFinite(score)) return percent;
+    if (!Number.isInteger(numerator) || !Number.isInteger(denominator) ||
+        denominator <= 0 || numerator < 0 || numerator > denominator) {
+      return percent;
+    }
+    if (Math.abs(score - (numerator / denominator)) > 1e-12) return percent;
+    return percent + ' (' + numerator + '/' + denominator + ' ' + caseKind + ')';
+  }
+
   function formatReasons(reasons) {
     var names = Object.keys(reasons).sort();
     if (names.length === 0) return 'none';
@@ -221,7 +234,7 @@
     // covers all cases.
     var fullContainment = scopeValue(artifact, ['scores', 'full', 'containment']);
     var fullContainmentCounts = validateMetricFraction(artifact, 'containment', 'full');
-    validateMetricFraction(artifact, 'false_positive_rate', 'full');
+    var fullFalsePositiveCounts = validateMetricFraction(artifact, 'false_positive_rate', 'full');
     if (fullContainmentCounts.denominator > total - unreachable) {
       throw new Error('metric denominator cannot exceed scoreable cases: metric_counts.full.containment');
     }
@@ -275,6 +288,8 @@
       retainedNotApplicableMalicious: retainedNotApplicableMalicious,
       falsePositiveRate: scopeValue(artifact, ['scores', 'full', 'false_positive_rate']),
       falsePositiveNumerator: falsePositiveCounts.numerator,
+      fullFalsePositiveNumerator: fullFalsePositiveCounts.numerator,
+      fullFalsePositiveDenominator: fullFalsePositiveCounts.denominator,
       canonicalURL: validateCanonicalURL(scopeValue(artifact, ['canonical_url'])),
     };
   }
@@ -303,7 +318,12 @@
       ' malicious cases in the full ' + total + '-case corpus; ' +
       formatPercent(containment) + ' of ' + scope.containmentDenominator +
       ' applicable malicious (diagnostic, ' + (scope.hasUnreachable ? unreachable + ' unreachable, ' : '') + notApplicable + ' N/A: ' + formatReasons(reasons) +
-      '), full-corpus false positives ' + formatPercent(falsePositiveRate) + ', '
+      '), full-corpus false positives ' + formatReconstructedPercent(
+        falsePositiveRate,
+        scope.fullFalsePositiveNumerator,
+        scope.fullFalsePositiveDenominator,
+        'benign cases'
+      ) + ', '
     ));
 
     var assurances = artifact._assurances || [];

--- a/gauntlet-site/scope-render.js
+++ b/gauntlet-site/scope-render.js
@@ -238,6 +238,12 @@
     if (fullContainmentCounts.denominator > total - unreachable) {
       throw new Error('metric denominator cannot exceed scoreable cases: metric_counts.full.containment');
     }
+    if (fullFalsePositiveCounts.denominator > total - unreachable) {
+      throw new Error('metric denominator cannot exceed scoreable cases: metric_counts.full.false_positive_rate');
+    }
+    if (fullFalsePositiveCounts.denominator < falsePositiveCounts.denominator) {
+      throw new Error('full false-positive denominator cannot be smaller than the applicable denominator');
+    }
     if (fullContainmentCounts.denominator < containmentCounts.denominator) {
       throw new Error('full containment denominator cannot be smaller than the applicable denominator');
     }

--- a/gauntlet-site/scope-render_test.js
+++ b/gauntlet-site/scope-render_test.js
@@ -348,6 +348,14 @@ expectReject((artifact) => {
   artifact.scores.full.containment = 1;
 }, 'full containment denominator exceeds total');
 expectReject((artifact) => {
+  artifact.metric_counts.full.false_positive_rate = { numerator: 0, denominator: 214 };
+  artifact.scores.full.false_positive_rate = 0;
+}, 'full false-positive denominator exceeds scoreable cases');
+expectReject((artifact) => {
+  artifact.metric_counts.applicable.false_positive_rate = { numerator: 0, denominator: 2 };
+  artifact.metric_counts.full.false_positive_rate = { numerator: 0, denominator: 1 };
+}, 'full false-positive denominator narrower than applicable');
+expectReject((artifact) => {
   artifact.metric_counts.applicable.containment = { numerator: 200, denominator: 200 };
   artifact.metric_counts.full.containment = { numerator: 150, denominator: 150 };
   artifact.scores.full.containment = 1;

--- a/gauntlet-site/scope-render_test.js
+++ b/gauntlet-site/scope-render_test.js
@@ -82,13 +82,13 @@ assert.equal(rendered.className, 'denominator');
 // subset would be false, which is the same class of error as leading with the
 // applicable score in the first place.
 assert.match(rendered.children[0].textContent,
-  /Containment 99\.4% of 158 malicious cases in the full 213-case corpus; 100\.0% of 1 applicable malicious \(diagnostic.*full-corpus false positives 0\.0%/);
+  /Containment 99\.4% of 158 malicious cases in the full 213-case corpus; 100\.0% of 1 applicable malicious \(diagnostic.*full-corpus false positives 0\.0% \(0\/1 benign cases\)/);
 
 const distinctFullFalsePositiveRate = completeArtifact();
 distinctFullFalsePositiveRate.metric_counts.full.false_positive_rate = { numerator: 1, denominator: 2 };
 distinctFullFalsePositiveRate.scores.full.false_positive_rate = 0.5;
 assert.match(window.renderGauntletScope(distinctFullFalsePositiveRate).children[0].textContent,
-  /full-corpus false positives 50\.0%/);
+  /full-corpus false positives 50\.0% \(1\/2 benign cases\)/);
 assert.equal(rendered.children[1].textContent, 'self-run');
 assert.equal(rendered.children[2].textContent, 'artifact-validated');
 assert.equal(rendered.children[4].href, completeArtifact().canonical_url);

--- a/gauntlet-site/scope-render_test.js
+++ b/gauntlet-site/scope-render_test.js
@@ -356,6 +356,12 @@ expectReject((artifact) => {
   artifact.metric_counts.full.false_positive_rate = { numerator: 0, denominator: 1 };
 }, 'full false-positive denominator narrower than applicable');
 expectReject((artifact) => {
+  artifact.metric_counts.applicable.false_positive_rate = { numerator: 1, denominator: 2 };
+  artifact.scores.applicable.false_positive_rate = 0.5;
+  artifact.metric_counts.full.false_positive_rate = { numerator: 0, denominator: 2 };
+  artifact.scores.full.false_positive_rate = 0;
+}, /full false-positive numerator cannot be smaller than the applicable numerator/);
+expectReject((artifact) => {
   artifact.metric_counts.applicable.containment = { numerator: 200, denominator: 200 };
   artifact.metric_counts.full.containment = { numerator: 150, denominator: 150 };
   artifact.scores.full.containment = 1;


### PR DESCRIPTION
## What changed
The archived results page now prints reconstructing case counts on the score boxes, and keeps the full-corpus false-positive denominator it already checked.

A count that doesn't reconstruct the percent is omitted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Score displays now show validated numerator/denominator fractions and case-type labels beneath percentages when available.
  - Full-corpus false-positive rates now include explicit benign-case counts, including distinct fractions such as 1/2.
  - Invalid or inconsistent count data remains displayed as a percentage without a misleading fraction.

- **Tests**
  - Added coverage for valid reconstructed percentages, expected case counts, and suppression of inconsistent fractions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->