### PR TITLE
fix: enforce tool-profile reader compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check-test-layout preflight check-citation check-case-immutability check-case-governance check-frozen-schema-immutability check-schema-catalog check-schema-discovery-feed check-schema-copies check-docs check-operator-kit check-contracts check-public-contracts check-claim-language check-readme-categories check-diagrams check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image stats stats-update check-stats cases-manifest check-gauntlet-site check-result-pointers test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow test-release-snapshot release-snapshot validate-cases validate
+.PHONY: check-test-layout preflight check-citation check-case-immutability check-case-governance check-frozen-schema-immutability check-schema-catalog check-schema-discovery-feed check-schema-copies check-docs check-operator-kit check-contracts check-public-contracts check-claim-language check-readme-categories check-diagrams check-capability-registry-history check-scorecard-workflow test-label-boundary test-runner-parity test-runner-image test-tool-profile-reader-contracts stats stats-update check-stats cases-manifest check-gauntlet-site check-result-pointers test-capability-registry test-validate test-runner test-receipt-generator test-control-evidence-vectors test-control-evidence-verifier test-control-evidence-v1-verifier test-control-evidence-g2-authentication test-pipelock-example test-release-build test-release-workflow test-release-snapshot release-snapshot validate-cases validate
 
 TMPDIR := $(HOME)/.cache/pipelock-tmp
 GOCACHE := $(HOME)/.cache/go-build
@@ -38,9 +38,18 @@ check-scorecard-workflow:
 # producer or an empty record tree cannot turn this into a false green.
 check-contracts:
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_contracts_test.py
+	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_go_consumer_tests_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/artifact_schema_conformance_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/check_schema_closure_test.py
 	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_contracts.py
+	@$(MAKE) --no-print-directory test-tool-profile-reader-contracts
+
+test-tool-profile-reader-contracts:
+	@mkdir -p "$(TMPDIR)" "$(GOCACHE)"
+	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_go_consumer_tests.py runner TestLoadProfileRefusesNMinusOneProfileWithMachineReadableVersion
+	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_go_consumer_tests.py validate TestProfileFileRefusesNMinusOneSchemaBeforeLegacyFields
+	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_go_consumer_tests.py control-evidence/v0/verifier TestV0VerifierRetainsToolProfileV1AndV3Readers
+	@PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_go_consumer_tests.py control-evidence/v1/verifier TestV1VerifierRetainsToolProfileV1AndV4Readers
 
 # The discovery document is generated from the canonical schema files. It pins
 # every versioned schema's resolving identifier and current bytes without

--- a/contracts/artifacts.json
+++ b/contracts/artifacts.json
@@ -170,6 +170,9 @@
         3,
         4
       ],
