### PR TITLE
chore: name the repository scan for what it does

### DIFF
--- a/.github/workflows/pipelock.yaml
+++ b/.github/workflows/pipelock.yaml
@@ -1,4 +1,20 @@
-name: Pipelock self-scan
+name: Repository secret scan (self-run)
+
+# Named for what it does rather than for the product that does it. This
+# repository maintains a corpus used to evaluate agent egress tools, and the
+# scanner here is the maintainer's own product, so a check reading
+# "Pipelock self-scan / security-scan" on every pull request invites the
+# conclusion that the evaluated tool gates the evaluation. It does not: this job
+# is repository hygiene, it scans this repository's own files for secrets, and it
+# awards nothing to any tool including the one it runs. The scanner's identity is
+# visible in the job log and pinned in the step below rather than announced in
+# the check name.
+#
+# The job id stays `security-scan` deliberately. It is the required-status-check
+# context in this repository's `main` ruleset, so renaming it here without editing
+# that ruleset first would leave every pull request waiting on a context that can
+# never report. Changing it is a two-step repository-admin operation: add the new
+# context, land the rename, then drop the old one.
 
 on:
   # Promotion pull requests are created with GITHUB_TOKEN, which intentionally

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -7,6 +7,8 @@ How this corpus is maintained, how decisions are made, and how conflicts are han
 Case design is tool-neutral: no case targets a product. The project itself is not independent yet. PipeLab maintains the corpus and holds decision rights over case semantics and scoring, and says so rather than calling itself neutral. It was created by the [Pipelock](https://github.com/luckyPipewrench/pipelock) author and is designed for any agent egress security tool. This repository publishes no ranking, leaderboard, or cross-tool comparison table, awards no badge, and certifies nothing. <!-- claim-ok: states the non-claim -->
 Optional receipt profiles under `profiles/` are maintainer-published evidence artifacts, not corpus-issued endorsements. [RESULTS-USE.md](RESULTS-USE.md) defines the labels a publisher may use, the facts that travel with a public result, and the limits this policy places on the maintainer.
 
+This repository's own continuous integration runs the maintainer's product against this repository's files to check for committed secrets. That is repository hygiene and a self-run check, not a security audit, not an endorsement, and not evidence about that product or any other. It gates changes to this repository only, it awards nothing, and no result it produces may be cited as a corpus outcome. <!-- claim-ok: states the non-claim -->
+
 No case is written to favor or penalize a specific tool. Cases test observable behavior on the wire (did the request get blocked?), not implementation internals.
 
 ## Case ID immutability


### PR DESCRIPTION
## What changed

The repository scan is now named for what it does. A check reading `Pipelock self-scan / security-scan` on every pull request of the corpus repository invites the conclusion that the evaluated tool gates the evaluation. It does not: the job scans this repository's own files for committed secrets, it gates changes to this repository only, and it awards nothing to any tool including the one it runs. The scanner stays pinned to an exact release and remains visible in the job log rather than announced in the check name.

The neutrality section now states the arrangement in prose, because that is where this repository already handles disclosures of this kind and because a reader looking at a pull request sees the check name rather than the documentation. It says plainly that this is repository hygiene and a self-run check, not a security audit, not an endorsement, and not evidence about any product, and that no result it produces may be cited as a corpus outcome.

The job id is deliberately unchanged. It is the required-status-check context in this repository's `main` ruleset, so renaming it here without editing that ruleset first would leave every pull request waiting on a context that can never report. Changing it is a two-step repository-admin operation and the workflow comment says so, so the constraint is discoverable by the next person who reads it rather than rediscovered by breaking the branch.
