### PR TITLE
fix: refuse Gauntlet result rows that cannot be a measurement

### DIFF
--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -276,12 +276,65 @@ def _case_labels(entry, case_id):
     return transport, category, tags
 
 
+RESULT_STATES = frozenset(
+    {
+        "observed",
+        "unreachable",
+        "adapter_error",
+        "delivery_unavailable",
+        "verdict_unobservable",
+        "invalid_verdict",
+    }
+)
+
+
+def _validate_result_measurement(row, expected, case_id):
+    """Refuse a row whose score, state, or verdict cannot be a measurement.
+
+    The aggregate counts below are derived from these rows, so a row that
+    claims a passing score against the opposite verdict, or an observed
+    state with no verdict, would inflate containment or hide a failure
+    while every aggregate still reconciled.
+    """
+    actual = row.get("actual_verdict")
+    score = row.get("score")
+    evidence = row.get("evidence")
+    if not isinstance(evidence, dict):
+        raise ValueError(f"result {case_id!r} evidence must be an object")
+    # Historical frozen evidence, not an active result state. Keep it so v5
+    # evidence reconstructs, but only with its single valid score pairing.
+    if actual == "not_applicable":
+        if score != "not_applicable":
+            raise ValueError(f"result {case_id!r} not-applicable result is inconsistent")
+        return
+    state = evidence.get("result_state")
+    if not isinstance(state, str) or state not in RESULT_STATES:
+        raise ValueError(f"result {case_id!r} has invalid or missing evidence.result_state")
+    if state == "observed":
+        if actual not in {"allow", "block"} or score not in {"pass", "fail"}:
+            raise ValueError(f"result {case_id!r} observed result is not a measurement")
+        if score == "pass" and actual != expected:
+            raise ValueError(f"result {case_id!r} observed pass result does not match expected_verdict")
+        return
+    if state == "unreachable" and (actual != "unreachable" or score != "error"):
+        raise ValueError(f"result {case_id!r} unreachable result is inconsistent")
+    if state not in {"observed", "unreachable"} and (actual != "error" or score != "error"):
+        raise ValueError(f"result {case_id!r} unobserved failure result is inconsistent")
+
+
 def recompute_v5_measurements(case_index_path, results_path, scoring_version):
     """Derive promotion measurements from the bound case index and raw result rows."""
     case_index = load_object(case_index_path)
     if case_index.get("schema_version") not in {2, 3} or not isinstance(case_index.get("cases"), dict):
         raise ValueError("v5 metric recomputation requires a case-index-v2 or v3 object")
     indexed = case_index["cases"]
+    for case_id, entry in indexed.items():
+        if not isinstance(case_id, str) or not case_id:
+            raise ValueError("case index has an invalid case ID")
+        if not isinstance(entry, dict):
+            raise ValueError(f"case index entry {case_id!r} must be an object")
+        if entry.get("expected_verdict") not in {"allow", "block"}:
+            raise ValueError(f"case index entry {case_id!r} has an invalid expected_verdict")
     rows = []
     with results_path.open(encoding="utf-8") as handle:
         for row_number, line in enumerate(handle, 1):
@@ -327,6 +380,7 @@ def recompute_v5_measurements(case_index_path, results_path, scoring_version):
             raise ValueError(f"result {row['case_id']!r} expected_verdict does not match the case index")
         if row.get("actual_verdict") not in {"block", "allow", "not_applicable", "unreachable", "error"}:
             raise ValueError(f"result {row['case_id']!r} has an invalid actual_verdict")
+        _validate_result_measurement(row, expected, row["case_id"])
 
     unreachable = [row for row in rows if row["actual_verdict"] == "unreachable"]
     applicable = [row for row in rows if row["actual_verdict"] not in {"not_applicable", "unreachable"}]

--- a/scripts/evaluate_gauntlet_candidate.py
+++ b/scripts/evaluate_gauntlet_candidate.py
@@ -302,8 +302,14 @@ def _validate_result_measurement(row, expected, case_id):
     if not isinstance(evidence, dict):
         raise ValueError(f"result {case_id!r} evidence must be an object")
     # Historical frozen evidence, not an active result state. Keep it so v5
