### PR TITLE
feat: record the toolchain that builds the runner

### DIFF
--- a/docs/RUNNER.md
+++ b/docs/RUNNER.md
@@ -390,7 +390,7 @@ The renderer reads these artifacts when present:
 |---|---|
 | `raw-summary.json` | Method versions, target product and version, profile digest, exact registry reference, reporting labels, scope counts, two outcome metrics, and two diagnostic rates |
 | `results.jsonl` | Every historical not-applicable or unreachable case ID and its recorded reason |
-| `run-metadata.json` | Repository and exact method commit |
+| `run-metadata.json` | Repository, exact method commit, and the Go toolchain's own reported version, since the runner is compiled from source on every run and the compiler is part of what produced the measuring instrument. Records at `schema_version: 2` and above carry `runner_go_version`; records at version 1 predate the field and cannot have it reconstructed |
 | `run-bundle.json` | Bundle status, publication eligibility, retained material digests, and candidate bindings |
 | `execution-decision.json` | Execution status, failures, review notes, and publication eligibility |
 | `entrypoint-command.txt` and `command.txt` | The retained reproduction commands |

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -73,6 +73,11 @@ ACTIVE_SUMMARY_SCHEMA_VERSIONS = frozenset({4, 5})
 ACTIVE_SUMMARY_SCHEMA_VERSION = 5
 ACTIVE_PROVENANCE_CANDIDATE_SCHEMA_VERSION = artifact_contracts.active_version("provenance_candidate")
 SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
