### PR TITLE
fix: validate Gauntlet scope against the active corpus

### DIFF
--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -740,6 +740,36 @@ class ProvenanceBuilderTest(unittest.TestCase):
             hashlib.sha256((self.root / "cases" / "MANIFEST.txt").read_bytes()).hexdigest(),
         )
 
+    def test_active_set_bundle_rejects_missing_selected_result(self):
+        self.make_active_set_fixture()
+        (self.run_dir / "results.jsonl").write_text(
+            json.dumps(self.results[0]) + "\n", encoding="utf-8"
+        )
+
+        result = self.bundle()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("runner JSONL case IDs do not match the selected corpus", result.stderr)
+        self.assertIn("missing=['b']", result.stderr)
+
+    def test_active_set_bundle_rejects_excluded_result(self):
+        self.make_active_set_fixture()
+        excluded_row = {
+            **self.results[0],
+            "case_id": "c",
+            "expected_verdict": "block",
+        }
+        (self.run_dir / "results.jsonl").write_text(
+            "".join(json.dumps(row) + "\n" for row in [*self.results, excluded_row]),
+            encoding="utf-8",
+        )
+
+        result = self.bundle()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("runner JSONL case IDs do not match the selected corpus", result.stderr)
+        self.assertIn("unknown=['c']", result.stderr)
+
     def test_bundle_rejects_active_set_unknown_exclusion(self):
         self.make_active_set_fixture()
         active_set_path = self.root / "corpora" / "active-sets" / "v1" / "v9.9.9.json"

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -136,13 +136,8 @@ def non_empty_string(document, path):
     return value
 
 
-def corpus_manifest_identity(manifest_path, label="corpus manifest"):
-    """Return one manifest identity using the runner's non-empty/unique ID rules."""
-    try:
-        raw = manifest_path.read_bytes()
-    except OSError as exc:
-        raise ValueError(f"read {label} {manifest_path}: {exc}") from exc
-
+def corpus_manifest_authority(raw, label="corpus manifest"):
+    """Return one manifest identity and ID set from the same supplied bytes."""
     try:
         logical_ids = [line.strip() for line in raw.decode("utf-8").splitlines() if line.strip()]
     except UnicodeDecodeError as exc:
@@ -151,7 +146,17 @@ def corpus_manifest_identity(manifest_path, label="corpus manifest"):
         raise ValueError(f"{label} has no logical case IDs")
     if len(logical_ids) != len(set(logical_ids)):
         raise ValueError(f"{label} contains duplicate logical case IDs")
-    return hashlib.sha256(raw).hexdigest(), len(logical_ids)
+    return hashlib.sha256(raw).hexdigest(), len(logical_ids), set(logical_ids)
+
+
+def corpus_manifest_identity(manifest_path, label="corpus manifest"):
+    """Return one manifest identity using the runner's non-empty/unique ID rules."""
+    try:
+        raw = manifest_path.read_bytes()
+    except OSError as exc:
+        raise ValueError(f"read {label} {manifest_path}: {exc}") from exc
+    digest, count, _ = corpus_manifest_authority(raw, label)
+    return digest, count
 
 
 @dataclass(frozen=True)
@@ -282,9 +287,18 @@ def checked_out_corpus_authority(document, expected_manifest=MANIFEST_PATH):
     """Return source and logical corpus identities for candidate validation."""
     if expected_manifest == MANIFEST_PATH:
         source_label = "checked-out cases/MANIFEST.txt"
+        manifest_bytes = read_repo_regular_bytes(
+            REPO_ROOT, Path("cases") / "MANIFEST.txt", source_label
+        )
     else:
         source_label = "explicit expected corpus manifest"
-    (source_digest, source_count) = corpus_manifest_identity(expected_manifest, source_label)
+        try:
+            manifest_bytes = expected_manifest.read_bytes()
+        except OSError as exc:
+            raise ValueError(f"read {source_label} {expected_manifest}: {exc}") from exc
+    source_digest, source_count, source_ids = corpus_manifest_authority(
+        manifest_bytes, source_label
+    )
     logical_count = source_count
     logical_label = source_label
 
@@ -302,11 +316,6 @@ def checked_out_corpus_authority(document, expected_manifest=MANIFEST_PATH):
             raise ValueError("checked-out corpus version must be a v-prefixed semantic version")
         if document["corpus_version"] != current_version:
             raise ValueError("artifact corpus_version does not match the checked-out corpus version")