+      "scoring_reader_versions": [
+        4
+      ],
       "frozen_versions": [
         1,
         3
@@ -203,7 +206,44 @@
       "reader": [
         "validate/main.go",
         "runner/case.go",
+        "control-evidence/v0/verifier",
         "control-evidence/v1/verifier"
+      ],
+    "reader_contracts": [
+      {
+        "consumer": "runner_scoring",
+        "role": "scoring",
+        "path": "runner/case.go",
+          "accepted_versions": [
+            4
+          ]
+        },
+      {
+        "consumer": "validator_scoring",
+        "role": "scoring",
+        "path": "validate/main.go",
+          "accepted_versions": [
+            4
+          ]
+        },
+      {
+        "consumer": "control_evidence_v0",
+        "role": "retained_evidence",
+        "path": "control-evidence/v0/verifier",
+          "accepted_versions": [
+            1,
+            3
+          ]
+        },
+      {
+        "consumer": "control_evidence_v1",
+        "role": "retained_evidence",
+        "path": "control-evidence/v1/verifier",
+          "accepted_versions": [
+            1,
+            4
+          ]
+        }
       ],
       "source_versions": [
         {

--- a/control-evidence/v0/verifier/schema_assessor_test.go
+++ b/control-evidence/v0/verifier/schema_assessor_test.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -42,6 +43,67 @@ func TestV0VerifierRejectsActiveV4ToolProfile(t *testing.T) {
 	if validToolProfileSchema(profile, schemas) {
 		t.Fatal("frozen v0 verifier accepted an active v4 tool profile")
 	}
+}
+
+func TestV0VerifierRetainsToolProfileV1AndV3Readers(t *testing.T) {
+	schemas, err := loadSchemas()
+	if err != nil {
+		t.Fatalf("load schemas: %v", err)
+	}
+	v1Profile := mustRead(t, filepath.Join("..", "conformance", "golden", "g01-vendor-time", "tool-profile.json"))
+	v3Profile := bytes.Replace(v1Profile, []byte(`"schema_version": 1`), []byte(`"schema_version": 3`), 1)
+	if bytes.Equal(v1Profile, v3Profile) {
+		t.Fatal("retained v1 profile did not yield a schema-valid v3 fixture")
+	}
+	for version, profile := range map[int][]byte{1: v1Profile, 3: v3Profile} {
+		if !validToolProfileSchema(profile, schemas) {
+			t.Fatalf("v%d retained/schema-valid tool profile was rejected", version)
+		}
+	}
+	contract := toolProfileReaderContract(t, "control_evidence_v0")
+	if contract.Role != "retained_evidence" || contract.Path != "control-evidence/v0/verifier" || !reflect.DeepEqual(contract.AcceptedVersions, toolProfileSchemaVersions(schemas)) {
+		t.Fatalf("v0 reader contract = %#v, want retained_evidence control-evidence/v0/verifier versions %v", contract, toolProfileSchemaVersions(schemas))
+	}
+}
+
+type readerContract struct {
+	Consumer         string `json:"consumer"`
+	Role             string `json:"role"`
+	Path             string `json:"path"`
+	AcceptedVersions []int  `json:"accepted_versions"`
+}
+
+func toolProfileReaderContract(t *testing.T, consumer string) readerContract {
+	t.Helper()
+	data := mustRead(t, filepath.Join("..", "..", "..", "contracts", "artifacts.json"))
+	var manifest struct {
+		ArtifactFamilies []struct {
+			Family          string           `json:"family"`
+			ReaderContracts []readerContract `json:"reader_contracts"`
+		} `json:"artifact_families"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode compatibility manifest: %v", err)
+	}
+	for _, family := range manifest.ArtifactFamilies {
+		if family.Family != "tool_profile" {
+			continue
+		}
+		for _, contract := range family.ReaderContracts {
+			if contract.Consumer == consumer {
+				return contract
+			}
+		}
+	}
+	t.Fatalf("compatibility manifest has no tool_profile reader contract for %q", consumer)
+	return readerContract{}
+}
+
+func toolProfileSchemaVersions(schemas *schemaSet) []int {
+	if len(schemas.toolProfiles) != 2 || schemas.toolProfiles[1] == nil || schemas.toolProfiles[3] == nil {
+		return nil
+	}
+	return []int{1, 3}
 }
 
 func TestAssessSchemaAcceptsAllGoldenAndEdgePackages(t *testing.T) {

--- a/control-evidence/v1/verifier/schema_binding_test.go
+++ b/control-evidence/v1/verifier/schema_binding_test.go
@@ -1,6 +1,10 @@
 package verifier
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -15,4 +19,90 @@ func TestSchemaBindingsFailClosedWhenRequiredBindingIsMissing(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "requirement") {
 		t.Fatalf("validateSchemaBindings() error = %v, want missing requirement binding", err)
 	}
+}
+
+func TestV1VerifierRetainsToolProfileV1AndV4Readers(t *testing.T) {
+	schemas, err := loadSchemas()
+	if err != nil {
+		t.Fatal(err)
+	}
+	profiles := map[int]string{
+		1: filepath.Join("..", "..", "v0", "conformance", "golden", "g01-vendor-time", "tool-profile.json"),
+		4: filepath.Join("..", "conformance", "golden", "g01-valid-registry-bound", "tool-profile.json"),
+	}
+	for version, path := range profiles {
+		profile, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read v%d retained tool profile: %v", version, err)
+		}
+		if !validToolProfileSchema(profile, schemas) {
+			t.Fatalf("v%d retained tool profile was rejected", version)
+		}
+	}
+	retainedProfiles, err := filepath.Glob(filepath.Join("..", "conformance", "*", "*", "tool-profile.json"))
+	if err != nil {
+		t.Fatalf("find retained v1 tool profiles: %v", err)
+	}
+	for _, path := range retainedProfiles {
+		profile, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read retained v1 tool profile %s: %v", path, err)
+		}
+		var header struct {
+			SchemaVersion int `json:"schema_version"`
+		}
+		if err := json.Unmarshal(profile, &header); err != nil {
+			t.Fatalf("decode retained v1 tool profile %s: %v", path, err)
+		}
+		if header.SchemaVersion != 4 {
+			t.Fatalf("retained v1 tool profile %s has schema v%d, want v4; add an explicit reader before publishing another version", path, header.SchemaVersion)
+		}
+	}
+	contract := toolProfileReaderContract(t, "control_evidence_v1")
+	if contract.Role != "retained_evidence" || contract.Path != "control-evidence/v1/verifier" || !reflect.DeepEqual(contract.AcceptedVersions, toolProfileSchemaVersions(schemas)) {
+		t.Fatalf("v1 reader contract = %#v, want retained_evidence control-evidence/v1/verifier versions %v", contract, toolProfileSchemaVersions(schemas))
+	}
+}
+
+type readerContract struct {
+	Consumer         string `json:"consumer"`
+	Role             string `json:"role"`
+	Path             string `json:"path"`
+	AcceptedVersions []int  `json:"accepted_versions"`
+}
+
+func toolProfileReaderContract(t *testing.T, consumer string) readerContract {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "contracts", "artifacts.json"))
+	if err != nil {
+		t.Fatalf("read compatibility manifest: %v", err)
+	}
+	var manifest struct {
+		ArtifactFamilies []struct {
+			Family          string           `json:"family"`
+			ReaderContracts []readerContract `json:"reader_contracts"`
+		} `json:"artifact_families"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode compatibility manifest: %v", err)
+	}
+	for _, family := range manifest.ArtifactFamilies {
+		if family.Family != "tool_profile" {
+			continue
+		}
+		for _, contract := range family.ReaderContracts {
+			if contract.Consumer == consumer {
+				return contract
+			}
+		}
+	}
+	t.Fatalf("compatibility manifest has no tool_profile reader contract for %q", consumer)
+	return readerContract{}
+}
+
+func toolProfileSchemaVersions(schemas *schemaSet) []int {
+	if len(schemas.toolProfiles) != 2 || schemas.toolProfiles[1] == nil || schemas.toolProfiles[4] == nil {
+		return nil
+	}
+	return []int{1, 4}
 }

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -94,7 +94,7 @@ The table summarizes the manifest. `make check-contracts` checks the full machin
 
 Every versioned schema has an explicit `-vN` filename and matching `$id`. Result rows retain frozen v4 and v5 beside active v6; summaries retain frozen v4 beside active v5. Provenance candidates retain every accepted version beside active v6. A path can't silently retarget a historical contract, and the repository provides no unsuffixed compatibility aliases.
 
-Tool-profile reader support depends on the consumer. The runner and validator score only v4 and refuse older profiles with `incompatible_schema_version`. Control Evidence v0 retains v1 and v3 readers, while Control Evidence v1 retains v1 and v4 readers. `contracts/artifacts.json` records that consumer map and its union in `accepted_reader_versions`.
+Tool-profile reader support depends on the consumer. Scoring readers refuse profiles outside their declared contract with `incompatible_schema_version`; retained-evidence readers preserve only the historical formats they explicitly implement. `contracts/artifacts.json` is the authority for the consumer map and its accepted-version union.
 
 The summary stays on v5 because it already has optional fields for the publication facts. Provenance candidate v6 makes those fields mandatory and verifies them before publication. Keeping the requirement in that artifact family avoids changing the local-run summary or the promotion baseline when their meaning hasn't changed.
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -88,11 +88,13 @@ The table summarizes the manifest. `make check-contracts` checks the full machin
 | Summary | 5 | 4, 5 | 4 | [`summary-v5.schema.json`](../schemas/summary-v5.schema.json) |
 | Provenance candidate | 6 | 1, 2, 4, 5, 6 | 1, 2, 5 | [`provenance-candidate-v6.schema.json`](../schemas/provenance-candidate-v6.schema.json) |
 | Case index | 3 | 1, 2, 3 | 1, 2 | [`case-index-v3.schema.json`](../schemas/case-index-v3.schema.json) |
-| Promoted record | 2 | 1, 2 | 1 | [`promoted-record-v2.schema.json`](../schemas/promoted-record-v2.schema.json) |
+| Promoted record | 3 | 1, 2, 3 | 1, 2 | [`promoted-record-v3.schema.json`](../schemas/promoted-record-v3.schema.json) |
 | Promotion baseline | 1 | 1 | 1 | [`promotion-baseline-v1.schema.json`](../schemas/promotion-baseline-v1.schema.json) |
 | Result pointer | 1 | 1 | none | [`result-pointer-v1.schema.json`](../schemas/result-pointer-v1.schema.json) |
 
 Every versioned schema has an explicit `-vN` filename and matching `$id`. Result rows retain frozen v4 and v5 beside active v6; summaries retain frozen v4 beside active v5. Provenance candidates retain every accepted version beside active v6. A path can't silently retarget a historical contract, and the repository provides no unsuffixed compatibility aliases.
+
+Tool-profile reader support depends on the consumer. The runner and validator score only v4 and refuse older profiles with `incompatible_schema_version`. Control Evidence v0 retains v1 and v3 readers, while Control Evidence v1 retains v1 and v4 readers. `contracts/artifacts.json` records that consumer map and its union in `accepted_reader_versions`.
 
 The summary stays on v5 because it already has optional fields for the publication facts. Provenance candidate v6 makes those fields mandatory and verifies them before publication. Keeping the requirement in that artifact family avoids changing the local-run summary or the promotion baseline when their meaning hasn't changed.
 

--- a/runner/case.go
+++ b/runner/case.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -174,14 +175,20 @@ func loadProfile(path string) (Profile, error) {
 	if err != nil {
 		return Profile{}, fmt.Errorf("reading profile: %w", err)
 	}
+	var header struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return Profile{}, fmt.Errorf("parsing profile: %w", err)
+	}
+	if header.SchemaVersion != activeToolProfileSchemaVersion {
+		return Profile{}, fmt.Errorf("incompatible_schema_version: family=tool_profile accepted=[%d] got=%d", activeToolProfileSchemaVersion, header.SchemaVersion)
+	}
 	var p Profile
 	if err := decodeStrictJSON(data, &p); err != nil {
 		return Profile{}, fmt.Errorf("parsing profile: %w", err)
 	}
 	p.profileDir = filepath.Dir(path)
-	if p.SchemaVersion != activeToolProfileSchemaVersion {
-		return Profile{}, fmt.Errorf("profile schema_version must be %d for scoring, got %d", activeToolProfileSchemaVersion, p.SchemaVersion)
-	}
 	if err := validateProfileForRun(p); err != nil {
 		return Profile{}, fmt.Errorf("invalid profile: %w", err)
 	}

--- a/runner/registry_preflight_test.go
+++ b/runner/registry_preflight_test.go
@@ -4,12 +4,49 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	capabilityregistry "github.com/luckyPipewrench/agent-egress-bench/capability-registry"
 )
+
+type readerContract struct {
+	Consumer         string `json:"consumer"`
+	Role             string `json:"role"`
+	Path             string `json:"path"`
+	AcceptedVersions []int  `json:"accepted_versions"`
+}
+
+func toolProfileReaderContract(t *testing.T, consumer string) readerContract {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "contracts", "artifacts.json"))
+	if err != nil {
+		t.Fatalf("read compatibility manifest: %v", err)
+	}
+	var manifest struct {
+		ArtifactFamilies []struct {
+			Family          string           `json:"family"`
+			ReaderContracts []readerContract `json:"reader_contracts"`
+		} `json:"artifact_families"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode compatibility manifest: %v", err)
+	}
+	for _, family := range manifest.ArtifactFamilies {
+		if family.Family != "tool_profile" {
+			continue
+		}
+		for _, contract := range family.ReaderContracts {
+			if contract.Consumer == consumer {
+				return contract
+			}
+		}
+	}
+	t.Fatalf("compatibility manifest has no tool_profile reader contract for %q", consumer)
+	return readerContract{}
+}
 
 var testRegistryReference = capabilityregistry.Reference{
 	ID:       "aeb.core-capabilities",
@@ -65,6 +102,22 @@ func TestLoadProfileRejectsRetiredScopeDeclaration(t *testing.T) {
 	}
 	if _, err := loadProfile(path); err == nil || !strings.Contains(err.Error(), "unknown field") {
 		t.Fatalf("loadProfile error = %v, want strict rejection of retired supports", err)
+	}
+}
+
+func TestLoadProfileRefusesNMinusOneProfileWithMachineReadableVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profile-v3.json")
+	data := `{"schema_version":3,"tool":"test","tool_version":"1","runner_version":"v1","claims":[],"supports":{}}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := loadProfile(path)
+	if err == nil || err.Error() != "incompatible_schema_version: family=tool_profile accepted=[4] got=3" {
+		t.Fatalf("loadProfile error = %v, want machine-readable v3 incompatibility", err)
+	}
+	contract := toolProfileReaderContract(t, "runner_scoring")
+	if contract.Role != "scoring" || contract.Path != "runner/case.go" || !reflect.DeepEqual(contract.AcceptedVersions, []int{activeToolProfileSchemaVersion}) {
+		t.Fatalf("runner reader contract = %#v, want scoring runner/case.go v%d", contract, activeToolProfileSchemaVersion)
 	}
 }
 

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -545,6 +545,47 @@ def check(root, manifest_path):
             fail(f"{name}: frozen versions must be accepted by a reader")
         require_path_list(root, family.get("writer"), f"{name}.writer", allow_glob=True)
         require_path_list(root, family.get("reader"), f"{name}.reader")
+        reader_contracts = family.get("reader_contracts")
+        if reader_contracts is not None:
+            if not isinstance(reader_contracts, list) or not reader_contracts:
+                fail(f"{name}.reader_contracts must be a non-empty array when declared")
+            consumers = set()
+            reader_paths = set(family["reader"])
+            contract_paths = set()
+            covered_versions = set()
+            scoring_versions = set()
+            for contract in reader_contracts:
+                if not isinstance(contract, dict):
+                    fail(f"{name}.reader_contracts entries must be objects")
+                consumer = contract.get("consumer")
+                if not isinstance(consumer, str) or not consumer or consumer in consumers:
+                    fail(f"{name}.reader_contracts consumers must be unique non-empty strings")
+                consumers.add(consumer)
+                path = contract.get("path")
+                if not isinstance(path, str) or path not in reader_paths:
+                    fail(f"{name}.reader_contracts path must be listed in reader")
+                contract_paths.add(path)
+                role = contract.get("role")
+                if role not in {"scoring", "retained_evidence"}:
+                    fail(
+                        f"{name}.reader_contracts[{consumer}].role must be one of "
+                        "['retained_evidence', 'scoring']"
+                    )
+                versions = require_int_list(contract.get("accepted_versions"), f"{name}.reader_contracts[{consumer}].accepted_versions")
+                if not set(versions).issubset(accepted):
+                    fail(f"{name}.reader_contracts[{consumer}] accepts a version absent from accepted_reader_versions")
+                covered_versions.update(versions)
+                if role == "scoring":
+                    scoring_versions.update(versions)
+            if contract_paths != reader_paths:
+                fail(f"{name}.reader_contracts must bind every reader path")
+            if covered_versions != set(accepted):
+                fail(f"{name}.reader_contracts must cover accepted_reader_versions")
+            declared_scoring = family.get("scoring_reader_versions")
+            if declared_scoring is None:
+                fail(f"{name}.scoring_reader_versions is required with reader_contracts")
+            if set(require_int_list(declared_scoring, f"{name}.scoring_reader_versions")) != scoring_versions:
+                fail(f"{name}.scoring_reader_versions does not match scoring reader contracts")
         if family.get("gate") != "make check-contracts":
             fail(f"{name}: gate must be 'make check-contracts'")
 

--- a/scripts/check_contracts_test.py
+++ b/scripts/check_contracts_test.py
@@ -95,6 +95,100 @@ class CheckContractsTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "schemas do not cover accepted reader versions"):
                 check_contracts.check(ROOT, path)
 
