### PR TITLE
Check the kernel features the target sandbox requires

### DIFF
--- a/assets/terminal-doctor.svg
+++ b/assets/terminal-doctor.svg
@@ -1,12 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="504" viewBox="0 0 1200 504" role="img" aria-label="Two terminals. Left: ./scripts/run-pipelock-gauntlet.sh --doctor reports every prerequisite check as ok and ends with ready: local prerequisites are satisfied. Right: the evidence directory one run leaves behind, listing every retained file.">
-  <rect x="0.5" y="0.5" width="589" height="503" rx="12" fill="#0e0e11" stroke="#ffffff" stroke-opacity="0.10" stroke-width="1"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="525" viewBox="0 0 1200 525" role="img" aria-label="Two terminals. Left: ./scripts/run-pipelock-gauntlet.sh --doctor reports every prerequisite check as ok and ends with ready: local prerequisites are satisfied. Right: the evidence directory one run leaves behind, listing every retained file.">
+  <rect x="0.5" y="0.5" width="589" height="524" rx="12" fill="#0e0e11" stroke="#ffffff" stroke-opacity="0.10" stroke-width="1"/>
   <path d="M 12 0.5 H 578 A 12 12 0 0 1 589.5 12 V 40 H 0.5 V 12 A 12 12 0 0 1 12 0.5 Z" fill="#ffffff" fill-opacity="0.03"/>
   <path d="M 0.5 40 L 589.5 40" stroke="#ffffff" stroke-opacity="0.06" stroke-width="1" stroke-linecap="butt" fill="none"/>
   <circle cx="22" cy="20" r="6" fill="#ef4444" opacity="0.85"/>
   <circle cx="42" cy="20" r="6" fill="#f59e0b" opacity="0.85"/>
   <circle cx="62" cy="20" r="6" fill="#00e5a0" opacity="0.85"/>
   <text x="295.0" y="25" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12" fill="#64748b" text-anchor="middle">preflight</text>
-  <rect x="610.5" y="0.5" width="589" height="503" rx="12" fill="#0e0e11" stroke="#ffffff" stroke-opacity="0.10" stroke-width="1"/>
+  <rect x="610.5" y="0.5" width="589" height="524" rx="12" fill="#0e0e11" stroke="#ffffff" stroke-opacity="0.10" stroke-width="1"/>
   <path d="M 622 0.5 H 1188 A 12 12 0 0 1 1199.5 12 V 40 H 610.5 V 12 A 12 12 0 0 1 622 0.5 Z" fill="#ffffff" fill-opacity="0.03"/>
   <path d="M 610.5 40 L 1199.5 40" stroke="#ffffff" stroke-opacity="0.06" stroke-width="1" stroke-linecap="butt" fill="none"/>
   <circle cx="632" cy="20" r="6" fill="#ef4444" opacity="0.85"/>
@@ -41,11 +41,13 @@
   <text x="240" y="331" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#00e5a0" font-weight="700">ok</text>
   <text x="24" y="352" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#94a3b8">mcp_stdio_bridge</text>
   <text x="240" y="352" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#00e5a0" font-weight="700">ok</text>
-  <text x="24" y="373" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#94a3b8">repository_root</text>
+  <text x="24" y="373" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#94a3b8">kernel_sandbox</text>
   <text x="240" y="373" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#00e5a0" font-weight="700">ok</text>
-  <text x="24" y="394" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#94a3b8">release_pin</text>
+  <text x="24" y="394" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#94a3b8">repository_root</text>
   <text x="240" y="394" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#00e5a0" font-weight="700">ok</text>
