### PR TITLE
Select the Go toolchain for the reference lane with --go and AEB_GO

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ Tools already sit in that path. What a buyer usually gets is each vendor's own e
 
 ## Quick start
 
-You need [Go 1.25 or newer](https://go.dev/dl/) from that page. A distribution `golang` package often installs something older and the runner won't build on it. The reference lane below also needs Linux, Git, Python 3, curl, jq, Make, tar, GNU timeout, a SHA-256 utility, and one of `socat`, `ncat`, or `nc`. Its `--doctor` checks each of those along with the installed Go version, and rejects a stale or prerelease toolchain rather than guessing.
+You need [Go 1.25 or newer](https://go.dev/dl/) from that page. A distribution `golang` package often installs something older and the runner won't build on it; Debian and Ubuntu both currently ship an older Go. The floor is not ours to lower, because `golang.org/x/sys` sets it. If a new enough toolchain is already installed somewhere else, point the reference lane at it instead of changing `PATH`:
+
+```bash
+./scripts/run-pipelock-gauntlet.sh --go /path/to/go1.25/bin/go --doctor   # or: export AEB_GO=/path/to/go1.25/bin/go
+```
+
+That selects the toolchain; it never waives the minimum version. A toolchain below the floor is still refused. The reference lane also needs Linux, Git, Python 3, curl, jq, Make, tar, GNU timeout, a SHA-256 utility, and one of `socat`, `ncat`, or `nc`. Its `--doctor` checks each of those along with the selected Go version, and rejects a stale or prerelease toolchain rather than guessing.
 
 ```bash
 git clone --branch main https://github.com/luckyPipewrench/agent-egress-bench.git

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Tools already sit in that path. What a buyer usually gets is each vendor's own e
 
 ## Quick start
 
-You need [Go 1.25 or newer](https://go.dev/dl/) from that page. A distribution `golang` package often installs something older and the runner won't build on it; Debian and Ubuntu both currently ship an older Go. The floor is not ours to lower, because `golang.org/x/sys` sets it. If a new enough toolchain is already installed somewhere else, point the reference lane at it instead of changing `PATH`:
+You need [Go 1.25 or newer](https://go.dev/dl/) from that page. A distribution `golang` package can be older than that, depending on the release you are on, and the runner won't build on it. Run `go version` to see what you have. The floor is not ours to lower, because `golang.org/x/sys` sets it. If a new enough toolchain is already installed somewhere else, point the reference lane at it instead of changing `PATH`:
 
 ```bash
 ./scripts/run-pipelock-gauntlet.sh --go /path/to/go1.25/bin/go --doctor   # or: export AEB_GO=/path/to/go1.25/bin/go

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -349,6 +349,67 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
                 "differently after the script changes directory",
             )
 
+    def test_the_selected_toolchain_is_never_reassigned_after_canonicalization(self):
+        # The doctor cannot prove this on its own: it validates the selection
+        # without entering runner/ or validate/, so a test that only runs
+        # --doctor-json would still pass if a later execution path re-derived a
+        # relative value. Combined with the bare-go-invocation guard, asserting
+        # that go_bin is assigned only before canonicalization means every
+        # consumer, including the ones that change directory, sees the absolute
+        # path.
+        lines = self.entrypoint.splitlines()
+        canonicalize_at = None
+        assignments = []
+        for number, line in enumerate(lines, start=1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            # Anchor on the resolution itself. The same shape test appears in the
+            # availability helper, so matching that would anchor too early and
+            # flag the legitimate --go flag assignment.
+            if canonicalize_at is None and re.match(r"^go_bin_resolved=", stripped):
+                canonicalize_at = number
+            if re.match(r"^go_bin=", stripped):
+                assignments.append(number)
+        self.assertIsNotNone(canonicalize_at, "the canonicalization block is gone")
+        late = [n for n in assignments if n > canonicalize_at]
+        self.assertEqual(
+            late, [],
+            f"go_bin reassigned at {late} after canonicalization at line {canonicalize_at}; "
+            "a consumer that changes directory would resolve the un-canonicalized value",
+        )
+
+    def test_doctor_rejects_a_realpath_without_the_required_gnu_options(self):
+        # Presence is not capability. BusyBox realpath takes no options, so a
+        # doctor that only checks for the command reports ready and the run then
+        # fails during release-pin resolution.
+        with tempfile.TemporaryDirectory() as temporary:
+            stub = Path(temporary) / "realpath"
+            stub.write_text(
+                "#!/bin/sh\n"
+                'for a in "$@"; do\n'
+                '  case "$a" in\n'
+                '    -*) echo "realpath: $a: No such file or directory" >&2; exit 1 ;;\n'
+                "  esac\n"
+                "done\n"
+                'printf "%s\\n" "$@"\n',
+                encoding="utf-8",
+            )
+            stub.chmod(0o755)
+            result = subprocess.run(
+                ["bash", str(ENTRYPOINT), "--doctor-json"],
+                cwd=REPO_ROOT,
+                env={**os.environ, "AEB_GO": "", "PATH": f"{temporary}:{os.environ.get('PATH', '')}"},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        report = json.loads(result.stdout)
+        check = next(c for c in report["checks"] if c["code"] == "command_realpath")
+        self.assertEqual(check["status"], "unsupported")
+        self.assertTrue(check["remediation"])
+
     def test_aeb_go_environment_variable_selects_the_toolchain(self):
         with tempfile.TemporaryDirectory() as temporary:
             stale = self._stub_go(temporary, "go version go1.24.0 linux/amd64")

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -179,7 +179,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             result = subprocess.run(
                 ["/bin/bash", str(ENTRYPOINT), "--doctor-json"],
                 cwd=REPO_ROOT,
-                env={**os.environ, "PATH": str(fake_path)},
+                env={**os.environ, "AEB_GO": "", "PATH": str(fake_path)},
                 text=True,
                 capture_output=True,
                 check=False,
@@ -227,7 +227,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             result = subprocess.run(
                 ["bash", str(ENTRYPOINT), "--doctor-json"],
                 cwd=REPO_ROOT,
-                env={**os.environ, "PATH": f"{temporary}:{os.environ.get('PATH', '')}"},
+                env={**os.environ, "AEB_GO": "", "PATH": f"{temporary}:{os.environ.get('PATH', '')}"},
                 text=True,
                 capture_output=True,
                 check=False,
@@ -238,6 +238,116 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertFalse(report["ready"])
         self.assertEqual(go_version["status"], "too_old")
         self.assertIn("go.dev/dl", go_version["remediation"])
+
+    def test_every_go_invocation_honors_the_selected_toolchain(self):
+        # A bare `go build` or `go run` added later would silently ignore --go and
+        # AEB_GO, so the run would use a toolchain the doctor never checked. Parse
+        # the command position rather than searching for a substring.
+        offenders = []
+        for number, line in enumerate(self.entrypoint.splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            # Strip leading VAR=value assignments, which precede the command.
+            words = stripped.split()
+            index = 0
+            while index < len(words) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", words[index]):
+                index += 1
+            if index < len(words) - 1 and words[index] == "go" and words[index + 1] in {
+                "build", "run", "test", "install", "vet", "version", "env", "mod",
+            }:
+                offenders.append(f"{number}: {stripped}")
+        self.assertEqual(offenders, [], "bare go invocations bypass --go/AEB_GO")
+
+    def _stub_go(self, directory, version_line, name="go"):
+        stub = Path(directory) / name
+        stub.write_text(
+            f"#!/bin/sh\nprintf '{version_line}\\n'\n",
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+        return stub
+
+    def test_doctor_checks_the_selected_go_binary_rather_than_path(self):
+        # An evaluator on a distribution that ships an older Go points --go at a
+        # newer toolchain installed elsewhere. The selected binary must be the one
+        # reported, not whichever `go` happens to be first on PATH.
+        with tempfile.TemporaryDirectory() as temporary:
+            stale = self._stub_go(temporary, "go version go1.24.0 linux/amd64")
+            selected_dir = Path(temporary) / "selected"
+            selected_dir.mkdir()
+            selected = self._stub_go(selected_dir, "go version go1.25.0 linux/amd64")
+            result = subprocess.run(
+                ["bash", str(ENTRYPOINT), "--go", str(selected), "--doctor-json"],
+                cwd=REPO_ROOT,
+                env={**os.environ, "AEB_GO": "", "PATH": f"{stale.parent}:{os.environ.get('PATH', '')}"},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        report = json.loads(result.stdout)
+        statuses = {check["code"]: check["status"] for check in report["checks"]}
+        self.assertEqual(statuses["command_go"], "ok")
+        self.assertEqual(statuses["go_version"], "ok")
+
+    def test_go_override_cannot_bypass_the_minimum_version(self):
+        # The override selects a toolchain; it must never waive the floor. A
+        # too-old --go has to fail exactly like a too-old PATH toolchain.
+        with tempfile.TemporaryDirectory() as temporary:
+            selected = self._stub_go(temporary, "go version go1.24.0 linux/amd64")
+            result = subprocess.run(
+                ["bash", str(ENTRYPOINT), "--go", str(selected), "--doctor-json"],
+                cwd=REPO_ROOT,
+                env={**os.environ, "AEB_GO": ""},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        report = json.loads(result.stdout)
+        go_version = next(check for check in report["checks"] if check["code"] == "go_version")
+        self.assertFalse(report["ready"])
+        self.assertEqual(go_version["status"], "too_old")
+
+    def test_aeb_go_environment_variable_selects_the_toolchain(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            stale = self._stub_go(temporary, "go version go1.24.0 linux/amd64")
+            selected_dir = Path(temporary) / "selected"
+            selected_dir.mkdir()
+            selected = self._stub_go(selected_dir, "go version go1.25.0 linux/amd64")
+            result = subprocess.run(
+                ["bash", str(ENTRYPOINT), "--doctor-json"],
+                cwd=REPO_ROOT,
+                env={
+                    **os.environ,
+                    "AEB_GO": str(selected),
+                    "PATH": f"{stale.parent}:{os.environ.get('PATH', '')}",
+                },
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        report = json.loads(result.stdout)
+        statuses = {check["code"]: check["status"] for check in report["checks"]}
+        self.assertEqual(statuses["go_version"], "ok")
+
+    def test_go_override_rejects_a_directory_and_a_missing_path(self):
+        # Pointing --go at a toolchain's bin directory instead of its go binary is
+        # the likeliest operator mistake, and a directory is executable.
+        with tempfile.TemporaryDirectory() as temporary:
+            for candidate in (temporary, str(Path(temporary) / "absent" / "go")):
+                result = subprocess.run(
+                    ["bash", str(ENTRYPOINT), "--go", candidate, "--doctor-json"],
+                    cwd=REPO_ROOT,
+                    env={**os.environ, "AEB_GO": ""},
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertNotEqual(result.returncode, 0, candidate)
+                report = json.loads(result.stdout)
+                statuses = {check["code"]: check["status"] for check in report["checks"]}
+                self.assertEqual(statuses["command_go"], "missing", candidate)
 
     def test_doctor_rejects_prerelease_go_toolchain(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -250,7 +360,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             result = subprocess.run(
                 ["bash", str(ENTRYPOINT), "--doctor-json"],
                 cwd=REPO_ROOT,
-                env={**os.environ, "PATH": f"{temporary}:{os.environ.get('PATH', '')}"},
+                env={**os.environ, "AEB_GO": "", "PATH": f"{temporary}:{os.environ.get('PATH', '')}"},
                 text=True,
                 capture_output=True,
                 check=False,
@@ -273,7 +383,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             result = subprocess.run(
                 ["bash", str(ENTRYPOINT), "--doctor-json"],
                 cwd=REPO_ROOT,
-                env={**os.environ, "PATH": f"{temporary}:{os.environ.get('PATH', '')}"},
+                env={**os.environ, "AEB_GO": "", "PATH": f"{temporary}:{os.environ.get('PATH', '')}"},
                 text=True,
                 capture_output=True,
                 check=False,
@@ -292,7 +402,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             result = subprocess.run(
                 ["bash", str(ENTRYPOINT), "--doctor-json"],
                 cwd=REPO_ROOT,
-                env={**os.environ, "PATH": f"{temporary}:{os.environ.get('PATH', '')}"},
+                env={**os.environ, "AEB_GO": "", "PATH": f"{temporary}:{os.environ.get('PATH', '')}"},
                 text=True,
                 capture_output=True,
                 check=False,
@@ -306,8 +416,19 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
     def test_readme_tells_operators_doctor_checks_go_version(self):
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
         self.assertNotIn("does not check the installed Go version", readme)
-        self.assertIn("the installed Go version", readme)
+        self.assertNotIn("does not check the selected Go version", readme)
+        # "selected" rather than "installed" since --go and AEB_GO can choose a
+        # toolchain that is not the one on PATH. Either wording satisfies the
+        # operator-facing promise this guard exists to protect.
+        self.assertTrue(
+            "the installed Go version" in readme or "the selected Go version" in readme,
+            "README must tell operators that doctor checks the Go version",
+        )
         self.assertIn("distribution `golang` package", readme)
+        # The override has to be discoverable, or an evaluator on a distribution
+        # with an older Go concludes the benchmark simply will not run.
+        self.assertIn("--go", readme)
+        self.assertIn("AEB_GO", readme)
         self.assertIn("Make", readme)
         self.assertIn(
             "git clone --branch main https://github.com/luckyPipewrench/agent-egress-bench.git",
@@ -375,7 +496,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertIn("canonical receipt does not bind the clean corpus commit", self.entrypoint)
 
     def test_target_runs_under_a_filesystem_restricted_environment(self):
-        self.assertIn("go build -o \"$target_sandbox\" ./cmd/target-sandbox", self.entrypoint)
+        self.assertIn("\"$go_bin\" build -o \"$target_sandbox\" ./cmd/target-sandbox", self.entrypoint)
         self.assertIn('pipelock_bin="$target_wrapper"', self.entrypoint)
         self.assertIn(
             'PIPELOCK_POSTURE_PROOF=$work_dir/absent-posture-proof.json',

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -309,6 +309,46 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         self.assertFalse(report["ready"])
         self.assertEqual(go_version["status"], "too_old")
 
+    def test_a_relative_go_selection_is_canonicalized_before_use(self):
+        # The build and validation steps cd into runner/ and validate/, so a
+        # relative selection validated from the repository root would resolve
+        # somewhere else once they run: doctor reports ready and the run then
+        # fails, or silently picks a different file at the same relative path.
+        # Assert on the path the toolchain is actually INVOKED as, not on the
+        # doctor verdict, which passes either way and would make this vacuous.
+        with tempfile.TemporaryDirectory() as temporary:
+            recorded = Path(temporary) / "invoked-as"
+            stub_dir = REPO_ROOT / "_reltest_toolchain"
+            stub_dir.mkdir(exist_ok=True)
+            stub = stub_dir / "go"
+            stub.write_text(
+                "#!/bin/sh\n"
+                f'printf "%s\\n" "$0" >> {recorded}\n'
+                "printf 'go version go1.25.0 linux/amd64\\n'\n",
+                encoding="utf-8",
+            )
+            stub.chmod(0o755)
+            try:
+                subprocess.run(
+                    ["bash", str(ENTRYPOINT), "--go", "./_reltest_toolchain/go", "--doctor-json"],
+                    cwd=REPO_ROOT,
+                    env={**os.environ, "AEB_GO": ""},
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                invocations = recorded.read_text(encoding="utf-8").split()
+            finally:
+                stub.unlink(missing_ok=True)
+                stub_dir.rmdir()
+        self.assertTrue(invocations, "the selected toolchain was never invoked")
+        for path in invocations:
+            self.assertTrue(
+                path.startswith("/"),
+                f"toolchain invoked by relative path {path!r}; it would resolve "
+                "differently after the script changes directory",
+            )
+
     def test_aeb_go_environment_variable_selects_the_toolchain(self):
         with tempfile.TemporaryDirectory() as temporary:
             stale = self._stub_go(temporary, "go version go1.24.0 linux/amd64")

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -280,6 +280,24 @@ run_doctor() {
       fi
       continue
     fi
+    if [[ "$command_name" == "realpath" ]]; then
+      # Presence is not enough. This script resolves paths with GNU options
+      # (-e, -m, and --), and the BusyBox realpath common on minimal images
+      # takes no options at all: it would treat them as filenames. Without this
+      # probe the doctor reports ready and the run fails later, during
+      # release-pin resolution, which is the failure the doctor exists to
+      # prevent. Reported under the same command_realpath code so the check
+      # list, and the terminal drawing generated from it, are unchanged.
+      if ! command -v realpath >/dev/null 2>&1; then
+        add_doctor_result "command_realpath" "missing" "install realpath and retry"
+      elif realpath -e -- "$repo_root" >/dev/null 2>&1 && realpath -m -- "$repo_root" >/dev/null 2>&1; then
+        add_doctor_result "command_realpath" "ok" ""
+      else
+        add_doctor_result "command_realpath" "unsupported" \
+          "install GNU coreutils realpath: this realpath does not accept -e, -m and --"
+      fi
+      continue
+    fi
     if command -v "$command_name" >/dev/null 2>&1; then
       add_doctor_result "command_${command_name//-/_}" "ok" ""
     else

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -6,8 +6,9 @@ umask 077
 
 github_api_token="${GH_TOKEN:-}"
 unset GH_TOKEN GITHUB_TOKEN
-# Doctor checks this process's `go`. GOTOOLCHAIN=auto would let later
-# go build/run download a different toolchain than the one just checked.
+# Doctor checks the same resolved go binary the builds use. GOTOOLCHAIN=auto
+# would let later go build/run download a different toolchain than the one just
+# checked, so selecting a toolchain is deliberate through --go or AEB_GO.
 export GOTOOLCHAIN=local
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
@@ -16,6 +17,12 @@ release_pin="$repo_root/examples/pipelock/release.env"
 corpus_repository="luckyPipewrench/agent-egress-bench"
 
 output_dir=""
+# The Go toolchain every go invocation below uses. Defaults to the `go` on PATH.
+# AEB_GO or --go selects a toolchain installed elsewhere, so an evaluator whose
+# distribution ships an older Go does not have to rewrite PATH on every
+# invocation. Doctor checks this same resolved binary, so the toolchain that is
+# verified and the toolchain that builds cannot diverge.
+go_bin="${AEB_GO:-go}"
 development_mode=false
 development_binary=""
 doctor_mode=""
@@ -37,6 +44,7 @@ Options:
   --reserve-seconds SECONDS        Keep this many seconds before the deadline (default: 360).
   --benchmark-timeout-seconds N    Maximum runner time without a deadline (default: 1440).
   --release-pin FILE               Read the reviewed Pipelock release identity from FILE.
+  --go BINARY                      Use this Go toolchain instead of the `go` on PATH (env: AEB_GO).
   --development                    Allow a dirty or unreviewed corpus and mark the run noncanonical.
   --development-binary PATH        Use PATH instead of a released binary and mark the run noncanonical.
   --doctor                         Check commands, runner Go version, and other local prerequisites without starting a run.
@@ -122,10 +130,23 @@ go_version_ge() {
   ((have_pat >= need_pat))
 }
 
+go_bin_available() {
+  # A bare name resolves through PATH; anything containing a slash must be an
+  # executable file at that exact path. Reject a directory explicitly: pointing
+  # --go at a toolchain's bin directory instead of its go binary is the likeliest
+  # operator mistake, and `-x` alone is true for directories.
+  if [[ "$go_bin" == */* ]]; then
+    [[ -f "$go_bin" && -x "$go_bin" ]]
+    return
+  fi
+  command -v "$go_bin" >/dev/null 2>&1
+}
+
 installed_go_version() {
   local line=""
   local version_re='^go version go([0-9]+\.[0-9]+(\.[0-9]+)?)[[:space:]]'
-  line="$(command go version 2>/dev/null || true)"
+  go_bin_available || return 1
+  line="$("$go_bin" version 2>/dev/null || true)"
   # Released toolchains print "go version go1.25.0 linux/amd64". A substring
   # match would treat go1.25rc1 as 1.25 and devel go1.26-... as 1.26.
   if [[ "$line" =~ $version_re ]]; then
@@ -139,10 +160,10 @@ require_go_toolchain() {
   local required_go=""
   local installed_go=""
   required_go="$(required_go_version)" || die "runner Go requirement is unreadable"
-  command -v go >/dev/null 2>&1 || die "required command is unavailable: go"
+  go_bin_available || die "required command is unavailable: ${go_bin}"
   installed_go="$(installed_go_version)" || die "go version is unreadable"
   go_version_ge "$installed_go" "$required_go" || \
-    die "Go ${required_go} or newer is required; installed ${installed_go}"
+    die "Go ${required_go} or newer is required; ${go_bin} is ${installed_go}. Select another toolchain with --go BINARY or AEB_GO."
 }
 
 while (($#)); do
@@ -165,6 +186,12 @@ while (($#)); do
     --benchmark-timeout-seconds)
       (($# >= 2)) || die "--benchmark-timeout-seconds requires a value"
       benchmark_timeout_seconds="$2"
+      shift 2
+      ;;
+    --go)
+      (($# >= 2)) || die "--go requires a value"
+      [[ -n "$2" ]] || die "--go requires a non-empty value"
+      go_bin="$2"
       shift 2
       ;;
     --release-pin)
@@ -223,7 +250,20 @@ run_doctor() {
   else
     add_doctor_result "platform_linux" "unsupported" "run this reference lane on Linux"
   fi
+  # `go` keeps its position in this list. The doctor terminal drawing in the
+  # README is generated from the reported check order, so reordering here silently
+  # invalidates a published asset. It resolves through go_bin rather than PATH so
+  # the check follows --go and AEB_GO.
   for command_name in git python3 go curl jq sha256sum tar timeout realpath make; do
+    if [[ "$command_name" == "go" ]]; then
+      if go_bin_available; then
+        add_doctor_result "command_go" "ok" ""
+      else
+        add_doctor_result "command_go" "missing" \
+          "install go, or select a toolchain with --go BINARY or AEB_GO, and retry"
+      fi
+      continue
+    fi
     if command -v "$command_name" >/dev/null 2>&1; then
       add_doctor_result "command_${command_name//-/_}" "ok" ""
     else
@@ -231,9 +271,9 @@ run_doctor() {
     fi
   done
   required_go="$(required_go_version || true)"
-  if ! command -v go >/dev/null 2>&1; then
+  if ! go_bin_available; then
     add_doctor_result "go_version" "missing" \
-      "install Go ${required_go:-1.25} or newer from https://go.dev/dl/ and retry"
+      "install Go ${required_go:-1.25} or newer from https://go.dev/dl/, or select an installed toolchain with --go BINARY or AEB_GO, and retry"
   elif ! installed_go="$(installed_go_version)"; then
     add_doctor_result "go_version" "unreadable" \
       "install Go ${required_go:-1.25} or newer from https://go.dev/dl/ and retry"
@@ -243,7 +283,7 @@ run_doctor() {
     add_doctor_result "go_version" "ok" ""
   else
     add_doctor_result "go_version" "too_old" \
-      "install Go ${required_go} or newer from https://go.dev/dl/ and retry"
+      "install Go ${required_go} or newer from https://go.dev/dl/, or select an installed Go ${required_go} toolchain with --go BINARY or AEB_GO, and retry"
   fi
   for command_name in socat ncat nc; do
     if command -v "$command_name" >/dev/null 2>&1; then
@@ -574,7 +614,7 @@ export TMPDIR GOCACHE
 mkdir -p "$TMPDIR" "$GOCACHE"
 (
   cd "$repo_root/runner"
-  go build -o "$target_sandbox" ./cmd/target-sandbox
+  "$go_bin" build -o "$target_sandbox" ./cmd/target-sandbox
 )
 mkdir "$target_state"
 chmod 0700 "$target_state"
@@ -628,7 +668,7 @@ failure_reason="Gauntlet runner build failed"
 gauntlet_bin="$work_dir/aeb-gauntlet"
 (
   cd "$repo_root/runner"
-  go build -o "$gauntlet_bin" .
+  "$go_bin" build -o "$gauntlet_bin" .
 )
 
 export PIPELOCK_BIN="$pipelock_bin"
@@ -732,7 +772,7 @@ results_abs="$(realpath "$results_path")"
 # claiming a denial-of-wallet block it could not evidence went unnoticed.
 (
   cd "$repo_root/validate"
-  AEB_CAPABILITY_REGISTRY="$repo_root/capability-registry" go run . results "$results_abs" "$repo_root/cases"
+  AEB_CAPABILITY_REGISTRY="$repo_root/capability-registry" "$go_bin" run . results "$results_abs" "$repo_root/cases"
 )
 jq -e '.case_count.errors == 0' "$summary_path" >/dev/null || \
   die "runner summary contains errors"

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -226,6 +226,22 @@ while (($#)); do
   esac
 done
 
+# Canonicalize a path-shaped toolchain selection to an absolute path before
+# anything validates or runs it. The build and validation steps cd into
+# runner/ and validate/, so a relative selection would be checked against one
+# directory and executed from another: doctor would report ready and the run
+# would then fail, or worse, resolve a different file that happens to sit at
+# the same relative path. A bare name is left alone so it keeps resolving
+# through PATH.
+if [[ "$go_bin" == */* ]]; then
+  # Best-effort on purpose. An unresolvable selection is left as written so the
+  # doctor still reports it as a missing prerequisite alongside everything else
+  # it found; dying here would collapse the whole prerequisite report into one
+  # error, which is the opposite of what --doctor-json exists to produce.
+  go_bin_resolved="$(realpath -e -- "$go_bin" 2>/dev/null || true)"
+  [[ -n "$go_bin_resolved" ]] && go_bin="$go_bin_resolved"
+fi
+
 run_doctor() {
   local failed=0
   local command_name


### PR DESCRIPTION
## What changed

The reference lane needed a Go toolchain on `PATH` that met the runner's minimum version. Debian and Ubuntu both currently ship an older Go, and that floor is set by a dependency rather than by this repository, so an evaluator who already had a suitable toolchain installed somewhere else had to rewrite `PATH` on every invocation.

`--go BINARY` and the `AEB_GO` environment variable now select the toolchain for every `go` invocation in `scripts/run-pipelock-gauntlet.sh`. `--doctor` checks the same resolved binary that the builds use, so the toolchain that is verified and the toolchain that builds cannot diverge.

Selection is not a waiver. A toolchain below the minimum is still refused with the same `too_old` result and nonzero exit as before, and a path that is a directory or does not exist is reported as missing rather than being treated as usable. Reviewers should distrust this in the direction of the override silently widening what is accepted: the failure to look for is a run proceeding on a toolchain `--doctor` never approved.

The doctor's reported check order is unchanged on purpose, because the terminal drawing in the README is generated from that order and reordering the checks invalidates a published asset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a Go toolchain with `--go` or `AEB_GO`.
  * The selected toolchain is used consistently for version checks, builds, and validation.
  * Added checks for invalid, stale, prerelease, or below-minimum Go versions.
  * Toolchain paths are normalized before use.
  * Doctor checks now identify selected-toolchain issues and verify required path-handling capabilities.

* **Documentation**
  * Updated the Quick Start guide with toolchain selection and validation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->