### PR TITLE
chore(release): state and enforce what the release tag promises

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -79,6 +79,25 @@ Retained v1 and v2 evidence records are frozen. The v4 case and tool-profile for
 
 Every active profile and result binds an immutable capability-registry snapshot by ID, format, revision, and raw-byte SHA-256. Adding or deprecating a reporting label creates a registry revision, not an artifact schema bump.
 
+### Release tag identity
+
+The release tag versions one thing: the release bundle. That bundle is the public API this
+repository promises against, and it is the archive layout, the `aeb-gauntlet` and `aeb-validate`
+command behavior, the `release-identity.json` format, the reusable Action interface, and the
+verification procedure in [RELEASES.md](RELEASES.md). Tags are `vMAJOR.MINOR.PATCH` under
+[Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html), validated on the release path,
+and a tag that is not a valid version, or that does not resolve to the release commit, fails the
+build before anything is produced.
+
+The tag is not a summary of the per-family versions above and cannot be read as one. Those answer
+whether a saved artifact still opens; the tag answers what an installable package is and whether a
+cited result came from a package anyone can rebuild. A release may bump the tag's MINOR while every
+artifact family holds its version, and a family may bump while the tag takes a PATCH, because they
+measure different things. Ask the compatibility question of the family manifest, never of the tag.
+
+Tags are immutable once published. A published tag is never moved, deleted, or reinterpreted, since
+results cite it and the verification procedure resolves it.
+
 ### Corpus version identity
 
 `corpus_version` names one exact corpus and is bound to it. [`ci/corpus-versions.json`](../ci/corpus-versions.json) records, for each label, the scored case count and the `benchmark_manifest_sha256` of the corpus that label names, and `runner/corpus_version_test.go` fails when the corpus on disk is not the corpus the current label names. An active-set entry also records the SHA-256 of its versioned selection artifact. Adding, removing, or re-expecting a scored case therefore requires a new label and a new ledger entry in the same change. The current label must be the ledger's final entry.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,6 +1,6 @@
 # Release artifacts
 