-  <text x="24" y="423" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#00e5a0" font-weight="700">ready: local prerequisites are satisfied</text>
+  <text x="24" y="415" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#94a3b8">release_pin</text>
+  <text x="240" y="415" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#00e5a0" font-weight="700">ok</text>
+  <text x="24" y="444" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#00e5a0" font-weight="700">ready: local prerequisites are satisfied</text>
   <text x="634" y="70" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#64748b">$</text>
   <text x="650" y="70" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#e2e8f0">./scripts/run-pipelock-gauntlet.sh</text>
   <text x="634" y="91" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13.5" fill="#64748b">$</text>

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -380,7 +380,7 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         )
 
     def _kernel_sandbox_probe(self, lsm_contents, seccomp_field=True, seccomp_filter=True,
-                              status_readable=True):
+                              status_readable=True, status_denied=False):
         """Drive the whole doctor with substituted kernel probe paths.
 
         Exercises run_doctor rather than kernel_sandbox_state alone. Testing the
@@ -399,6 +399,10 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
                 status_path.write_text(
                     "Seccomp:\t2\n" if seccomp_field else "Name:\tsh\n", encoding="utf-8"
                 )
+                if status_denied:
+                    # A present-but-unreadable file is a different errno from a
+                    # missing one, and the two can take different branches.
+                    status_path.chmod(0o000)
             filter_path = root / ("actions_avail" if seccomp_filter else "absent-filter")
             if seccomp_filter:
                 filter_path.write_text("kill_process filter\n", encoding="utf-8")
@@ -465,9 +469,12 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             # One grep exits nonzero for both "no Seccomp: field" and "could not
             # read the file", and folding them together refused a machine over
             # an unreadable procfs rather than over evidence.
-            ("unreadable process status", {"lsm_contents": "capability,landlock", "status_readable": False}),
+            ("missing process status", {"lsm_contents": "capability,landlock", "status_readable": False}),
+            ("unreadable process status", {"lsm_contents": "capability,landlock", "status_denied": True}),
         ):
             with self.subTest(name):
+                if kwargs.get("status_denied") and os.geteuid() == 0:
+                    self.skipTest("root reads through a denied mode, so this case proves nothing")
                 status, ready, code = self._kernel_sandbox_probe(**kwargs)
                 self.assertEqual(status, "unknown")
                 self.assertTrue(ready, "an inconclusive probe must not refuse the machine")

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -404,7 +404,16 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             # temp directory makes repo_root resolve to that directory and the
             # repository-root and release-pin checks fail for reasons that have
             # nothing to do with the kernel probe.
-            patched = ENTRYPOINT.parent / "run-pipelock-gauntlet.kernelprobe-test.sh"
+            #
+            # The name is unique per invocation. A fixed one let two concurrent
+            # invocations write and unlink each other's copy, which fails
+            # nondeterministically and can leave the file behind after an
+            # interrupt.
+            handle, patched_name = tempfile.mkstemp(
+                dir=ENTRYPOINT.parent, prefix="run-pipelock-gauntlet.kernelprobe-", suffix=".sh"
+            )
+            os.close(handle)
+            patched = Path(patched_name)
             script = ENTRYPOINT.read_text(encoding="utf-8")
             script = script.replace('"/sys/kernel/security/lsm"', f'"{lsm_path}"')
             script = script.replace('"/proc/self/status"', f'"{status_path}"')

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -379,44 +379,82 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             "a consumer that changes directory would resolve the un-canonicalized value",
         )
 
-    def _kernel_sandbox_state(self, lsm_contents, seccomp=True):
-        """Run the entrypoint's kernel_sandbox_state helper against a fake LSM list."""
-        script = ENTRYPOINT.read_text(encoding="utf-8")
-        start = script.index("kernel_sandbox_state() {")
-        end = script.index("\n}\n", start) + 3
-        helper = script[start:end]
+    def _kernel_sandbox_probe(self, lsm_contents, seccomp_field=True, seccomp_filter=True):
+        """Drive the whole doctor with substituted kernel probe paths.
+
+        Exercises run_doctor rather than kernel_sandbox_state alone. Testing the
+        classifier in isolation verified the label and not its consequence, and
+        that is exactly how an inconclusive result shipped while still failing
+        the doctor: the helper said unknown, which was correct, and the doctor
+        counted it as a failed prerequisite, which was not.
+        """
         with tempfile.TemporaryDirectory() as temporary:
-            if lsm_contents is None:
-                lsm_path = str(Path(temporary) / "absent")
-            else:
-                lsm_path = str(Path(temporary) / "lsm")
-                Path(lsm_path).write_text(lsm_contents, encoding="utf-8")
-            status_path = str(Path(temporary) / "status")
-            Path(status_path).write_text("Seccomp:\t2\n" if seccomp else "Name:\tsh\n", encoding="utf-8")
-            program = helper.replace("/sys/kernel/security/lsm", lsm_path)
-            program = program.replace("/proc/self/status", status_path)
-            return subprocess.run(
-                ["bash", "-c", program + "\nkernel_sandbox_state"],
-                text=True, capture_output=True, check=False,
-            ).stdout.strip()
+            root = Path(temporary)
+            lsm_path = root / ("lsm" if lsm_contents is not None else "absent-lsm")
+            if lsm_contents is not None:
+                lsm_path.write_text(lsm_contents, encoding="utf-8")
+            status_path = root / "status"
+            status_path.write_text("Seccomp:\t2\n" if seccomp_field else "Name:\tsh\n", encoding="utf-8")
+            filter_path = root / ("actions_avail" if seccomp_filter else "absent-filter")
+            if seccomp_filter:
+                filter_path.write_text("kill_process filter\n", encoding="utf-8")
+
+            # The entrypoint derives repo_root from its own location, so the
+            # patched copy has to live beside the original. Running it from a
+            # temp directory makes repo_root resolve to that directory and the
+            # repository-root and release-pin checks fail for reasons that have
+            # nothing to do with the kernel probe.
+            patched = ENTRYPOINT.parent / "run-pipelock-gauntlet.kernelprobe-test.sh"
+            script = ENTRYPOINT.read_text(encoding="utf-8")
+            script = script.replace('"/sys/kernel/security/lsm"', f'"{lsm_path}"')
+            script = script.replace('"/proc/self/status"', f'"{status_path}"')
+            script = script.replace('"/proc/sys/kernel/seccomp/actions_avail"', f'"{filter_path}"')
+            patched.write_text(script, encoding="utf-8")
+            try:
+                result = subprocess.run(
+                    ["bash", str(patched), "--doctor-json"],
+                    cwd=REPO_ROOT,
+                    env={**os.environ, "AEB_GO": ""},
+                    text=True, capture_output=True, check=False,
+                )
+            finally:
+                patched.unlink(missing_ok=True)
+            report = json.loads(result.stdout)
+            check = next(c for c in report["checks"] if c["code"] == "kernel_sandbox")
+            return check["status"], report["ready"], result.returncode
 
     def test_kernel_sandbox_probe_classifies_each_state(self):
         # The target runs under Landlock and seccomp. Before this check the
         # doctor reported ready and the run died on `query Landlock ABI:
         # function not implemented`, after the evaluator had paid for a release
         # download and a toolchain build.
-        self.assertEqual(self._kernel_sandbox_state("capability,yama,landlock,bpf"), "ok")
-        self.assertEqual(self._kernel_sandbox_state("landlock"), "ok")
-        self.assertEqual(self._kernel_sandbox_state("capability,landlock"), "ok")
-        self.assertEqual(self._kernel_sandbox_state("capability,yama,apparmor"), "no_landlock")
-        self.assertEqual(self._kernel_sandbox_state("capability,yama", seccomp=False), "no_seccomp")
+        for name, kwargs, want in (
+            ("landlock present", {"lsm_contents": "capability,yama,landlock,bpf"}, "ok"),
+            ("landlock alone", {"lsm_contents": "landlock"}, "ok"),
+            ("landlock last", {"lsm_contents": "capability,landlock"}, "ok"),
+            ("landlock absent", {"lsm_contents": "capability,yama,apparmor"}, "unavailable"),
+            ("no seccomp field", {"lsm_contents": "capability,landlock", "seccomp_field": False}, "unavailable"),
+        ):
+            with self.subTest(name):
+                status, _, _ = self._kernel_sandbox_probe(**kwargs)
+                self.assertEqual(status, want)
 