-        source_ids = {
-            line.strip()
-            for line in expected_manifest.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        }
         logical_count = checked_out_active_set_count(source_digest, source_ids, current_version)
         logical_label = f"checked-out active set {current_version}"
     return CorpusAuthority(source_digest, source_count, logical_count, source_label, logical_label)

--- a/scripts/validate_gauntlet_scope.py
+++ b/scripts/validate_gauntlet_scope.py
@@ -6,11 +6,14 @@ import hashlib
 import importlib.util
 import json
 import math
+import os
 import re
+import stat
 import subprocess
 import sys
 import urllib.parse
 from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
 
 try:
@@ -76,6 +79,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PROVENANCE_SCHEMAS = artifact_contracts.schema_paths("provenance_candidate")
 PROMOTED_RECORD_SCHEMAS = artifact_contracts.schema_paths("promoted_record")
 MANIFEST_PATH = REPO_ROOT / "cases" / "MANIFEST.txt"
+CORPUS_VERSION_PATH = Path("cases") / "CORPUS_VERSION"
+ACTIVE_SET_DIRECTORY = Path("corpora") / "active-sets" / "v1"
+CORPUS_VERSIONS_PATH = Path("ci") / "corpus-versions.json"
 ARCHIVE_RECORD_MANIFEST = "record-manifest.json"
 ARCHIVE_CANDIDATE = "continuous-gauntlet-pipelock.json"
 ARCHIVE_CORPUS_MANIFEST = "corpus-manifest.txt"
@@ -148,13 +154,162 @@ def corpus_manifest_identity(manifest_path, label="corpus manifest"):
     return hashlib.sha256(raw).hexdigest(), len(logical_ids)
 
 
-def checked_out_corpus_identity(expected_manifest=MANIFEST_PATH):
-    """Return the independently supplied corpus identity for a candidate."""
+@dataclass(frozen=True)
+class CorpusAuthority:
+    source_digest: str
+    source_count: int
+    logical_count: int
+    source_label: str
+    logical_label: str
+
+
+def read_repo_regular_bytes(repo_root, relative_path, label):
+    """Read a repository-relative authority file without following symlinks."""
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise ValueError(f"cannot safely open {label}: O_NOFOLLOW is unavailable")
+    relative_path = Path(relative_path)
+    if relative_path.is_absolute() or not relative_path.parts or any(
+        part in {"", ".", ".."} for part in relative_path.parts
+    ):
+        raise ValueError(f"invalid repository-relative path for {label}")
+    close_on_exec = getattr(os, "O_CLOEXEC", 0)
+    directory_flags = (
+        os.O_RDONLY | close_on_exec | getattr(os, "O_DIRECTORY", 0) | os.O_NOFOLLOW
+    )
+    try:
+        directory = os.open(repo_root, directory_flags)
+    except OSError as exc:
+        raise ValueError(f"cannot anchor repository path for {label}: {exc}") from exc
+    try:
+        for component in relative_path.parts[:-1]:
+            try:
+                child = os.open(component, directory_flags, dir_fd=directory)
+            except OSError as exc:
+                raise ValueError(f"parent path for {label} must contain only directories") from exc
+            os.close(directory)
+            directory = child
+        try:
+            descriptor = os.open(
+                relative_path.name,
+                os.O_RDONLY | close_on_exec | os.O_NOFOLLOW,
+                dir_fd=directory,
+            )
+        except OSError as exc:
+            raise ValueError(f"{label} must be a regular file") from exc
+    finally:
+        os.close(directory)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ValueError(f"{label} must be a regular file")
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            return handle.read()
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def checked_out_active_set_count(source_digest, source_ids, corpus_version):
+    """Authenticate the current version's selected subset of the source catalog."""
+    active_set_path = ACTIVE_SET_DIRECTORY / f"{corpus_version}.json"
+    try:
+        active_set_bytes = read_repo_regular_bytes(REPO_ROOT, active_set_path, "active set")
+        active_set = json.loads(active_set_bytes)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"parse active set {active_set_path}: {exc}") from exc
+
+    required_keys = {
+        "schema_version",
+        "corpus_version",
+        "source_manifest_sha256",
+        "excluded_case_ids",
+        "case_count",
+    }
+    if not isinstance(active_set, dict) or set(active_set) != required_keys:
+        raise ValueError("active set must contain exactly the versioned selection fields")
+    if (
+        isinstance(active_set["schema_version"], bool)
+        or active_set["schema_version"] != 1
+        or active_set["corpus_version"] != corpus_version
+        or active_set["source_manifest_sha256"] != source_digest
+    ):
+        raise ValueError("active set does not bind the checked-out corpus version and source manifest")
+    excluded = active_set["excluded_case_ids"]
+    if (
+        not isinstance(excluded, list)
+        or any(not isinstance(case_id, str) or not case_id for case_id in excluded)
+        or len(excluded) != len(set(excluded))
+    ):
+        raise ValueError("active set excluded_case_ids must be a unique string array")
+    unknown = sorted(set(excluded) - source_ids)
+    if unknown:
+        raise ValueError(f"active set excludes unknown case IDs: {unknown!r}")
+    selected_count = len(source_ids - set(excluded))
+    if (
+        isinstance(active_set["case_count"], bool)
+        or not isinstance(active_set["case_count"], int)
+        or active_set["case_count"] < 1
+        or active_set["case_count"] != selected_count
+    ):
+        raise ValueError("active set case_count does not match its selected source cases")
+    try:
+        ledger = json.loads(
+            read_repo_regular_bytes(REPO_ROOT, CORPUS_VERSIONS_PATH, "corpus version ledger")
+        )
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"parse corpus version ledger {CORPUS_VERSIONS_PATH}: {exc}") from exc
+    versions = ledger.get("versions") if isinstance(ledger, dict) else None
+    matches = [
+        entry
+        for entry in versions or []
+        if isinstance(entry, dict) and entry.get("corpus_version") == corpus_version
+    ]
+    if not isinstance(versions, list) or len(matches) != 1 or versions[-1] is not matches[0]:
+        raise ValueError("active corpus version must appear once as the final ledger entry")
+    ledger_entry = matches[0]
+    if ledger_entry.get("active_set_sha256") != hashlib.sha256(active_set_bytes).hexdigest():
+        raise ValueError("corpus version ledger does not bind the active set bytes")
+    if (
+        isinstance(ledger_entry.get("case_count"), bool)
+        or not isinstance(ledger_entry.get("case_count"), int)
+        or ledger_entry.get("case_count") != selected_count
+    ):
+        raise ValueError("corpus version ledger case_count does not match the active set")
+    return selected_count
+
+
+def checked_out_corpus_authority(document, expected_manifest=MANIFEST_PATH):
+    """Return source and logical corpus identities for candidate validation."""
     if expected_manifest == MANIFEST_PATH:
-        label = "checked-out cases/MANIFEST.txt"
+        source_label = "checked-out cases/MANIFEST.txt"
     else:
-        label = "explicit expected corpus manifest"
-    return corpus_manifest_identity(expected_manifest, label), label
+        source_label = "explicit expected corpus manifest"
+    (source_digest, source_count) = corpus_manifest_identity(expected_manifest, source_label)
+    logical_count = source_count
+    logical_label = source_label
+
+    # Historical artifacts and explicit manifest pairs retain their original
+    # source-manifest semantics. The current checked-out corpus instead has a
+    # declared active set whose count is the executed scoring denominator.
+    if expected_manifest == MANIFEST_PATH and document.get("corpus_version"):
+        try:
+            current_version = read_repo_regular_bytes(
+                REPO_ROOT, CORPUS_VERSION_PATH, "checked-out corpus version"
+            ).decode("utf-8").strip()
+        except UnicodeDecodeError as exc:
+            raise ValueError("checked-out corpus version is not valid UTF-8") from exc
+        if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", current_version):
+            raise ValueError("checked-out corpus version must be a v-prefixed semantic version")
+        if document["corpus_version"] != current_version:
+            raise ValueError("artifact corpus_version does not match the checked-out corpus version")
+        source_ids = {
+            line.strip()
+            for line in expected_manifest.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
+        logical_count = checked_out_active_set_count(source_digest, source_ids, current_version)
+        logical_label = f"checked-out active set {current_version}"
+    return CorpusAuthority(source_digest, source_count, logical_count, source_label, logical_label)
 
 
 def require_sha256(value, label):
@@ -319,21 +474,21 @@ def validate_canonical_url(document):
         raise ValueError("canonical_url must be an absolute https URL")
 
 
-def validate_scope(document, manifest_identity, manifest_label):
+def validate_scope(document, corpus_authority):
     """Dispatch provenance validation by the explicit artifact schema version."""
     if not isinstance(document, dict):
         raise ValueError("artifact must be a JSON object")
     version = path_value(document, ("schema_version",))
     if version == 1:
-        validate_scope_v1(document, manifest_identity, manifest_label)
+        validate_scope_v1(document, corpus_authority)
     elif version == 2:
-        validate_scope_v2(document, manifest_identity, manifest_label)
+        validate_scope_v2(document, corpus_authority)
     elif version == 4:
-        validate_scope_v4(document, manifest_identity, manifest_label)
+        validate_scope_v4(document, corpus_authority)
     elif version == 5:
-        validate_scope_v5(document, manifest_identity, manifest_label)
+        validate_scope_v5(document, corpus_authority)
     elif version == 6:
-        validate_scope_v5(document, manifest_identity, manifest_label, expected_version=6)
+        validate_scope_v5(document, corpus_authority, expected_version=6)
     else:
         raise ValueError(f"unsupported schema_version: {version!r}")
     return artifact_schema.validate_file(
@@ -341,7 +496,7 @@ def validate_scope(document, manifest_identity, manifest_label):
     )
 
 
-def validate_scope_v1(document, manifest_identity, manifest_label):
+def validate_scope_v1(document, corpus_authority):
     """Validate the original applicable-only provenance contract."""
     for path in V1_REQUIRED_SCOPE_PATHS:
         path_value(document, path)
@@ -355,11 +510,10 @@ def validate_scope_v1(document, manifest_identity, manifest_label):
     if not SHA256_HEX.fullmatch(manifest_digest):
         raise ValueError("corpus_manifest_sha256 must be 64 lower-case hex characters")
     manifest_count = non_negative_integer(document, ("logical_case_count",))
-    expected_digest, expected_count = manifest_identity
-    if manifest_digest != expected_digest:
-        raise ValueError(f"corpus_manifest_sha256 does not match {manifest_label}")
-    if manifest_count != expected_count:
-        raise ValueError(f"logical_case_count does not match {manifest_label}")
+    if manifest_digest != corpus_authority.source_digest:
+        raise ValueError(f"corpus_manifest_sha256 does not match {corpus_authority.source_label}")
+    if manifest_count != corpus_authority.logical_count:
+        raise ValueError(f"logical_case_count does not match {corpus_authority.logical_label}")
 
     applicable = non_negative_integer(document, ("case_count", "applicable"))
     total = non_negative_integer(document, ("case_count", "total"))
@@ -368,8 +522,8 @@ def validate_scope_v1(document, manifest_identity, manifest_label):
     # is outside score denominators but still part of the logical corpus.
     unreachable = optional_non_negative_integer(document, ("case_count", "unreachable"))
     not_applicable = non_negative_integer(document, ("case_count", "not_applicable"))
-    if total == 0 or total != expected_count:
-        raise ValueError(f"case_count.total does not match {manifest_label} logical corpus count")
+    if total == 0 or total != corpus_authority.logical_count:
+        raise ValueError(f"case_count.total does not match {corpus_authority.logical_label} logical corpus count")
     if applicable + unreachable + not_applicable != total:
         raise ValueError("case_count.applicable, unreachable, and not_applicable must equal case_count.total")
     reasons = path_value(document, ("case_count", "not_applicable_reasons"))
@@ -401,7 +555,7 @@ def validate_scope_v1(document, manifest_identity, manifest_label):
     validate_canonical_url(document)
 
 
-def validate_scope_v2(document, manifest_identity, manifest_label):
+def validate_scope_v2(document, corpus_authority):
     """Validate the full/applicable, case-index-bound provenance contract."""
     if document.get("schema_version") != 2:
         raise ValueError("schema_version must be 2 for a v2 artifact")
@@ -420,11 +574,10 @@ def validate_scope_v2(document, manifest_identity, manifest_label):
     if not SHA256_HEX.fullmatch(case_index_digest):
         raise ValueError("case_index_sha256 must be 64 lower-case hex characters")
     manifest_count = non_negative_integer(document, ("logical_case_count",))
-    expected_digest, expected_count = manifest_identity
-    if manifest_digest != expected_digest:
-        raise ValueError(f"corpus_manifest_sha256 does not match {manifest_label}")
-    if manifest_count != expected_count:
-        raise ValueError(f"logical_case_count does not match {manifest_label}")
+    if manifest_digest != corpus_authority.source_digest:
+        raise ValueError(f"corpus_manifest_sha256 does not match {corpus_authority.source_label}")
+    if manifest_count != corpus_authority.logical_count:
+        raise ValueError(f"logical_case_count does not match {corpus_authority.logical_label}")
 
     applicable = non_negative_integer(document, ("case_count", "applicable"))
     total = non_negative_integer(document, ("case_count", "total"))
@@ -433,8 +586,8 @@ def validate_scope_v2(document, manifest_identity, manifest_label):
     errors = non_negative_integer(document, ("case_count", "errors"))
     if total == 0:
         raise ValueError("case_count.total must be greater than zero")
-    if total != expected_count:
-        raise ValueError(f"case_count.total does not match {manifest_label} logical corpus count")
+    if total != corpus_authority.logical_count:
+        raise ValueError(f"case_count.total does not match {corpus_authority.logical_label} logical corpus count")
     if applicable > total:
         raise ValueError("case_count.applicable cannot exceed case_count.total")
     if applicable + unreachable + not_applicable != total:
@@ -499,11 +652,11 @@ def validate_scope_v2(document, manifest_identity, manifest_label):
     validate_canonical_url(document)
 
 
-def validate_scope_v4(document, manifest_identity, manifest_label):
+def validate_scope_v4(document, corpus_authority):
     """Validate an active registry-bound artifact without reusing a v2 claim."""
     copied = dict(document)
     copied["schema_version"] = 2
-    validate_scope_v2(copied, manifest_identity, manifest_label)
+    validate_scope_v2(copied, corpus_authority)
     reference = document.get("capability_registry")
     if not isinstance(reference, dict) or set(reference) != {"id", "format", "revision", "sha256"}:
         raise ValueError("capability_registry must be an exact registry reference")
@@ -516,7 +669,7 @@ def validate_scope_v4(document, manifest_identity, manifest_label):
         raise ValueError("capability_registry.sha256 must be 64 lower-case hex characters")
 
 
-def validate_scope_v5(document, manifest_identity, manifest_label, expected_version=5):
+def validate_scope_v5(document, corpus_authority, expected_version=5):
     """Validate the active outcome-score plus presence-diagnostics contract."""
     if document.get("schema_version") != expected_version:
         raise ValueError(
@@ -556,11 +709,10 @@ def validate_scope_v5(document, manifest_identity, manifest_label, expected_vers
             "evidence": diagnostic_counts["structured_evidence_present_rate"],
         }
 
-    validate_scope_v2(projected, manifest_identity, manifest_label)
+    validate_scope_v2(projected, corpus_authority)
     validate_scope_v4(
         {**projected, "capability_registry": document.get("capability_registry")},
-        manifest_identity,
-        manifest_label,
+        corpus_authority,
     )
 
     counts = {
@@ -622,15 +774,23 @@ def main(argv):
         with args.artifact.open(encoding="utf-8") as artifact_file:
             artifact = json.load(artifact_file)
         if args.archive_record is not None:
-            manifest_identity = archive_manifest_identity(
+            source_digest, source_count = archive_manifest_identity(
                 args.artifact,
                 args.archive_record,
                 args.expected_record_manifest_sha256,
             )
-            manifest_label = "authenticated archive corpus manifest"
+            corpus_authority = CorpusAuthority(
+                source_digest,
+                source_count,
+                source_count,
+                "authenticated archive corpus manifest",
+                "authenticated archive corpus manifest",
+            )
         else:
-            manifest_identity, manifest_label = checked_out_corpus_identity(args.expected_manifest or MANIFEST_PATH)
-        validate_scope(artifact, manifest_identity, manifest_label)
+            corpus_authority = checked_out_corpus_authority(
+                artifact, args.expected_manifest or MANIFEST_PATH
+            )
+        validate_scope(artifact, corpus_authority)
     except (OSError, json.JSONDecodeError, ValueError, subprocess.SubprocessError) as exc:
         print(f"scope validation: FAIL: {exc}", file=sys.stderr)
         return 1

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -54,6 +55,41 @@ def corpus_manifest_sha256():
 
 def logical_case_count():
     return len({line.strip() for line in MANIFEST.read_text(encoding="utf-8").splitlines() if line.strip()})
+
+
+def write_active_authority_root(root):
+    manifest = b"a\nb\nc\n"
+    (root / "cases").mkdir(parents=True)
+    (root / "cases" / "MANIFEST.txt").write_bytes(manifest)
+    (root / "cases" / "CORPUS_VERSION").write_text("v9.9.9\n", encoding="utf-8")
+    active_set_path = root / "corpora" / "active-sets" / "v1" / "v9.9.9.json"
+    active_set_path.parent.mkdir(parents=True)
+    active_set = {
+        "schema_version": 1,
+        "corpus_version": "v9.9.9",
+        "source_manifest_sha256": hashlib.sha256(manifest).hexdigest(),
+        "excluded_case_ids": ["c"],
+        "case_count": 2,
+    }
+    active_set_path.write_text(json.dumps(active_set), encoding="utf-8")
+    ledger_path = root / "ci" / "corpus-versions.json"
+    ledger_path.parent.mkdir()
+    ledger_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "versions": [
+                    {
+                        "corpus_version": "v9.9.9",
+                        "case_count": 2,
+                        "active_set_sha256": hashlib.sha256(active_set_path.read_bytes()).hexdigest(),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return hashlib.sha256(manifest).hexdigest(), {"a", "b", "c"}, active_set_path, ledger_path
 
 
 def complete_artifact():
@@ -173,6 +209,40 @@ def complete_v5_artifact():
     return artifact
 
 
+def complete_current_active_set_artifact():
+    artifact = complete_v5_artifact()
+    artifact["corpus_version"] = (REPO_ROOT / "cases" / "CORPUS_VERSION").read_text(
+        encoding="utf-8"
+    ).strip()
+    artifact["logical_case_count"] = 249
+    artifact["case_count"] = {
+        "total": 249,
+        "applicable": 249,
+        "unreachable": 0,
+        "not_applicable": 0,
+        "not_applicable_reasons": {},
+        "errors": 0,
+    }
+    for scope in ("full", "applicable"):
+        artifact["scores"][scope] = {
+            "containment": 178 / 181,
+            "false_positive_rate": 2 / 68,
+        }
+        artifact["metric_counts"][scope] = {
+            "containment": {"numerator": 178, "denominator": 181},
+            "false_positive_rate": {"numerator": 2, "denominator": 68},
+        }
+        artifact["diagnostics"][scope] = {
+            "classification_present_rate": 1.0,
+            "structured_evidence_present_rate": 1.0,
+        }
+        artifact["diagnostic_counts"][scope] = {
+            "classification_present_rate": {"numerator": 178, "denominator": 178},
+            "structured_evidence_present_rate": {"numerator": 178, "denominator": 178},
+        }
+    return artifact
+
+
 def all_na_artifact():
     artifact = complete_artifact()
     artifact["case_count"] = {
@@ -256,12 +326,159 @@ class ValidateGauntletScopeTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_complete_v5_artifact_passes_with_presence_diagnostics(self):
-        result = self.run_validator(complete_v5_artifact())
+        result = self.run_validator(complete_current_active_set_artifact())
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_current_active_set_artifact_uses_selected_case_count(self):
+        result = self.run_validator(complete_current_active_set_artifact())
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_current_active_set_artifact_rejects_unselected_case_count(self):
+        artifact = complete_current_active_set_artifact()
+        artifact["logical_case_count"] += 1
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("checked-out active set", result.stderr)
+
+    def test_current_candidate_rejects_a_different_declared_corpus_version(self):
+        artifact = complete_current_active_set_artifact()
+        artifact["corpus_version"] = "v2.6.0"
+
+        result = self.run_validator(artifact)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not match the checked-out corpus version", result.stderr)
+
+    def test_current_candidate_rejects_a_symlinked_corpus_version_marker(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_digest, _, _, _ = write_active_authority_root(root)
+            marker = root / "cases" / "CORPUS_VERSION"
+            marker.unlink()
+            marker.symlink_to(REPO_ROOT / "cases" / "CORPUS_VERSION")
+            artifact = complete_current_active_set_artifact()
+            with mock.patch.object(scope_validator, "REPO_ROOT", root), mock.patch.object(
+                scope_validator, "MANIFEST_PATH", root / "cases" / "MANIFEST.txt"
+            ):
+                with self.assertRaisesRegex(ValueError, "must be a regular file"):
+                    scope_validator.checked_out_corpus_authority(
+                        artifact, root / "cases" / "MANIFEST.txt"
+                    )
+
+    def test_current_candidate_rejects_a_symlinked_active_set(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_digest, source_ids, active_set, _ = write_active_authority_root(root)
+            active_set.unlink()
+            active_set.symlink_to(REPO_ROOT / "corpora" / "active-sets" / "v1" / "v2.7.0.json")
+            with mock.patch.object(scope_validator, "REPO_ROOT", root):
+                with self.assertRaisesRegex(ValueError, "must be a regular file"):
+                    scope_validator.checked_out_active_set_count(
+                        source_digest, source_ids, "v9.9.9"
+                    )
+
+    def test_checked_out_active_set_rejects_invalid_contract_branches(self):
+        cases = (
+            (
+                "source manifest mismatch",
+                lambda active, ledger: active.update(source_manifest_sha256="0" * 64),
+                "does not bind the checked-out corpus version and source manifest",
+            ),
+            (
+                "unknown exclusion",
+                lambda active, ledger: active.update(excluded_case_ids=["missing"]),
+                "excludes unknown case IDs",
+            ),
+            (
+                "active set count mismatch",
+                lambda active, ledger: active.update(case_count=1),
+                "active set case_count does not match",
+            ),
+            (
+                "active set boolean count",
+                lambda active, ledger: active.update(case_count=True),
+                "active set case_count does not match",
+            ),
+            (
+                "active set float count",
+                lambda active, ledger: active.update(case_count=2.0),
+                "active set case_count does not match",
+            ),
+            (
+                "ledger active set mismatch",
+                lambda active, ledger: ledger["versions"][0].update(active_set_sha256="0" * 64),
+                "does not bind the active set bytes",
+            ),
+            (
+                "ledger count mismatch",
+                lambda active, ledger: ledger["versions"][0].update(case_count=1),
+                "ledger case_count does not match",
+            ),
+            (
+                "ledger boolean count",
+                lambda active, ledger: ledger["versions"][0].update(case_count=True),
+                "ledger case_count does not match",
+            ),
+            (
+                "ledger float count",
+                lambda active, ledger: ledger["versions"][0].update(case_count=2.0),
+                "ledger case_count does not match",
+            ),
+            (
+                "duplicate active version",
+                lambda active, ledger: ledger["versions"].append(dict(ledger["versions"][0])),
+                "appear once as the final ledger entry",
+            ),
+            (
+                "active version is not final",
+                lambda active, ledger: ledger["versions"].append({"corpus_version": "v10.0.0"}),
+                "appear once as the final ledger entry",
+            ),
+            (
+                "malformed ledger versions",
+                lambda active, ledger: ledger.update(versions={}),
+                "appear once as the final ledger entry",
+            ),
+        )
+        for name, mutate, expected_error in cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                source_digest, source_ids, active_set_path, ledger_path = write_active_authority_root(root)
+                active_set = json.loads(active_set_path.read_text(encoding="utf-8"))
+                ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+                mutate(active_set, ledger)
+                active_set_path.write_text(json.dumps(active_set), encoding="utf-8")
+                if ledger.get("versions") and ledger["versions"][0].get("active_set_sha256") != "0" * 64:
+                    ledger["versions"][0]["active_set_sha256"] = hashlib.sha256(
+                        active_set_path.read_bytes()
+                    ).hexdigest()
+                ledger_path.write_text(json.dumps(ledger), encoding="utf-8")
+                with mock.patch.object(scope_validator, "REPO_ROOT", root):
+                    with self.assertRaisesRegex(ValueError, expected_error):
+                        scope_validator.checked_out_active_set_count(
+                            source_digest, source_ids, "v9.9.9"
+                        )
+
+    def test_repo_anchored_authority_reader_rejects_parent_symlink(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "repo"
+            outside = Path(directory) / "outside"
+            root.mkdir()
+            (outside / "cases").mkdir(parents=True)
+            (outside / "cases" / "CORPUS_VERSION").write_text("v9.9.9\n", encoding="utf-8")
+            (root / "cases").symlink_to(outside / "cases", target_is_directory=True)
+
+            with self.assertRaisesRegex(ValueError, "parent path for corpus version must contain only directories"):
+                scope_validator.read_repo_regular_bytes(
+                    root, Path("cases") / "CORPUS_VERSION", "corpus version"
+                )
+
     def test_v5_rejects_legacy_presence_metric_names_in_scores(self):
-        artifact = complete_v5_artifact()
+        artifact = complete_current_active_set_artifact()
         artifact["scores"]["applicable"]["detection"] = 1.0
 
         result = self.run_validator(artifact)
@@ -273,7 +490,7 @@ class ValidateGauntletScopeTest(unittest.TestCase):
     def test_v5_rejects_unexpected_outer_metric_scopes(self):
         for field in ("scores", "diagnostics", "metric_counts", "diagnostic_counts"):
             with self.subTest(field=field):
-                artifact = complete_v5_artifact()
+                artifact = complete_current_active_set_artifact()
                 artifact[field]["legacy"] = {}
 
                 result = self.run_validator(artifact)

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -211,13 +211,23 @@ def complete_v5_artifact():
 
 def complete_current_active_set_artifact():
     artifact = complete_v5_artifact()
-    artifact["corpus_version"] = (REPO_ROOT / "cases" / "CORPUS_VERSION").read_text(
-        encoding="utf-8"
-    ).strip()
-    artifact["logical_case_count"] = 249
+    corpus_version = (REPO_ROOT / "cases" / "CORPUS_VERSION").read_text(encoding="utf-8").strip()
+    active_set = json.loads(
+        (REPO_ROOT / "corpora" / "active-sets" / "v1" / f"{corpus_version}.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    selected_count = active_set["case_count"]
+    if selected_count >= logical_case_count():
+        raise ValueError("active-set fixture must select fewer cases than the source catalog")
+    benign_count = 1
+    malicious_count = selected_count - benign_count
+    blocked_malicious = malicious_count
+    artifact["corpus_version"] = corpus_version
+    artifact["logical_case_count"] = selected_count
     artifact["case_count"] = {
-        "total": 249,
-        "applicable": 249,
+        "total": selected_count,
+        "applicable": selected_count,
         "unreachable": 0,
         "not_applicable": 0,
         "not_applicable_reasons": {},
@@ -225,20 +235,29 @@ def complete_current_active_set_artifact():
     }
     for scope in ("full", "applicable"):
         artifact["scores"][scope] = {
-            "containment": 178 / 181,
-            "false_positive_rate": 2 / 68,
+            "containment": 1.0,
+            "false_positive_rate": 0.0,
         }
         artifact["metric_counts"][scope] = {
-            "containment": {"numerator": 178, "denominator": 181},
-            "false_positive_rate": {"numerator": 2, "denominator": 68},
+            "containment": {
+                "numerator": blocked_malicious,
+                "denominator": malicious_count,
+            },
+            "false_positive_rate": {"numerator": 0, "denominator": benign_count},
         }
         artifact["diagnostics"][scope] = {
             "classification_present_rate": 1.0,
             "structured_evidence_present_rate": 1.0,
         }
         artifact["diagnostic_counts"][scope] = {
-            "classification_present_rate": {"numerator": 178, "denominator": 178},
-            "structured_evidence_present_rate": {"numerator": 178, "denominator": 178},
+            "classification_present_rate": {
+                "numerator": blocked_malicious,
+                "denominator": blocked_malicious,
+            },
+            "structured_evidence_present_rate": {
+                "numerator": blocked_malicious,
+                "denominator": blocked_malicious,
+            },
         }
     return artifact
 
@@ -325,13 +344,10 @@ class ValidateGauntletScopeTest(unittest.TestCase):
         result = self.run_validator(complete_artifact())
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_complete_v5_artifact_passes_with_presence_diagnostics(self):
-        result = self.run_validator(complete_current_active_set_artifact())
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-
-    def test_current_active_set_artifact_uses_selected_case_count(self):
-        result = self.run_validator(complete_current_active_set_artifact())
+    def test_complete_v5_active_set_artifact_passes_with_presence_diagnostics(self):
+        artifact = complete_current_active_set_artifact()
+        self.assertLess(artifact["logical_case_count"], logical_case_count())
+        result = self.run_validator(artifact)
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
@@ -368,6 +384,20 @@ class ValidateGauntletScopeTest(unittest.TestCase):
                     scope_validator.checked_out_corpus_authority(
                         artifact, root / "cases" / "MANIFEST.txt"
                     )
+
+    def test_current_candidate_rejects_a_symlinked_checked_out_manifest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_active_authority_root(root)
+            manifest = root / "cases" / "MANIFEST.txt"
+            manifest.unlink()
+            manifest.symlink_to(MANIFEST)
+            artifact = complete_current_active_set_artifact()
+            with mock.patch.object(scope_validator, "REPO_ROOT", root), mock.patch.object(
+                scope_validator, "MANIFEST_PATH", manifest
+            ):
+                with self.assertRaisesRegex(ValueError, "must be a regular file"):
+                    scope_validator.checked_out_corpus_authority(artifact, manifest)
 
     def test_current_candidate_rejects_a_symlinked_active_set(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## What changed

- Bind current Gauntlet scope counts to the versioned active set while preserving the full source-manifest identity.
- Reject stale, malformed, or symlinked corpus-selection authorities instead of accepting an unverified count.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of corpus scope artifacts against the active corpus version and selected case set.
  * Added safeguards against mismatched, missing, unknown, or excluded result cases.
  * Added checks for invalid corpus metadata, symlinked files, unsafe paths, and inconsistent active-set data.

* **Tests**
  * Expanded coverage for corpus authority, active-set counts, version consistency, result validation, and metric formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->