### PR TITLE
fix(records): replay the active corpus and bind a policy origin

### DIFF
--- a/contracts/artifacts.json
+++ b/contracts/artifacts.json
@@ -209,36 +209,36 @@
         "control-evidence/v0/verifier",
         "control-evidence/v1/verifier"
       ],
-    "reader_contracts": [
-      {
-        "consumer": "runner_scoring",
-        "role": "scoring",
-        "path": "runner/case.go",
+      "reader_contracts": [
+        {
+          "consumer": "runner_scoring",
+          "role": "scoring",
+          "path": "runner/case.go",
           "accepted_versions": [
             4
           ]
         },
-      {
-        "consumer": "validator_scoring",
-        "role": "scoring",
-        "path": "validate/main.go",
+        {
+          "consumer": "validator_scoring",
+          "role": "scoring",
+          "path": "validate/main.go",
           "accepted_versions": [
             4
           ]
         },
-      {
-        "consumer": "control_evidence_v0",
-        "role": "retained_evidence",
-        "path": "control-evidence/v0/verifier",
+        {
+          "consumer": "control_evidence_v0",
+          "role": "retained_evidence",
+          "path": "control-evidence/v0/verifier",
           "accepted_versions": [
             1,
             3
           ]
         },
-      {
-        "consumer": "control_evidence_v1",
-        "role": "retained_evidence",
-        "path": "control-evidence/v1/verifier",
+        {
+          "consumer": "control_evidence_v1",
+          "role": "retained_evidence",
+          "path": "control-evidence/v1/verifier",
           "accepted_versions": [
             1,
             4
@@ -473,17 +473,19 @@
     },
     {
       "family": "promoted_record",
-      "active_writer_version": 3,
+      "active_writer_version": 4,
       "accepted_reader_versions": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "frozen_versions": [
         1,
         2,
         3
       ],
-      "frozen_versions": [
-        1,
-        2
-      ],
-      "canonical_schema_path": "schemas/promoted-record-v3.schema.json",
+      "canonical_schema_path": "schemas/promoted-record-v4.schema.json",
       "schemas": [
         {
           "version": 1,
@@ -501,9 +503,16 @@
         },
         {
           "version": 3,
-          "status": "active",
+          "status": "frozen",
           "path": "schemas/promoted-record-v3.schema.json",
-          "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v3.schema.json"
+          "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v3.schema.json",
+          "sha256": "a6f63ef8a6fed1476beaf8b7ef126d107034b356637db8ec10396313475c57a8"
+        },
+        {
+          "version": 4,
+          "status": "active",
+          "path": "schemas/promoted-record-v4.schema.json",
+          "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v4.schema.json"
         }
       ],
       "writer": [

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -101,7 +101,7 @@ The table summarizes the manifest. `make check-contracts` checks the full machin
 | Summary | 5 | 4, 5 | 4 | [`summary-v5.schema.json`](../schemas/summary-v5.schema.json) |
 | Provenance candidate | 6 | 1, 2, 4, 5, 6 | 1, 2, 5 | [`provenance-candidate-v6.schema.json`](../schemas/provenance-candidate-v6.schema.json) |
 | Case index | 3 | 1, 2, 3 | 1, 2 | [`case-index-v3.schema.json`](../schemas/case-index-v3.schema.json) |
-| Promoted record | 3 | 1, 2, 3 | 1, 2 | [`promoted-record-v3.schema.json`](../schemas/promoted-record-v3.schema.json) |
+| Promoted record | 4 | 1, 2, 3, 4 | 1, 2, 3 | [`promoted-record-v4.schema.json`](../schemas/promoted-record-v4.schema.json) |
 | Promotion baseline | 1 | 1 | 1 | [`promotion-baseline-v1.schema.json`](../schemas/promotion-baseline-v1.schema.json) |
 | Result pointer | 1 | 1 | none | [`result-pointer-v1.schema.json`](../schemas/result-pointer-v1.schema.json) |
 

--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -1,7 +1,7 @@
 {
   "format": 1,
   "catalog": "schemas/index.json",
-  "catalog_sha256": "4b21f3ca93f25e11e5cb6fac558e55c5a11bdab1f9c75a1f694a21bd0817feb8",
+  "catalog_sha256": "39e60589fc4646a7d5e90aab38e85450d5042f0c818ba95e49285394df159d60",
   "schemas": [
     {
       "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/case-governance-decision-v1.schema.json",
@@ -258,6 +258,10 @@
     {
       "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v3.schema.json",
       "path": "schemas/promoted-record-v3.schema.json"
+    },
+    {
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v4.schema.json",
+      "path": "schemas/promoted-record-v4.schema.json"
     },
     {
       "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promotion-baseline-v1.schema.json",

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -218,6 +218,11 @@
       "sha256": "a6f63ef8a6fed1476beaf8b7ef126d107034b356637db8ec10396313475c57a8"
     },
     {
+      "path": "schemas/promoted-record-v4.schema.json",
+      "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v4.schema.json",
+      "sha256": "69dec703511484df6a9b67c6dbc514b39d2d6b355823276945803a3a122a2786"
+    },
+    {
       "path": "schemas/promotion-baseline-v1.schema.json",
       "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promotion-baseline-v1.schema.json",
       "sha256": "b15fa9c5288caf4f8714989d2b8ed19cfb10ed9cd7951d21c335002c97efc144"

--- a/schemas/promoted-record-v4.schema.json
+++ b/schemas/promoted-record-v4.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/luckyPipewrench/agent-egress-bench/schemas/promoted-record-v4.schema.json",
+  "title": "agent-egress-bench Promoted Record v4",
+  "x-aeb-nullable-required": [
+    "previous_candidate_sha256",
+    "previous_record_manifest_sha256"
+  ],
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "tool",
+    "tool_version",
+    "artifact_id",
+    "canonical_url",
+    "generated_at",
+    "candidate_sha256",
+    "previous_candidate_sha256",
+    "previous_record_manifest_sha256",
+    "files"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 4
+    },
+    "tool": {
+      "$ref": "#/$defs/nonempty"
+    },
+    "tool_version": {
+      "$ref": "#/$defs/nonempty"
+    },
+    "artifact_id": {
+      "$ref": "#/$defs/nonempty"
+    },
+    "canonical_url": {
+      "type": "string",
+      "pattern": "^https://[^?#]+$"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "candidate_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "previous_candidate_sha256": {
+      "$ref": "#/$defs/nullable_sha256"
+    },
+    "previous_record_manifest_sha256": {
+      "$ref": "#/$defs/nullable_sha256"
+    },
+    "files": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "continuous-gauntlet-pipelock.json",
+        "destination-baseline.json",
+        "destination-promotion-decision.json",
+        "reviewed-baseline.json",
+        "reviewed-promotion-decision.json",
+        "source-baseline-origin.json",
+        "source-baseline.json",
+        "source-promotion-decision.json"
+      ],
+      "properties": {
+        "capability-registry.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "case-index.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "checksums.txt": {
+          "$ref": "#/$defs/sha256"
+        },
+        "command.txt": {
+          "$ref": "#/$defs/sha256"
+        },
+        "continuous-gauntlet-pipelock.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "corpus-manifest.txt": {
+          "$ref": "#/$defs/sha256"
+        },
+        "destination-baseline.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "destination-promotion-decision.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "entrypoint-command.txt": {
+          "$ref": "#/$defs/sha256"
+        },
+        "execution-decision.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "make-stats.txt": {
+          "$ref": "#/$defs/sha256"
+        },
+        "pipelock-release.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "pipelock-version.txt": {
+          "$ref": "#/$defs/sha256"
+        },
+        "raw-summary.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "receipt-profile.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "results.jsonl": {
+          "$ref": "#/$defs/sha256"
+        },
+        "reviewed-baseline.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "reviewed-promotion-decision.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "run-bundle.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "run-metadata.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "runner.stderr": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source-baseline-origin.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source-baseline.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source-promotion-decision.json": {
+          "$ref": "#/$defs/sha256"
+        },
+        "tool-profile.json": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "nonempty": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "nullable_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/scripts/build_gauntlet_provenance.py
+++ b/scripts/build_gauntlet_provenance.py
@@ -43,10 +43,31 @@ FROZEN_SCORING_VERSIONS = frozenset({"2.4"})
 PROVENANCE_SCHEMAS = artifact_contracts.schema_paths("provenance_candidate")
 CASE_INDEX_SCHEMAS = artifact_contracts.schema_paths("case_index")
 ACTIVE_CASE_INDEX_SCHEMA_VERSION = artifact_contracts.active_version("case_index")
-FROZEN_V5_SUMMARY_V4_RECEIPT = (
-    "1e182405cdff08f8f0e8835c7c0aed7047b4c0e2fbd539f22c390175d5507b64",
-    "2beeb7194b0e1a5f610198e2d4e29ddb793f8213177627cb9f0de4775f36481b",
-)
+# Records published before the v5 receipt profile was required. Each pair is a
+# published record that was produced under a corpus commit predating that rule,
+# so it was valid when it was made and is immutable now. Membership is decided
+# by exact digest rather than by a date or a self-declared contract version,
+# because either of those can be claimed by a later record to escape the rule.
+# A pair belongs here only with the record it covers and the commit it was
+# produced against named in the comment beside it.
+FROZEN_V5_SUMMARY_V4_RECEIPTS = frozenset({
+    # agent-egress-bench gauntlet-site record 23ff4c7c, produced against a
+    # corpus commit before 95c4e76d ("bind receipt profiles to observed
+    # provenance") introduced the requirement.
+    (
+        "1e182405cdff08f8f0e8835c7c0aed7047b4c0e2fbd539f22c390175d5507b64",
+        "2beeb7194b0e1a5f610198e2d4e29ddb793f8213177627cb9f0de4775f36481b",
+    ),
+    # pipelab.org published record a4a6d7c8, the Pipelock 3.4.0 result the
+    # public pointer names. Produced against corpus commit 2d6cb1d6, which does
+    # not contain 95c4e76d. It was missed when the first pair was recorded
+    # because it did not exist yet and because it lives in the site repository
+    # rather than this one.
+    (
+        "436149a0f28eaf6aed0f0f20a711a39856dae43a0b05905284b2c592c73d95dd",
+        "63d20b502f5b901b3b42bb78d06b590b3bbd93b103a733abcf266980e21f76d2",
+    ),
+})
 
 RAW_EVIDENCE = {
     "raw_summary": "raw-summary.json",
@@ -388,7 +409,7 @@ def validate_active_registry_binding(run_dir, summary, results):
     if summary.get("schema_version") == 5 and receipt_version != 5:
         summary_bytes = (run_dir / RAW_EVIDENCE["raw_summary"]).read_bytes()
         pair = (hashlib.sha256(summary_bytes).hexdigest(), hashlib.sha256(receipt_bytes).hexdigest())
-        if pair != FROZEN_V5_SUMMARY_V4_RECEIPT:
+        if pair not in FROZEN_V5_SUMMARY_V4_RECEIPTS:
             raise ValueError("v5 summary requires a v5 receipt profile")
     try:
         profile = json.loads(profile_bytes)

--- a/scripts/build_gauntlet_provenance_test.py
+++ b/scripts/build_gauntlet_provenance_test.py
@@ -1905,5 +1905,36 @@ exec git "$@"
         self.assertTrue((output_dir / "runner.stderr").is_file())
 
 
+class FrozenReceiptExceptionTest(unittest.TestCase):
+    """The grandfathered pairs must describe records that actually exist.
+
+    The v5-receipt requirement shipped with one hardcoded exception that missed
+    the published site record, because that record did not exist yet and lives
+    in a different repository. A constant nobody checks against a real record is
+    how that happens twice.
+    """
+
+    def test_each_frozen_pair_is_two_distinct_digests(self):
+        pairs = build_gauntlet_provenance.FROZEN_V5_SUMMARY_V4_RECEIPTS
+        self.assertGreaterEqual(len(pairs), 2)
+        seen = set()
+        for summary_digest, receipt_digest in pairs:
+            for digest in (summary_digest, receipt_digest):
+                self.assertRegex(digest, r"^[0-9a-f]{64}$")
+            self.assertNotEqual(summary_digest, receipt_digest)
+            self.assertNotIn(summary_digest, seen)
+            seen.add(summary_digest)
+
+    def test_the_published_site_record_pair_is_present(self):
+        """The record the public pointer names, which the first exception missed."""
+        self.assertIn(
+            (
+                "436149a0f28eaf6aed0f0f20a711a39856dae43a0b05905284b2c592c73d95dd",
+                "63d20b502f5b901b3b42bb78d06b590b3bbd93b103a733abcf266980e21f76d2",
+            ),
+            build_gauntlet_provenance.FROZEN_V5_SUMMARY_V4_RECEIPTS,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/promote_gauntlet_candidate.py
+++ b/scripts/promote_gauntlet_candidate.py
@@ -307,11 +307,23 @@ SOURCE_BASELINE_ORIGIN_KEYS = {"schema_version", "repository", "commit", "path",
 def load_source_baseline_origin(path, source_baseline_bytes):
     """Read the origin record and bind it to the baseline bytes it describes.
 
-    The record already proves its decision was computed from the retained
-    baseline. It cannot say whose policy that was or where it lived, so a
-    substituted baseline with a recomputed decision satisfies every other
-    check. This document supplies that missing locator, and is only meaningful
-    when its digest matches the bytes actually used.
+    WHAT THIS PROVES, AND WHAT IT DOES NOT. The record already proves its
+    decision was computed from the retained baseline. It cannot say whose
+    policy that was or where it lived, so this document supplies that locator
+    and is only accepted when its digest matches the bytes actually used.
+
+    It is a LOCATOR, not an origin proof. This repository has no network and
+    should not acquire one, so nothing here resolves the named repository,
+    commit and path to confirm those bytes were ever published there. A forged
+    locator whose digest matches a forged policy is accepted by this function.
+    The producer is what makes it meaningful: the site promotion fetches the
+    policy from the named repository at the run's own commit and writes the
+    locator from what it fetched, so it is a true audit pointer at write time
+    and an unresolved claim at archive-validation time.
+
+    Closing that gap needs a product-signed acceptance artifact rather than a
+    stricter check here, because no check over self-authored data can establish
+    origin.
     """
     document = require_object(Path(path))
     if set(document) != SOURCE_BASELINE_ORIGIN_KEYS:

--- a/scripts/promote_gauntlet_candidate.py
+++ b/scripts/promote_gauntlet_candidate.py
@@ -305,6 +305,12 @@ SOURCE_BASELINE_ORIGIN_KEYS = {"schema_version", "repository", "commit", "path",
 
 
 def load_source_baseline_origin(path, source_baseline_bytes):
+    """Read the file once and validate exactly the bytes the caller will keep."""
+    origin_bytes = Path(path).read_bytes()
+    return validate_source_baseline_origin(origin_bytes, source_baseline_bytes, path)
+
+
+def validate_source_baseline_origin(origin_bytes, source_baseline_bytes, path="origin"):
     """Read the origin record and bind it to the baseline bytes it describes.
 
     WHAT THIS PROVES, AND WHAT IT DOES NOT. The record already proves its
@@ -325,7 +331,12 @@ def load_source_baseline_origin(path, source_baseline_bytes):
     stricter check here, because no check over self-authored data can establish
     origin.
     """
-    document = require_object(Path(path))
+    try:
+        document = json.loads(origin_bytes)
+    except (json.JSONDecodeError, UnicodeError) as exc:
+        raise ValueError(f"{path} is not readable JSON: {exc}") from exc
+    if not isinstance(document, dict):
+        raise ValueError(f"{path} must contain a JSON object")
     if set(document) != SOURCE_BASELINE_ORIGIN_KEYS:
         raise ValueError(
             "source baseline origin must contain exactly "
@@ -350,7 +361,7 @@ def load_source_baseline_origin(path, source_baseline_bytes):
         raise ValueError(
             "source baseline origin does not describe the retained source baseline"
         )
-    return document
+    return origin_bytes
 
 
 def atomic_copy(source, destination):
@@ -670,8 +681,12 @@ def promote(args):
     if source_baseline_origin_path is None:
         raise ValueError("--source-baseline-origin is required: a record must state whose policy judged it")
     source_baseline_origin_path = Path(source_baseline_origin_path).resolve()
-    load_source_baseline_origin(source_baseline_origin_path, source_baseline_bytes)
-    source_baseline_origin_bytes = source_baseline_origin_path.read_bytes()
+    # Read once and archive exactly what was validated. Reading again after the
+    # check would let a concurrent producer swap the file in between, so the
+    # record would carry origin bytes nothing ever checked.
+    source_baseline_origin_bytes = load_source_baseline_origin(
+        source_baseline_origin_path, source_baseline_bytes
+    )
     destination_baseline_bytes = destination_baseline.read_bytes()
     source_decision_bytes = source_decision_path.read_bytes()
     with tempfile.TemporaryDirectory(prefix="gauntlet-baseline-snapshots-") as temporary:

--- a/scripts/promote_gauntlet_candidate.py
+++ b/scripts/promote_gauntlet_candidate.py
@@ -3,6 +3,7 @@
 
 import argparse
 import importlib.util
+import hashlib
 import json
 import os
 import re
@@ -35,6 +36,7 @@ RUN_BUNDLE_FILENAME = "run-bundle.json"
 PUBLISHED_DECISION_FILENAME = "reviewed-promotion-decision.json"
 BASELINE_SNAPSHOT_FILENAME = "reviewed-baseline.json"
 SOURCE_BASELINE_FILENAME = "source-baseline.json"
+SOURCE_BASELINE_ORIGIN_FILENAME = "source-baseline-origin.json"
 RECORD_MANIFEST_FILENAME = "record-manifest.json"
 LATEST_POINTER_FILENAME = "latest-verified.json"
 FIRST_PARTY_ASSURANCES = ["self-run", "artifact-validated"]
@@ -297,6 +299,46 @@ def proposed_baseline(candidate, candidate_sha256):
         baseline, PROMOTION_BASELINE_SCHEMA, "proposed baseline"
     )
     return baseline
+
+
+SOURCE_BASELINE_ORIGIN_KEYS = {"schema_version", "repository", "commit", "path", "sha256"}
+
+
+def load_source_baseline_origin(path, source_baseline_bytes):
+    """Read the origin record and bind it to the baseline bytes it describes.
+
+    The record already proves its decision was computed from the retained
+    baseline. It cannot say whose policy that was or where it lived, so a
+    substituted baseline with a recomputed decision satisfies every other
+    check. This document supplies that missing locator, and is only meaningful
+    when its digest matches the bytes actually used.
+    """
+    document = require_object(Path(path))
+    if set(document) != SOURCE_BASELINE_ORIGIN_KEYS:
+        raise ValueError(
+            "source baseline origin must contain exactly "
+            f"{sorted(SOURCE_BASELINE_ORIGIN_KEYS)!r}"
+        )
+    if document["schema_version"] != 1:
+        raise ValueError("source baseline origin schema_version must be 1")
+    for key in ("repository", "path"):
+        value = document[key]
+        if not isinstance(value, str) or not value or value.strip() != value:
+            raise ValueError(f"source baseline origin {key} must be a trimmed non-empty string")
+    commit = document["commit"]
+    if (
+        not isinstance(commit, str)
+        or len(commit) != 40
+        or any(character not in "0123456789abcdef" for character in commit)
+    ):
+        raise ValueError("source baseline origin commit must be a lower-case 40-character Git SHA")
+    require_sha256(document["sha256"], "source baseline origin sha256")
+    actual = hashlib.sha256(source_baseline_bytes).hexdigest()
+    if document["sha256"] != actual:
+        raise ValueError(
+            "source baseline origin does not describe the retained source baseline"
+        )
+    return document
 
 
 def atomic_copy(source, destination):
@@ -612,6 +654,12 @@ def promote(args):
     source_baseline = (getattr(args, "source_baseline", None) or args.baseline).resolve()
     destination_baseline = args.baseline.resolve()
     source_baseline_bytes = source_baseline.read_bytes()
+    source_baseline_origin_path = getattr(args, "source_baseline_origin", None)
+    if source_baseline_origin_path is None:
+        raise ValueError("--source-baseline-origin is required: a record must state whose policy judged it")
+    source_baseline_origin_path = Path(source_baseline_origin_path).resolve()
+    load_source_baseline_origin(source_baseline_origin_path, source_baseline_bytes)
+    source_baseline_origin_bytes = source_baseline_origin_path.read_bytes()
     destination_baseline_bytes = destination_baseline.read_bytes()
     source_decision_bytes = source_decision_path.read_bytes()
     with tempfile.TemporaryDirectory(prefix="gauntlet-baseline-snapshots-") as temporary:
@@ -665,6 +713,9 @@ def promote(args):
                 source_decision_bytes
             )
             (temporary_record / SOURCE_BASELINE_FILENAME).write_bytes(source_baseline_bytes)
+            (temporary_record / SOURCE_BASELINE_ORIGIN_FILENAME).write_bytes(
+                source_baseline_origin_bytes
+            )
             (temporary_record / DESTINATION_BASELINE_FILENAME).write_bytes(
                 destination_baseline_bytes
             )
@@ -744,6 +795,12 @@ def parse_args():
         "--source-baseline",
         type=Path,
         help="baseline used by the producer to create promotion-decision.json; defaults to --baseline",
+    )
+    parser.add_argument(
+        "--source-baseline-origin",
+        type=Path,
+        required=True,
+        help="JSON document naming the repository, commit, path and digest of the source baseline",
     )
     parser.add_argument("--store-root", type=Path, default=Path("gauntlet-site/results"))
     parser.add_argument("--latest", type=Path, default=Path("gauntlet-site") / LATEST_POINTER_FILENAME)

--- a/scripts/promote_gauntlet_candidate_test.py
+++ b/scripts/promote_gauntlet_candidate_test.py
@@ -235,6 +235,8 @@ class PromotionFixture:
         self.summary = root / "promotion-summary.md"
         write_json(self.baseline_path, baseline_value or baseline())
         write_json(self.source_baseline_path, baseline_value or baseline())
+        self.source_baseline_origin_path = root / "source-baseline-origin.json"
+        self.write_source_baseline_origin()
 
         value = dict(candidate_value or v6_candidate())
         publication_fields = (
@@ -391,6 +393,21 @@ class PromotionFixture:
         write_json(self.candidate_path, self.candidate_value)
         self.write_source_decision()
 
+    def write_source_baseline_origin(self):
+        """Describe the retained policy so the promoter can bind it to an owner."""
+        write_json(
+            self.source_baseline_origin_path,
+            {
+                "schema_version": 1,
+                "repository": "luckyPipewrench/example-product",
+                "commit": "c" * 40,
+                "path": "benchmark/gauntlet-baseline.json",
+                "sha256": hashlib.sha256(
+                    self.source_baseline_path.read_bytes()
+                ).hexdigest(),
+            },
+        )
+
     def write_source_decision(self):
         decision = evaluator.evaluate(self.candidate_path, self.source_baseline_path, self.evidence)
         write_json(self.artifact_dir / promotion.SOURCE_DECISION_FILENAME, decision)
@@ -407,6 +424,8 @@ class PromotionFixture:
             str(self.baseline_path),
             "--source-baseline",
             str(self.source_baseline_path),
+            "--source-baseline-origin",
+            str(self.source_baseline_origin_path),
             "--store-root",
             str(self.store_root),
             "--latest",
@@ -636,6 +655,7 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
             artifact_dir=fixture.artifact_dir,
             baseline=fixture.baseline_path,
             source_baseline=fixture.source_baseline_path,
+            source_baseline_origin=fixture.source_baseline_origin_path,
             store_root=fixture.store_root,
             latest=fixture.latest,
             summary=None,
@@ -661,6 +681,10 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
         source = evaluator.load_object(fixture.source_baseline_path)
         source["pipelock_version"] = "3.2.0"
         write_json(fixture.source_baseline_path, source)
+        # A changed policy needs a matching origin, exactly as a real producer
+        # would rewrite both. Leaving the origin behind would fail on the digest
+        # first and this test would stop exercising the policy-change gate.
+        fixture.write_source_baseline_origin()
         fixture.write_source_decision()
 
         blocked = fixture.run()
@@ -688,6 +712,7 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
             artifact_dir=fixture.artifact_dir,
             baseline=fixture.baseline_path,
             source_baseline=None,
+            source_baseline_origin=fixture.source_baseline_origin_path,
             store_root=fixture.store_root,
             latest=fixture.latest,
             summary=None,
@@ -884,7 +909,9 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
         record = fixture.store_root / "pipelock" / pointer["candidate_sha256"]
         manifest_path = record / promotion.RECORD_MANIFEST_FILENAME
         manifest = evaluator.load_object(manifest_path)
-        manifest["schema_version"] = 4
+        # Sentinel for "a version this promoter does not know". Bump it when a
+        # real version catches up, or the test silently stops testing anything.
+        manifest["schema_version"] = 99
         write_json(manifest_path, manifest)
         with self.assertRaisesRegex(ValueError, "manifest schema_version is unsupported"):
             promotion.validate_record(record, pointer["candidate_sha256"])

--- a/scripts/promote_gauntlet_candidate_test.py
+++ b/scripts/promote_gauntlet_candidate_test.py
@@ -676,6 +676,48 @@ class PromoteGauntletCandidateTest(unittest.TestCase):
             destination_bytes,
         )
 
+    def test_archived_origin_is_the_bytes_that_were_validated(self):
+        """Swapping the origin file after validation must not reach the record.
+
+        The promoter used to validate the path and then read it again for
+        archival, so a concurrent producer could replace the file between those
+        two reads and the record would carry origin bytes nothing checked.
+        """
+        fixture = self.fixture()
+        validated = fixture.source_baseline_origin_path.read_bytes()
+        forged = json.dumps(
+            {
+                "schema_version": 1,
+                "repository": "attacker/friendly-policy",
+                "commit": "d" * 40,
+                "path": "benchmark/gauntlet-baseline.json",
+                "sha256": "0" * 64,
+            }
+        ).encode()
+        self.assertNotEqual(validated, forged)
+
+        original_read = Path.read_bytes
+        state = {"calls": 0}
+
+        def swapping_read(self_path, *args, **kwargs):
+            data = original_read(self_path, *args, **kwargs)
+            if self_path == fixture.source_baseline_origin_path:
+                state["calls"] += 1
+                # Replace the file the instant it is first read, which is what a
+                # concurrent producer does.
+                original_write = Path.write_bytes
+                original_write(self_path, forged)
+            return data
+
+        with mock.patch.object(Path, "read_bytes", swapping_read):
+            archived = promotion.load_source_baseline_origin(
+                fixture.source_baseline_origin_path,
+                fixture.source_baseline_path.read_bytes(),
+            )
+        self.assertGreaterEqual(state["calls"], 1)
+        self.assertEqual(archived, validated)
+        self.assertNotEqual(archived, forged)
+
     def test_blocked_source_decision_requires_explicit_review(self):
         fixture = self.fixture()
         source = evaluator.load_object(fixture.source_baseline_path)

--- a/scripts/validate_gauntlet_records.py
+++ b/scripts/validate_gauntlet_records.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -18,13 +19,15 @@ import promote_gauntlet_candidate as promotion
 RESULTS_PATH = Path("gauntlet-site/results/pipelock")
 
 
-def file_at_commit(repo_root, corpus_git_sha, path):
+def file_at_commit(repo_root, corpus_git_sha, path, allow_missing=False):
     retained = subprocess.run(
         ["git", "-C", str(repo_root), "show", f"{corpus_git_sha}:{path}"],
         check=False,
         capture_output=True,
     )
     if retained.returncode != 0:
+        if allow_missing:
+            return None
         raise ValueError(f"corpus_git_sha does not retain {path}")
     return retained.stdout
 
@@ -54,6 +57,39 @@ def reconstruct_result_contract(repo_root, corpus_git_sha, root):
     (root / contract_path).write_bytes(contract_bytes)
 
 
+def reconstruct_active_set(repo_root, corpus_git_sha, root, summary):
+    """Materialize the files that define which cases the run was meant to execute.
+
+    The reconstruction is only equivalent to the original derivation when it
+    carries the corpus version marker and its active set. Without them the
+    selection silently widens to the whole manifest, and a record measured
+    against the active corpus reads as missing every excluded case.
+    """
+    marker_bytes = file_at_commit(
+        repo_root, corpus_git_sha, "cases/CORPUS_VERSION", allow_missing=True
+    )
+    if marker_bytes is None:
+        # A record measured before the corpus carried a version marker selected
+        # the whole manifest. Reconstructing it must select the whole manifest
+        # too, so leaving these files absent is the faithful reconstruction.
+        return
+    marker = marker_bytes.decode("utf-8").strip()
+    if marker != summary.get("corpus_version"):
+        raise ValueError("corpus version marker does not match retained runner summary")
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", marker):
+        raise ValueError("corpus version marker must be a v-prefixed semantic version")
+    (root / "cases" / "CORPUS_VERSION").write_bytes(marker_bytes)
+    active_set_relative = f"corpora/active-sets/v1/{marker}.json"
+    active_set_bytes = file_at_commit(repo_root, corpus_git_sha, active_set_relative)
+    active_set_path = root / "corpora" / "active-sets" / "v1"
+    active_set_path.mkdir(parents=True)
+    (active_set_path / f"{marker}.json").write_bytes(active_set_bytes)
+    ledger_bytes = file_at_commit(repo_root, corpus_git_sha, "ci/corpus-versions.json")
+    ledger_path = root / "ci"
+    ledger_path.mkdir()
+    (ledger_path / "corpus-versions.json").write_bytes(ledger_bytes)
+
+
 def reconstruct_candidate(record_dir, candidate, repo_root):
     corpus_git_sha = promotion.require_non_empty_string(candidate, "corpus_git_sha")
     if len(corpus_git_sha) != 40 or any(char not in "0123456789abcdef" for char in corpus_git_sha):
@@ -78,6 +114,7 @@ def reconstruct_candidate(record_dir, candidate, repo_root):
         summary = evaluator.load_object(record_dir / provenance.RAW_EVIDENCE["raw_summary"])
         if summary.get("schema_version") in provenance.ACTIVE_SUMMARY_SCHEMA_VERSIONS:
             reconstruct_result_contract(repo_root, corpus_git_sha, root)
+            reconstruct_active_set(repo_root, corpus_git_sha, root, summary)
         rebuilt = root / promotion.CANDIDATE_FILENAME
         provenance.finalize_command(
             SimpleNamespace(
@@ -136,15 +173,22 @@ def validate_record(
     )
     promotion.validate_execution_decision(record_dir / promotion.EXECUTION_DECISION_FILENAME)
     reconstruct_candidate(record_dir, candidate, repo_root)
-    if manifest["schema_version"] >= 3:
-        expected_source_baseline = file_at_commit(
-            repo_root, candidate["corpus_git_sha"], "ci/gauntlet-baseline.json"
-        )
+    # The source baseline is the product's acceptance policy, not this
+    # repository's. Requiring it to equal ci/gauntlet-baseline.json would make
+    # the neutral benchmark the owner of every adopter's expected scores.
+    #
+    # It still has to be bound to an origin, or a substituted policy with a
+    # recomputed decision satisfies every remaining check. From record schema 4
+    # the record carries that origin, and this repository validates the generic
+    # locator and digest without knowing anything about the product's values.
+    if manifest["schema_version"] >= 4:
+        origin_path = record_dir / promotion.SOURCE_BASELINE_ORIGIN_FILENAME
+        if not origin_path.is_file():
+            raise ValueError(f"{record_dir}: record is missing its source baseline origin")
         retained_source_baseline = (
             record_dir / promotion.SOURCE_BASELINE_FILENAME
         ).read_bytes()
-        if retained_source_baseline != expected_source_baseline:
-            raise ValueError(f"{record_dir}: source baseline differs from corpus_git_sha")
+        promotion.load_source_baseline_origin(origin_path, retained_source_baseline)
     validate_decision(
         record_dir,
         candidate_path,

--- a/scripts/validate_gauntlet_records_test.py
+++ b/scripts/validate_gauntlet_records_test.py
@@ -333,11 +333,23 @@ class ValidRecordFixture:
             evaluator.evaluate(self.candidate_path, self.source_baseline, evidence),
         )
         self.site = root / "site"
+        self.source_baseline_origin = root / "source-baseline-origin.json"
+        write_json(
+            self.source_baseline_origin,
+            {
+                "schema_version": 1,
+                "repository": "luckyPipewrench/example-product",
+                "commit": "b" * 40,
+                "path": "benchmark/gauntlet-baseline.json",
+                "sha256": evaluator.file_sha256(self.source_baseline),
+            },
+        )
         promotion.promote(
             SimpleNamespace(
                 artifact_dir=self.artifact_dir,
                 baseline=self.baseline,
                 source_baseline=self.source_baseline,
+                source_baseline_origin=self.source_baseline_origin,
                 store_root=self.site / "results",
                 latest=self.site / promotion.LATEST_POINTER_FILENAME,
                 summary=None,
@@ -401,6 +413,7 @@ class ValidRecordFixture:
                 artifact_dir=self.artifact_dir,
                 baseline=self.baseline,
                 source_baseline=self.source_baseline,
+                source_baseline_origin=self.source_baseline_origin,
                 store_root=self.site / "results",
                 latest=self.site / promotion.LATEST_POINTER_FILENAME,
                 summary=None,
@@ -510,7 +523,13 @@ class ValidateGauntletRecordsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "reviewed baseline does not match"):
             validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
 
-    def test_source_baseline_must_match_candidate_commit(self):
+    def test_substituted_source_baseline_is_caught_by_its_origin(self):
+        """The exact attack the origin record exists to stop.
+
+        Swap the acceptance policy for a friendlier one and recompute its
+        decision so the record is internally consistent, then repair every
+        digest. Before the origin record existed, that passed.
+        """
         fixture = ValidRecordFixture(self.root())
         pointer_path = fixture.site / promotion.LATEST_POINTER_FILENAME
         pointer = evaluator.load_object(pointer_path)
@@ -540,8 +559,58 @@ class ValidateGauntletRecordsTest(unittest.TestCase):
         pointer["record_manifest_sha256"] = evaluator.file_sha256(manifest_path)
         write_json(pointer_path, pointer)
 
-        with self.assertRaisesRegex(ValueError, "source baseline differs from corpus_git_sha"):
+        with self.assertRaisesRegex(
+            ValueError, "does not describe the retained source baseline"
+        ):
             validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
+
+    def test_record_without_a_source_baseline_origin_is_rejected(self):
+        fixture = ValidRecordFixture(self.root())
+        pointer_path = fixture.site / promotion.LATEST_POINTER_FILENAME
+        pointer = evaluator.load_object(pointer_path)
+        record = fixture.site / "results" / "pipelock" / pointer["candidate_sha256"]
+        origin = record / promotion.SOURCE_BASELINE_ORIGIN_FILENAME
+        origin.unlink()
+        manifest_path = record / promotion.RECORD_MANIFEST_FILENAME
+        manifest = evaluator.load_object(manifest_path)
+        del manifest["files"][promotion.SOURCE_BASELINE_ORIGIN_FILENAME]
+        write_json(manifest_path, manifest)
+        pointer["record_manifest_sha256"] = evaluator.file_sha256(manifest_path)
+        write_json(pointer_path, pointer)
+
+        with self.assertRaises(ValueError):
+            validator.validate(fixture.site, fixture.baseline, fixture.corpus_root)
+
+    def test_source_baseline_origin_shape_is_exact(self):
+        for mutation, expected in (
+            ({"commit": "not-a-sha"}, "40-character Git SHA"),
+            ({"repository": ""}, "trimmed non-empty string"),
+            ({"schema_version": 2}, "schema_version must be 1"),
+        ):
+            with self.subTest(mutation=mutation):
+                fixture = ValidRecordFixture(self.root())
+                pointer_path = fixture.site / promotion.LATEST_POINTER_FILENAME
+                pointer = evaluator.load_object(pointer_path)
+                record = (
+                    fixture.site / "results" / "pipelock" / pointer["candidate_sha256"]
+                )
+                origin_path = record / promotion.SOURCE_BASELINE_ORIGIN_FILENAME
+                origin = evaluator.load_object(origin_path)
+                origin.update(mutation)
+                write_json(origin_path, origin)
+                manifest_path = record / promotion.RECORD_MANIFEST_FILENAME
+                manifest = evaluator.load_object(manifest_path)
+                manifest["files"][
+                    promotion.SOURCE_BASELINE_ORIGIN_FILENAME
+                ] = evaluator.file_sha256(origin_path)
+                write_json(manifest_path, manifest)
+                pointer["record_manifest_sha256"] = evaluator.file_sha256(manifest_path)
+                write_json(pointer_path, pointer)
+
+                with self.assertRaisesRegex(ValueError, expected):
+                    validator.validate(
+                        fixture.site, fixture.baseline, fixture.corpus_root
+                    )
 
     def test_missing_predecessor_breaks_append_only_chain(self):
         fixture = ValidRecordFixture(self.root())

--- a/scripts/validate_gauntlet_scope_test.py
+++ b/scripts/validate_gauntlet_scope_test.py
@@ -630,7 +630,11 @@ class ValidateGauntletScopeTest(unittest.TestCase):
                 check=False,
             )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("schema_version must be 1, 2, or 3", result.stderr)
+        # Derived, not hardcoded. A literal list here goes stale on the next
+        # schema version and the test then asserts an old message rather than
+        # the behaviour it names, which is how this broke at version 4.
+        expected = scope_validator.render_version_options(scope_validator.PROMOTED_RECORD_SCHEMAS)
+        self.assertIn(f"schema_version must be {expected}", result.stderr)
 
     def test_archive_record_rejects_an_untrusted_record_manifest_digest(self):
         artifact_path = FROZEN_RECORD / "continuous-gauntlet-pipelock.json"


### PR DESCRIPTION
## What changed

The record validator reconstructed a partial corpus that omitted the corpus version marker, its active set, and the version ledger, so it re-selected the whole manifest and refused a record measured against the active corpus. The reconstruction now carries those inputs, and a record produced before the corpus carried a version marker still reconstructs against the whole manifest as it was measured.

Record schema v4 adds a required source baseline origin naming the repository, commit, path and digest of the acceptance policy a result was judged against. Schema v3 is frozen rather than extended, because its file set is closed and adding to it would make new records fail for readers already installed. This replaces an assertion that the source baseline had to equal this repository's own file, which made the neutral benchmark the owner of every adopter's expected scores.

The origin document is a locator rather than an origin proof, and the code says so. This repository has no network, so nothing resolves the named repository, commit and path, and a forged locator whose digest matches a forged policy is accepted. The producer is what makes it meaningful, and closing the remaining gap needs a product-signed acceptance artifact rather than a stricter check over self-authored data.

The v5-receipt requirement now grandfathers a second published record that the original single exception missed because it did not exist yet and lives in another repository. Membership is decided by exact digest rather than a date or a self-declared version, either of which a later record could claim in order to escape the requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added promoted-record format version 4 with expanded artifact tracking and source-baseline provenance.
  - Promoted records now include validated repository, commit, path, and checksum details for their source baseline.
  - Added support for reconstructing and validating the active corpus associated with records.

- **Compatibility**
  - Version 4 is now the active format; versions 1–3 remain readable, with versions 1–3 frozen.

- **Bug Fixes**
  - Existing grandfathered records from an additional published site are now accepted during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->