-A tagged release fixes the corpus, schemas, contracts, runner source revision, and runner archives in one package. A release tag identifies the source revision. The `release-identity.json` asset records the exact revision and the SHA-256 digest of every bundled corpus and schema file.
+A tagged release fixes the corpus, schemas, contracts, runner source revision, and runner archives in one package. A release tag identifies the source revision. The tag versions the release bundle under [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html), where the bundle is the archive layout, the `aeb-gauntlet` and `aeb-validate` command behavior, the `release-identity.json` format, the reusable Action interface, and the verification procedure below. Whether a saved artifact still opens is a separate question answered per family by [`contracts/artifacts.json`](../contracts/artifacts.json), not by the tag; [GOVERNANCE.md](GOVERNANCE.md#release-tag-identity) states both rules. The `release-identity.json` asset records the exact revision and the SHA-256 digest of every bundled corpus and schema file.
 
 Each release contains:
 

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -22,8 +22,19 @@ from typing import Any
 
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
-VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
-SNAPSHOT_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?-SNAPSHOT-[0-9a-f]{4,40}$")
+# Numeric identifiers, per the Semantic Versioning 2.0.0 specification: a numeric
+# identifier is either 0 or a non-zero digit followed by digits, so leading zeroes
+# are invalid. The previous [0-9]+ accepted "01.2.3" and calendar-style
+# "2026.09.0", so the release path advertised a SemVer check it did not perform.
+# Derived from the suggested expression published at semver.org, with its capture
+# groups removed because nothing here reads the parts.
+NUMERIC_ID = r"(?:0|[1-9][0-9]*)"
+PRERELEASE_ID = r"(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)"
+PRERELEASE = rf"(?:-{PRERELEASE_ID}(?:\.{PRERELEASE_ID})*)?"
+BUILD_METADATA = r"(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?"
+CORE_VERSION = rf"{NUMERIC_ID}\.{NUMERIC_ID}\.{NUMERIC_ID}"
+VERSION_RE = re.compile(rf"^{CORE_VERSION}{PRERELEASE}{BUILD_METADATA}$")
+SNAPSHOT_VERSION_RE = re.compile(rf"^{CORE_VERSION}{PRERELEASE}-SNAPSHOT-[0-9a-f]{{4,40}}$")
 IDENTITY_NAME = "release-identity.json"
 CHECKSUM_NAME = "checksums.txt"
 SCHEMA_CATALOG_PATH = "schemas/index.json"

--- a/scripts/release_build.py
+++ b/scripts/release_build.py
@@ -35,6 +35,13 @@ BUILD_METADATA = r"(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?"
 CORE_VERSION = rf"{NUMERIC_ID}\.{NUMERIC_ID}\.{NUMERIC_ID}"
 VERSION_RE = re.compile(rf"^{CORE_VERSION}{PRERELEASE}{BUILD_METADATA}$")
 SNAPSHOT_VERSION_RE = re.compile(rf"^{CORE_VERSION}{PRERELEASE}-SNAPSHOT-[0-9a-f]{{4,40}}$")
+# A snapshot version is the source tag with -SNAPSHOT-<short-commit> appended, so a
+# source tag carrying build metadata cannot produce a valid one: the specification
+# allows nothing after build metadata, and the GoReleaser template renders the tag
+# verbatim before the suffix. Such a tag is refused at selection, where the message
+# can name the cause, rather than at render, where it surfaces as an opaque template
+# mismatch.
+SNAPSHOT_SOURCE_VERSION_RE = re.compile(rf"^{CORE_VERSION}{PRERELEASE}$")
 IDENTITY_NAME = "release-identity.json"
 CHECKSUM_NAME = "checksums.txt"
 SCHEMA_CATALOG_PATH = "schemas/index.json"
@@ -157,8 +164,13 @@ def snapshot_source_tag(repo: Path, commit: str) -> str:
     if not COMMIT_RE.fullmatch(commit):
         fail("snapshot commit must be a 40-character lower-case Git SHA")
     tags = git(repo, "tag", "--merged", commit, "--sort=-v:refname").splitlines()
-    tag = next((candidate for candidate in tags if candidate.startswith("v") and VERSION_RE.fullmatch(candidate[1:])), "")
+    tag = next(
+        (candidate for candidate in tags if candidate.startswith("v") and SNAPSHOT_SOURCE_VERSION_RE.fullmatch(candidate[1:])),
+        "",
+    )
     if not tag:
+        if any(candidate.startswith("v") and VERSION_RE.fullmatch(candidate[1:]) for candidate in tags):
+            fail("GoReleaser snapshot source tag must not carry build metadata")
         fail("GoReleaser snapshot source tag must be a v-prefixed semantic version")
     return tag
 

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -1325,6 +1325,51 @@ class ReleaseBuildTest(unittest.TestCase):
         spec.loader.exec_module(module)
         return module
 
+    def test_release_version_validation_follows_the_published_semver_grammar(self) -> None:
+        """A release tag claims SemVer, so the check must be SemVer and not merely dotted digits.
+
+        The earlier expression accepted any run of digits per position, so
+        "01.2.3" and a calendar-style "2026.09.0" both passed a check whose
+        failure message promises a semantic version. Cases below are taken
+        from the specification's own rules for numeric identifiers.
+        """
+        module = self.release_build_module()
+        accepted = (
+            "1.0.0",
+            "0.1.2",
+            "10.20.30",
+            "1.0.0-alpha.1",
+            "1.0.0-alpha.beta",
+            "1.0.0+build.5",
+            "1.0.0-alpha.1+build.5",
+            "2026.9.0",
+        )
+        rejected = (
+            "01.2.3",
+            "1.02.3",
+            "1.2.03",
+            "2026.09.0",
+            "1.0",
+            "1.0.0.0",
+            "v1.0.0",
+            "1.0.0-01",
+            "",
+        )
+        for version in accepted:
+            with self.subTest(accepted=version):
+                self.assertIsNotNone(module.VERSION_RE.fullmatch(version))
+        for version in rejected:
+            with self.subTest(rejected=version):
+                self.assertIsNone(module.VERSION_RE.fullmatch(version))
+
+    def test_snapshot_version_validation_rejects_leading_zero_cores(self) -> None:
+        """The snapshot expression shares the version core, so it inherits the same rule."""
+        module = self.release_build_module()
+        self.assertIsNotNone(module.SNAPSHOT_VERSION_RE.fullmatch("0.1.2-SNAPSHOT-abcdef12"))
+        self.assertIsNotNone(module.SNAPSHOT_VERSION_RE.fullmatch("1.0.0-alpha.1-SNAPSHOT-abcdef12"))
+        self.assertIsNone(module.SNAPSHOT_VERSION_RE.fullmatch("01.2.3-SNAPSHOT-abcdef12"))
+        self.assertIsNone(module.SNAPSHOT_VERSION_RE.fullmatch("0.1.2-SNAPSHOT-zz"))
+
     def test_checksums_reports_an_absent_distribution_directory(self) -> None:
         self.prepare()
         missing = self.root / "missing-dist"

--- a/scripts/release_build_test.py
+++ b/scripts/release_build_test.py
@@ -1362,6 +1362,21 @@ class ReleaseBuildTest(unittest.TestCase):
             with self.subTest(rejected=version):
                 self.assertIsNone(module.VERSION_RE.fullmatch(version))
 
+    def test_snapshot_source_tag_refuses_a_build_metadata_tag(self) -> None:
+        """A tag that cannot yield a valid snapshot version is refused where the cause is known.
+
+        The snapshot version appends the snapshot suffix to the source tag, and
+        the specification permits nothing after build metadata, so a `+build`
+        tag renders a string the snapshot contract must reject. Selecting it and
+        failing later reports a template mismatch instead of the real reason.
+        """
+        module = self.release_build_module()
+        self.assertIsNotNone(module.VERSION_RE.fullmatch("1.0.0+build.5"))
+        self.assertIsNone(module.SNAPSHOT_SOURCE_VERSION_RE.fullmatch("1.0.0+build.5"))
+        self.assertIsNone(module.SNAPSHOT_VERSION_RE.fullmatch("1.0.0+build.5-SNAPSHOT-abcdef12"))
+        self.assertIsNotNone(module.SNAPSHOT_SOURCE_VERSION_RE.fullmatch("1.0.0"))
+        self.assertIsNotNone(module.SNAPSHOT_SOURCE_VERSION_RE.fullmatch("1.0.0-alpha.1"))
+
     def test_snapshot_version_validation_rejects_leading_zero_cores(self) -> None:
         """The snapshot expression shares the version core, so it inherits the same rule."""
         module = self.release_build_module()


### PR DESCRIPTION
## What changed

The release tag is validated on the release path and bound into `release-identity.json`, and the verification procedure asks people to clone the cited tag, but the repository never wrote down what that tag promises. GOVERNANCE.md now states it: the tag versions the release bundle, meaning the archive layout, the `aeb-gauntlet` and `aeb-validate` command behavior, the `release-identity.json` format, the reusable Action interface, and the verification procedure. It also states what the tag is not, because the per-family artifact versions answer a different question and a reader should not treat the tag as their summary.

The version check accepted any run of digits per position, so a leading-zero version passed a check whose failure message promises a semantic version. The grammar now follows the published specification, including numeric identifiers inside prerelease strings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that release tags version the complete release bundle under Semantic Versioning 2.0.0.
  - Documented which release components and verification procedures are covered by the tag.
  - Clarified that artifact compatibility is determined per artifact family, not by the release tag.
  - Documented that published tags are immutable and are never moved, deleted, or reinterpreted.

- **Bug Fixes**
  - Tightened release and snapshot version validation to follow SemVer 2.0.0, rejecting invalid formats such as leading-zero identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->