### PR TITLE
fix(brand): complete benchmark asset set

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Agent Egress Bench logomark: a combination square set at forty-five degrees.">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="55%" r="55%">
+      <stop offset="0%" stop-color="#00e5a0" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#00e5a0" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="#09090b"/>
+  <rect width="64" height="64" rx="12" fill="url(#glow)"/>
+  <g transform="rotate(-45 32 32)">
+    <rect x="7" y="22" width="50" height="15" rx="3" fill="#0e0e11" stroke="#00e5a0" stroke-width="2.6"/>
+    <path d="M 13 37 L 13 30" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+    <path d="M 19 37 L 19 33" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+    <path d="M 25 37 L 25 30" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+    <path d="M 31 37 L 31 33" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+    <path d="M 37 37 L 37 30" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+    <path d="M 43 37 L 43 33" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+    <path d="M 49 37 L 49 30" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+    <path d="M 31 39 L 25.5 48 L 36.5 48 Z" fill="#00e5a0"/>
+  </g>
+</svg>

--- a/assets/lockup-stacked.svg
+++ b/assets/lockup-stacked.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="444.72" height="196" viewBox="0 0 444.72 196" role="img" aria-label="Agent Egress Bench stacked logo lockup">
+  <g transform="translate(174.36 18) scale(1.5)">
+    <g transform="rotate(-45 32 32)">
+      <rect x="7" y="22" width="50" height="15" rx="3" fill="#0e0e11" stroke="#00e5a0" stroke-width="2.6"/>
+      <path d="M 13 37 L 13 30" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 19 37 L 19 33" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 25 37 L 25 30" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 31 37 L 31 33" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 37 37 L 37 30" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 43 37 L 43 33" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 49 37 L 49 30" stroke="#00e5a0" stroke-width="2" stroke-linecap="round"/>
+      <path d="M 31 39 L 25.5 48 L 36.5 48 Z" fill="#00e5a0"/>
+    </g>
+  </g>
+  <text x="222.36" y="166" text-anchor="middle" font-family="'JetBrains Mono', 'JetBrainsMono Nerd Font', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, monospace" font-size="38" font-weight="700" letter-spacing="-0.02em" xml:space="preserve"><tspan fill="#e2e8f0">Agent Egress </tspan><tspan fill="#00e5a0">Bench</tspan></text>
+</svg>

--- a/scripts/render_diagrams.py
+++ b/scripts/render_diagrams.py
@@ -451,9 +451,32 @@ def lockup() -> str:
     return "\n".join(out) + "\n"
 
 
-def logo() -> str:
+def stacked_lockup() -> str:
+    """Mark above the wordmark for square and narrow placements."""
     a = BRAND["accent"]
-    out = ['<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 64 64" role="img" '
+    margin, mark_size, size = 24, 96, 38
+    word = WORDMARK_LEAD + WORDMARK_ACCENT
+    text_w = round(len(word) * size * (MONO_ADVANCE - TRACKING), 2)
+    width = round(text_w + margin * 2, 2)
+    mark_x = round((width - mark_size) / 2, 2)
+    text_y = 166
+    out = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="196" '
+           f'viewBox="0 0 {width} 196" role="img" '
+           f'aria-label="Agent Egress Bench stacked logo lockup">',
+           f'  <g transform="translate({mark_x} 18) scale({round(mark_size / 64, 6)})">']
+    out += [f"  {line}" for line in _ruler_glyph(a, BRAND["bg_elevated"])]
+    out.append("  </g>")
+    out.append(f'  <text x="{width / 2}" y="{text_y}" text-anchor="middle" font-family="{MONO}" '
+               f'font-size="{size}" font-weight="700" letter-spacing="-{TRACKING}em" xml:space="preserve">'
+               f'<tspan fill="{BRAND["text"]}">{WORDMARK_LEAD}</tspan>'
+               f'<tspan fill="{a}">{WORDMARK_ACCENT}</tspan></text>')
+    out.append("</svg>")
+    return "\n".join(out) + "\n"
+
+
+def logo(size: int = 256) -> str:
+    a = BRAND["accent"]
+    out = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{size}" height="{size}" viewBox="0 0 64 64" role="img" '
            'aria-label="Agent Egress Bench logomark: a combination square set at forty-five degrees.">',
            "  <defs>",
            '    <radialGradient id="glow" cx="50%" cy="55%" r="55%">',
@@ -1315,7 +1338,9 @@ DIAGRAMS = {
 SINGLES = {
     "social-preview.svg": social_preview,
     "logo.svg": logo,
+    "favicon.svg": lambda: logo(64),
     "lockup.svg": lockup,
+    "lockup-stacked.svg": stacked_lockup,
     "terminal-doctor.svg": terminal_doctor,
 }
 # Hand-exported rasters, each pinned to the SVG it came from.

--- a/scripts/render_diagrams_test.py
+++ b/scripts/render_diagrams_test.py
@@ -416,6 +416,16 @@ class CommittedAssetTest(unittest.TestCase):
         # quietly now that no README reference points at it.
         self.assertIn("social-preview.svg", {path.name for path in generator.build()})
 
+    def test_the_complete_brand_asset_set_is_produced(self):
+        produced = {path.name for path in generator.build()}
+        self.assertTrue({
+            "favicon.svg",
+            "lockup.svg",
+            "lockup-stacked.svg",
+            "logo.svg",
+            "social-preview.svg",
+        }.issubset(produced))
+
     def test_every_png_matches_its_source(self):
         self.assertEqual(generator.png_problems(), [])
         for png in generator.PNG_EXPORTS:


### PR DESCRIPTION
## What changed
Add the generated favicon and stacked lockup so Agent Egress Bench carries the same complete asset set as the other portfolio repositories.