-    def test_kernel_sandbox_probe_does_not_refuse_when_it_cannot_tell(self):
-        # An unreadable LSM list means securityfs is not mounted, which says
-        # nothing about the kernel. Reporting that as unavailable would refuse a
-        # machine that would have worked, which is its own failure: the operator
-        # whose run is blocked for no reason turns the check off.
-        self.assertEqual(self._kernel_sandbox_state(None), "unknown")
+    def test_kernel_sandbox_unknown_does_not_fail_the_doctor(self):
+        # The availability half, and the one that shipped wrong. An unreadable
+        # LSM list means securityfs is not mounted, which says nothing about the
+        # kernel. Reporting it and refusing the machine are different things:
+        # the operator whose run is blocked for no reason turns the check off.
+        # Assert on `ready` and the exit code, not just the reported status,
+        # because the status was already right while the verdict was wrong.
+        for name, kwargs in (
+            ("unreadable LSM list", {"lsm_contents": None}),
+            ("seccomp filter support unprovable", {"lsm_contents": "capability,landlock", "seccomp_filter": False}),
+        ):
+            with self.subTest(name):
+                status, ready, code = self._kernel_sandbox_probe(**kwargs)
+                self.assertEqual(status, "unknown")
+                self.assertTrue(ready, "an inconclusive probe must not refuse the machine")
+                self.assertEqual(code, 0, "an inconclusive probe must not fail the doctor")
 
     def test_doctor_rejects_a_realpath_without_the_required_gnu_options(self):
         # Presence is not capability. BusyBox realpath takes no options, so a

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -379,7 +379,8 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             "a consumer that changes directory would resolve the un-canonicalized value",
         )
 