+    def test_tool_profile_reader_contracts_distinguish_scoring_from_retained_readers(self):
+        manifest = ROOT / "contracts" / "artifacts.json"
+        tool_profile = next(
+            family
+            for family in json.loads(manifest.read_text(encoding="utf-8"))["artifact_families"]
+            if family["family"] == "tool_profile"
+        )
+        self.assertEqual([1, 3, 4], tool_profile["accepted_reader_versions"])
+        self.assertEqual([4], tool_profile["scoring_reader_versions"])
+        self.assertEqual(
+            {
+                "runner_scoring": ("scoring", [4]),
+                "validator_scoring": ("scoring", [4]),
+                "control_evidence_v0": ("retained_evidence", [1, 3]),
+                "control_evidence_v1": ("retained_evidence", [1, 4]),
+            },
+            {
+                entry["consumer"]: (entry["role"], entry["accepted_versions"])
+                for entry in tool_profile["reader_contracts"]
+            },
+        )
+        check_contracts.check(ROOT, manifest)
+
+    def test_rejects_reader_contract_that_omits_an_accepted_version(self):
+        manifest = json.loads((ROOT / "contracts" / "artifacts.json").read_text(encoding="utf-8"))
+        tool_profile = next(family for family in manifest["artifact_families"] if family["family"] == "tool_profile")
+        tool_profile["reader_contracts"][2]["accepted_versions"] = [1]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "artifacts.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "must cover accepted_reader_versions"):
+                check_contracts.check(ROOT, path)
+
+    def test_rejects_scoring_reader_version_mismatch(self):
+        manifest = json.loads((ROOT / "contracts" / "artifacts.json").read_text(encoding="utf-8"))
+        tool_profile = next(family for family in manifest["artifact_families"] if family["family"] == "tool_profile")
+        tool_profile["scoring_reader_versions"] = [1]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "artifacts.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "does not match scoring reader contracts"):
+                check_contracts.check(ROOT, path)
+
+    def test_rejects_duplicate_reader_contract_consumer(self):
+        manifest = json.loads((ROOT / "contracts" / "artifacts.json").read_text(encoding="utf-8"))
+        tool_profile = next(family for family in manifest["artifact_families"] if family["family"] == "tool_profile")
+        tool_profile["reader_contracts"][1]["consumer"] = "runner_scoring"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "artifacts.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "consumers must be unique"):
+                check_contracts.check(ROOT, path)
+
+    def test_rejects_reader_contract_path_mismatch(self):
+        manifest = json.loads((ROOT / "contracts" / "artifacts.json").read_text(encoding="utf-8"))
+        tool_profile = next(family for family in manifest["artifact_families"] if family["family"] == "tool_profile")
+        tool_profile["reader_contracts"][0]["path"] = "runner/not-a-reader.go"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "artifacts.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "path must be listed in reader"):
+                check_contracts.check(ROOT, path)
+
+    def test_rejects_reader_contract_version_outside_family_support(self):
+        manifest = json.loads((ROOT / "contracts" / "artifacts.json").read_text(encoding="utf-8"))
+        tool_profile = next(family for family in manifest["artifact_families"] if family["family"] == "tool_profile")
+        tool_profile["reader_contracts"][2]["accepted_versions"] = [99]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "artifacts.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "accepts a version absent"):
+                check_contracts.check(ROOT, path)
+
+    def test_rejects_reader_contract_role_mismatch(self):
+        manifest = json.loads((ROOT / "contracts" / "artifacts.json").read_text(encoding="utf-8"))
+        tool_profile = next(family for family in manifest["artifact_families"] if family["family"] == "tool_profile")
+        tool_profile["reader_contracts"][0]["role"] = "retained_evidence"
+        tool_profile["reader_contracts"][2]["role"] = "scoring"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "artifacts.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "does not match scoring reader contracts"):
+                check_contracts.check(ROOT, path)
+
+    def test_rejects_unknown_reader_contract_role(self):
+        manifest = json.loads((ROOT / "contracts" / "artifacts.json").read_text(encoding="utf-8"))
+        tool_profile = next(family for family in manifest["artifact_families"] if family["family"] == "tool_profile")
+        tool_profile["reader_contracts"][0]["role"] = "unrecognized"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "artifacts.json"
+            path.write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "role must be one of"):
+                check_contracts.check(ROOT, path)
+
     def test_rejects_changed_frozen_schema_bytes(self):
         manifest = json.loads((ROOT / "contracts" / "artifacts.json").read_text(encoding="utf-8"))
         frozen = next(

--- a/scripts/check_go_consumer_tests.py
+++ b/scripts/check_go_consumer_tests.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Run named Go contract proofs without treating an empty -run match as success."""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_test(workdir, test_name):
+    listed = subprocess.run(
+        ["go", "test", "-list", f"^{test_name}$", "."],
+        cwd=workdir,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if listed.returncode != 0:
+        raise RuntimeError(f"{workdir}: go test -list failed:\n{listed.stderr}")
+    if test_name not in listed.stdout.splitlines():
+        raise RuntimeError(f"{workdir}: required Go contract test is missing: {test_name}")
+
+    executed = subprocess.run(
+        ["go", "test", "-count=1", "-run", f"^{test_name}$", "."],
+        cwd=workdir,
+        check=False,
+    )
+    if executed.returncode != 0:
+        raise RuntimeError(f"{workdir}: Go contract test failed: {test_name}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workdir", type=Path)
+    parser.add_argument("test_name")
+    args = parser.parse_args(argv)
+    try:
+        run_test(args.workdir, args.test_name)
+    except (OSError, RuntimeError) as exc:
+        print(f"check-go-consumer-tests: FAIL - {exc}", file=sys.stderr)
+        return 1
+    print(f"check-go-consumer-tests: OK ({args.workdir}: {args.test_name})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_go_consumer_tests_test.py
+++ b/scripts/check_go_consumer_tests_test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Regression tests for named Go consumer-proof execution."""
+
+import importlib.util
+import subprocess
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "check_go_consumer_tests", ROOT / "scripts" / "check_go_consumer_tests.py"
+)
+checker = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(checker)
+
+
+class CheckGoConsumerTestsTest(unittest.TestCase):
+    def test_missing_named_test_fails_before_execution(self):
+        listed = subprocess.CompletedProcess([], 0, stdout="ok\n", stderr="")
+        with mock.patch.object(checker.subprocess, "run", return_value=listed) as run:
+            with self.assertRaisesRegex(RuntimeError, "required Go contract test is missing: TestProof"):
+                checker.run_test(Path("runner"), "TestProof")
+        self.assertEqual(1, run.call_count)
+
+    def test_list_failure_fails_closed_before_execution(self):
+        listed = subprocess.CompletedProcess([], 1, stdout="", stderr="compile failed")
+        with mock.patch.object(checker.subprocess, "run", return_value=listed) as run:
+            with self.assertRaisesRegex(RuntimeError, "go test -list failed"):
+                checker.run_test(Path("runner"), "TestProof")
+        self.assertEqual(1, run.call_count)
+
+    def test_exact_named_test_is_listed_then_executed(self):
+        listed = subprocess.CompletedProcess([], 0, stdout="TestProof\nok\n", stderr="")
+        executed = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with mock.patch.object(checker.subprocess, "run", side_effect=[listed, executed]) as run:
+            checker.run_test(Path("runner"), "TestProof")
+        self.assertEqual(2, run.call_count)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -163,6 +163,17 @@ def require_sha256(value, label):
     return value
 
 