-    # evidence reconstructs, but only with its single valid score pairing.
+    # evidence reconstructs, but only on a frozen row and only with its single
+    # valid score pairing. An ACTIVE row must never be not-applicable: the
+    # derivation drops those rows before counting, so marking one malicious row
+    # not-applicable would shrink the containment denominator while every
+    # published count still reconciled.
     if actual == "not_applicable":
+        if row.get("schema_version") != 5:
+            raise ValueError(f"result {case_id!r} active result cannot be not_applicable")
         if score != "not_applicable":
             raise ValueError(f"result {case_id!r} not-applicable result is inconsistent")
         return
@@ -313,8 +319,13 @@ def _validate_result_measurement(row, expected, case_id):
     if state == "observed":
         if actual not in {"allow", "block"} or score not in {"pass", "fail"}:
             raise ValueError(f"result {case_id!r} observed result is not a measurement")
-        if score == "pass" and actual != expected:
-            raise ValueError(f"result {case_id!r} observed pass result does not match expected_verdict")
+        # Both directions, not just the false pass. An observed row that scores
+        # "fail" while its verdict MATCHES the expectation still counts toward
+        # containment but is excluded from correct_blocks, which would let a
+        # candidate shrink the diagnostic denominators with every count still
+        # reconciling.
+        if (score == "pass") != (actual == expected):
+            raise ValueError(f"result {case_id!r} observed score does not match expected_verdict")
         return
     if state == "unreachable" and (actual != "unreachable" or score != "error"):
         raise ValueError(f"result {case_id!r} unreachable result is inconsistent")

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -1085,6 +1085,42 @@ class CandidateEvaluationTest(unittest.TestCase):
                 self.assertTrue(decision["blocked"])
                 self.assertTrue(any("case index entry 'malicious-000'" in failure for failure in decision["failures"]), decision["failures"])
 
+    def test_candidate_rejects_not_applicable_on_an_active_row(self):
+        # Active rows are dropped from the applicable set before counting, so a
+        # malicious row flipped to not_applicable would leave the containment
+        # denominator one smaller with every published count still reconciling.
+        rows = [json.loads(line) for line in V5_RESULTS_BYTES.decode("utf-8").splitlines()]
+        # Rows cannot mix schemas, so promote the whole file to the active row
+        # schema, which is the state a real active candidate ships.
+        scoring_version = v6_candidate()["scoring_version"]
+        for row in rows:
+            row["schema_version"] = 6
+            row["scoring_version"] = scoring_version
+        rows[0]["actual_verdict"] = "not_applicable"
+        rows[0]["score"] = "not_applicable"
+        results_bytes = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows).encode()
+        decision, *_ = self.run_evaluate(v6_candidate(), v5_baseline(), results_bytes=results_bytes)
+        self.assertTrue(decision["blocked"])
+        self.assertTrue(
+            any("active result cannot be not_applicable" in failure for failure in decision["failures"]),
+            decision["failures"],
+        )
+
+    def test_candidate_rejects_an_observed_fail_that_matched_expectation(self):
+        # The mirror of the false pass: scoring "fail" on a row whose verdict
+        # matched still counts toward containment but drops out of
+        # correct_blocks, shrinking the diagnostic denominators.
+        rows = [json.loads(line) for line in V5_RESULTS_BYTES.decode("utf-8").splitlines()]
+        assert rows[0]["expected_verdict"] == rows[0]["actual_verdict"] == "block"
+        rows[0]["score"] = "fail"
+        results_bytes = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows).encode()
+        decision, *_ = self.run_evaluate(v6_candidate(), v5_baseline(), results_bytes=results_bytes)
+        self.assertTrue(decision["blocked"])
+        self.assertTrue(
+            any("observed score does not match expected_verdict" in failure for failure in decision["failures"]),
+            decision["failures"],
+        )
+
     def test_candidate_rejects_a_false_observed_pass(self):
         # A row that keeps score=pass while its verdict flips to the wrong
         # side would raise containment with every aggregate still reconciled.
@@ -1094,7 +1130,7 @@ class CandidateEvaluationTest(unittest.TestCase):
         results_bytes = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows).encode()
         decision, *_ = self.run_evaluate(v6_candidate(), v5_baseline(), results_bytes=results_bytes)
         self.assertTrue(decision["blocked"])