-    def _kernel_sandbox_probe(self, lsm_contents, seccomp_field=True, seccomp_filter=True):
+    def _kernel_sandbox_probe(self, lsm_contents, seccomp_field=True, seccomp_filter=True,
+                              status_readable=True):
         """Drive the whole doctor with substituted kernel probe paths.
 
         Exercises run_doctor rather than kernel_sandbox_state alone. Testing the
@@ -393,8 +394,11 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             lsm_path = root / ("lsm" if lsm_contents is not None else "absent-lsm")
             if lsm_contents is not None:
                 lsm_path.write_text(lsm_contents, encoding="utf-8")
-            status_path = root / "status"
-            status_path.write_text("Seccomp:\t2\n" if seccomp_field else "Name:\tsh\n", encoding="utf-8")
+            status_path = root / ("status" if status_readable else "absent-status")
+            if status_readable:
+                status_path.write_text(
+                    "Seccomp:\t2\n" if seccomp_field else "Name:\tsh\n", encoding="utf-8"
+                )
             filter_path = root / ("actions_avail" if seccomp_filter else "absent-filter")
             if seccomp_filter:
                 filter_path.write_text("kill_process filter\n", encoding="utf-8")
@@ -458,6 +462,10 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
         for name, kwargs in (
             ("unreadable LSM list", {"lsm_contents": None}),
             ("seccomp filter support unprovable", {"lsm_contents": "capability,landlock", "seccomp_filter": False}),
+            # One grep exits nonzero for both "no Seccomp: field" and "could not
+            # read the file", and folding them together refused a machine over
+            # an unreadable procfs rather than over evidence.
+            ("unreadable process status", {"lsm_contents": "capability,landlock", "status_readable": False}),
         ):
             with self.subTest(name):
                 status, ready, code = self._kernel_sandbox_probe(**kwargs)

--- a/scripts/continuous_gauntlet_workflow_test.py
+++ b/scripts/continuous_gauntlet_workflow_test.py
@@ -379,6 +379,45 @@ class ContinuousGauntletWorkflowTest(unittest.TestCase):
             "a consumer that changes directory would resolve the un-canonicalized value",
         )
 
+    def _kernel_sandbox_state(self, lsm_contents, seccomp=True):
+        """Run the entrypoint's kernel_sandbox_state helper against a fake LSM list."""
+        script = ENTRYPOINT.read_text(encoding="utf-8")
+        start = script.index("kernel_sandbox_state() {")
+        end = script.index("\n}\n", start) + 3
+        helper = script[start:end]
+        with tempfile.TemporaryDirectory() as temporary:
+            if lsm_contents is None:
+                lsm_path = str(Path(temporary) / "absent")
+            else:
+                lsm_path = str(Path(temporary) / "lsm")
+                Path(lsm_path).write_text(lsm_contents, encoding="utf-8")
+            status_path = str(Path(temporary) / "status")
+            Path(status_path).write_text("Seccomp:\t2\n" if seccomp else "Name:\tsh\n", encoding="utf-8")
+            program = helper.replace("/sys/kernel/security/lsm", lsm_path)
+            program = program.replace("/proc/self/status", status_path)
+            return subprocess.run(
+                ["bash", "-c", program + "\nkernel_sandbox_state"],
+                text=True, capture_output=True, check=False,
+            ).stdout.strip()
+
+    def test_kernel_sandbox_probe_classifies_each_state(self):
+        # The target runs under Landlock and seccomp. Before this check the
+        # doctor reported ready and the run died on `query Landlock ABI:
+        # function not implemented`, after the evaluator had paid for a release
+        # download and a toolchain build.
+        self.assertEqual(self._kernel_sandbox_state("capability,yama,landlock,bpf"), "ok")
+        self.assertEqual(self._kernel_sandbox_state("landlock"), "ok")
+        self.assertEqual(self._kernel_sandbox_state("capability,landlock"), "ok")
+        self.assertEqual(self._kernel_sandbox_state("capability,yama,apparmor"), "no_landlock")
+        self.assertEqual(self._kernel_sandbox_state("capability,yama", seccomp=False), "no_seccomp")
+
+    def test_kernel_sandbox_probe_does_not_refuse_when_it_cannot_tell(self):
+        # An unreadable LSM list means securityfs is not mounted, which says
+        # nothing about the kernel. Reporting that as unavailable would refuse a
+        # machine that would have worked, which is its own failure: the operator
+        # whose run is blocked for no reason turns the check off.
+        self.assertEqual(self._kernel_sandbox_state(None), "unknown")
+
     def test_doctor_rejects_a_realpath_without_the_required_gnu_options(self):
         # Presence is not capability. BusyBox realpath takes no options, so a
         # doctor that only checks for the command reports ready and the run then