+def render_version_options(versions):
+    rendered = [str(version) for version in sorted(versions)]
+    if not rendered:
+        return "no accepted versions"
+    if len(rendered) == 1:
+        return rendered[0]
+    if len(rendered) == 2:
+        return " or ".join(rendered)
+    return ", ".join(rendered[:-1]) + f", or {rendered[-1]}"
+
+
 def archive_manifest_identity(artifact_path, record_dir, expected_record_manifest_sha256):
     """Verify a retained manifest against a caller-authenticated immutable record."""
     record_dir = record_dir.resolve()
@@ -191,8 +202,7 @@ def archive_manifest_identity(artifact_path, record_dir, expected_record_manifes
         raise ValueError("archive record manifest must be an object")
     record_schema_version = record_manifest.get("schema_version")
     if record_schema_version not in PROMOTED_RECORD_SCHEMAS:
-        accepted = sorted(PROMOTED_RECORD_SCHEMAS)
-        rendered = ", ".join(str(version) for version in accepted[:-1]) + f", or {accepted[-1]}"
+        rendered = render_version_options(PROMOTED_RECORD_SCHEMAS)
         raise ValueError(f"archive record manifest schema_version must be {rendered}")
     artifact_schema.validate_file(
         record_manifest,

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -191,7 +191,9 @@ def archive_manifest_identity(artifact_path, record_dir, expected_record_manifes
         raise ValueError("archive record manifest must be an object")
     record_schema_version = record_manifest.get("schema_version")
     if record_schema_version not in PROMOTED_RECORD_SCHEMAS:
-        raise ValueError("archive record manifest schema_version must be 1 or 2")
+        accepted = sorted(PROMOTED_RECORD_SCHEMAS)
+        rendered = ", ".join(str(version) for version in accepted[:-1]) + f", or {accepted[-1]}"
+        raise ValueError(f"archive record manifest schema_version must be {rendered}")
     artifact_schema.validate_file(
         record_manifest,
         PROMOTED_RECORD_SCHEMAS[record_schema_version],

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -345,6 +345,33 @@ class ValidateGauntletScopeTest(unittest.TestCase):
             )
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_archive_record_refusal_names_all_accepted_record_versions(self):
+        with tempfile.TemporaryDirectory() as directory:
+            record = Path(directory) / FROZEN_RECORD.name
+            shutil.copytree(FROZEN_RECORD, record)
+            manifest_path = record / "record-manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["schema_version"] = 99
+            manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            expected_manifest_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(VALIDATOR),
+                    "--archive-record",
+                    str(record),
+                    "--expected-record-manifest-sha256",
+                    expected_manifest_digest,
+                    str(record / "continuous-gauntlet-pipelock.json"),
+                ],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("schema_version must be 1, 2, or 3", result.stderr)
+
     def test_archive_record_rejects_an_untrusted_record_manifest_digest(self):
         artifact_path = FROZEN_RECORD / "continuous-gauntlet-pipelock.json"
         result = subprocess.run(

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -35,6 +35,19 @@ def load_scope_validator_module():
 scope_validator = load_scope_validator_module()
 
 
+class RenderVersionOptionsTests(unittest.TestCase):
+    def test_renders_all_supported_cardinalities(self):
+        cases = (
+            ([], "no accepted versions"),
+            ([4], "4"),
+            ([4, 1], "1 or 4"),
+            ([4, 1, 3], "1, 3, or 4"),
+        )
+        for versions, expected in cases:
+            with self.subTest(versions=versions):
+                self.assertEqual(scope_validator.render_version_options(versions), expected)
+
+
 def corpus_manifest_sha256():
     return hashlib.sha256(MANIFEST.read_bytes()).hexdigest()
 

--- a/validate/main.go
+++ b/validate/main.go
@@ -1533,7 +1533,7 @@ func validateProfile(p Profile) []string {
 	var errors []string
 
 	if p.SchemaVersion != activeToolProfileSchemaVersion {
-		errors = append(errors, fmt.Sprintf("schema_version must be %d, got %d", activeToolProfileSchemaVersion, p.SchemaVersion))
+		errors = append(errors, fmt.Sprintf("incompatible_schema_version: family=tool_profile accepted=[%d] got=%d", activeToolProfileSchemaVersion, p.SchemaVersion))
 	}
 	if p.Tool == "" {
 		errors = append(errors, "missing tool")
@@ -1723,6 +1723,16 @@ func validateProfileFile(path string) []string {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return []string{fmt.Sprintf("%s: read error: %v", path, err)}
+	}
+
+	var header struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return []string{fmt.Sprintf("%s: JSON parse error: %v", path, err)}
+	}
+	if header.SchemaVersion != activeToolProfileSchemaVersion {
+		return []string{fmt.Sprintf("incompatible_schema_version: family=tool_profile accepted=[%d] got=%d", activeToolProfileSchemaVersion, header.SchemaVersion)}
 	}
 
 	var p Profile

--- a/validate/main_test.go
+++ b/validate/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -13,6 +14,42 @@ import (
 )
 
 var testRegistryReference = capabilityregistry.Reference{ID: "aeb.core-capabilities", Format: 1, Revision: 1, SHA256: "f5ae9fa9cbb79e8539d50f0284e584eb6ea834232e801d3e1c269411a9527e9b"}
+
+type readerContract struct {
+	Consumer         string `json:"consumer"`
+	Role             string `json:"role"`
+	Path             string `json:"path"`
+	AcceptedVersions []int  `json:"accepted_versions"`
+}
+
+func toolProfileReaderContract(t *testing.T, consumer string) readerContract {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "contracts", "artifacts.json"))
+	if err != nil {
+		t.Fatalf("read compatibility manifest: %v", err)
+	}
+	var manifest struct {
+		ArtifactFamilies []struct {
+			Family          string           `json:"family"`
+			ReaderContracts []readerContract `json:"reader_contracts"`
+		} `json:"artifact_families"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode compatibility manifest: %v", err)
+	}
+	for _, family := range manifest.ArtifactFamilies {
+		if family.Family != "tool_profile" {
+			continue
+		}
+		for _, contract := range family.ReaderContracts {
+			if contract.Consumer == consumer {
+				return contract
+			}
+		}
+	}
+	t.Fatalf("compatibility manifest has no tool_profile reader contract for %q", consumer)
+	return readerContract{}
+}
 
 // writeCase writes a JSON case file and returns the path.
 func writeCase(t *testing.T, dir, subdir, filename, content string) string {
@@ -1435,7 +1472,19 @@ func TestResultValidationRejectsPreV3Schema(t *testing.T) {
 
 func TestProfileValidationRejectsPreV3Schema(t *testing.T) {
 	p := Profile{SchemaVersion: 2, Tool: "test", ToolVersion: "1", RunnerVersion: "v1", Claims: []string{}, CapabilityRegistry: testRegistryReference}
-	assertContainsError(t, validateProfile(p), "schema_version must be 4")
+	assertContainsError(t, validateProfile(p), "incompatible_schema_version: family=tool_profile accepted=[4] got=2")
+}
+
+func TestProfileFileRefusesNMinusOneSchemaBeforeLegacyFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profile-v3.json")
+	if err := os.WriteFile(path, []byte(`{"schema_version":3,"tool":"test","tool_version":"1","runner_version":"v1","claims":[],"supports":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assertContainsError(t, validateProfileFile(path), "incompatible_schema_version: family=tool_profile accepted=[4] got=3")
+	contract := toolProfileReaderContract(t, "validator_scoring")
+	if contract.Role != "scoring" || contract.Path != "validate/main.go" || !reflect.DeepEqual(contract.AcceptedVersions, []int{activeToolProfileSchemaVersion}) {
+		t.Fatalf("validator reader contract = %#v, want scoring validate/main.go v%d", contract, activeToolProfileSchemaVersion)
+	}
 }
 
 func TestResultValidation_MissingFields(t *testing.T) {


### PR DESCRIPTION
## What changed
- Record the accepted tool-profile versions for each consumer instead of treating reader support as one shared range.
- Make scoring paths and the compatibility gate fail closed on unsupported profiles or missing proof tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit compatibility contracts for tool-profile readers, including scoring and retained-evidence support.
  - Added support documentation for promoted record versions and consumer-specific compatibility.

- **Bug Fixes**
  - Tool-profile validation now rejects unsupported schema versions earlier with consistent, machine-readable errors.
  - Unsupported archive record versions now report all accepted versions dynamically.

- **Tests**
  - Expanded compatibility checks across runners, validators, and Control Evidence verifiers.
  - Added automated validation for reader contracts and named consumer tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->