+# A go toolchain's own version line, bounded so an arbitrary string cannot ride
+# into recorded evidence. Accepts released, release-candidate, beta and devel
+# self-reports, and the optional GOEXPERIMENT field real toolchains emit, for
+# example "go version go1.25.12 X:nodwarf5 linux/amd64".
+GO_VERSION_REPORT = re.compile(r"go version go[0-9A-Za-z.\-+]{1,40}( X:[0-9A-Za-z,_\-]{1,80})? [a-z0-9]{1,20}/[a-z0-9]{1,20}")
 V5_SCOPES = frozenset({"full", "applicable"})
 V5_OUTCOME_SCORE_FIELDS = frozenset({"containment", "false_positive_rate"})
 V5_DIAGNOSTIC_FIELDS = frozenset(
@@ -1113,8 +1118,14 @@ def measurements(repo_root, run_dir, allow_frozen_result_rows=False):
 
 
 def validate_metadata(metadata):
-    if metadata.get("schema_version") != 1:
-        raise ValueError("run metadata schema_version must be 1")
+    # Version 2 adds runner_go_version. Version 1 is retained because published
+    # records carry it and are append-only: their toolchain was never recorded and
+    # cannot be reconstructed, so requiring the field of them would either
+    # invalidate real evidence or invite a fabricated value. New runs are written
+    # as version 2, so the requirement binds every run from here on.
+    metadata_version = metadata.get("schema_version")
+    if metadata_version not in (1, 2):
+        raise ValueError("run metadata schema_version must be 1 or 2")
     for key in (
         "local_run_id",
         "generated_at",
@@ -1130,6 +1141,18 @@ def validate_metadata(metadata):
     reasons = metadata.get("noncanonical_reasons")
     if not isinstance(reasons, list) or any(not isinstance(item, str) or not item for item in reasons):
         raise ValueError("run metadata noncanonical_reasons must be an array of strings")
+    # Required at version 2 rather than optional there. An optional field would let
+    # a new run publish with the toolchain simply absent, which is the
+    # unrecorded-compiler state this records in order to end. A version 1 record
+    # that carries the field anyway is still checked, so a malformed value cannot
+    # ride in under the older version.
+    if metadata_version >= 2 or "runner_go_version" in metadata:
+        go_version = require_non_empty_string(metadata, "runner_go_version", "run metadata runner_go_version")
+        if not GO_VERSION_REPORT.fullmatch(go_version):
+            raise ValueError(
+                "run metadata runner_go_version must be a go toolchain self-report such as "
+                "'go version go1.25.12 linux/amd64'"
+            )
     if metadata["canonical_execution"] and (metadata["dirty"] or reasons):
         raise ValueError("canonical execution cannot be dirty or have noncanonical reasons")
     if not re.fullmatch(r"[0-9a-f]{40}", metadata["corpus_git_sha"]):
@@ -1390,7 +1413,7 @@ def finalize_command(args):
 
 def start_command(args):
     metadata = {
-        "schema_version": 1,
+        "schema_version": 2,
         "local_run_id": args.local_run_id,
         "generated_at": args.generated_at,
         "corpus_repository": args.corpus_repository,
@@ -1399,6 +1422,14 @@ def start_command(args):
         "dirty": args.dirty,
         "canonical_execution": args.canonical_execution,
         "noncanonical_reasons": args.noncanonical_reason,
+        # The compiler that built the measuring instrument. The runner is
+        # compiled from source on every run, so two runs can otherwise publish
+        # identical provenance from different toolchains. This records the go
+        # binary's own self-report rather than a version parsed from go.mod,
+        # which states a floor and not what ran. The resolved binary's PATH is
+        # deliberately not recorded: it can be a private local path, and the
+        # version is the fact a reader needs.
+        "runner_go_version": args.runner_go_version,
     }
     validate_metadata(metadata)
     atomic_json_write(args.output, metadata)
@@ -1442,6 +1473,7 @@ def parse_args():
     start.add_argument("--dirty", type=bool_value, required=True)
     start.add_argument("--canonical-execution", type=bool_value, required=True)
     start.add_argument("--noncanonical-reason", action="append", default=[])
+    start.add_argument("--runner-go-version", required=True)
 
     release = subparsers.add_parser("release")
     release.add_argument("--output", type=Path, required=True)

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -355,7 +355,7 @@ class ProvenanceBuilderTest(unittest.TestCase):
         (self.run_dir / "run-metadata.json").write_text(
             json.dumps(
                 {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "local_run_id": "local:test:1",
                     "generated_at": "2026-08-04T00:00:00Z",
                     "corpus_repository": "luckyPipewrench/agent-egress-bench",
@@ -364,6 +364,7 @@ class ProvenanceBuilderTest(unittest.TestCase):
                     "dirty": False,
                     "canonical_execution": True,
                     "noncanonical_reasons": [],
+                    "runner_go_version": "go version go1.25.0 linux/amd64",
                 }
             ),
             encoding="utf-8",
@@ -1312,6 +1313,61 @@ class ProvenanceBuilderTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("version output does not match", result.stderr)
 
+    def test_version_one_metadata_stays_valid_without_a_toolchain(self):
+        # Published records are append-only and were written before this field
+        # existed. Their toolchain was never recorded and cannot be reconstructed,
+        # so requiring it of them would either invalidate real evidence or invite a
+        # fabricated value. Version 1 therefore keeps its original contract, and the
+        # requirement binds version 2, which is what new runs write.
+        metadata_path = self.run_dir / "run-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["schema_version"] = 1
+        del metadata["runner_go_version"]
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+        result = self.bundle()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_version_one_metadata_still_checks_a_malformed_toolchain(self):
+        # Retaining version 1 must not create a lane where an unchecked value rides
+        # in under the older label.
+        metadata_path = self.run_dir / "run-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["schema_version"] = 1
+        metadata["runner_go_version"] = "not a go version"
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+        result = self.bundle()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("runner_go_version", result.stderr)
+        self.write_fixture()
+
+    def test_metadata_without_a_recorded_toolchain_is_refused(self):
+        # The runner is compiled from source on every run, so the compiler is part
+        # of what produced the measuring instrument. An absent field is refused
+        # rather than tolerated: tolerating it is the unrecorded-toolchain state
+        # this field exists to end, and it would fail silently.
+        metadata_path = self.run_dir / "run-metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        del metadata["runner_go_version"]
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+        result = self.bundle()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("runner_go_version", result.stderr)
+
+    def test_metadata_toolchain_must_be_a_go_self_report(self):
+        # Bounded on purpose. The value is copied from a subprocess into recorded
+        # evidence, so an arbitrary string would be an unvalidated passthrough
+        # into an artifact readers are asked to trust.
+        metadata_path = self.run_dir / "run-metadata.json"
+        for invalid in ("1.25.0", "go1.25.0", "definitely not a version", ""):
+            with self.subTest(invalid=invalid):
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+                metadata["runner_go_version"] = invalid
+                metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+                result = self.bundle()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("runner_go_version", result.stderr)
+        self.write_fixture()
+
     def test_canonical_metadata_cannot_claim_a_development_ref(self):
         metadata_path = self.run_dir / "run-metadata.json"
         metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
@@ -1521,6 +1577,30 @@ exec git "$@"
             "origin did not match luckyPipewrench/agent-egress-bench",
             metadata["noncanonical_reasons"],
         )
+
+    def test_run_metadata_records_the_toolchain_that_builds_the_runner(self):
+        # Drives the real script, so this covers the shell-to-provenance wiring
+        # rather than only the validator. The expected value comes from asking the
+        # go binary, not from a literal, because a literal would pass on a machine
+        # whose toolchain was never consulted.
+        # The harness puts a stub go on PATH that reports go1.25.0. Asserting that
+        # exact line proves the recorded value comes from the toolchain that will
+        # build the runner rather than from whatever go the machine happens to
+        # have, which is the whole point of recording it.
+        expected = "go version go1.25.0 linux/amd64"
+        result, output_dir, _ = self.run_with_fake_runner("error")
+        self.assertEqual(result.returncode, 23, result.stderr)
+        metadata = json.loads((output_dir / "run-metadata.json").read_text(encoding="utf-8"))
+        self.assertEqual(expected, metadata["runner_go_version"])
+        ambient = subprocess.run(
+            ["go", "version"], text=True, capture_output=True, check=True
+        ).stdout.splitlines()[0]
+        if ambient != expected:
+            self.assertNotEqual(
+                ambient,
+                metadata["runner_go_version"],
+                "recorded toolchain tracked the ambient go rather than the resolved one",
+            )
 
     def test_github_tokens_are_not_inherited_by_the_tool_under_test(self):
         result, _, _ = self.run_with_fake_runner("error", inject_tokens=True)

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -1592,15 +1592,11 @@ exec git "$@"
         self.assertEqual(result.returncode, 23, result.stderr)
         metadata = json.loads((output_dir / "run-metadata.json").read_text(encoding="utf-8"))
         self.assertEqual(expected, metadata["runner_go_version"])
-        ambient = subprocess.run(
-            ["go", "version"], text=True, capture_output=True, check=True
-        ).stdout.splitlines()[0]
-        if ambient != expected:
-            self.assertNotEqual(
-                ambient,
-                metadata["runner_go_version"],
-                "recorded toolchain tracked the ambient go rather than the resolved one",
-            )
+        # No ambient `go version` call: the stub IS the contract. The harness puts a
+        # go on PATH that reports a version no real toolchain here reports, so the
+        # equality above already proves the recorded value came from the resolved
+        # binary rather than from whatever go the host happens to have. Asking the
+        # host as well would make this test depend on the machine it runs on.
 
     def test_github_tokens_are_not_inherited_by_the_tool_under_test(self):
         result, _, _ = self.run_with_fake_runner("error", inject_tokens=True)

--- a/scripts/run-pipelock-gauntlet.sh
+++ b/scripts/run-pipelock-gauntlet.sh
@@ -156,6 +156,27 @@ installed_go_version() {
   return 1
 }
 
+# go_version_report returns the toolchain's own version line, which is what run
+# provenance records. installed_go_version above returns only the parsed
+# semantic version because comparisons need it; a reader of the evidence wants
+# the full self-report, including platform and any GOEXPERIMENT field. The line
+# is emitted by the go binary that will actually build the runner, so it is the
+# artifact's own claim rather than the floor stated in go.mod.
+go_version_report() {
+  local line=""
+  go_bin_available || return 1
+  line="$("$go_bin" version 2>/dev/null | head -n 1 || true)"
+  # Anything this function cannot recognize would be rejected downstream by the
+  # provenance validator. Refuse here so the failure names the toolchain instead
+  # of surfacing as an invalid metadata field. require_go_toolchain already
+  # refuses a devel or otherwise unparseable toolchain for the same reason.
+  if [[ "$line" =~ ^go\ version\ go[0-9] ]]; then
+    printf '%s\n' "$line"
+    return 0
+  fi
+  return 1
+}
+
 require_go_toolchain() {
   local required_go=""
   local installed_go=""
@@ -623,8 +644,11 @@ if [[ -n "$development_binary" ]]; then
   add_noncanonical_reason "development Pipelock binary was requested"
 fi
 
+runner_go_version="$(go_version_report)" || die "go version is unreadable; the toolchain that builds the runner must report its own version so the run records which compiler produced the measuring instrument"
+
 start_args=(
   start
+  --runner-go-version "$runner_go_version"
   --output "$output_dir/run-metadata.json"
   --local-run-id "$local_run_id"
   --generated-at "$started_at"

--- a/scripts/validate_gauntlet_records_test.py
+++ b/scripts/validate_gauntlet_records_test.py
@@ -254,7 +254,7 @@ class ValidRecordFixture:
         write_json(
             self.artifact_dir / "run-metadata.json",
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "local_run_id": "local:test:1",
                 "generated_at": "2026-08-05T00:10:08Z",
                 "corpus_repository": "luckyPipewrench/agent-egress-bench",
@@ -263,6 +263,7 @@ class ValidRecordFixture:
                 "dirty": False,
                 "canonical_execution": True,
                 "noncanonical_reasons": [],
+                "runner_go_version": "go version go1.25.0 linux/amd64",
             },
         )
         write_json(


### PR DESCRIPTION
## What changed

A run now records the Go toolchain that built the runner. The runner is compiled from source on every run, so the compiler is part of what produced the measuring instrument, and two runs could previously publish identical provenance from different compilers. The recorded value is the go binary's own reported version line rather than the floor stated in `go.mod`, and it comes from the resolved binary, so a `--go` or `AEB_GO` override is reflected instead of hidden. The resolved path is deliberately not recorded, because it can be a private local path and the version is the fact a reader needs.

Run metadata moves to `schema_version: 2`, where the field is required. Version 1 is retained because published records carry it and are append-only: their toolchain was never recorded and cannot be reconstructed, so requiring it of them would either invalidate real evidence or invite a fabricated value. A version 1 record that carries the field anyway is still validated, so an unchecked value cannot ride in under the older label.

The field is required rather than optional at version 2 on purpose. An optional field would let a new run publish with the toolchain simply absent, which is the unrecorded-compiler state this exists to end. The value is validated against a bounded pattern because it is copied from a subprocess into recorded evidence.

It lands in run metadata rather than the provenance candidate. The candidate schema is closed, so adding a field there is a new schema version and a change for every reader. Run metadata is hashed into the run bundle, so a reader of published evidence still sees the toolchain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run metadata now records the Go toolchain version used to build the runner.
  * Metadata schema version 2 is supported, while legacy version-1 records remain readable.
  * Runner setup now automatically captures and records the toolchain’s self-reported version.

* **Bug Fixes**
  * Added validation to reject missing or malformed toolchain version details in version-2 metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->