--- a/scripts/render_diagrams.py
+++ b/scripts/render_diagrams.py
@@ -1107,7 +1107,7 @@ def coverage(p) -> str:
 DOCTOR_LINES = tuple((name, "ok") for name in (
     "platform_linux", "command_git", "command_python3", "command_go", "command_curl", "command_jq",
     "command_sha256sum", "command_tar", "command_timeout", "command_realpath", "command_make",
-    "go_version", "mcp_stdio_bridge", "repository_root", "release_pin",
+    "go_version", "mcp_stdio_bridge", "kernel_sandbox", "repository_root", "release_pin",
 ))
 DOCTOR_READY = "ready: local prerequisites are satisfied"
 

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -263,7 +263,17 @@ kernel_sandbox_state() {
   # Absent field means no seccomp at all and is definitive. Field present but no
   # filter evidence is inconclusive rather than a refusal, because a kernel can
   # withhold that sysctl without lacking the capability.
-  if ! grep -q '^Seccomp:' "$status_path" 2>/dev/null; then
+  # Read before judging. A single grep cannot tell "the field is absent" from
+  # "the file could not be read", and it exits nonzero for both, so folding
+  # them together refused a machine whose procfs was merely unreadable. That is
+  # the definitive-negative treatment this function reserves for evidence, and
+  # it contradicts the rule stated above.
+  local status_contents=""
+  if ! status_contents="$(<"$status_path")"; then
+    printf '%s\n' "unknown"
+    return 0
+  fi
+  if ! printf '%s\n' "$status_contents" | grep -q '^Seccomp:'; then
     printf '%s\n' "no_seccomp"
     return 0
   fi

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -249,9 +249,26 @@ fi
 # that would have worked.
 kernel_sandbox_state() {
   local lsm_path="/sys/kernel/security/lsm"
+  local status_path="/proc/self/status"
+  local seccomp_filter_path="/proc/sys/kernel/seccomp/actions_avail"
   local lsm=""
-  if ! grep -q '^Seccomp:' /proc/self/status 2>/dev/null; then
+  # The Seccomp field in procfs reports the calling process's seccomp MODE. Its
+  # presence means the kernel was built with CONFIG_SECCOMP, which does not imply
+  # CONFIG_SECCOMP_FILTER, and the target installs a filter. Treating the field
+  # as proof of capability would report ok and let the run die installing that
+  # filter, which is the failure this whole check exists to prevent.
+  #
+  # seccomp_filter appears in /proc/sys/kernel/ only when filter support is
+  # compiled in, so it is positive evidence where the procfs field is not.
+  # Absent field means no seccomp at all and is definitive. Field present but no
+  # filter evidence is inconclusive rather than a refusal, because a kernel can
+  # withhold that sysctl without lacking the capability.
+  if ! grep -q '^Seccomp:' "$status_path" 2>/dev/null; then
     printf '%s\n' "no_seccomp"
+    return 0
+  fi
+  if [[ ! -e "$seccomp_filter_path" ]]; then
+    printf '%s\n' "unknown"
     return 0
   fi
   if [[ ! -r "$lsm_path" ]]; then
@@ -289,6 +306,17 @@ run_doctor() {
     details+=("$2")
     remediations+=("$3")
     [[ "$2" == "ok" ]] || failed=$((failed + 1))
+  }
+
+  # An advisory result is reported and does NOT count as a failed prerequisite.
+  # It exists for a probe that cannot reach a verdict, where the honest answer is
+  # "I could not tell" rather than "this machine is unusable". Routing that
+  # through add_doctor_result would refuse the machine, because everything other
+  # than ok is counted as a failure there.
+  add_doctor_advisory() {
+    codes+=("$1")
+    details+=("$2")
+    remediations+=("$3")
   }
 
   if [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]; then
@@ -380,8 +408,8 @@ run_doctor() {
       "this kernel reports no seccomp support and the target sandbox requires it; use a kernel built with CONFIG_SECCOMP_FILTER"
     ;;
   *)
-    add_doctor_result "kernel_sandbox" "unknown" \
-      "could not determine Landlock support because the kernel LSM list is unreadable; the run will fail early if it is absent"
+    add_doctor_advisory "kernel_sandbox" "unknown" \
+      "could not determine kernel sandbox support because the LSM list is unreadable or seccomp filter support could not be established; the run fails early if either is absent"
     ;;
   esac
   if [[ "$(pwd -P)" == "$repo_root" ]]; then

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -242,6 +242,36 @@ if [[ "$go_bin" == */* ]]; then
   [[ -n "$go_bin_resolved" ]] && go_bin="$go_bin_resolved"
 fi
 
+# kernel_sandbox_state reports whether this kernel can host the target sandbox.
+# Echoes ok, no_landlock, no_seccomp, or unknown. Only a readable LSM list that
+# omits landlock is treated as definitive: an unreadable one means securityfs is
+# not mounted, which says nothing about the kernel and must not refuse a machine
+# that would have worked.
+kernel_sandbox_state() {
+  local lsm_path="/sys/kernel/security/lsm"
+  local lsm=""
+  if ! grep -q '^Seccomp:' /proc/self/status 2>/dev/null; then
+    printf '%s\n' "no_seccomp"
+    return 0
+  fi
+  if [[ ! -r "$lsm_path" ]]; then
+    printf '%s\n' "unknown"
+    return 0
+  fi
+  lsm="$(<"$lsm_path")" || {
+    printf '%s\n' "unknown"
+    return 0
+  }
+  case ",$lsm," in
+  *,landlock,*)
+    printf '%s\n' "ok"
+    ;;
+  *)
+    printf '%s\n' "no_landlock"
+    ;;
+  esac
+}
+
 run_doctor() {
   local failed=0
   local command_name
@@ -330,6 +360,30 @@ run_doctor() {
   else
     add_doctor_result "mcp_stdio_bridge" "missing" "install socat, ncat, or nc and retry"
   fi
+  # The target runs under Landlock and seccomp, so a kernel built without either
+  # cannot host a run. Without this check the doctor reported every prerequisite
+  # satisfied and the run then died on `query Landlock ABI: function not
+  # implemented`, after the evaluator had already paid for a release download
+  # and a toolchain build. Observed on an arm64 board whose kernel omits
+  # Landlock. A definitive negative fails; an inconclusive probe does not,
+  # because refusing a machine that would have worked is its own failure.
+  case "$(kernel_sandbox_state)" in
+  ok)
+    add_doctor_result "kernel_sandbox" "ok" ""
+    ;;
+  no_landlock)
+    add_doctor_result "kernel_sandbox" "unavailable" \
+      "this kernel reports no Landlock support and the target sandbox requires it; use a kernel built with CONFIG_SECURITY_LANDLOCK and landlock in its active LSM list"
+    ;;
+  no_seccomp)
+    add_doctor_result "kernel_sandbox" "unavailable" \
+      "this kernel reports no seccomp support and the target sandbox requires it; use a kernel built with CONFIG_SECCOMP_FILTER"
+    ;;
+  *)
+    add_doctor_result "kernel_sandbox" "unknown" \
+      "could not determine Landlock support because the kernel LSM list is unreadable; the run will fail early if it is absent"
+    ;;
+  esac
   if [[ "$(pwd -P)" == "$repo_root" ]]; then
     repo_ok=true
   fi


### PR DESCRIPTION
## What changed

The target under test runs inside a Landlock and seccomp sandbox, and the preflight checked for neither. On a kernel built without Landlock every prerequisite reported satisfied and the run then died with `target-sandbox: query Landlock ABI: function not implemented`, after the evaluator had already downloaded a pinned release and built a toolchain. That was observed on an arm64 board, not hypothesised.

`--doctor` now probes both features and reports them under a `kernel_sandbox` check.

The failure direction is the part worth reviewing. A definitive negative fails: a readable kernel LSM list that omits landlock, or a kernel reporting no seccomp support. An inconclusive probe does not fail. An unreadable LSM list means securityfs is not mounted, which says nothing about whether the kernel has Landlock, and refusing a machine that would have worked is its own failure mode here: an operator whose run is blocked for no reason turns the check off, and then it protects nobody. Distrust this in that direction rather than the detection one.

The doctor terminal drawing in the README lists exactly the checks the script reports and its renderer refuses to derive that list automatically, so the asset is regenerated with the new check rather than left to drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a kernel sandbox readiness check to the terminal doctor.
  - Detects required Landlock and seccomp capabilities, including seccomp filter support.
  - Reports supported, unavailable, or unknown statuses.
  - Treats inconclusive checks as advisories without blocking readiness.
  - Updated the terminal preflight diagram to include the kernel sandbox check.

- **Tests**
  - Added coverage for missing or unreadable system status files and other supported, unavailable, and inconclusive kernel environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->