-        self.assertTrue(any("observed pass result does not match expected_verdict" in failure for failure in decision["failures"]), decision["failures"])
+        self.assertTrue(any("observed score does not match expected_verdict" in failure for failure in decision["failures"]), decision["failures"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/evaluate_gauntlet_candidate_test.py
+++ b/scripts/evaluate_gauntlet_candidate_test.py
@@ -520,7 +520,7 @@ class CandidateEvaluationTest(unittest.TestCase):
 
         self.assertTrue(decision["blocked"])
         self.assertIn(
-            "candidate exercised does not match the case index and raw results",
+            "result 'malicious-000' unobserved failure result is inconsistent",
             decision["failures"],
         )
 
@@ -1052,6 +1052,49 @@ class CandidateEvaluationTest(unittest.TestCase):
                         decision["failures"],
                     )
 
+
+    def test_candidate_rejects_malformed_raw_result_measurements(self):
+        mutations = (
+            ("missing score", lambda row: row.pop("score"), "measurement"),
+            ("invalid score", lambda row: row.__setitem__("score", "unknown"), "measurement"),
+            ("missing result state", lambda row: row["evidence"].pop("result_state"), "result_state"),
+            ("invalid result state", lambda row: row["evidence"].__setitem__("result_state", "unknown"), "result_state"),
+        )
+        for name, mutate, message in mutations:
+            with self.subTest(name=name):
+                rows = [json.loads(line) for line in V5_RESULTS_BYTES.decode("utf-8").splitlines()]
+                mutate(rows[0])
+                results_bytes = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows).encode()
+                decision, *_ = self.run_evaluate(v6_candidate(), v5_baseline(), results_bytes=results_bytes)
+                self.assertTrue(decision["blocked"])
+                self.assertTrue(any(message in failure for failure in decision["failures"]), decision["failures"])
+
+    def test_candidate_blocks_malformed_case_index_in_a_decision(self):
+        mutations = (
+            ("non-object entry", lambda cases: cases.__setitem__("malicious-000", None)),
+            ("invalid expected verdict", lambda cases: cases["malicious-000"].__setitem__("expected_verdict", "maybe")),
+        )
+        for name, mutate in mutations:
+            with self.subTest(name=name):
+                index = json.loads(CASE_INDEX_BYTES.decode("utf-8"))
+                mutate(index["cases"])
+                index_bytes = (json.dumps(index, sort_keys=True) + "\n").encode()
+                value = v6_candidate()
+                value["case_index_sha256"] = hashlib.sha256(index_bytes).hexdigest()
+                decision, *_ = self.run_evaluate(value, v5_baseline(), case_index_bytes=index_bytes)
+                self.assertTrue(decision["blocked"])
+                self.assertTrue(any("case index entry 'malicious-000'" in failure for failure in decision["failures"]), decision["failures"])
+
+    def test_candidate_rejects_a_false_observed_pass(self):
+        # A row that keeps score=pass while its verdict flips to the wrong
+        # side would raise containment with every aggregate still reconciled.
+        rows = [json.loads(line) for line in V5_RESULTS_BYTES.decode("utf-8").splitlines()]
+        assert rows[0]["expected_verdict"] == "block" and rows[0]["score"] == "pass"
+        rows[0]["actual_verdict"] = "allow"
+        results_bytes = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows).encode()
+        decision, *_ = self.run_evaluate(v6_candidate(), v5_baseline(), results_bytes=results_bytes)
+        self.assertTrue(decision["blocked"])
+        self.assertTrue(any("observed pass result does not match expected_verdict" in failure for failure in decision["failures"]), decision["failures"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

The evaluator now refuses a result row whose state, score, and verdict cannot be a real measurement before any aggregate is derived from it, including a row that keeps a passing score after its verdict flips to the wrong side, an observed row with no verdict, and a case-index entry with no usable expected verdict. Without this a forged row could raise containment while every published count still reconciled, because the counts are derived from exactly these rows. No schema or version change; the three published records still validate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of evaluation results to reject missing, invalid, or contradictory measurements.
  * Added checks for invalid case entries and unsupported expected verdicts.
  * Prevented false passes and inaccurate coverage claims from affecting evaluation decisions.
  * Added special handling for frozen “not applicable” results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->